### PR TITLE
Implements #29 - Ability to disable certificate validation

### DIFF
--- a/rPDU2MQTT/Models/Config/Schemas/Connection.cs
+++ b/rPDU2MQTT/Models/Config/Schemas/Connection.cs
@@ -30,4 +30,9 @@ public class Connection
     [Display(Name = "Connection Scheme", Description = "Connection scheme used")]
     [Description("Default connection scheme.")]
     public string? Scheme { get; set; }
+
+    [DefaultValue(true)]
+    [Display(Name = "Validate Certificate", Description = "Enables certificate validation")]
+    [YamlMember(Alias = "ValidateCertificate")]
+    public bool? ValidateCertificate { get; set; } = true;
 }

--- a/rPDU2MQTT/config.defaults.yaml
+++ b/rPDU2MQTT/config.defaults.yaml
@@ -24,6 +24,9 @@ Mqtt:
         # Timeout (in seconds) for connection.
         Timeout: 15
 
+        # (Optional) Enable or Disable Certificate Validation. Defaults to true.
+        ValidateCertificate: true
+
 Pdu:
     # (Required) Connection details for MQTT server
     Connection:
@@ -39,6 +42,9 @@ Pdu:
 
         # Timeout (in seconds) for requests.
         Timeout: 15
+
+        # (Optional) Enable or Disable Certificate Validation. Defaults to true.
+        ValidateCertificate: true
 
     # (Optional) Credentials to connect to MQTT server
     Credentials:


### PR DESCRIPTION
Adds an option to config.yaml, which allows for disabling certificate validation.

```
Pdu:
    Connection:
        # (Optional) Enable or Disable Certificate Validation. Defaults to true.
        ValidateCertificate: true
```