### PR TITLE
Added "Debug" Configuration

### DIFF
--- a/rPDU2MQTT/Models/Config/Config.cs
+++ b/rPDU2MQTT/Models/Config/Config.cs
@@ -19,4 +19,7 @@ public class Config
 
     [YamlMember(Alias = "Overrides", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Overrides")]
     public Overrides Overrides { get; set; } = new Overrides();
+
+    [YamlMember(Alias = "Debug", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Settings for debugging and diagnostics.")]
+    public DebugConfig Debug { get; set; } = new DebugConfig();
 }

--- a/rPDU2MQTT/Models/Config/DebugConfig.cs
+++ b/rPDU2MQTT/Models/Config/DebugConfig.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel;
+using YamlDotNet.Serialization;
+
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>
+/// Settings for debugging and diagnostics.
+/// </summary>
+public class DebugConfig
+{
+    /// <summary>
+    /// This- determines if messages are actually PUSHED to the MQTT broker.
+    /// </summary>
+    /// <remarks>
+    /// Intended usage, is to allow the entire process to be tested, and debugged, without actually publishing the mwssages.
+    /// </remarks>
+    [YamlMember(Alias = "PublishMessages")]
+    [DefaultValue(true)]
+    public bool PublishMessages { get; set; } = true;
+
+
+    /// <summary>
+    /// When enabled, this will print the MQTT discovery messages to the console.
+    /// </summary>
+    [YamlMember(Alias = "PrintDiscovery")]
+    [DefaultValue(false)]
+    public bool PrintDiscovery { get; set; } = false;
+}

--- a/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
@@ -113,7 +113,8 @@ public abstract class baseDiscoveryService : baseMQTTTService
             PayloadAsString = System.Text.Json.JsonSerializer.Serialize<T>(sensor, this.jsonOptions)
         };
 
-        Console.WriteLine(msg.PayloadAsString);
+        if (cfg.Debug.PrintDiscovery)
+            log.LogDebug(msg.PayloadAsString);
 
         return this.Publish(msg, cancellationToken);
     }

--- a/rPDU2MQTT/Services/baseTypes/baseMQTTTService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseMQTTTService.cs
@@ -110,14 +110,13 @@ public abstract class baseMQTTTService : IHostedService, IDisposable
     /// <returns></returns>
     protected Task Publish(MQTT5PublishMessage msg, CancellationToken cancellationToken)
     {
+        if (cfg.Debug.PublishMessages == false)
+            return Task.CompletedTask;
+
         if (!mqtt.IsConnected())
             log.LogError("MQTT Broker is not connected!!!!!");
 
-        return cfg.Debug.PublishMessages switch
-        {
-            false => Task.CompletedTask,
-            _ => mqtt.PublishAsync(msg, cancellationToken);
-        };
+        return mqtt.PublishAsync(msg, cancellationToken);
     }
 
     /// <summary>

--- a/rPDU2MQTT/Services/baseTypes/baseMQTTTService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseMQTTTService.cs
@@ -20,7 +20,7 @@ public abstract class baseMQTTTService : IHostedService, IDisposable
 {
     private readonly int interval;
     protected ILogger log { get; init; }
-    protected IHiveMQClient mqtt { get; init; }
+    private IHiveMQClient mqtt { get; init; }
     private PeriodicTimer timer;
     private Task timerTask = Task.CompletedTask;
     protected Config cfg { get; }
@@ -113,7 +113,11 @@ public abstract class baseMQTTTService : IHostedService, IDisposable
         if (!mqtt.IsConnected())
             log.LogError("MQTT Broker is not connected!!!!!");
 
-        return mqtt.PublishAsync(msg, cancellationToken);
+        return cfg.Debug.PublishMessages switch
+        {
+            false => Task.CompletedTask,
+            _ => mqtt.PublishAsync(msg, cancellationToken);
+        };
     }
 
     /// <summary>

--- a/rPDU2MQTT/config.defaults.yaml
+++ b/rPDU2MQTT/config.defaults.yaml
@@ -149,3 +149,14 @@ HomeAssistant:
     DiscoveryInterval: 300
     # Default expireAfter interval applied to all sensors. After this time- the sensor will be marked as unavailable.
     SensorExpireAfterSeconds: 300
+
+# These settings are used when debugging, or when additional data or diagnostics is needed.
+Debug:
+    # When enabled, discovery messages will be formatted, and printed to console.
+    # Default: false
+    PrintDiscovery: false
+
+    # When set to false, this will prevent messages from being published to the MQTT Broker.
+    # This is used to test the entire program, WITHOUT sending messages.
+    # Default: true
+    PublishMessages: true


### PR DESCRIPTION
This is a small change, which adds a few options to the configuration, around debug. 

Purpose, is to give me a few tools to much more easily test bugs, and conditions.

```
# These settings are used when debugging, or when additional data or diagnostics is needed.
Debug:
    # When enabled, discovery messages will be formatted, and printed to console.
    # Default: false
    PrintDiscovery: false

    # When set to false, this will prevent messages from being published to the MQTT Broker.
    # This is used to test the entire program, WITHOUT sending messages.
    # Default: true
    PublishMessages: true
```