### PR TITLE
#15 - Retain Discovery Messages

### DIFF
--- a/Examples/Configuration/config.spec.yaml
+++ b/Examples/Configuration/config.spec.yaml
@@ -144,9 +144,26 @@ Overrides:
             Enabled: false
 
 HomeAssistant:
+    # Is home assistant mQTT-discovery enabled?
+    # If you want to manually create entities, or, just want your PDU data pushed to MQTT without home-assistant, change to false.
+    # (Optional) Default: false
     DiscoveryEnabled: true
+
+    # Should discovery messages  be retained? Strongly recommend leaving this to true!
+    # (Optional) Default: true
+    DiscoveryRetain: true
+
+    # This is the home-assistant discovery topic.
+    # Should prob leave this set as-is.
     DiscoveryTopic: "homeassistant/discovery"
+
+    # How often should discovery messages be sent?
+    # 0 = Send Once at startup.
+    # Note, if you have DiscoveryRetain=true, the only benefit to running more discovery jobs- is to update the names of entityes
+    # based on labels set in the PDU.
+    # (Optional) Default: 0
     DiscoveryInterval: 300
+
     # Default expireAfter interval applied to all sensors. After this time- the sensor will be marked as unavailable.
     SensorExpireAfterSeconds: 300
 

--- a/rPDU2MQTT/Models/Config/HomeAssistantConfig.cs
+++ b/rPDU2MQTT/Models/Config/HomeAssistantConfig.cs
@@ -20,7 +20,15 @@ public class HomeAssistantConfig
     /// <summary>
     /// How often should discovery data be published?
     /// </summary>
-    public int DiscoveryInterval { get; set; } = 300;
+    /// <remarks>
+    /// A value of 0, will run a single discovery, and not run a re-discovery until the application is restarted.
+    /// </remarks>
+    public int DiscoveryInterval { get; set; } = 0;
+
+    /// <summary>
+    /// Should discovery messages be retained?
+    /// </summary>
+    public bool DiscoveryRetain { get; set; } = true;
 
     /// <summary>
     ///  Default expireAfter interval applied to all sensors. After this time- the sensor will be marked as unavailable.

--- a/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
@@ -110,7 +110,8 @@ public abstract class baseDiscoveryService : baseMQTTTService
         var msg = new MQTT5PublishMessage(topic, QualityOfService.AtLeastOnceDelivery)
         {
             ContentType = "json",
-            PayloadAsString = System.Text.Json.JsonSerializer.Serialize<T>(sensor, this.jsonOptions)
+            PayloadAsString = System.Text.Json.JsonSerializer.Serialize<T>(sensor, this.jsonOptions),
+            Retain = cfg.HASS.DiscoveryRetain,
         };
 
         if (cfg.Debug.PrintDiscovery)


### PR DESCRIPTION
This PR adds two features-

1. Implements #15 - Enables retaining discovery messages.

If- you don't retain discovery messages, home assistant will not update the entities until the next discovery job runs.

2. Adds the ability to only run a single discovery. If you set the discovery interval to 0, then only a single discovery will be executed when the application starts / restarts.

Don't recommend using it- as frequent discovery jobs will update labels in home assistant automatically.