### PR TITLE
Prometheus push (Pushgateway) mode

### DIFF
--- a/Examples/Configuration/config.spec.yaml
+++ b/Examples/Configuration/config.spec.yaml
@@ -311,11 +311,22 @@ Logging:
         Severity: Information
 
 # (Optional) Export measurements to Prometheus, in addition to MQTT.
+# The exporter (scrape) and the Pushgateway (push) are independent — enable either or both.
 Prometheus:
-    # (Optional). Default: false
-    Enabled: false
+    # Expose a /metrics endpoint for Prometheus to scrape. Default: false
+    Exporter: false
     # Port the /metrics endpoint listens on. Default: 9184
     Port: 9184
+    # Push to a Prometheus Pushgateway.
+    Pushgateway:
+        # (Optional). Default: false
+        Enabled: false
+        # Pushgateway endpoint. Required when Pushgateway is enabled.
+        Url: "http://pushgateway:9091/metrics"
+        # The "job" label applied to pushed metrics. Default: rpdu2mqtt
+        Job: "rpdu2mqtt"
+        # How often to push, in seconds. 0 = use Pdu.PollInterval. Default: 0
+        IntervalSeconds: 0
 
 # (Optional) Push measurements to an EmonCMS server (inputs are auto-created).
 EmonCMS:

--- a/Examples/Configuration/recommended-configuration.yaml
+++ b/Examples/Configuration/recommended-configuration.yaml
@@ -71,10 +71,15 @@ HomeAssistant:
 #        Host: "10.0.0.10"
 #        Protocol: UDP   # UDP or TCP
 
-# Optional: expose metrics for Prometheus at http://<host>:9184/metrics
+# Optional: expose metrics for Prometheus at http://<host>:9184/metrics (Exporter),
+# and/or push to a Pushgateway. Both are independent.
 #Prometheus:
-#    Enabled: true
+#    Exporter: true
 #    Port: 9184
+#    #Pushgateway:
+#    #    Enabled: true
+#    #    Url: "http://pushgateway:9091/metrics"
+#    #    Job: "rpdu2mqtt"
 
 # Optional: push measurements to EmonCMS (inputs are auto-created).
 #EmonCMS:

--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -282,10 +282,29 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
                 properties:
-                  Enabled:
+                  Exporter:
                     type: boolean
+                    description: Expose a /metrics endpoint for Prometheus to scrape.
                   Port:
                     type: integer
+                    description: Port the /metrics endpoint listens on (Exporter).
+                  Pushgateway:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      Enabled:
+                        type: boolean
+                        description: Push metrics to a Pushgateway.
+                      Url:
+                        type: string
+                        description: Pushgateway endpoint, e.g. http://pushgateway:9091/metrics.
+                      Job:
+                        type: string
+                        description: The 'job' label applied to pushed metrics.
+                      IntervalSeconds:
+                        type: integer
+                        description: How often to push, in seconds. Falls back to the PDU poll interval when 0.
+                    description: Push metrics to a Prometheus Pushgateway.
                 description: Prometheus metrics exporter
               EmonCMS:
                 type: object

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -282,10 +282,29 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
                 properties:
-                  Enabled:
+                  Exporter:
                     type: boolean
+                    description: Expose a /metrics endpoint for Prometheus to scrape.
                   Port:
                     type: integer
+                    description: Port the /metrics endpoint listens on (Exporter).
+                  Pushgateway:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      Enabled:
+                        type: boolean
+                        description: Push metrics to a Pushgateway.
+                      Url:
+                        type: string
+                        description: Pushgateway endpoint, e.g. http://pushgateway:9091/metrics.
+                      Job:
+                        type: string
+                        description: The 'job' label applied to pushed metrics.
+                      IntervalSeconds:
+                        type: integer
+                        description: How often to push, in seconds. Falls back to the PDU poll interval when 0.
+                    description: Push metrics to a Prometheus Pushgateway.
                 description: Prometheus metrics exporter
               EmonCMS:
                 type: object

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -264,14 +264,24 @@ In addition to MQTT, measurements can be exported to Prometheus and/or EmonCMS. 
 by default and poll on the same `Pdu.PollInterval` cadence.
 
 ### Prometheus
-Exposes a `/metrics` endpoint. Each measurement type becomes a gauge (e.g. `rpdu2mqtt_realpower`)
-labelled by `device`, `source`, and `units`.
+Each measurement type becomes a gauge (e.g. `rpdu2mqtt_realpower`) labelled by `device`, `source`, and
+`units`. Two independent delivery methods — enable **either or both**:
+
+- **`Exporter`** — expose a `/metrics` endpoint for Prometheus to **scrape** (pull).
+- **`Pushgateway`** — **push** to a Prometheus **Pushgateway** (for setups where scraping isn't practical).
 
 ```yaml
 Prometheus:
-  Enabled: false
-  Port: 9184   # /metrics endpoint port
+  Exporter: false       # expose /metrics for scraping
+  Port: 9184            # /metrics endpoint port (Exporter)
+  Pushgateway:
+    Enabled: false      # push to a Pushgateway
+    Url: "http://pushgateway:9091/metrics"
+    Job: "rpdu2mqtt"
+    IntervalSeconds: 0  # 0 = use Pdu.PollInterval
 ```
+
+> The older `Prometheus.Enabled: true` still works — it's treated as `Exporter: true`.
 
 ### EmonCMS
 Pushes measurements to an EmonCMS server's `input/post` API (EmonCMS auto-creates the inputs).

--- a/rPDU2MQTT.Tests/PrometheusConfigTests.cs
+++ b/rPDU2MQTT.Tests/PrometheusConfigTests.cs
@@ -1,0 +1,50 @@
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Services.Gui;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+public class PrometheusConfigTests
+{
+    [Fact]
+    public void Defaults_BothDeliveryMethodsOff()
+    {
+        var cfg = new Config();
+        Assert.False(cfg.Prometheus.Exporter);
+        Assert.False(cfg.Prometheus.Pushgateway.Enabled);
+        Assert.Equal(9184, cfg.Prometheus.Port);
+        Assert.Equal("rpdu2mqtt", cfg.Prometheus.Pushgateway.Job);
+    }
+
+    [Fact]
+    public void ExporterAndPush_CanBothBeEnabled_AndRoundTrip()
+    {
+        var cfg = new Config();
+        cfg.Prometheus.Exporter = true;
+        cfg.Prometheus.Pushgateway.Enabled = true;
+        cfg.Prometheus.Pushgateway.Url = "http://pushgateway:9091/metrics";
+        cfg.Prometheus.Pushgateway.IntervalSeconds = 15;
+
+        var back = ConfigSchema.FromJson(ConfigSchema.ToJson(cfg));
+
+        Assert.True(back.Prometheus.Exporter);
+        Assert.True(back.Prometheus.Pushgateway.Enabled);
+        Assert.Equal("http://pushgateway:9091/metrics", back.Prometheus.Pushgateway.Url);
+        Assert.Equal(15, back.Prometheus.Pushgateway.IntervalSeconds);
+    }
+
+    [Fact]
+    public void Schema_ExposesIndependentToggles()
+    {
+        var prometheus = ConfigSchema.Build().Single(n => n.Key == "Prometheus");
+        var keys = prometheus.Properties!.Select(n => n.Key).ToList();
+        Assert.Contains("Exporter", keys);
+        Assert.Contains("Pushgateway", keys);
+        Assert.DoesNotContain("Mode", keys);
+        Assert.DoesNotContain("Enabled", keys);   // back-compat alias is hidden from the GUI
+
+        var pushgateway = prometheus.Properties!.Single(n => n.Key == "Pushgateway");
+        Assert.Contains("Enabled", pushgateway.Properties!.Select(n => n.Key));
+    }
+}

--- a/rPDU2MQTT/Models/Config/PrometheusConfig.cs
+++ b/rPDU2MQTT/Models/Config/PrometheusConfig.cs
@@ -1,16 +1,54 @@
 using System.ComponentModel;
+using System.Text.Json.Serialization;
+using YamlDotNet.Serialization;
 
 namespace rPDU2MQTT.Models.Config;
 
 /// <summary>
-/// Configuration for the Prometheus metrics exporter.
+/// Configuration for Prometheus metrics. The scrape exporter and the Pushgateway push are independent
+/// — enable either or both.
 /// </summary>
 public class PrometheusConfig
 {
     [DefaultValue(false)]
+    [Description("Expose a /metrics endpoint for Prometheus to scrape.")]
+    public bool Exporter { get; set; }
+
+    /// <summary>Port the /metrics endpoint listens on (Exporter).</summary>
+    [DefaultValue(9184)]
+    [Description("Port the /metrics endpoint listens on (Exporter).")]
+    public int Port { get; set; } = 9184;
+
+    [Description("Push metrics to a Prometheus Pushgateway.")]
+    public PrometheusPushgatewayConfig Pushgateway { get; set; } = new();
+
+    /// <summary>
+    /// Back-compat: the old single "Enabled" flag meant "run the exporter". Applied during config load.
+    /// Hidden from the GUI/JSON.
+    /// </summary>
+    [JsonIgnore]
+    [YamlMember(Alias = "Enabled", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public bool? EnabledAlias { get; set; }
+}
+
+/// <summary>Settings for pushing metrics to a Prometheus Pushgateway.</summary>
+public class PrometheusPushgatewayConfig
+{
+    [DefaultValue(false)]
+    [Description("Push metrics to a Pushgateway.")]
     public bool Enabled { get; set; }
 
-    /// <summary>Port the /metrics endpoint listens on.</summary>
-    [DefaultValue(9184)]
-    public int Port { get; set; } = 9184;
+    /// <summary>Pushgateway endpoint, e.g. "http://pushgateway:9091/metrics".</summary>
+    [Description("Pushgateway endpoint, e.g. http://pushgateway:9091/metrics.")]
+    public string? Url { get; set; }
+
+    /// <summary>The "job" label applied to pushed metrics.</summary>
+    [DefaultValue("rpdu2mqtt")]
+    [Description("The 'job' label applied to pushed metrics.")]
+    public string Job { get; set; } = "rpdu2mqtt";
+
+    /// <summary>How often to push, in seconds. Falls back to the PDU poll interval when 0.</summary>
+    [DefaultValue(0)]
+    [Description("How often to push, in seconds. Falls back to the PDU poll interval when 0.")]
+    public int IntervalSeconds { get; set; }
 }

--- a/rPDU2MQTT/Services/PrometheusExportService.cs
+++ b/rPDU2MQTT/Services/PrometheusExportService.cs
@@ -6,25 +6,57 @@ using rPDU2MQTT.Services.baseTypes;
 namespace rPDU2MQTT.Services;
 
 /// <summary>
-/// Exposes PDU measurements as Prometheus metrics on a /metrics endpoint. Each measurement type
-/// becomes a gauge (e.g. rpdu2mqtt_realpower) labelled by device and source. Enabled via config.
+/// Publishes PDU measurements as Prometheus metrics. Each measurement type becomes a gauge
+/// (e.g. rpdu2mqtt_realpower) labelled by device and source. Can expose a /metrics endpoint for
+/// scraping (Exporter) and/or push to a Pushgateway (Pushgateway) — both independent.
 /// </summary>
 public class PrometheusExportService : baseMQTTService
 {
     private readonly Dictionary<string, Gauge> gauges = new();
-    private readonly IMetricServer? server;
+    private readonly IMetricServer? exporter;
+    private readonly IMetricServer? pusher;
 
     public PrometheusExportService(MQTTServiceDependencies deps) : base(deps, deps.Cfg.PDU.PollInterval)
     {
-        var port = deps.Cfg.Prometheus.Port;
-        try
+        var cfg = deps.Cfg.Prometheus;
+
+        if (cfg.Exporter)
         {
-            server = new MetricServer(port: port).Start();
-            Log.Information($"Prometheus exporter listening on :{port}/metrics");
+            try
+            {
+                exporter = new MetricServer(port: cfg.Port).Start();
+                Log.Information($"Prometheus exporter listening on :{cfg.Port}/metrics");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Failed to start the Prometheus exporter on port {cfg.Port}.");
+            }
         }
-        catch (Exception ex)
+
+        if (cfg.Pushgateway.Enabled)
         {
-            Log.Error(ex, $"Failed to start the Prometheus metric server on port {port}.");
+            if (string.IsNullOrWhiteSpace(cfg.Pushgateway.Url))
+            {
+                Log.Error("Prometheus Pushgateway is enabled but Prometheus.Pushgateway.Url is not set; no metrics will be pushed.");
+            }
+            else
+            {
+                try
+                {
+                    var seconds = cfg.Pushgateway.IntervalSeconds > 0 ? cfg.Pushgateway.IntervalSeconds : deps.Cfg.PDU.PollInterval;
+                    pusher = new MetricPusher(new MetricPusherOptions
+                    {
+                        Endpoint = cfg.Pushgateway.Url,
+                        Job = cfg.Pushgateway.Job,
+                        IntervalMilliseconds = Math.Max(1, seconds) * 1000,
+                    }).Start();
+                    Log.Information($"Prometheus pushing to {cfg.Pushgateway.Url} (job '{cfg.Pushgateway.Job}') every {seconds}s.");
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to start the Prometheus Pushgateway pusher.");
+                }
+            }
         }
     }
 

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -117,7 +117,7 @@ public static class ServiceConfiguration
         services.AddHostedService<MQTTPublishingService>();
 
         // Optional metric exporters.
-        if (cfg.Prometheus.Enabled)
+        if (cfg.Prometheus.Exporter || cfg.Prometheus.Pushgateway.Enabled)
             services.AddHostedService<PrometheusExportService>();
 
         if (cfg.EmonCMS.Enabled)

--- a/rPDU2MQTT/Startup/YamlConfigLoader.cs
+++ b/rPDU2MQTT/Startup/YamlConfigLoader.cs
@@ -121,6 +121,10 @@ internal class YamlConfigLoader
         if (config.PDU.EnableActionsAlias.HasValue)
             config.PDU.ActionsEnabled = config.PDU.EnableActionsAlias.Value;
 
+        // Backwards-compatible alias: the old Prometheus.Enabled meant "run the exporter".
+        if (config.Prometheus.EnabledAlias == true)
+            config.Prometheus.Exporter = true;
+
         ApplyEnvironmentOverrides(config);
 
         return config;


### PR DESCRIPTION
## Summary

Adds a **push** delivery method for Prometheus alongside the existing scrape **exporter**. They're independent toggles — enable either or both (no technical reason they can't both run).

## Changes

- **`Prometheus.Exporter`** (bool) — expose `/metrics` for Prometheus to scrape (the previous behavior).
- **`Prometheus.Pushgateway`** `{ Enabled, Url, Job, IntervalSeconds }` — push to a Prometheus Pushgateway (interval defaults to `Pdu.PollInterval`). Implemented via prometheus-net's `MetricPusher`; the gauge logic is shared between both.
- **Back-compat:** the old `Prometheus.Enabled: true` is still honored (treated as `Exporter: true`), so existing configs keep working.
- The **GUI** renders both toggles automatically (schema-driven); docs + example configs updated.
- **Regenerated the `RpduConfig` CRD** schema so it reflects the new `Exporter` / `Pushgateway` fields.

## Verification

- Build: **0 warnings**; **31 tests** pass (3 new Prometheus tests: defaults, both-enabled round-trip, schema exposes both toggles).
- **Live push smoke test** against a local Pushgateway: **168 `rpdu2mqtt_*` metrics pushed per interval**.
- `helm lint` + `kubectl --dry-run=client` of the regenerated CRD.
- The scrape exporter is the unchanged original code; it couldn't bind its `HttpListener` on the Windows dev box (URL-ACL restriction) but runs in the Linux container as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
