### PR TITLE
Bump HiveMQtt 0.23.0 -> 0.24.2

### DIFF
--- a/rPDU2MQTT/rPDU2MQTT.csproj
+++ b/rPDU2MQTT/rPDU2MQTT.csproj
@@ -24,7 +24,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="HiveMQtt" Version="0.23.0" />
+		<PackageReference Include="HiveMQtt" Version="0.24.2" />
 		<PackageReference Include="KubernetesClient" Version="19.0.2" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 		<PackageReference Include="prometheus-net" Version="8.2.1" />


### PR DESCRIPTION
## Summary

Bumps **HiveMQtt `0.23.0` → `0.24.2`**.

Supersedes the stale Dependabot PR #67, which was based on the old .NET 8 `csproj` (conflicting with current `main`) and also bumped YamlDotNet — **already at 16.3.0 on main**. Only the HiveMQtt bump was still relevant.

## Verification
- Builds against current `main` with **no code changes** (0 warnings).
- **31 unit tests** pass.
- Not runtime MQTT-tested in CI; the API surface we use compiles unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
