### PR TITLE
GUI/CRD: friendly field labels + help text

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -125,20 +125,21 @@ spec:
                       Password:
                         type: string
                         description: Password to login with
+                    description: PDU login used for write actions (outlet control). Can also be supplied via RPDU2MQTT_PDU_USERNAME / RPDU2MQTT_PDU_PASSWORD.
                   PollInterval:
                     type: integer
-                    description: The polling interval for the PDU in seconds.
+                    description: How often (seconds) to poll the PDU and publish readings.
                     minimum: 1
                     maximum: 2147483647
                   ActionsEnabled:
                     type: boolean
-                    description: Configuration to enable write actions via PDU
+                    description: Allow the bridge to make changes on the PDU (e.g. toggle outlets). When off, no switches or other write controls are exposed to Home Assistant. Requires PDU credentials.
                   RemapModel:
                     type: boolean
-                    description: Enables remapping the model column for devices to display data related to which PDU, Outlet.
+                    description: Replace each outlet/group's Model (shown in the Home Assistant device info) with contextual text (e.g. parent PDU + name) instead of the PDU's hardware model.
                   RemapManufacturer:
                     type: boolean
-                    description: Enables remapping the manufacturer column for devices to display the type of entity. Aka, Outlet, Group, etc..
+                    description: Replace each entity's Manufacturer (shown in Home Assistant) with the entity type (Outlet, Group, etc.) instead of the hardware manufacturer.
                 description: PDU Configuration
               HomeAssistant:
                 type: object
@@ -275,8 +276,10 @@ spec:
                 properties:
                   PublishMessages:
                     type: boolean
+                    description: Actually publish messages to the broker. Turn off to dry-run the whole pipeline without sending anything.
                   PrintDiscovery:
                     type: boolean
+                    description: Log the Home Assistant discovery JSON to the console (verbose; for troubleshooting discovery).
                 description: Settings for debugging and diagnostics.
               Prometheus:
                 type: object

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -125,20 +125,21 @@ spec:
                       Password:
                         type: string
                         description: Password to login with
+                    description: PDU login used for write actions (outlet control). Can also be supplied via RPDU2MQTT_PDU_USERNAME / RPDU2MQTT_PDU_PASSWORD.
                   PollInterval:
                     type: integer
-                    description: The polling interval for the PDU in seconds.
+                    description: How often (seconds) to poll the PDU and publish readings.
                     minimum: 1
                     maximum: 2147483647
                   ActionsEnabled:
                     type: boolean
-                    description: Configuration to enable write actions via PDU
+                    description: Allow the bridge to make changes on the PDU (e.g. toggle outlets). When off, no switches or other write controls are exposed to Home Assistant. Requires PDU credentials.
                   RemapModel:
                     type: boolean
-                    description: Enables remapping the model column for devices to display data related to which PDU, Outlet.
+                    description: Replace each outlet/group's Model (shown in the Home Assistant device info) with contextual text (e.g. parent PDU + name) instead of the PDU's hardware model.
                   RemapManufacturer:
                     type: boolean
-                    description: Enables remapping the manufacturer column for devices to display the type of entity. Aka, Outlet, Group, etc..
+                    description: Replace each entity's Manufacturer (shown in Home Assistant) with the entity type (Outlet, Group, etc.) instead of the hardware manufacturer.
                 description: PDU Configuration
               HomeAssistant:
                 type: object
@@ -275,8 +276,10 @@ spec:
                 properties:
                   PublishMessages:
                     type: boolean
+                    description: Actually publish messages to the broker. Turn off to dry-run the whole pipeline without sending anything.
                   PrintDiscovery:
                     type: boolean
+                    description: Log the Home Assistant discovery JSON to the console (verbose; for troubleshooting discovery).
                 description: Settings for debugging and diagnostics.
               Prometheus:
                 type: object

--- a/rPDU2MQTT.Tests/ConfigSchemaTests.cs
+++ b/rPDU2MQTT.Tests/ConfigSchemaTests.cs
@@ -19,6 +19,18 @@ public class ConfigSchemaTests
     }
 
     [Fact]
+    public void Build_UsesFriendlyDisplayNamesAndHelpText()
+    {
+        var pdu = ConfigSchema.Build().Single(n => n.Key == "PDU");
+        var actions = pdu.Properties!.Single(n => n.Key == "ActionsEnabled");
+
+        // Key stays the config field; Label is the friendly GUI title from [Display(Name)].
+        Assert.Equal("Enable Write Actions", actions.Label);
+        Assert.False(string.IsNullOrWhiteSpace(actions.Description));
+        Assert.All(pdu.Properties!, p => Assert.False(string.IsNullOrWhiteSpace(p.Description)));
+    }
+
+    [Fact]
     public void Build_ClassifiesScalarTypes()
     {
         var mqtt = ConfigSchema.Build().Single(n => n.Key == "MQTT");

--- a/rPDU2MQTT/Models/Config/DebugConfig.cs
+++ b/rPDU2MQTT/Models/Config/DebugConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using YamlDotNet.Serialization;
 
 namespace rPDU2MQTT.Models.Config;
@@ -15,6 +16,7 @@ public class DebugConfig
     /// Intended usage, is to allow the entire process to be tested, and debugged, without actually publishing the mwssages.
     /// </remarks>
     [YamlMember(Alias = "PublishMessages")]
+    [Display(Name = "Publish to MQTT", Description = "Actually publish messages to the broker. Turn off to dry-run the whole pipeline without sending anything.")]
     [DefaultValue(true)]
     public bool PublishMessages { get; set; } = true;
 
@@ -23,6 +25,7 @@ public class DebugConfig
     /// When enabled, this will print the MQTT discovery messages to the console.
     /// </summary>
     [YamlMember(Alias = "PrintDiscovery")]
+    [Display(Name = "Print Discovery Payloads", Description = "Log the Home Assistant discovery JSON to the console (verbose; for troubleshooting discovery).")]
     [DefaultValue(false)]
     public bool PrintDiscovery { get; set; } = false;
 }

--- a/rPDU2MQTT/Models/Config/PduConfig.cs
+++ b/rPDU2MQTT/Models/Config/PduConfig.cs
@@ -21,6 +21,7 @@ public class PduConfig
     /// Credentials used when connection to PDU.
     /// </summary>
     [YamlMember(Alias = "Credentials", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [Display(Description = "PDU login used for write actions (outlet control). Can also be supplied via RPDU2MQTT_PDU_USERNAME / RPDU2MQTT_PDU_PASSWORD.")]
     [DefaultValue(null)]
     public Schemas.Credentials? Credentials { get; set; } = null;
 
@@ -28,16 +29,13 @@ public class PduConfig
     /// Gets or sets the polling interval for the PDU in seconds.
     /// </summary>
     [Range(1, int.MaxValue, ErrorMessage = "PollInterval must be greater than 0.")]
-    [Display(Description = "The polling interval for the PDU in seconds.")]
+    [Display(Name = "Poll Interval (seconds)", Description = "How often (seconds) to poll the PDU and publish readings.")]
     [DefaultValue(5)]
     public int PollInterval { get; set; } = 5;
 
     [DefaultValue(false)]
-    [YamlMember(Alias = "ActionsEnabled", DefaultValuesHandling = DefaultValuesHandling.OmitNull, Description = "Configuration to enable write actions via PDU")]
-    /// <summary>
-    /// Gets or sets a value indicating whether actions are enabled.
-    /// </summary>
-    [Display(Description = "Indicates whether actions are enabled.")]
+    [YamlMember(Alias = "ActionsEnabled", DefaultValuesHandling = DefaultValuesHandling.OmitNull, Description = "Allow the bridge to make changes on the PDU (e.g. toggle outlets). When off, no switches or other write controls are exposed to Home Assistant. Requires PDU credentials.")]
+    [Display(Name = "Enable Write Actions", Description = "Allow the bridge to make changes on the PDU (e.g. toggle outlets). When off, no switches or other write controls are exposed to Home Assistant. Requires PDU credentials.")]
     public bool ActionsEnabled { get; set; }
 
     /// <summary>
@@ -49,18 +47,12 @@ public class PduConfig
     public bool? EnableActionsAlias { get; set; }
 
     [DefaultValue(false)]
-    [YamlMember(Alias = "RemapModel", DefaultValuesHandling = DefaultValuesHandling.OmitNull, Description = "Enables remapping the model column for devices to display data related to which PDU, Outlet.")]
-    /// <summary>
-    /// Gets or sets a value indicating whether actions are enabled.
-    /// </summary>
-    [Display(Description = "This setting can be enabled, which will remap the model value for individual outlets to provide more contextual information.")]
+    [YamlMember(Alias = "RemapModel", DefaultValuesHandling = DefaultValuesHandling.OmitNull, Description = "Replace each outlet/group's Model (shown in the Home Assistant device info) with contextual text (e.g. parent PDU + name) instead of the PDU's hardware model.")]
+    [Display(Name = "Remap Model column", Description = "Replace each outlet/group's Model (in Home Assistant device info) with contextual text instead of the PDU's hardware model.")]
     public bool RemapModel { get; set; }
 
     [DefaultValue(false)]
-    [YamlMember(Alias = "RemapMake", DefaultValuesHandling = DefaultValuesHandling.OmitNull, Description = "Enables remapping the manufacturer column for devices to display the type of entity. Aka, Outlet, Group, etc..")]
-    /// <summary>
-    /// Gets or sets a value indicating whether actions are enabled.
-    /// </summary>
-    [Display(Description = "This setting can be enabled, which will remap the manufacturer value for individual outlets to provide more contextual information.")]
-    public bool RemapManufacturer { get; set;}
+    [YamlMember(Alias = "RemapMake", DefaultValuesHandling = DefaultValuesHandling.OmitNull, Description = "Replace each entity's Manufacturer (shown in Home Assistant) with the entity type (Outlet, Group, etc.) instead of the hardware manufacturer.")]
+    [Display(Name = "Remap Manufacturer column", Description = "Replace each entity's Manufacturer (in Home Assistant) with the entity type (Outlet, Group, etc.) instead of the hardware manufacturer.")]
+    public bool RemapManufacturer { get; set; }
 }

--- a/rPDU2MQTT/Services/Gui/ConfigSchema.cs
+++ b/rPDU2MQTT/Services/Gui/ConfigSchema.cs
@@ -81,7 +81,10 @@ public static class ConfigSchema
             // Key drives the JSON payload + the CR spec; align it with [JsonPropertyName] so the GUI
             // JSON, the Kubernetes CR spec, and the YAML config all share one field vocabulary.
             Key = prop.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? prop.Name,
-            Label = prop.GetCustomAttribute<YamlMemberAttribute>()?.Alias ?? prop.Name,
+            // Friendly display title for the GUI: [Display(Name)] wins, else the YAML alias / property name.
+            Label = prop.GetCustomAttribute<DisplayAttribute>()?.Name
+                ?? prop.GetCustomAttribute<YamlMemberAttribute>()?.Alias
+                ?? prop.Name,
             Description = ResolveDescription(prop),
             Required = prop.GetCustomAttribute<RequiredAttribute>() is not null,
         };


### PR DESCRIPTION
## Summary

Makes the configuration **GUI (and the CRD) self-explanatory** — the form showed cryptic field names (`ActionsEnabled`, `RemapMake`, …) with thin or missing help. This adds friendly titles and clear descriptions that flow to **both** the GUI form and the generated CRD schema.

Addresses the TODO items: *"Configuration GUI needs explanation of various settings"*, *"Kubernetes CRDs should contain descriptions too"*, and *"rename ActionsEnabled to Enable Write Actions"*.

## Changes

- **`ConfigSchema`** now uses `[Display(Name)]` as the GUI field title (falling back to the YAML alias / property name). The field **key and CR-spec name are unchanged** — display only.
- **PDU section:**
  - `ActionsEnabled` → titled **"Enable Write Actions"**, with a clear explanation that it gates outlet control and that no switches/write controls are exposed when off.
  - Clearer text for **Poll Interval**, **Remap Model**, **Remap Manufacturer**, and **PDU credentials**.
- **Debug section:** friendly names + help for **Publish to MQTT** and **Print Discovery Payloads**.
- **Regenerated the `RpduConfig` CRD** so the new descriptions show up (e.g. `kubectl explain rpduconfig.spec.PDU`).

## Notes

- **No behavior change.** Write actions were already gated on `ActionsEnabled` (outlet `switch` discovery + `OutletCommandService` registration); confirmed.
- The config field names are unchanged, so existing `config.yaml` / CRs keep working.

## Verification

- Build 0 warnings; **32 unit tests** pass (added one asserting the friendly label + that every PDU field has help text).
- `helm lint` clean; CRD regenerated from the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
