### PR TITLE
Per-entity Make/Model override (Home Assistant device info)

### DIFF
--- a/Examples/Configuration/config.spec.yaml
+++ b/Examples/Configuration/config.spec.yaml
@@ -103,12 +103,15 @@ Overrides:
             # These are number-based, start at 1. 
             # "Outlet 1" in the PDU corresponds to 1, for example. 
             # Note- You can set the Label field in the PDU itself, instead of setting the Name here, as the default "Name" is the Label value from the PDU.
-            Outlets:        
+            Outlets:
                 1:
                     # Set both ID (entity name), and Display Name
                     ID: kube02
                     Name: "Proxmox: Kube02"
                     Enabled: true
+                    # Override the Manufacturer/Model shown in Home Assistant (optional).
+                    Make: "Dell"
+                    Model: "PowerEdge R730xd"
                 2:
                     # Only set ID.
                     ID: dell_md1220

--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -178,6 +178,12 @@ spec:
                       Enabled:
                         type: boolean
                         description: Is this entity enabled?
+                      Make:
+                        type: string
+                        description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                      Model:
+                        type: string
+                        description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                     description: Allows overriding values for the rPDU2MQTT.
                   Devices:
                     type: object
@@ -202,6 +208,12 @@ spec:
                               Enabled:
                                 type: boolean
                                 description: Is this entity enabled?
+                              Make:
+                                type: string
+                                description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                              Model:
+                                type: string
+                                description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                           description: Allows overriding values for individual outlets.
                         ID:
                           type: string
@@ -212,6 +224,12 @@ spec:
                         Enabled:
                           type: boolean
                           description: Is this entity enabled?
+                        Make:
+                          type: string
+                          description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                        Model:
+                          type: string
+                          description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                     description: Allows overriding configuration for individual devices.
                   Measurements:
                     type: object
@@ -229,6 +247,12 @@ spec:
                         Enabled:
                           type: boolean
                           description: Is this entity enabled?
+                        Make:
+                          type: string
+                          description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                        Model:
+                          type: string
+                          description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                     description: Allows overriding individual measurements
                   OneviewGroups:
                     type: object
@@ -250,6 +274,12 @@ spec:
                             Enabled:
                               type: boolean
                               description: Is this entity enabled?
+                            Make:
+                              type: string
+                              description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                            Model:
+                              type: string
+                              description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                         description: Allows overriding individual measurements for groups
                       Overrides:
                         type: object
@@ -267,6 +297,12 @@ spec:
                             Enabled:
                               type: boolean
                               description: Is this entity enabled?
+                            Make:
+                              type: string
+                              description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                            Model:
+                              type: string
+                              description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                         description: Allows overriding group ID, Name, and enabled state.
                     description: Overrides specific to Oneview groups
                 description: Overrides

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -178,6 +178,12 @@ spec:
                       Enabled:
                         type: boolean
                         description: Is this entity enabled?
+                      Make:
+                        type: string
+                        description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                      Model:
+                        type: string
+                        description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                     description: Allows overriding values for the rPDU2MQTT.
                   Devices:
                     type: object
@@ -202,6 +208,12 @@ spec:
                               Enabled:
                                 type: boolean
                                 description: Is this entity enabled?
+                              Make:
+                                type: string
+                                description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                              Model:
+                                type: string
+                                description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                           description: Allows overriding values for individual outlets.
                         ID:
                           type: string
@@ -212,6 +224,12 @@ spec:
                         Enabled:
                           type: boolean
                           description: Is this entity enabled?
+                        Make:
+                          type: string
+                          description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                        Model:
+                          type: string
+                          description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                     description: Allows overriding configuration for individual devices.
                   Measurements:
                     type: object
@@ -229,6 +247,12 @@ spec:
                         Enabled:
                           type: boolean
                           description: Is this entity enabled?
+                        Make:
+                          type: string
+                          description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                        Model:
+                          type: string
+                          description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                     description: Allows overriding individual measurements
                   OneviewGroups:
                     type: object
@@ -250,6 +274,12 @@ spec:
                             Enabled:
                               type: boolean
                               description: Is this entity enabled?
+                            Make:
+                              type: string
+                              description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                            Model:
+                              type: string
+                              description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                         description: Allows overriding individual measurements for groups
                       Overrides:
                         type: object
@@ -267,6 +297,12 @@ spec:
                             Enabled:
                               type: boolean
                               description: Is this entity enabled?
+                            Make:
+                              type: string
+                              description: Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.
+                            Model:
+                              type: string
+                              description: Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.
                         description: Allows overriding group ID, Name, and enabled state.
                     description: Overrides specific to Oneview groups
                 description: Overrides

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -159,16 +159,25 @@ Overrides:
 ```
 
 ### Outlets Override
-Customize individual outlets by their number. 
+Customize individual outlets by their number (1-based, matching the PDU UI). Outlets are nested under
+their device's serial number.
 
 ```yaml
 Overrides:
-  Outlets:
-    1:
-      ID: kube02                # Customize the outlet ID
-      Name: "Proxmox: Kube02"   # Customize the outlet name
-      Enabled: true             # Set to false to disable this outlet
+  Devices:
+    A0AE260C851900C3:           # Device serial number
+      Outlets:
+        1:
+          ID: kube02                # Customize the outlet ID
+          Name: "Proxmox: Kube02"   # Customize the outlet name
+          Enabled: true             # Set to false to disable this outlet
+          Make: "Dell"              # Manufacturer shown in Home Assistant
+          Model: "PowerEdge R730xd" # Model shown in Home Assistant
 ```
+
+`Make` and `Model` override what Home Assistant shows in the device info (instead of the PDU's
+hardware make/model, e.g. `GEI` / `MNU3E1R1-...`). They apply to devices, outlets, and OneView groups,
+and take precedence over the `RemapMake` / `RemapModel` toggles.
 
 ### Measurements Override
 Customize how metrics are sent to services. The entity ID used for metrics is `[DEVICE_ID]_[METRIC_TYPE]`.

--- a/rPDU2MQTT.Tests/ConfigSchemaTests.cs
+++ b/rPDU2MQTT.Tests/ConfigSchemaTests.cs
@@ -1,4 +1,5 @@
 using rPDU2MQTT.Classes;
+using rPDU2MQTT.Models.Config.Schemas;
 using rPDU2MQTT.Services.Gui;
 using Xunit;
 
@@ -16,6 +17,32 @@ public class ConfigSchemaTests
         Assert.Contains("PDU", keys);
         Assert.Contains("Gui", keys);
         Assert.All(schema, n => Assert.False(string.IsNullOrEmpty(n.Label)));
+    }
+
+    [Fact]
+    public void Build_OverrideDevicesAndOutletsExposeMakeAndModel()
+    {
+        var overrides = ConfigSchema.Build().Single(n => n.Key == "Overrides");
+        var deviceVal = overrides.Properties!.Single(n => n.Key == "Devices").ValueSchema!;
+        Assert.Contains("Make", deviceVal.Properties!.Select(n => n.Key));
+        Assert.Contains("Model", deviceVal.Properties!.Select(n => n.Key));
+
+        var outletVal = deviceVal.Properties!.Single(n => n.Key == "Outlets").ValueSchema!;
+        Assert.Contains("Make", outletVal.Properties!.Select(n => n.Key));
+        Assert.Contains("Model", outletVal.Properties!.Select(n => n.Key));
+    }
+
+    [Fact]
+    public void OverrideMakeModel_JsonRoundTrips()
+    {
+        var cfg = new Config();
+        cfg.Overrides.Devices["DEV"] = new DeviceOverride { Outlets = { [1] = new EntityOverride { Make = "Dell", Model = "PowerEdge R730xd" } } };
+
+        var back = ConfigSchema.FromJson(ConfigSchema.ToJson(cfg));
+        var outlet = back.Overrides.Devices["DEV"]!.Outlets[1]!;
+
+        Assert.Equal("Dell", outlet.Make);
+        Assert.Equal("PowerEdge R730xd", outlet.Model);
     }
 
     [Fact]

--- a/rPDU2MQTT/Extensions/EntityWithName_Overrides.cs
+++ b/rPDU2MQTT/Extensions/EntityWithName_Overrides.cs
@@ -59,6 +59,8 @@ public static class EntityWithName_Overrides
                 // Fall back to Entity_Name so a missing display name doesn't throw.
                 entity.Entity_DisplayName = Coalesce(entityOverride.Name, DefaultDisplayNameFunc?.Invoke(entity), entity.Entity_DisplayName, entity.Entity_Name) ?? throw new Exception("Unable to determine entity name.");
                 entity.Entity_Enabled = entityOverride.Enabled; //Always default to enabled.
+                entity.Entity_Make = entityOverride.Make;
+                entity.Entity_Model = entityOverride.Model;
             }
             else // No overrides defined. Set defaults.
             {

--- a/rPDU2MQTT/Models/Config/Schemas/EntityOverride.cs
+++ b/rPDU2MQTT/Models/Config/Schemas/EntityOverride.cs
@@ -34,4 +34,16 @@ public class EntityOverride
     /// </remarks>
     [YamlMember(Alias = "Enabled", DefaultValuesHandling = DefaultValuesHandling.OmitNull, Description = "Is this entity enabled?")]
     public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Override the Manufacturer shown in Home Assistant for this device/outlet/group.
+    /// </summary>
+    [YamlMember(Alias = "Make", DefaultValuesHandling = DefaultValuesHandling.OmitNull, Description = "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.")]
+    public string? Make { get; set; }
+
+    /// <summary>
+    /// Override the Model shown in Home Assistant for this device/outlet/group.
+    /// </summary>
+    [YamlMember(Alias = "Model", DefaultValuesHandling = DefaultValuesHandling.OmitNull, Description = "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.")]
+    public string? Model { get; set; }
 }

--- a/rPDU2MQTT/Models/PDU/basePDU/NamedEntity.cs
+++ b/rPDU2MQTT/Models/PDU/basePDU/NamedEntity.cs
@@ -20,4 +20,11 @@ public class NamedEntity : BaseEntity, IEntityName
     [JsonIgnore]
     /// <inheritdoc cref="IEntityName.DisplayName"/>
     public string Entity_DisplayName { get; set; }
+
+    /// <summary>Optional Manufacturer/Model overrides (from config), surfaced in HA discovery.</summary>
+    [JsonIgnore]
+    public string? Entity_Make { get; set; }
+
+    [JsonIgnore]
+    public string? Entity_Model { get; set; }
 }

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -247,7 +247,8 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                     objectId = d.Entity_Name,
                     outlets = d.Outlets.OrderBy(o => o.Key).Select(o => new
                     {
-                        index = o.Key,
+                        // 1-based: matches the PDU UI and the outlet override keys (Outlets.<n>).
+                        index = o.Key + 1,
                         label = o.Label,
                         name = o.Name,
                         displayName = o.Entity_DisplayName,

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -107,6 +107,7 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
         {
             // Create a device, to represent this device.
             var newParent = parent.CreateChild(device);
+            ApplyMakeModelOverride(newParent, device);
 
             // Device-level alarm.
             components.Add(BuildAlarm(device, newParent));
@@ -146,6 +147,8 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
 
             // Remap Make/Model, IF specified in the configuration.
             RemapColumns(newParent, "Outlet", outlet.Name);
+            // Per-outlet Make/Model override wins over the remap/inherited values.
+            ApplyMakeModelOverride(newParent, outlet);
 
             // Discover outlet's state.
             components.Add(BuildState(outlet, newParent));
@@ -182,6 +185,7 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
 
             // Remap Make/Model, IF specified in the configuration.
             RemapColumns(newParent, "Oneview Group", group.Label);
+            ApplyMakeModelOverride(newParent, group);
 
             // Discover measurements.
             collectDiscovery(group.Entity.Outlets.SelectMany(o => o.Measurements), newParent, components);

--- a/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
@@ -274,6 +274,19 @@ public abstract class baseDiscoveryService : baseMQTTService
             discoveryDevice.Manufacturer = Make;
 
     }
+
+    /// <summary>
+    /// Apply per-entity Manufacturer/Model overrides (Overrides.*.Make/Model) to a discovery device.
+    /// Takes precedence over the inherited values and the RemapColumns behavior.
+    /// </summary>
+    protected static void ApplyMakeModelOverride(DiscoveryDevice discoveryDevice, NamedEntity entity)
+    {
+        if (!string.IsNullOrWhiteSpace(entity.Entity_Make))
+            discoveryDevice.Manufacturer = entity.Entity_Make;
+
+        if (!string.IsNullOrWhiteSpace(entity.Entity_Model))
+            discoveryDevice.Model = entity.Entity_Model;
+    }
 }
 
 

--- a/rPDU2MQTT/wwwroot/index.html
+++ b/rPDU2MQTT/wwwroot/index.html
@@ -316,11 +316,16 @@ function ovEnabled(path) {
   f.appendChild(inp); f.appendChild(s); return f;
 }
 // ph: { name, id } placeholders showing the current (default) values.
-function overrideFields(objPath, ph) {
+// makeModel: also render Manufacturer/Model overrides (devices/outlets/groups, not measurements).
+function overrideFields(objPath, ph, makeModel) {
   ph = ph || {};
   const wrap = document.createElement('div'); wrap.className = 'ov-fields';
   wrap.appendChild(ovText('Name (display)', [...objPath, 'Name'], ph.name));
   wrap.appendChild(ovText('ID (object_id)', [...objPath, 'ID'], ph.id));
+  if (makeModel) {
+    wrap.appendChild(ovText('Make (manufacturer)', [...objPath, 'Make'], 'e.g. Dell'));
+    wrap.appendChild(ovText('Model', [...objPath, 'Model'], 'e.g. PowerEdge R730xd'));
+  }
   wrap.appendChild(ovEnabled([...objPath, 'Enabled']));
   return wrap;
 }
@@ -330,13 +335,13 @@ function ovContext(parts) {
   span.textContent = parts.filter(p => p[1]).map(p => (p[0] ? p[0] + ' ' : '') + p[1]).join('   ·   ');
   return span;
 }
-function overrideCard(title, contextParts, objPath, ph) {
+function overrideCard(title, contextParts, objPath, ph, makeModel) {
   const card = document.createElement('div'); card.className = 'ov-card';
   const head = document.createElement('div'); head.className = 'ov-head';
   const t = document.createElement('div'); t.className = 'ov-title'; t.textContent = title; head.appendChild(t);
   if (contextParts && contextParts.some(p => p[1])) head.appendChild(ovContext(contextParts));
   card.appendChild(head);
-  card.appendChild(overrideFields(objPath, ph));
+  card.appendChild(overrideFields(objPath, ph, makeModel));
   return card;
 }
 function groupHeader(title, sub) {
@@ -353,7 +358,7 @@ function outletRow(deviceKey, o) {
   if (friendly) { const s = document.createElement('span'); s.textContent = ' — ' + friendly; lab.appendChild(s); }
   row.appendChild(lab);
   if (o.name || o.displayName) row.appendChild(ovContext([['PDU name:', o.name], ['discovered as:', o.displayName]]));
-  row.appendChild(overrideFields(['Devices', deviceKey, 'Outlets', String(o.index)], { name: o.displayName, id: o.objectId }));
+  row.appendChild(overrideFields(['Devices', deviceKey, 'Outlets', String(o.index)], { name: o.displayName, id: o.objectId }, true));
   return row;
 }
 function deviceCard(dev) {
@@ -363,7 +368,7 @@ function deviceCard(dev) {
   const t = document.createElement('div'); t.className = 'ov-title'; t.textContent = 'Device: ' + friendly; head.appendChild(t);
   head.appendChild(ovContext([['key', dev.key], ['PDU name:', dev.name], ['discovered as:', dev.displayName]]));
   card.appendChild(head);
-  card.appendChild(overrideFields(['Devices', dev.key], { name: dev.displayName, id: dev.objectId }));
+  card.appendChild(overrideFields(['Devices', dev.key], { name: dev.displayName, id: dev.objectId }, true));
 
   // Merge live outlets with any override-only outlet keys (e.g. disabled ones not in live data).
   const live = dev.outlets || [];
@@ -392,7 +397,7 @@ async function renderOverrides(container) {
   const lv = r.body.ok ? r.body : { devices: [], measurements: [], groups: [] };
   const ov = data.Overrides;
 
-  container.appendChild(overrideCard('Bridge (rPDU2MQTT)', [['', 'the top-level bridge device']], ['PDU'], {}));
+  container.appendChild(overrideCard('Bridge (rPDU2MQTT)', [['', 'the top-level bridge device']], ['PDU'], {}, true));
 
   container.appendChild(groupHeader('Devices', 'Each discovered device and its outlets. Leave a field blank to keep the value shown in the placeholder.'));
   const liveKeys = new Set();
@@ -406,7 +411,7 @@ async function renderOverrides(container) {
 
   if (lv.groups && lv.groups.length) {
     container.appendChild(groupHeader('OneView Groups', null));
-    lv.groups.forEach(g => container.appendChild(overrideCard('Group: ' + (g.label || g.name || g.key), [['key', g.key], ['discovered as:', g.displayName]], ['OneviewGroups', 'Overrides', g.key], { name: g.displayName })));
+    lv.groups.forEach(g => container.appendChild(overrideCard('Group: ' + (g.label || g.name || g.key), [['key', g.key], ['discovered as:', g.displayName]], ['OneviewGroups', 'Overrides', g.key], { name: g.displayName }, true)));
   }
 }
 

--- a/rPDU2MQTT/wwwroot/index.html
+++ b/rPDU2MQTT/wwwroot/index.html
@@ -51,6 +51,8 @@
   .ov-fields { display:flex; gap:14px; flex-wrap:wrap; align-items:flex-end; }
   .ov-field { display:flex; flex-direction:column; gap:3px; font-size:12px; color:var(--muted); }
   .ov-field input[type=text] { width:210px; }
+  .ov-pair { display:flex; gap:14px; }
+  .ov-note { flex-basis:100%; color:var(--muted); font-size:12px; margin-top:2px; }
   .ov-field.ov-check { flex-direction:row; align-items:center; gap:6px; color:var(--fg); }
   .ov-outlets { margin:10px 0 2px 6px; border-left:2px solid var(--line); padding-left:14px; }
   .ov-outlet { padding:8px 0; }
@@ -323,10 +325,18 @@ function overrideFields(objPath, ph, makeModel) {
   wrap.appendChild(ovText('Name (display)', [...objPath, 'Name'], ph.name));
   wrap.appendChild(ovText('ID (object_id)', [...objPath, 'ID'], ph.id));
   if (makeModel) {
-    wrap.appendChild(ovText('Make (manufacturer)', [...objPath, 'Make'], 'e.g. Dell'));
-    wrap.appendChild(ovText('Model', [...objPath, 'Model'], 'e.g. PowerEdge R730xd'));
+    // Keep Make + Model together on one line.
+    const pair = document.createElement('div'); pair.className = 'ov-pair';
+    pair.appendChild(ovText('Make (manufacturer)', [...objPath, 'Make'], 'e.g. Dell'));
+    pair.appendChild(ovText('Model', [...objPath, 'Model'], 'e.g. PowerEdge R730xd'));
+    wrap.appendChild(pair);
   }
   wrap.appendChild(ovEnabled([...objPath, 'Enabled']));
+  if (makeModel) {
+    const note = document.createElement('div'); note.className = 'ov-note';
+    note.textContent = 'Make/Model: leave blank to use the PDU’s value (or the Remap Model/Manufacturer result, if those toggles are enabled).';
+    wrap.appendChild(note);
+  }
   return wrap;
 }
 // A muted line of "label value" context bits; empty values are skipped.


### PR DESCRIPTION
## Summary

Lets you override the **Manufacturer and Model** Home Assistant shows for an outlet (or device / OneView group), so instead of the PDU's hardware values (e.g. `GEI` / `MNU3E1R1-12S203-...`) an outlet can read **`Dell` / `PowerEdge R730xd`**.

Addresses the TODO "Make / Model" item.

## Changes

- **`Overrides.*.Make` / `.Model`** added to the override schema. Carried onto the entity during processing and applied to the Home Assistant discovery device — **takes precedence** over the `RemapMake` / `RemapModel` toggles and the inherited PDU values. Applies to devices, outlets, and groups.
- **GUI Overrides editor** gains Make/Model inputs for devices, outlets, and groups (not measurements).
- **Bug fix:** `/api/live` now returns **1-based outlet numbers** (`o.Key + 1`). Previously it returned 0-based indices, so GUI-set outlet overrides were written at the wrong key (the backend reads `Outlets.<n>` 1-based) and outlets displayed starting at "Outlet 0". Now the GUI shows the correct number and outlet overrides actually apply.
- Regenerated the `RpduConfig` CRD; docs + example config updated.

## Verification

- Build 0 warnings; **34 unit tests** pass (added override-schema + JSON round-trip tests).
- **Live (PrintDiscovery):** an `Outlets.1` override produced, on the first outlet's device:
  `"manufacturer": "Dell"`, `"model": "PowerEdge R730xd"` — confirming both the feature and the 1-based key alignment.
- `helm lint` clean; CRD regenerated from the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
