### PR TITLE
OneView group rollup sensors (incl. cluster Total)

### DIFF
--- a/docs/Aggregation.md
+++ b/docs/Aggregation.md
@@ -31,9 +31,18 @@ master via `via_device`.
 
 ## OneView groups
 
-OneView lets you define **groups** (e.g. all the outlets feeding one server). Groups are published
-with aggregated measurements (sum across the group). Customize them under
-`Overrides.OneviewGroups`:
+OneView lets you define **groups** (e.g. all the outlets feeding one server). Each group is published
+as a Home Assistant device carrying **rollup sensors** — the group's aggregated measurements (sum
+across its outlets). The cluster-wide **"Total"** group is included too (its rollup comes from the
+PDU's `pduTotal`), giving you whole-cluster Power/Energy/etc. sensors.
+
+> **Group switches aren't possible.** The PDU's OneView API exposes a group only as *aggregate
+> measurements* — it does not list the group's member outlets, and the outlets themselves carry no
+> group membership. With no way to map a group to its outlets, the bridge cannot offer per-member or
+> "whole group" switches. Toggle the individual outlets on their own devices instead (they work
+> cluster-wide; see *Outlet control* below).
+
+Customize groups under `Overrides.OneviewGroups`:
 
 ```yaml
 Overrides:

--- a/rPDU2MQTT.Tests/OneViewGroupTests.cs
+++ b/rPDU2MQTT.Tests/OneViewGroupTests.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using rPDU2MQTT.Models.PDU.OneView;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+public class OneViewGroupTests
+{
+    // The "Total" group exposes its rollup as pduTotal, keyed like outlet ({"0": {...}}).
+    // It must deserialize into a list with its measurements (previously it was silently dropped).
+    [Fact]
+    public void PduTotal_DeserializesAsListWithMeasurements()
+    {
+        const string json = """
+        {
+          "pduTotal": {
+            "0": {
+              "name": "outlet",
+              "measurement": {
+                "3": { "type": "energy", "units": "kWh", "sumValue": "8909.927" },
+                "0": { "type": "realPower", "units": "W", "sumValue": "564" }
+              }
+            }
+          }
+        }
+        """;
+
+        var entities = JsonSerializer.Deserialize<OneViewGroupEntities>(json);
+
+        Assert.NotNull(entities);
+        var total = Assert.Single(entities!.PduTotal);
+        Assert.Equal(2, total.Measurements.Count);
+        Assert.Contains(total.Measurements, m => m.Type == "energy" && m.SumValue == "8909.927");
+        Assert.Contains(total.Measurements, m => m.Type == "realPower" && m.Units == "W");
+    }
+
+    [Fact]
+    public void Outlet_AggregateStillDeserializes()
+    {
+        const string json = """
+        { "outlet": { "0": { "name": "outlet", "measurement": { "3": { "type": "energy", "units": "kWh", "sumValue": "2573.487" } } } } }
+        """;
+
+        var entities = JsonSerializer.Deserialize<OneViewGroupEntities>(json);
+
+        Assert.NotNull(entities);
+        var outlet = Assert.Single(entities!.Outlets);
+        Assert.Equal("energy", Assert.Single(outlet.Measurements).Type);
+        Assert.Empty(entities.PduTotal);
+    }
+}

--- a/rPDU2MQTT/Classes/PDU.cs
+++ b/rPDU2MQTT/Classes/PDU.cs
@@ -262,17 +262,16 @@ public partial class PDU
             if (grp.Entity is null)
                 return;
 
-            if (grp.Entity.PduTotal?.Measurements?.Any() ?? false)
-                grp.Entity.PduTotal.Measurements.SetEntityNamePrefix(parent.Entity_Name);
-
-            foreach (var outlet in grp.Entity.Outlets)
+            // A group exposes its rollup either as per-group aggregate "outlets" or, for the
+            // cluster-wide "Total" group, as pduTotal. Both are grouped measurements under the group.
+            foreach (var rollup in grp.Entity.Outlets.Concat(grp.Entity.PduTotal))
             {
                 // All measurements will be stored into a sub-key.
-                outlet.Measurements.SetParentAndIdentifier(BaseEntity.FromDevice(entity, MqttPath.Measurements), IdentifierFunc: o => o.Type);
-                outlet.Measurements.SetEntityNameAndEnabled(config.Overrides, o => o.Type, DefaultNames.UseMeasurementType);
-                outlet.Measurements.PruneDisabled();
+                rollup.Measurements.SetParentAndIdentifier(BaseEntity.FromDevice(entity, MqttPath.Measurements), IdentifierFunc: o => o.Type);
+                rollup.Measurements.SetEntityNameAndEnabled(config.Overrides, o => o.Type, DefaultNames.UseMeasurementType);
+                rollup.Measurements.PruneDisabled();
 
-                outlet.Measurements.SetEntityNamePrefix(parent.Entity_Name);
+                rollup.Measurements.SetEntityNamePrefix(parent.Entity_Name);
             }
         }
         else

--- a/rPDU2MQTT/Models/PDU/OneView/OneViewGroupEntities.cs
+++ b/rPDU2MQTT/Models/PDU/OneView/OneViewGroupEntities.cs
@@ -9,6 +9,8 @@ public class OneViewGroupEntities
     [JsonConverter(typeof(DictionaryToListConverter<OneViewGroupedOutlet, int>))]
     public List<OneViewGroupedOutlet> Outlets { get; set; } = new List<OneViewGroupedOutlet>();
 
+    // pduTotal is keyed the same way as outlet (e.g. {"0": {...}}), so deserialize it as a list too.
     [JsonPropertyName("pduTotal")]
-    public OneViewGroupedOutlet? PduTotal { get; set; }
+    [JsonConverter(typeof(DictionaryToListConverter<OneViewGroupedOutlet, int>))]
+    public List<OneViewGroupedOutlet> PduTotal { get; set; } = new List<OneViewGroupedOutlet>();
 }

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -187,8 +187,8 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
             RemapColumns(newParent, "Oneview Group", group.Label);
             ApplyMakeModelOverride(newParent, group);
 
-            // Discover measurements.
-            collectDiscovery(group.Entity.Outlets.SelectMany(o => o.Measurements), newParent, components);
+            // Discover measurements (per-group aggregate, and the cluster-wide PduTotal rollup).
+            collectDiscovery(group.Entity.Outlets.Concat(group.Entity.PduTotal).SelectMany(o => o.Measurements), newParent, components);
         }
     }
 

--- a/rPDU2MQTT/Services/MQTTPublishingService.cs
+++ b/rPDU2MQTT/Services/MQTTPublishingService.cs
@@ -46,7 +46,8 @@ public class MQTTPublishingService : basePublishingService
             await PublishName(group, cancellationToken);
             await PublishUniqueIdentifier(group, cancellationToken);
 
-            foreach (var outlet in group.Entity.Outlets)
+            // Per-group aggregates, plus the cluster-wide total (the "Total" group's pduTotal).
+            foreach (var outlet in group.Entity.Outlets.Concat(group.Entity.PduTotal))
             {
                 await PublishOneViewGroupMeasurements(outlet.Measurements, cancellationToken);
             }


### PR DESCRIPTION
## Summary

Adds **rollup sensors for OneView groups**, including the cluster-wide **Total**. Investigated member/master **switches** — they're not possible with the PDU's API (details below).

## Rollup sensors

Each OneView group is published as an HA device with its aggregated measurements. Two fixes:

- The cluster-wide **"Total"** group (and "unassigned") were producing **empty** devices. Their rollup lives in `pduTotal`, which the model mis-declared as a single object — but the PDU returns it keyed like `outlet` (`{"0": {...}}`), so it deserialized to nothing. Now `pduTotal` deserializes as a list (same converter as `outlet`) and is processed / published / discovered alongside the per-group aggregates.
- Result: the **Total** group now exposes whole-cluster rollup sensors (energy, realPower, …); per-group aggregate sensors are unchanged.

## Group switches — not possible (investigated against live hardware)

The TODO asked for per-member and master group switches. I pulled the raw `/oneview` from the cluster and confirmed they can't be built:

- A group's `entity.outlet` is a **single aggregate entry** (generic name `"outlet"`, summed measurements) — the API **does not enumerate the group's member outlets**, and provides no device/outlet references.
- The real outlets carry **no group-membership field** either.

So there's no mapping in either direction to target a switch (or to fan out a master on/off). Documented in [Aggregation.md](docs/Aggregation.md); the recommendation is to control the individual outlets (which already works cluster-wide).

## Verification

- **Live against the OneView cluster:** `rPDU2MQTT_Groups_total` now publishes `energy` (kWh) and `realPower` (W) sensors at `Rack_PDU/Groups/total/measurements/*`.
- Build 0 warnings; **36 unit tests** pass (2 new covering `pduTotal`/`outlet` deserialization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
