### PR TITLE
HA device info: PDU MAC/IP + outlet number

### DIFF
--- a/rPDU2MQTT.Tests/DeviceConnectionsTests.cs
+++ b/rPDU2MQTT.Tests/DeviceConnectionsTests.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+public class DeviceConnectionsTests
+{
+    [Fact]
+    public void RPdu_Deserializes_Network_MacAndIp()
+    {
+        const string json = """
+        {
+          "sys": { "serialNumber": "ABC", "oem": "GEI" },
+          "conf": {
+            "network": {
+              "ethernet": {
+                "macAddr": "00:19:85:0c:26:ae",
+                "address": { "1": { "mutable": true, "prefix": 24, "address": "10.100.0.11" } }
+              }
+            }
+          }
+        }
+        """;
+
+        var pdu = JsonSerializer.Deserialize<rPDU>(json);
+
+        Assert.NotNull(pdu);
+        Assert.Equal("00:19:85:0c:26:ae", pdu!.Conf?.Network?.Ethernet?.MacAddr);
+        Assert.Equal("10.100.0.11", pdu.Conf?.Network?.Ethernet?.Address?.The1?.Address);
+    }
+}

--- a/rPDU2MQTT/Extensions/RootData_Extensions.cs
+++ b/rPDU2MQTT/Extensions/RootData_Extensions.cs
@@ -22,6 +22,24 @@ public static class RootData_Extensiosn
             SerialNumber = data.Sys.SerialNumber,
             SoftwareVersion = data.Sys.AppVersion,
             Name = data.Entity_DisplayName,
+            Connections = BuildConnections(data),
         };
+    }
+
+    /// <summary>Home Assistant device connections (MAC + IPv4) from the PDU's ethernet config.</summary>
+    private static List<string[]>? BuildConnections(rPDU data)
+    {
+        var ethernet = data.Conf?.Network?.Ethernet;
+        var connections = new List<string[]>();
+
+        var mac = ethernet?.MacAddr;
+        if (!string.IsNullOrWhiteSpace(mac))
+            connections.Add(["mac", mac]);
+
+        var ip = ethernet?.Address?.The1?.Address;
+        if (!string.IsNullOrWhiteSpace(ip))
+            connections.Add(["ip", ip]);
+
+        return connections.Count > 0 ? connections : null;
     }
 }

--- a/rPDU2MQTT/Models/HomeAssistant/DiscoveryDevice.cs
+++ b/rPDU2MQTT/Models/HomeAssistant/DiscoveryDevice.cs
@@ -34,6 +34,11 @@ public record DiscoveryDevice
     [JsonPropertyName("configuration_url")]
     public string ConfigurationUrl { get; set; }
 
+    // Home Assistant device "connections": list of [type, value] pairs (e.g. ["mac","00:.."], ["ip","10..."]).
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("connections")]
+    public List<string[]>? Connections { get; set; }
+
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull | JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("via_device")]
     [JsonConverter(typeof(DeviceToUniqueIdentifierConverter))]
@@ -47,12 +52,18 @@ public record DiscoveryDevice
     /// When true, prefix the child's name with this device's name (e.g. "Rack-PDU-1 Outlet 1"),
     /// so names stay unambiguous across multiple parents.
     /// </param>
-    public DiscoveryDevice CreateChild(NamedEntity entity, bool prefixWithParentName = false)
+    public DiscoveryDevice CreateChild(NamedEntity entity, bool prefixWithParentName = false, bool inheritConnections = false)
     {
         var name = prefixWithParentName
             ? $"{Name} {entity.Entity_DisplayName}"
             : entity.Entity_DisplayName;
 
-        return this with { UniqueIdentifier = entity.Entity_Identifier, ParentDevice = this, Name = name };
+        var child = this with { UniqueIdentifier = entity.Entity_Identifier, ParentDevice = this, Name = name };
+
+        // Only the physical PDU device carries the MAC/IP connections; outlets/groups must not.
+        if (!inheritConnections)
+            child.Connections = null;
+
+        return child;
     }
 }

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -105,8 +105,9 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
             return;
         else if (entity is Device device)
         {
-            // Create a device, to represent this device.
-            var newParent = parent.CreateChild(device);
+            // Create a device, to represent this device. It's the physical PDU shown in HA, so it
+            // inherits the MAC/IP connections from the PDU-level device.
+            var newParent = parent.CreateChild(device, inheritConnections: true);
             ApplyMakeModelOverride(newParent, device);
 
             // Device-level alarm.
@@ -144,6 +145,9 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
             // Create a device to represent the outlet. Prefix with the PDU name so outlets
             // stay distinguishable across multiple PDUs (e.g. "Rack-PDU-1 Dell: r730XD").
             var newParent = parent.CreateChild(outlet, prefixWithParentName: true);
+
+            // Surface the physical outlet number (1-based, matching the PDU UI) in the device info.
+            newParent.SerialNumber = $"Outlet {outlet.Key + 1}";
 
             // Remap Make/Model, IF specified in the configuration.
             RemapColumns(newParent, "Outlet", outlet.Name);


### PR DESCRIPTION
## Summary

Fills in the Home Assistant **device info** for PDUs and outlets (TODO items "Device Info → IP + MAC" and "Outlet Info → outlet number").

## Changes

- **PDU device → MAC + IP.** The physical PDU device now reports HA `connections` — `[["mac", …], ["ip", …]]` — read from the PDU's ethernet config (`Conf.Network.Ethernet`), alongside the existing `configuration_url`. HA shows these under the device's Connections.
- **Outlet device → outlet number.** Each outlet device now shows its physical outlet number as `serial_number` (`"Outlet N"`, 1-based, matching the PDU UI) instead of inheriting the PDU's serial.
- The MAC/IP land on the physical PDU device (inherited via `CreateChild(inheritConnections: true)`); **outlet/group devices do not** inherit them.

## Verification

- **Live against the OneView cluster:** the "Rack-PDU-1" device shows `mac 00:19:85:0c:26:ae` + `ip 10.100.0.11`; outlet devices show `serial_number: "Outlet N"` and no connections.
- Build 0 warnings; **37 tests** pass (added a network-deserialization test).

> Note: HA has no dedicated "IP" device field, so the IP is surfaced as an `["ip", …]` connection (shown under Connections) and the PDU web UI remains linked via `configuration_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
