### PR TITLE
MQTT Last-Will / availability toggle

### DIFF
--- a/Examples/Configuration/config.spec.yaml
+++ b/Examples/Configuration/config.spec.yaml
@@ -15,6 +15,11 @@ Mqtt:
 
     KeepAlive: 60
 
+    # Register a Last-Will + availability topic so Home Assistant marks entities unavailable
+    # immediately when the bridge disconnects. When false, entities rely on
+    # HomeAssistant.SensorExpireAfterSeconds (expire_after) instead. Default: true
+    LastWill: true
+
     # Connection details for MQTT server
     Connection:
         # Set this to the host / ip of your MQTT server.

--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -86,6 +86,9 @@ spec:
                     description: The keepalive interval for the MQTT connection in seconds.
                     minimum: 1
                     maximum: 2147483647
+                  LastWill:
+                    type: boolean
+                    description: Publish a Last-Will message and set an availability topic on entities, so Home Assistant marks them unavailable immediately when the bridge disconnects. When off, entities instead rely on HomeAssistant.SensorExpireAfterSeconds (expire_after) to go unavailable.
                 description: MQTT Configuration
               PDU:
                 type: object

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -86,6 +86,9 @@ spec:
                     description: The keepalive interval for the MQTT connection in seconds.
                     minimum: 1
                     maximum: 2147483647
+                  LastWill:
+                    type: boolean
+                    description: Publish a Last-Will message and set an availability topic on entities, so Home Assistant marks them unavailable immediately when the bridge disconnects. When off, entities instead rely on HomeAssistant.SensorExpireAfterSeconds (expire_after) to go unavailable.
                 description: MQTT Configuration
               PDU:
                 type: object

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -45,6 +45,29 @@ Mqtt:
   KeepAlive: 60  # Adjust as necessary
 ```
 
+### Last Will / Availability (Optional)
+By default the bridge registers an MQTT **Last-Will** message and sets an `availability_topic` on every
+entity, so Home Assistant marks them **unavailable the instant the bridge disconnects**.
+
+```yaml
+Mqtt:
+  LastWill: true   # default
+```
+
+Set `LastWill: false` to disable both the Last-Will and the availability topic. Entities then rely on
+**`HomeAssistant.SensorExpireAfterSeconds`** (the `expire_after` timeout) to go unavailable once their
+data goes stale — tune that value to control how long until they show unavailable:
+
+```yaml
+Mqtt:
+  LastWill: false
+HomeAssistant:
+  SensorExpireAfterSeconds: 300   # how long stale sensors stay "available"
+```
+
+> Note: `expire_after` only applies to sensors/binary-sensors. Outlet **switches** have no
+> `expire_after` in Home Assistant, so with `LastWill: false` switches will not auto-mark unavailable.
+
 ### Connection Details (Required)
 Configure the connection to your MQTT broker:
 

--- a/rPDU2MQTT.Tests/ConfigSchemaTests.cs
+++ b/rPDU2MQTT.Tests/ConfigSchemaTests.cs
@@ -46,6 +46,20 @@ public class ConfigSchemaTests
     }
 
     [Fact]
+    public void MqttLastWill_DefaultsTrue_AndRoundTrips()
+    {
+        Assert.True(new Config().MQTT.LastWill);
+
+        var cfg = new Config();
+        cfg.MQTT.LastWill = false;
+        var back = ConfigSchema.FromJson(ConfigSchema.ToJson(cfg));
+        Assert.False(back.MQTT.LastWill);
+
+        var mqtt = ConfigSchema.Build().Single(n => n.Key == "MQTT");
+        Assert.Contains("LastWill", mqtt.Properties!.Select(n => n.Key));
+    }
+
+    [Fact]
     public void Build_UsesFriendlyDisplayNamesAndHelpText()
     {
         var pdu = ConfigSchema.Build().Single(n => n.Key == "PDU");

--- a/rPDU2MQTT/Models/Config/MQTTConfig.cs
+++ b/rPDU2MQTT/Models/Config/MQTTConfig.cs
@@ -40,4 +40,13 @@ public class MQTTConfig
     [Range(1, int.MaxValue, ErrorMessage = "KeepAlive must be greater than 0.")]
     [Display(Description = "The keepalive interval for the MQTT connection in seconds.")]
     public int KeepAlive { get; set; } = 60;
+
+    /// <summary>
+    /// Use an MQTT Last-Will message + availability topic so Home Assistant marks entities
+    /// unavailable the moment the bridge disconnects.
+    /// </summary>
+    [DefaultValue(true)]
+    [YamlMember(Alias = "LastWill", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [Display(Name = "Last Will / Availability", Description = "Publish a Last-Will message and set an availability topic on entities, so Home Assistant marks them unavailable immediately when the bridge disconnects. When off, entities instead rely on HomeAssistant.SensorExpireAfterSeconds (expire_after) to go unavailable.")]
+    public bool LastWill { get; set; } = true;
 }

--- a/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
@@ -23,6 +23,12 @@ public abstract class baseDiscoveryService : baseMQTTService
     private TimeSpan StateExpiry => TimeSpan.FromSeconds(cfg.HASS.SensorExpireAfterSeconds);
 
     /// <summary>
+    /// The availability (LWT) topic for entities, or null when Last-Will is disabled
+    /// (entities then rely on expire_after to go unavailable).
+    /// </summary>
+    private string? Availability => cfg.MQTT.LastWill ? MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic) : null;
+
+    /// <summary>
     /// Build a sensor discovery for the specified <paramref name="measurement"/>, for device <paramref name="Parent"/>.
     /// Returns <see langword="null"/> if the measurement cannot be parsed.
     /// </summary>
@@ -52,7 +58,7 @@ public abstract class baseDiscoveryService : baseMQTTService
             PayloadOff = item.State_Off,
 
             ExpireAfter = StateExpiry,
-            AvailabilityTopic = MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic),
+            AvailabilityTopic = Availability,
         };
     }
 
@@ -79,7 +85,7 @@ public abstract class baseDiscoveryService : baseMQTTService
             PayloadOff = item.State_Off,
             CommandTopic = MQTTHelper.JoinPaths(item.GetTopicPath(), MqttPath.Set.ToJsonString()),
 
-            AvailabilityTopic = MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic),
+            AvailabilityTopic = Availability,
         };
     }
 
@@ -100,7 +106,7 @@ public abstract class baseDiscoveryService : baseMQTTService
             DeviceClass = deviceClass,
 
             CommandTopic = commandTopic,
-            AvailabilityTopic = MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic),
+            AvailabilityTopic = Availability,
         };
     }
 
@@ -127,7 +133,7 @@ public abstract class baseDiscoveryService : baseMQTTService
             PayloadOff = "OFF",
 
             ExpireAfter = StateExpiry,
-            AvailabilityTopic = MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic),
+            AvailabilityTopic = Availability,
         };
     }
 
@@ -167,7 +173,7 @@ public abstract class baseDiscoveryService : baseMQTTService
             ValueTemplate = valueTemplate,
 
             ExpireAfter = StateExpiry,
-            AvailabilityTopic = MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic),
+            AvailabilityTopic = Availability,
         };
     }
 

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -44,16 +44,17 @@ public static class ServiceConfiguration
             ThrowError.TestRequiredConfigurationSection(cfg.MQTT.Connection.Host, "MQTT.Connection.Host");
             ThrowError.TestRequiredConfigurationSection(cfg.MQTT.Connection.Host, "MQTT.Connection.Port");
 
-            var lwt = new LastWillAndTestament(
-                MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic), payload: "offline", HiveMQtt.MQTT5.Types.QualityOfService.AtLeastOnceDelivery, true);
-
             var mqttBuilder = new HiveMQClientOptionsBuilder()
                 .WithBroker(cfg.MQTT.Connection.Host)
                 .WithPort(cfg.MQTT.Connection.Port!.Value)
                 .WithClientId((cfg.MQTT.ClientID ?? "rpdu2mqtt") + Guid.NewGuid().ToString())
                 .WithAutomaticReconnect(true)
-                .WithKeepAlive(cfg.MQTT.KeepAlive)
-                .WithLastWillAndTestament(lwt);
+                .WithKeepAlive(cfg.MQTT.KeepAlive);
+
+            // Optional Last-Will so HA marks entities unavailable immediately on disconnect.
+            if (cfg.MQTT.LastWill)
+                mqttBuilder.WithLastWillAndTestament(new LastWillAndTestament(
+                    MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic), payload: "offline", HiveMQtt.MQTT5.Types.QualityOfService.AtLeastOnceDelivery, true));
 
             if (cfg.MQTT.Credentials?.Username is not null)
                 mqttBuilder.WithUserName(cfg.MQTT.Credentials.Username);


### PR DESCRIPTION
## Summary

Adds **`MQTT.LastWill`** (default `true`) to toggle the Last-Will / availability mechanism, per the TODO ("toggle last-will messages; when disabled, configure the time before entities show unavailable").

## Behavior

- **`LastWill: true`** (default, unchanged): the bridge registers an MQTT Last-Will and sets `availability_topic` on every entity → Home Assistant marks them **unavailable immediately** when the bridge disconnects.
- **`LastWill: false`**: no Last-Will, and `availability_topic` is omitted from entities. They instead rely on **`HomeAssistant.SensorExpireAfterSeconds`** (`expire_after`) to go unavailable once data is stale — that's the configurable "time before unavailable".

## Changes

- `ServiceConfiguration` registers the LWT only when enabled.
- `baseDiscoveryService` sets `availability_topic` only when enabled (gated helper), else it's omitted.
- Regenerated the `RpduConfig` CRD; docs + example config updated.

## Verification

- **Live against the cluster:** `LastWill: true` → entities carry `availability_topic: "Rack_PDU/Status"`; `LastWill: false` → no `availability_topic`, `expire_after` retained.
- Build 0 warnings; **38 tests** pass (1 new).

> Note: `expire_after` only applies to sensors/binary-sensors; HA switches have no `expire_after`, so with `LastWill: false` outlet switches won't auto-mark unavailable (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
