### PR TITLE
docs: re-baseline + batch the TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,8 @@
 
 ### Correctness
 - [x] **Retained-message cleanup** — stale `homeassistant/device/<id>/config` topics are cleared
-  when a device disappears between discovery runs (component removals are handled by republishing).
-- [x] **`JsonAttributes` flatten landmine** — removed the broken flatten converter and the unused
-  `JsonAttributes`/`JsonAttributeSettings` types.
+  when a device disappears between discovery runs.
+- [x] **`JsonAttributes` flatten landmine** — removed the broken flatten converter + unused types.
 - [x] **No-override naming NRE** — falls back to the identifier instead of throwing.
 - [x] **Nullable derefs in `PDU.cs`** — explicit null guards added.
 - [x] **`Debugger.Break()` fallbacks** — replaced with warning logs.
@@ -16,107 +15,78 @@
 - [x] **Sync-over-async** — timer loop runs without `Task.Run(...).Wait()`.
 - [x] **Build warnings** — all eliminated (0); CS8618 scoped via `.editorconfig`.
 - [x] **Credentials out of config** — env vars `RPDU2MQTT_*` / `*_FILE` (Docker secrets).
-- [x] **Tests** — xUnit project with helper/converter tests.
+- [x] **.NET 10** + dependency refresh.
 
 ### Features
 - [x] **Contextual default device names** — outlet names prefixed with their PDU.
-- [x] **Device hierarchy** — verified PDU→outlet ownership via `via_device`.
-- [x] **Outlet on/off control** — opt-in via `ActionsEnabled` (`switch` entities + command
-  subscriber + PDU control). NOTE: PDU control endpoint is from the Geist/Vertiv spec and is
-  **unverified against live hardware**.
+- [x] **Device hierarchy** — PDU→outlet ownership via `via_device`.
+- [x] **Outlet on/off control** — opt-in via `ActionsEnabled` (switch entities + command subscriber +
+  PDU control), verified on live hardware incl. the OneView cluster (proxy-port routing).
 - [x] **Alarm integration** — device + outlet `problem` binary_sensors from the PDU alarm state.
-- [x] **`expire_after` / QoS tuning** — `expire_after` derived from `PollInterval`; state at QoS 1.
-- [x] **Configuration GUI (#69)** — optional embedded web GUI (`Gui.Enabled`): password-protected,
-  structured form generated from the config model, MQTT/PDU connection tests, and saves back to
-  `config.yaml` (with a `.bak`). Restart applies changes.
+- [x] **`expire_after` / QoS tuning**.
+- [x] **Configuration GUI (#69/#70)** — embedded web GUI: password-protected, structured form
+  generated from the config model, live-data view, MQTT/PDU tests, YAML/CR export, saves config.
+- [x] **GUI/CRD help text (#75)** — friendly field labels + descriptions; `ActionsEnabled` shown as
+  **"Enable Write Actions"**; write-actions confirmed gated (no switches when disabled).
+- [x] **Per-entity Make/Model override (#76)** — `Overrides.*.Make/Model` (e.g. Dell / PowerEdge);
+  also fixed the GUI outlet index to 1-based.
+- [x] **HA device info (#86)** — PDU device shows MAC + IP (`connections`); outlet device shows the
+  outlet number (`serial_number`).
+- [x] **MQTT Last-Will / availability toggle (#87)** — `MQTT.LastWill`; when off, entities rely on
+  `SensorExpireAfterSeconds` (`expire_after`).
+- [x] **OneView group rollup sensors (#84)** — per-group aggregates + the cluster-wide **Total**
+  (pduTotal). NOTE: group **member/master switches are NOT possible** — the OneView API exposes only
+  aggregate measurements with no member-outlet list (see [Aggregation.md](docs/Aggregation.md)).
+- [x] **Prometheus exporter + Pushgateway push (#73)** — independent `Exporter` / `Pushgateway` toggles.
 
-### Ops
-- [x] **GHCR publishing** — workflow fixed (built-in BuildKit, no Docker Hub dependency) with
-  tagging: `main`→`:stable`, other branches→`:dev`, release tags→`:<version>`. (Already publishes
-  to GHCR, not Docker Hub.)
-- [x] **Simpler config format** — evaluated; see [ConfigFormatEvaluation.md](ConfigFormatEvaluation.md)
-  (recommendation: incremental YAML improvements, not a format switch).
+### Ops / deployment
+- [x] **GHCR publishing** — `main`→`:stable`, branches→`:dev`, tags→`:<version>`.
+- [x] **Helm chart (#71)** — config ConfigMap, credentials Secret, Deployment, optional GUI
+  Service/Ingress, metrics Service + Prometheus Operator `ServiceMonitor`.
+- [x] **Kubernetes CRD config source (#71)** — optional `RpduConfig` CRD (writable, GUI Save works,
+  status subresource, generated schema). See [KubernetesCRD.md](docs/KubernetesCRD.md).
+- [x] **Deployment Guide + config docs (#85)** — compose / Helm / CRD / unRAID, secrets, verifying.
+- [x] **Simpler config format** — evaluated; see [ConfigFormatEvaluation.md](docs/ConfigFormatEvaluation.md).
 
-## 📌 Open
+## 🚧 Planned (batched — roughly in order; each is one PR)
 
-- [x] **Outlet control — verified on live hardware** (both PDUs incl. OneView cluster via the
-  master's proxy port; auth, control, optimistic + latched state all confirmed working).
-- [ ] **Push / release** — this session's commits live on local `working-branch`. Push it (builds
-  `:dev`) and tag `v0.4.0` to publish a release image.
-- [ ] **Outlet control docs** — document setup: `ActionsEnabled`, a PDU user with **Control** on
-  every cluster node, proxy-port behavior, and the PDU apply-delay.
-- [ ] **Release workflow** — consider a dedicated GitHub Release workflow (changelog/artifacts)
-  beyond the container build.
-- [ ] **README & documentation** — make the README more thorough and less AI-generated in tone.
-- [x] **Helm chart** — [`charts/rpdu2mqtt`](charts/rpdu2mqtt): config ConfigMap, credentials Secret,
-  Deployment, optional GUI Service/Ingress, and a Prometheus Operator `ServiceMonitor`.
-- [ ] **Kubernetes CRD config source** — optional `RpduConfig` CRD as a writable config source
-  (makes GUI Save work in k8s), with status subresource. Design proposal:
-  [KubernetesCRD.md](docs/KubernetesCRD.md).
+### Batch A — Outlet operations & config (write actions)
+All PDU outlet control/config surfaced as HA entities, gated by **Enable Write Actions**. Shared
+control + discovery + command-subscriber path, so they synergize.
+- [ ] **Reboot button** (outlet / device).
+- [ ] **Reset Statistics button** (outlet / device) — exposed by the PDU as an operation, like reboot.
+- [ ] **Configurable On / Off / Reboot delays** — HA `number` entities.
+- [ ] **Power-On Action** — HA `select` (dropdown).
+- Refs: image-3, image-4, image-5. ⚠️ Write actions — needs verification on real hardware.
 
+### Batch B — Alarm configuration
+- [ ] View/configure PDU **alarm thresholds + actions** via the GUI and MQTT.
+- Synergy: builds on the write-action/control plumbing from Batch A + the GUI.
 
+### Batch C — GUI enhancements
+- [ ] Improve the **Live Data** view (richer layout) — ref image-6.
+- [ ] Show the **actual generated HA / Prometheus topics + metric types**, and how overrides affect
+  them (a "what will be published" preview).
+- Synergy: both are GUI visibility features in the embedded app.
 
+### Batch D — Diagnostics & health
+- [ ] **GUI Diagnostics/Status page**: uptime, app + container version, **Restart** button (kills the
+  app so the container restarts), and — when running in Kubernetes — view logs/events.
+- [ ] **Health-check endpoints** (liveness + readiness) and **Helm probe support** (optional, default on).
+- Synergy: operational visibility lives together; the health endpoints pair with the Helm probes.
 
+### Batch E — Helm / Kubernetes networking
+- [ ] **NetworkPolicy** support (optional).
+- [ ] **HTTPRoute** (Gateway API) support.
+- Synergy: chart networking add-ons; pairs with Batch D's k8s work.
 
-Configuration GUI needs explanation of various settings. Help text, etc... 
-- Ex- what is "ActionsEnabled"? What is "RemapMake and Remap Model???" GUI should display meaning....
-- Kubernetes CRDs should contain descriptiosn too.
+### Batch F — Tests & docs polish (do last)
+- [ ] Expand **unit tests** (spec/CRD generation, mapping); evaluate Helm chart tests / a
+  `helm template` + `kubectl --dry-run` smoke job in CI.
+- [ ] **README + screenshots** — Home Assistant, EmonCMS, Prometheus, and the GUI in use (commit the
+  `image-*.png` assets the TODO references).
+- Synergy: quality + presentation; last so screenshots reflect the final UI.
 
-GUI
-  - Would be nice to be able to see the ACTUAL generated paths and metric types for home assistant, prometheus, home assistant... etc.... and how overrides affects it.
-
-Home Assistant  - Groups
-  - For Oneview groups- I should be able to see the switches for contained group members, to allow me to toggle individual outlets in a group.
-  - Should be a master "switch" allowing the entire group to be toggled off as well.
-  - I would like to see some rollup sensors potentially populated for groups, if possible.
-
-Alarms-
-  There is nothing in the GUI, or MQTT to allow configuring any of the alarms or actions.
-  Seems like that could be useful functionality.
-
-Documentation
-  - Configuration guide will need to be updated to include details to configure either via GUI, or via CRDs.
-  - Will need to capture a bunch of screenshots and images too.
-  - The main readme, needs to have screenshots showing this in use, in home assistant, emoncms, and prometheus.
-
-Actions Enabled-
-  - If actions are not enabled, switches should not be discovered in home assistant. Or any other write actions.
-  - Should also prob rename this, to Enable Write Actions, or something.
-
-Unit Testing-
-  - Pretty lax. Need to expand unit testing.
-  - Unit testing k8s CRDs too?
-  - Helm chart unit tests?
-
-Make / Model
-  - As home assistant can display the Manufacturer and Model for individual switches, it would be pretty slick to be able to override the values for individual outlets, so instead of showing GEI / MNU3E1R1-12S203-3TL5A0E10-S-115, I could for example, show Dell / PowerEdge r730XD.
-
-Home Assistant / Device Info
-  - ![alt text](image-1.png)
-  - Should show the IP and MAC Address of the connected PDU.
-
-Home Assistant / Outlet Info
-  - ![alt text](image-2.png)
-  - Should ideally display the actual outlet number in the device info.
-
-MQTT / Home Assistant
-  - Add option/configuration to toggle last-will messages
-  - When disabled, then option to configure the amount of time before device/outlets/etc shows unavailable.
-
-Reset Statistics (Write Action)
-
-
-More Outlet Options / Metrics / Values
-  - Expose more PDU configuration options to home assistant
-  - ![alt text](image-3.png)
-  - Configurable On / Off / Reboot Delays.
-  - Reboot Button
-  - Dropdown for Power-On Action
-  - ![alt text](image-4.png)
-  - Add option to enable a diagnostics button in home assistant to reset the statistics for a outlet/device.
-    - This is exposed as a operation. Reboot is too.
-    - ![alt text](image-5.png)
-
-GUI / Live View Enhancements:
-  - Can improve the live view, to display data simlier to this:
-  - ![alt text](image-6.png)
+## 📌 Misc
+- [ ] **Release** — tag a version (v0.4.x) once the above land; consider a dedicated GitHub Release
+  workflow (changelog/artifacts) beyond the container build.


### PR DESCRIPTION
Re-baselines `TODO.md` after the recent merges and organizes the loose items into synergistic batches.

## Marked done
GUI help text/labels (#75), Make/Model override (#76), HA device info MAC/IP + outlet number (#86),
MQTT Last-Will toggle (#87), OneView group rollup + "switches not possible" finding (#84),
Prometheus exporter+Pushgateway (#73), Helm chart + CRD config source (#71), Deployment guide (#85).

## Remaining, batched for synergy
- **A — Outlet operations** (reboot, reset-stats, on/off/reboot delays, power-on action) — shared write-action/control path.
- **B — Alarm configuration** (GUI + MQTT).
- **C — GUI enhancements** (live-view; show generated HA/Prometheus topics + override effects).
- **D — Diagnostics & health** (GUI status page: uptime/version/restart/k8s logs; health endpoints + Helm probes).
- **E — Helm/k8s networking** (NetworkPolicy, HTTPRoute).
- **F — Tests & docs polish** (expand tests; README + screenshots) — last, so screenshots reflect final UI.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)