### PR TITLE
GUI: multi-column form layout (up to 3 columns)

### DIFF
--- a/rPDU2MQTT/wwwroot/index.html
+++ b/rPDU2MQTT/wwwroot/index.html
@@ -18,9 +18,13 @@
   nav a { display:block; padding:8px 20px; color:var(--muted); cursor:pointer; border-left:3px solid transparent; }
   nav a:hover { color:var(--fg); }
   nav a.active { color:var(--fg); border-left-color:var(--accent); background:var(--panel2); }
-  main { flex:1; padding:24px 28px; max-width:900px; }
+  main { flex:1; padding:24px 28px; max-width:1180px; }
   .section { display:none; } .section.active { display:block; }
   h2 { margin:0 0 4px; font-size:18px; }
+  /* Two-column layout for a section's top-level fields; collapses to one column when narrow. */
+  .grid { column-width:340px; column-count:2; column-gap:40px; }
+  .grid > .field, .grid > fieldset { break-inside:avoid; }
+  .grid .field input[type=text], .grid .field input[type=password], .grid .field input[type=number], .grid .field select { max-width:none; }
   .field { margin:14px 0; }
   .field > label { display:block; font-weight:600; margin-bottom:3px; }
   .field .desc { color:var(--muted); font-size:12px; margin-bottom:5px; }
@@ -220,7 +224,12 @@ function build() {
       sec.appendChild(refresh); sec.appendChild(container);
       link.onclick = () => { activate(link, sec); if (!container.dataset.loaded) renderOverrides(container); };
     } else {
-      if (node.type === 'object') { ensure(data, node.key, {}); (node.properties || []).forEach(c => renderNode(c, data[node.key], sec)); }
+      if (node.type === 'object') {
+        ensure(data, node.key, {});
+        const grid = document.createElement('div'); grid.className = 'grid';
+        (node.properties || []).forEach(c => renderNode(c, data[node.key], grid));
+        sec.appendChild(grid);
+      }
       else renderNode(node, data, sec);
       link.onclick = () => activate(link, sec);
     }

--- a/rPDU2MQTT/wwwroot/index.html
+++ b/rPDU2MQTT/wwwroot/index.html
@@ -18,11 +18,11 @@
   nav a { display:block; padding:8px 20px; color:var(--muted); cursor:pointer; border-left:3px solid transparent; }
   nav a:hover { color:var(--fg); }
   nav a.active { color:var(--fg); border-left-color:var(--accent); background:var(--panel2); }
-  main { flex:1; padding:24px 28px; max-width:1180px; }
+  main { flex:1; padding:24px 28px; max-width:1700px; }
   .section { display:none; } .section.active { display:block; }
   h2 { margin:0 0 4px; font-size:18px; }
-  /* Two-column layout for a section's top-level fields; collapses to one column when narrow. */
-  .grid { column-width:340px; column-count:2; column-gap:40px; }
+  /* Multi-column layout for a section's top-level fields; 3 → 2 → 1 columns as width shrinks. */
+  .grid { column-width:340px; column-count:3; column-gap:40px; }
   .grid > .field, .grid > fieldset { break-inside:avoid; }
   .grid .field input[type=text], .grid .field input[type=password], .grid .field input[type=number], .grid .field select { max-width:none; }
   .field { margin:14px 0; }


### PR DESCRIPTION
## What
The config GUI capped content at 900px and stacked every field in a single column, leaving most of the screen empty on wide monitors.

This lays each section's top-level fields out in **two responsive columns** and widens the content pane:
- CSS multi-column, so tall fieldsets (e.g. *Connection*) stay intact and pack naturally.
- Collapses back to a single column on narrow screens.
- Scoped to the generated config forms — **Live Data**, **Export**, and the **Overrides** editor are untouched.

## Notes
- Pure HTML/CSS/JS; no backend changes.
- Batch C (GUI enhancements) polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)