### PR TITLE
Batch A: outlet operations (control, reboot, delays, power-on action, reset stats)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,6 +38,9 @@
   (pduTotal). NOTE: group **member/master switches are NOT possible** — the OneView API exposes only
   aggregate measurements with no member-outlet list (see [Aggregation.md](docs/Aggregation.md)).
 - [x] **Prometheus exporter + Pushgateway push (#73)** — independent `Exporter` / `Pushgateway` toggles.
+- [x] **Outlet operations (Batch A, #91)** — reboot button, on/off/reboot delays (`number`), power-on
+  action (`select`), reset-statistics button; GUI **Control** tab to exercise them. ✅ on/off/reboot
+  hardware-verified; ⚠️ delays / power-on action / reset use Geist conventions, pending verification.
 
 ### Ops / deployment
 - [x] **GHCR publishing** — `main`→`:stable`, branches→`:dev`, tags→`:<version>`.
@@ -49,15 +52,6 @@
 - [x] **Simpler config format** — evaluated; see [ConfigFormatEvaluation.md](docs/ConfigFormatEvaluation.md).
 
 ## 🚧 Planned (batched — roughly in order; each is one PR)
-
-### Batch A — Outlet operations & config (write actions)
-All PDU outlet control/config surfaced as HA entities, gated by **Enable Write Actions**. Shared
-control + discovery + command-subscriber path, so they synergize.
-- [ ] **Reboot button** (outlet / device).
-- [ ] **Reset Statistics button** (outlet / device) — exposed by the PDU as an operation, like reboot.
-- [ ] **Configurable On / Off / Reboot delays** — HA `number` entities.
-- [ ] **Power-On Action** — HA `select` (dropdown).
-- Refs: image-3, image-4, image-5. ⚠️ Write actions — needs verification on real hardware.
 
 ### Batch B — Alarm configuration
 - [ ] View/configure PDU **alarm thresholds + actions** via the GUI and MQTT.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -160,8 +160,7 @@ The GUI **Control** tab is the easiest place to exercise these against a single 
 shows each outlet's current delays and power-on action so changes made from Home Assistant are
 visible there.
 
-> Note: the Power-On Action options and the Reset Statistics call use the Geist/Vertiv firmware
-> conventions; if your PDU rejects one, check the logs for the returned `retCode`/`retMsg`.
+> Power-On Action options are `on` / `off` / `last` (restore the pre-outage state).
 
 ## Overrides Configuration (Optional)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -138,14 +138,30 @@ Pdu:
 
 ### Actions Enabled
 Enable or disable the ability to perform write-actions on the PDU (e.g., toggling outlets).
-When enabled, each outlet is also published as a Home Assistant `switch`, and the bridge
-subscribes to its command topic to relay on/off commands to the PDU. Requires PDU
-`Credentials`. Disabled by default.
+Requires PDU `Credentials`. Disabled by default.
 
 ```yaml
 Pdu:
   ActionsEnabled: true  # Set to false to disable any changes on the PDU
 ```
+
+When enabled, each outlet gains the following **outlet operations** in Home Assistant
+(and a matching **Control** tab in the configuration GUI):
+
+| Entity | Type | Action |
+| --- | --- | --- |
+| Switch | `switch` | Turn the outlet on / off |
+| Reboot | `button` | Power-cycle the outlet |
+| On Delay / Off Delay / Reboot Delay | `number` | Configure the outlet's on/off/reboot timing (seconds) |
+| Power-On Action | `select` | What the outlet does when power is restored |
+| Reset Statistics | `button` | Reset the outlet's accumulated energy statistics |
+
+The GUI **Control** tab is the easiest place to exercise these against a single outlet. It also
+shows each outlet's current delays and power-on action so changes made from Home Assistant are
+visible there.
+
+> Note: the Power-On Action options and the Reset Statistics call use the Geist/Vertiv firmware
+> conventions; if your PDU rejects one, check the logs for the returned `retCode`/`retMsg`.
 
 ## Overrides Configuration (Optional)
 

--- a/rPDU2MQTT/Classes/PDU.cs
+++ b/rPDU2MQTT/Classes/PDU.cs
@@ -30,6 +30,8 @@ public partial class PDU
     // applies the change, during which it still reports the OLD state. Latch the commanded state
     // so polling doesn't flap Home Assistant back until the PDU actually catches up (or we time out).
     private readonly Dictionary<string, (string expected, DateTime expiresUtc)> pendingOutletStates = new();
+    // Same latch idea for writable config fields (delays / power-on action), keyed deviceId/index/field.
+    private readonly Dictionary<string, (string expected, DateTime expiresUtc)> pendingOutletConfig = new();
     private readonly object pendingLock = new();
     private static readonly TimeSpan PendingStateTimeout = TimeSpan.FromSeconds(120);
 
@@ -58,8 +60,34 @@ public partial class PDU
     }
 
     /// <summary>Write outlet configuration fields (delays, power-on action) — PDU.ActionsEnabled only.</summary>
-    public Task SetOutletConfigAsync(string deviceId, int outletIndex, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
-        => api.SetOutletConfigAsync(deviceId, outletIndex, fields, cancellationToken);
+    public async Task SetOutletConfigAsync(string deviceId, int outletIndex, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
+    {
+        await api.SetOutletConfigAsync(deviceId, outletIndex, fields, cancellationToken);
+
+        // Latch the new values so polling doesn't flap HA back to the stale config while the PDU applies.
+        lock (pendingLock)
+            foreach (var (field, value) in fields)
+                pendingOutletConfig[$"{deviceId}/{outletIndex}/{field}"] = (value?.ToString() ?? string.Empty, DateTime.UtcNow.Add(PendingStateTimeout));
+    }
+
+    /// <summary>Report the latched value for a writable config field until the PDU catches up (or we time out).</summary>
+    public string ResolveOutletConfig(string deviceId, int outletIndex, string field, string actual)
+    {
+        lock (pendingLock)
+        {
+            var key = $"{deviceId}/{outletIndex}/{field}";
+            if (!pendingOutletConfig.TryGetValue(key, out var pending))
+                return actual;
+
+            if (string.Equals(actual, pending.expected, StringComparison.OrdinalIgnoreCase) || DateTime.UtcNow >= pending.expiresUtc)
+            {
+                pendingOutletConfig.Remove(key);
+                return actual;
+            }
+
+            return pending.expected;
+        }
+    }
 
     /// <summary>Reset an outlet's accumulated statistics — PDU.ActionsEnabled only.</summary>
     public Task ResetOutletStatsAsync(string deviceId, int outletIndex, CancellationToken cancellationToken)

--- a/rPDU2MQTT/Classes/PDU.cs
+++ b/rPDU2MQTT/Classes/PDU.cs
@@ -45,6 +45,19 @@ public partial class PDU
     }
 
     /// <summary>
+    /// Issue a control action ("on", "off", "reboot") against an outlet (PDU.ActionsEnabled only).
+    /// on/off latch the expected state; reboot is left to the next poll to report.
+    /// </summary>
+    public async Task ControlOutletAsync(string deviceId, int outletIndex, string action, CancellationToken cancellationToken)
+    {
+        await api.ControlOutletAsync(deviceId, outletIndex, action, cancellationToken);
+
+        if (action is "on" or "off")
+            lock (pendingLock)
+                pendingOutletStates[$"{deviceId}/{outletIndex}"] = (action, DateTime.UtcNow.Add(PendingStateTimeout));
+    }
+
+    /// <summary>
     /// Resolve the state to report for an outlet: while a recent command is still pending (the PDU
     /// hasn't applied it yet) report the commanded state instead of the stale polled one.
     /// </summary>

--- a/rPDU2MQTT/Classes/PDU.cs
+++ b/rPDU2MQTT/Classes/PDU.cs
@@ -57,6 +57,14 @@ public partial class PDU
                 pendingOutletStates[$"{deviceId}/{outletIndex}"] = (action, DateTime.UtcNow.Add(PendingStateTimeout));
     }
 
+    /// <summary>Write outlet configuration fields (delays, power-on action) — PDU.ActionsEnabled only.</summary>
+    public Task SetOutletConfigAsync(string deviceId, int outletIndex, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
+        => api.SetOutletConfigAsync(deviceId, outletIndex, fields, cancellationToken);
+
+    /// <summary>Reset an outlet's accumulated statistics — PDU.ActionsEnabled only.</summary>
+    public Task ResetOutletStatsAsync(string deviceId, int outletIndex, CancellationToken cancellationToken)
+        => api.ResetOutletStatsAsync(deviceId, outletIndex, cancellationToken);
+
     /// <summary>
     /// Resolve the state to report for an outlet: while a recent command is still pending (the PDU
     /// hasn't applied it yet) report the commanded state instead of the stale polled one.

--- a/rPDU2MQTT/Classes/PduApiHandler.cs
+++ b/rPDU2MQTT/Classes/PduApiHandler.cs
@@ -47,18 +47,21 @@ public class PduApiHandler
         }
     }
 
+    /// <summary>Turn an outlet on or off.</summary>
+    public Task SetOutletStateAsync(string deviceId, int outletIndex, bool on, CancellationToken cancellationToken)
+        => ControlOutletAsync(deviceId, outletIndex, on ? "on" : "off", cancellationToken);
+
     /// <summary>
-    /// Turn an outlet on or off.
+    /// Issue a control action ("on", "off", "reboot") against an outlet.
     /// </summary>
     /// <remarks>
     /// Endpoint/auth match the Geist firmware (apiVersion 1.0.1): control is a POST to the
     /// outlet resource with the session token in the body. Only invoked when ActionsEnabled.
     /// </remarks>
-    public async Task SetOutletStateAsync(string deviceId, int outletIndex, bool on, CancellationToken cancellationToken)
+    public async Task ControlOutletAsync(string deviceId, int outletIndex, string action, CancellationToken cancellationToken)
     {
         var webPort = await ResolveWebPortAsync(deviceId, cancellationToken);
         var token = await GetTokenAsync(webPort, cancellationToken);
-        var action = on ? "on" : "off";
 
         // The control resource is the same /api/dev/{device}/outlet/{index} path as the read API,
         // targeted at the host that owns the device (a proxy port for cluster members).
@@ -70,7 +73,7 @@ public class PduApiHandler
             data = new { action, delay = false },
         };
 
-        Log.Information($"[PduApiHandler] Setting outlet {deviceId}/{outletIndex} -> {action}");
+        Log.Information($"[PduApiHandler] Outlet {deviceId}/{outletIndex} control -> {action}");
         var response = await PostJsonWithRetryAsync(url, body, cancellationToken);
         var result = await response.Content.ReadFromJsonAsync<GetResponse<JsonElement>>(cancellationToken);
 
@@ -78,7 +81,7 @@ public class PduApiHandler
         {
             // A stale token is the most likely failure; drop it so the next call re-authenticates.
             tokensByPort.Remove(webPort);
-            throw new Exception($"[PduApiHandler] Outlet control failed (HTTP {(int)response.StatusCode}, retCode {result?.RetCode} {result?.RetMsg}).");
+            throw new Exception($"[PduApiHandler] Outlet control '{action}' failed (HTTP {(int)response.StatusCode}, retCode {result?.RetCode} {result?.RetMsg}).");
         }
     }
 

--- a/rPDU2MQTT/Classes/PduApiHandler.cs
+++ b/rPDU2MQTT/Classes/PduApiHandler.cs
@@ -68,14 +68,10 @@ public class PduApiHandler
         => SendOutletCommandAsync(deviceId, outletIndex, "set", fields, $"set {string.Join(",", fields.Keys)}", cancellationToken);
 
     /// <summary>
-    /// Reset an outlet's accumulated statistics (energy).
+    /// Reset an outlet's accumulated energy statistics (cmd "reset", target "energy").
     /// </summary>
-    /// <remarks>
-    /// UNVERIFIED: the exact Geist control action for an energy/statistics reset isn't documented
-    /// here; "resetEnergy" is the best guess. Adjust if the PDU returns a non-zero retCode.
-    /// </remarks>
     public Task ResetOutletStatsAsync(string deviceId, int outletIndex, CancellationToken cancellationToken)
-        => SendOutletCommandAsync(deviceId, outletIndex, "control", new { action = "resetEnergy" }, "reset statistics", cancellationToken);
+        => SendOutletCommandAsync(deviceId, outletIndex, "reset", new { target = "energy" }, "reset statistics", cancellationToken);
 
     /// <summary>
     /// POST a command (control/set) to an outlet resource on the owning host, validating the result.

--- a/rPDU2MQTT/Classes/PduApiHandler.cs
+++ b/rPDU2MQTT/Classes/PduApiHandler.cs
@@ -58,22 +58,42 @@ public class PduApiHandler
     /// Endpoint/auth match the Geist firmware (apiVersion 1.0.1): control is a POST to the
     /// outlet resource with the session token in the body. Only invoked when ActionsEnabled.
     /// </remarks>
-    public async Task ControlOutletAsync(string deviceId, int outletIndex, string action, CancellationToken cancellationToken)
+    public Task ControlOutletAsync(string deviceId, int outletIndex, string action, CancellationToken cancellationToken)
+        => SendOutletCommandAsync(deviceId, outletIndex, "control", new { action, delay = false }, $"control '{action}'", cancellationToken);
+
+    /// <summary>
+    /// Write outlet configuration fields (e.g. onDelay/offDelay/rebootDelay/poaAction) via cmd "set".
+    /// </summary>
+    public Task SetOutletConfigAsync(string deviceId, int outletIndex, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
+        => SendOutletCommandAsync(deviceId, outletIndex, "set", fields, $"set {string.Join(",", fields.Keys)}", cancellationToken);
+
+    /// <summary>
+    /// Reset an outlet's accumulated statistics (energy).
+    /// </summary>
+    /// <remarks>
+    /// UNVERIFIED: the exact Geist control action for an energy/statistics reset isn't documented
+    /// here; "resetEnergy" is the best guess. Adjust if the PDU returns a non-zero retCode.
+    /// </remarks>
+    public Task ResetOutletStatsAsync(string deviceId, int outletIndex, CancellationToken cancellationToken)
+        => SendOutletCommandAsync(deviceId, outletIndex, "control", new { action = "resetEnergy" }, "reset statistics", cancellationToken);
+
+    /// <summary>
+    /// POST a command (control/set) to an outlet resource on the owning host, validating the result.
+    /// </summary>
+    /// <remarks>
+    /// Endpoint/auth match the Geist firmware (apiVersion 1.0.1): the session token travels in the
+    /// body, against the same /api/dev/{device}/outlet/{index} path as the read API (a proxy port
+    /// for cluster members). Only invoked when ActionsEnabled.
+    /// </remarks>
+    private async Task SendOutletCommandAsync(string deviceId, int outletIndex, string cmd, object data, string description, CancellationToken cancellationToken)
     {
         var webPort = await ResolveWebPortAsync(deviceId, cancellationToken);
         var token = await GetTokenAsync(webPort, cancellationToken);
 
-        // The control resource is the same /api/dev/{device}/outlet/{index} path as the read API,
-        // targeted at the host that owns the device (a proxy port for cluster members).
         var url = BuildUrl(webPort, $"/api/dev/{deviceId}/outlet/{outletIndex}");
-        var body = new
-        {
-            cmd = "control",
-            token,
-            data = new { action, delay = false },
-        };
+        var body = new { cmd, token, data };
 
-        Log.Information($"[PduApiHandler] Outlet {deviceId}/{outletIndex} control -> {action}");
+        Log.Information($"[PduApiHandler] Outlet {deviceId}/{outletIndex}: {description}");
         var response = await PostJsonWithRetryAsync(url, body, cancellationToken);
         var result = await response.Content.ReadFromJsonAsync<GetResponse<JsonElement>>(cancellationToken);
 
@@ -81,7 +101,7 @@ public class PduApiHandler
         {
             // A stale token is the most likely failure; drop it so the next call re-authenticates.
             tokensByPort.Remove(webPort);
-            throw new Exception($"[PduApiHandler] Outlet control '{action}' failed (HTTP {(int)response.StatusCode}, retCode {result?.RetCode} {result?.RetMsg}).");
+            throw new Exception($"[PduApiHandler] Outlet {description} failed (HTTP {(int)response.StatusCode}, retCode {result?.RetCode} {result?.RetMsg}).");
         }
     }
 

--- a/rPDU2MQTT/Models/HomeAssistant/DiscoveryTypes/NumberDiscovery.cs
+++ b/rPDU2MQTT/Models/HomeAssistant/DiscoveryTypes/NumberDiscovery.cs
@@ -1,0 +1,35 @@
+using rPDU2MQTT.Models.HomeAssistant.baseClasses;
+using System.Text.Json.Serialization;
+
+namespace rPDU2MQTT.Models.HomeAssistant.DiscoveryTypes;
+
+/// <summary>
+/// Discovery for a writable numeric setting, exposed as a Home Assistant MQTT number.
+/// Documentation: https://www.home-assistant.io/integrations/number.mqtt/
+/// </summary>
+public class NumberDiscovery : baseEntity
+{
+    /// <summary>Topic this number publishes the new value to (HA -> bridge).</summary>
+    [JsonPropertyName("command_topic")]
+    public string CommandTopic { get; set; } = string.Empty;
+
+    /// <summary>Template used to extract the current value from <c>state_topic</c>.</summary>
+    [JsonPropertyName("value_template")]
+    public string? ValueTemplate { get; set; }
+
+    [JsonPropertyName("min")]
+    public double? Min { get; set; }
+
+    [JsonPropertyName("max")]
+    public double? Max { get; set; }
+
+    [JsonPropertyName("step")]
+    public double? Step { get; set; }
+
+    [JsonPropertyName("unit_of_measurement")]
+    public string? UnitOfMeasurement { get; set; }
+
+    /// <summary>How the control is shown ("auto", "box" or "slider").</summary>
+    [JsonPropertyName("mode")]
+    public string? Mode { get; set; } = "box";
+}

--- a/rPDU2MQTT/Models/HomeAssistant/DiscoveryTypes/SelectDiscovery.cs
+++ b/rPDU2MQTT/Models/HomeAssistant/DiscoveryTypes/SelectDiscovery.cs
@@ -1,0 +1,23 @@
+using rPDU2MQTT.Models.HomeAssistant.baseClasses;
+using System.Text.Json.Serialization;
+
+namespace rPDU2MQTT.Models.HomeAssistant.DiscoveryTypes;
+
+/// <summary>
+/// Discovery for a writable enumerated setting, exposed as a Home Assistant MQTT select.
+/// Documentation: https://www.home-assistant.io/integrations/select.mqtt/
+/// </summary>
+public class SelectDiscovery : baseEntity
+{
+    /// <summary>Topic this select publishes the chosen option to (HA -> bridge).</summary>
+    [JsonPropertyName("command_topic")]
+    public string CommandTopic { get; set; } = string.Empty;
+
+    /// <summary>Template used to extract the current option from <c>state_topic</c>.</summary>
+    [JsonPropertyName("value_template")]
+    public string? ValueTemplate { get; set; }
+
+    /// <summary>The list of selectable options.</summary>
+    [JsonPropertyName("options")]
+    public List<string> Options { get; set; } = new();
+}

--- a/rPDU2MQTT/Models/HomeAssistant/Enums/EntityType.cs
+++ b/rPDU2MQTT/Models/HomeAssistant/Enums/EntityType.cs
@@ -64,6 +64,12 @@ public enum EntityType
     [JsonPropertyName("button")]
     Button,
 
+    [JsonPropertyName("number")]
+    Number,
+
+    [JsonPropertyName("select")]
+    Select,
+
     [JsonPropertyName("fan")]
     Fan,
 

--- a/rPDU2MQTT/Models/HomeAssistant/baseClasses/baseEntity.cs
+++ b/rPDU2MQTT/Models/HomeAssistant/baseClasses/baseEntity.cs
@@ -20,6 +20,8 @@ namespace rPDU2MQTT.Models.HomeAssistant.baseClasses;
 [JsonDerivedType(typeof(SensorDiscovery))]
 [JsonDerivedType(typeof(SwitchDiscovery))]
 [JsonDerivedType(typeof(ButtonDiscovery))]
+[JsonDerivedType(typeof(NumberDiscovery))]
+[JsonDerivedType(typeof(SelectDiscovery))]
 [JsonPolymorphic(IgnoreUnrecognizedTypeDiscriminators = false, TypeDiscriminatorPropertyName = nameof(JsonPolyMorphicTypeName), UnknownDerivedTypeHandling = JsonUnknownDerivedTypeHandling.FallBackToNearestAncestor)]
 public abstract class baseEntity : IBaseDiscovery
 {

--- a/rPDU2MQTT/Models/PDU/MqttPath.cs
+++ b/rPDU2MQTT/Models/PDU/MqttPath.cs
@@ -16,6 +16,9 @@ public enum MqttPath
     [JsonPropertyName("set")]
     Set,
 
+    [JsonPropertyName("reboot")]
+    Reboot,
+
     [JsonPropertyName("alarm")]
     Alarm,
 

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -191,6 +191,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             gitops = configSource.IsGitOpsManaged,
             mqttConnected = mqtt.IsConnected(),
             mqttHost = $"{mqtt.Options.Host}:{mqtt.Options.Port}",
+            actionsEnabled = config.PDU.ActionsEnabled,
         }, ConfigSchema.Json));
 
         app.MapPost("/api/test/mqtt", () =>
@@ -301,6 +302,60 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             }
         });
 
+        // Outlets available for control, with their current state (drives the Control tab).
+        app.MapGet("/api/control/outlets", async (HttpContext ctx) =>
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(20));
+            try
+            {
+                var data = await pdu.GetRootData_Public(cts.Token);
+                var outlets = data.Devices.SelectMany(d => d.Outlets.OrderBy(o => o.Key).Select(o => new
+                {
+                    deviceId = d.Key,
+                    device = d.Entity_DisplayName,
+                    index = o.Key,        // raw key the control API expects
+                    number = o.Key + 1,   // 1-based, matching the PDU UI
+                    name = o.Entity_DisplayName,
+                    state = pdu.ResolveOutletState(d.Key, o.Key, o.State),
+                })).ToList();
+                return Results.Json(new { ok = true, actionsEnabled = config.PDU.ActionsEnabled, outlets }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Could not read live PDU data: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
+        // Issue an outlet control action (on/off/reboot). Gated by PDU.ActionsEnabled.
+        app.MapPost("/api/control/outlet", async (HttpContext ctx) =>
+        {
+            if (!config.PDU.ActionsEnabled)
+                return Results.Json(new { ok = false, message = "Write actions are disabled (PDU.ActionsEnabled is false)." }, statusCode: 409);
+
+            ControlRequest? req;
+            try { req = await ctx.Request.ReadFromJsonAsync<ControlRequest>(ctx.RequestAborted); }
+            catch { req = null; }
+            if (req is null || string.IsNullOrWhiteSpace(req.DeviceId))
+                return Results.BadRequest(new { ok = false, message = "deviceId, index and action are required." });
+
+            var action = (req.Action ?? string.Empty).Trim().ToLowerInvariant();
+            if (action is not ("on" or "off" or "reboot"))
+                return Results.BadRequest(new { ok = false, message = "action must be on, off or reboot." });
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(20));
+            try
+            {
+                await pdu.ControlOutletAsync(req.DeviceId, req.Index, action, cts.Token);
+                return Results.Json(new { ok = true, message = $"Outlet {req.Index + 1} → {action}." }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Control failed: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
         // Render the current form state as YAML (for copy/paste into a ConfigMap, source control, etc.).
         app.MapPost("/api/config/yaml", async (HttpContext ctx) =>
         {
@@ -334,6 +389,9 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             return Results.Json(new { ok = true, message = "Cleared the retained Home Assistant discovery messages." }, ConfigSchema.Json);
         });
     }
+
+    /// <summary>Body of a POST /api/control/outlet request.</summary>
+    private sealed record ControlRequest(string DeviceId, int Index, string Action);
 
     private static string Version =>
         Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -318,6 +318,10 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                     number = o.Key + 1,   // 1-based, matching the PDU UI
                     name = o.Entity_DisplayName,
                     state = pdu.ResolveOutletState(d.Key, o.Key, o.State),
+                    onDelay = o.OnDelay,
+                    offDelay = o.OffDelay,
+                    rebootDelay = o.RebootDelay,
+                    poaAction = o.PoaAction,
                 })).ToList();
                 return Results.Json(new { ok = true, actionsEnabled = config.PDU.ActionsEnabled, outlets }, ConfigSchema.Json);
             }
@@ -340,14 +344,17 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 return Results.BadRequest(new { ok = false, message = "deviceId, index and action are required." });
 
             var action = (req.Action ?? string.Empty).Trim().ToLowerInvariant();
-            if (action is not ("on" or "off" or "reboot"))
-                return Results.BadRequest(new { ok = false, message = "action must be on, off or reboot." });
+            if (action is not ("on" or "off" or "reboot" or "resetstats"))
+                return Results.BadRequest(new { ok = false, message = "action must be on, off, reboot or resetstats." });
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
-                await pdu.ControlOutletAsync(req.DeviceId, req.Index, action, cts.Token);
+                if (action == "resetstats")
+                    await pdu.ResetOutletStatsAsync(req.DeviceId, req.Index, cts.Token);
+                else
+                    await pdu.ControlOutletAsync(req.DeviceId, req.Index, action, cts.Token);
                 return Results.Json(new { ok = true, message = $"Outlet {req.Index + 1} → {action}." }, ConfigSchema.Json);
             }
             catch (Exception ex)

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -99,8 +99,8 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
             MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, MQTTHelper.RestartSuffix), bridge, deviceClass: "restart");
     }
 
-    // Power-on action options (UNVERIFIED Geist values; adjust once confirmed against hardware).
-    private static readonly string[] PowerOnActions = { "on", "off", "previous" };
+    // Power-on action options (Geist values; "last" restores the pre-outage state).
+    private static readonly string[] PowerOnActions = { "on", "off", "last" };
 
     /// <summary>
     /// Write-action entities for a controllable outlet: switch, reboot button, on/off/reboot delays

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -160,9 +160,14 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
             // Outlet-level alarm.
             components.Add(BuildAlarm(outlet, newParent));
 
-            // When write-actions are enabled, also expose the outlet as a controllable switch.
+            // When write-actions are enabled, also expose the outlet as a controllable switch
+            // plus a reboot (power-cycle) button.
             if (cfg.PDU.ActionsEnabled)
+            {
                 components.Add(BuildSwitch(outlet, newParent));
+                components.Add(BuildButton(outlet.Entity_Identifier + "_reboot", "Reboot",
+                    MQTTHelper.JoinPaths(outlet.GetTopicPath(), MqttPath.Reboot.ToJsonString()), newParent, deviceClass: "restart"));
+            }
 
             // Discover measurements
             collectDiscovery(outlet.Measurements, newParent, components);

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -99,6 +99,34 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
             MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, MQTTHelper.RestartSuffix), bridge, deviceClass: "restart");
     }
 
+    // Power-on action options (UNVERIFIED Geist values; adjust once confirmed against hardware).
+    private static readonly string[] PowerOnActions = { "on", "off", "previous" };
+
+    /// <summary>
+    /// Write-action entities for a controllable outlet: switch, reboot button, on/off/reboot delays
+    /// (number), power-on action (select), and a reset-statistics button.
+    /// </summary>
+    private void collectOutletOperations(Outlet outlet, DiscoveryDevice parent, List<baseEntity> components)
+    {
+        var id = outlet.Entity_Identifier;
+        var basePath = outlet.GetTopicPath();
+        string state(string field) => MQTTHelper.JoinPaths(basePath, field);
+        string command(string field) => MQTTHelper.JoinPaths(basePath, field, MqttPath.Set.ToJsonString());
+
+        components.Add(BuildSwitch(outlet, parent));
+        components.Add(BuildButton(id + "_reboot", "Reboot",
+            MQTTHelper.JoinPaths(basePath, MqttPath.Reboot.ToJsonString()), parent, deviceClass: "restart"));
+
+        components.Add(BuildNumber(id + "_onDelay", "On Delay", state("onDelay"), command("onDelay"), parent, min: 0, max: 3600, step: 1, unit: "s"));
+        components.Add(BuildNumber(id + "_offDelay", "Off Delay", state("offDelay"), command("offDelay"), parent, min: 0, max: 3600, step: 1, unit: "s"));
+        components.Add(BuildNumber(id + "_rebootDelay", "Reboot Delay", state("rebootDelay"), command("rebootDelay"), parent, min: 0, max: 3600, step: 1, unit: "s"));
+
+        components.Add(BuildSelect(id + "_poaAction", "Power-On Action", state("poaAction"), command("poaAction"), PowerOnActions, parent));
+
+        components.Add(BuildButton(id + "_resetStats", "Reset Statistics",
+            MQTTHelper.JoinPaths(basePath, "resetStats"), parent));
+    }
+
     private void collectDiscovery<TEntity>([AllowNull] TEntity entity, DiscoveryDevice parent, List<baseEntity> components) where TEntity : BaseEntity
     {
         if (entity is null)
@@ -160,14 +188,10 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
             // Outlet-level alarm.
             components.Add(BuildAlarm(outlet, newParent));
 
-            // When write-actions are enabled, also expose the outlet as a controllable switch
-            // plus a reboot (power-cycle) button.
+            // When write-actions are enabled, expose the controllable switch plus the outlet
+            // operations: reboot, configurable delays, power-on action, and a reset-stats button.
             if (cfg.PDU.ActionsEnabled)
-            {
-                components.Add(BuildSwitch(outlet, newParent));
-                components.Add(BuildButton(outlet.Entity_Identifier + "_reboot", "Reboot",
-                    MQTTHelper.JoinPaths(outlet.GetTopicPath(), MqttPath.Reboot.ToJsonString()), newParent, deviceClass: "restart"));
-            }
+                collectOutletOperations(outlet, newParent, components);
 
             // Discover measurements
             collectDiscovery(outlet.Measurements, newParent, components);

--- a/rPDU2MQTT/Services/MQTTPublishingService.cs
+++ b/rPDU2MQTT/Services/MQTTPublishingService.cs
@@ -38,6 +38,10 @@ public class MQTTPublishingService : basePublishingService
                 await PublishState(outlet, state, cancellationToken);
                 await PublishAlarm(outlet, outlet.Alarm, cancellationToken);
                 await PublishMeasurements(outlet.Measurements, cancellationToken);
+
+                // Current values backing the writable delay/power-on entities (when control is enabled).
+                if (cfg.PDU.ActionsEnabled)
+                    await PublishOutletConfig(outlet, cancellationToken);
             }
         }
 

--- a/rPDU2MQTT/Services/MQTTPublishingService.cs
+++ b/rPDU2MQTT/Services/MQTTPublishingService.cs
@@ -41,7 +41,7 @@ public class MQTTPublishingService : basePublishingService
 
                 // Current values backing the writable delay/power-on entities (when control is enabled).
                 if (cfg.PDU.ActionsEnabled)
-                    await PublishOutletConfig(outlet, cancellationToken);
+                    await PublishOutletConfig(device.Key, outlet, cancellationToken);
             }
         }
 

--- a/rPDU2MQTT/Services/OutletCommandService.cs
+++ b/rPDU2MQTT/Services/OutletCommandService.cs
@@ -156,7 +156,7 @@ public class OutletCommandService : IHostedService
         var stateTopic = topic[..topic.LastIndexOf('/')];
         await mqtt.PublishAsync(new MQTT5PublishMessage(stateTopic, QualityOfService.AtLeastOnceDelivery)
         {
-            PayloadAsString = value.ToString(),
+            PayloadAsString = value.ToString() ?? string.Empty,
         });
     }
 }

--- a/rPDU2MQTT/Services/OutletCommandService.cs
+++ b/rPDU2MQTT/Services/OutletCommandService.cs
@@ -28,13 +28,22 @@ public class OutletCommandService : IHostedService
         cfg = deps.Cfg;
         pdu = deps.PDU;
 
-        // <ParentTopic>/+/outlets/+/{set,reboot}
+        // <ParentTopic>/+/outlets/+/{set,reboot,resetStats} and the per-field config set
+        // (<ParentTopic>/+/outlets/+/<field>/set).
+        var outlets = MqttPath.Outlets.ToJsonString();
         commandFilters = new[]
         {
-            MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", MqttPath.Outlets.ToJsonString(), "+", MqttPath.Set.ToJsonString()),
-            MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", MqttPath.Outlets.ToJsonString(), "+", MqttPath.Reboot.ToJsonString()),
+            MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", outlets, "+", MqttPath.Set.ToJsonString()),
+            MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", outlets, "+", MqttPath.Reboot.ToJsonString()),
+            MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", outlets, "+", ResetStatsCommand),
+            MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", outlets, "+", "+", MqttPath.Set.ToJsonString()),
         };
     }
+
+    // Command segment for the reset-statistics button, and the config fields settable via <field>/set.
+    private const string ResetStatsCommand = "resetStats";
+    private static readonly HashSet<string> DelayFields = new(StringComparer.OrdinalIgnoreCase) { "onDelay", "offDelay", "rebootDelay" };
+    private static readonly HashSet<string> ConfigFields = new(StringComparer.OrdinalIgnoreCase) { "onDelay", "offDelay", "rebootDelay", "poaAction" };
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
@@ -75,8 +84,22 @@ public class OutletCommandService : IHostedService
             if (!int.TryParse(parts[outletsIdx + 1], out var outletIndex))
                 return;
 
-            // Trailing segment selects the action: "set" carries on/off, "reboot" power-cycles.
-            var command = parts[^1];
+            // Segments after the index select the action:
+            //   [set]            -> on/off (payload)        [reboot] -> power-cycle
+            //   [resetStats]     -> reset statistics        [<field>, set] -> write config field
+            var rest = parts[(outletsIdx + 2)..];
+            var payload = (e.PublishMessage.PayloadAsString ?? string.Empty).Trim();
+
+            if (rest.Length == 2 && rest[1].Equals(MqttPath.Set.ToJsonString(), StringComparison.OrdinalIgnoreCase))
+            {
+                await HandleConfigSet(deviceId, outletIndex, rest[0], payload, topic);
+                return;
+            }
+
+            if (rest.Length != 1)
+                return;
+
+            var command = rest[0];
 
             if (command.Equals(MqttPath.Reboot.ToJsonString(), StringComparison.OrdinalIgnoreCase))
             {
@@ -84,9 +107,14 @@ public class OutletCommandService : IHostedService
                 return;
             }
 
-            var payload = (e.PublishMessage.PayloadAsString ?? string.Empty).Trim();
-            var on = payload.Equals("on", StringComparison.OrdinalIgnoreCase);
+            if (command.Equals(ResetStatsCommand, StringComparison.OrdinalIgnoreCase))
+            {
+                await pdu.ResetOutletStatsAsync(deviceId, outletIndex, CancellationToken.None);
+                return;
+            }
 
+            // Otherwise it's the on/off switch command ([set]).
+            var on = payload.Equals("on", StringComparison.OrdinalIgnoreCase);
             await pdu.SetOutletStateAsync(deviceId, outletIndex, on, CancellationToken.None);
 
             // Optimistically publish the new state so HA reflects it immediately instead of waiting
@@ -101,5 +129,34 @@ public class OutletCommandService : IHostedService
         {
             Log.Error(ex, $"Failed to handle outlet command on topic {topic}.");
         }
+    }
+
+    /// <summary>Write a single outlet config field (delay as a number, power-on action as a string).</summary>
+    private async Task HandleConfigSet(string deviceId, int outletIndex, string field, string payload, string topic)
+    {
+        if (!ConfigFields.Contains(field))
+            return;
+
+        object value;
+        if (DelayFields.Contains(field))
+        {
+            // HA number sends the value as text (e.g. "5" or "5.0"); the API expects an integer.
+            if (!double.TryParse(payload, System.Globalization.CultureInfo.InvariantCulture, out var num))
+                return;
+            value = (long)Math.Round(num);
+        }
+        else
+        {
+            value = payload; // poaAction: the selected option
+        }
+
+        await pdu.SetOutletConfigAsync(deviceId, outletIndex, new Dictionary<string, object> { [field] = value }, CancellationToken.None);
+
+        // Echo the new value back to the field's state topic so HA reflects it immediately.
+        var stateTopic = topic[..topic.LastIndexOf('/')];
+        await mqtt.PublishAsync(new MQTT5PublishMessage(stateTopic, QualityOfService.AtLeastOnceDelivery)
+        {
+            PayloadAsString = value.ToString(),
+        });
     }
 }

--- a/rPDU2MQTT/Services/OutletCommandService.cs
+++ b/rPDU2MQTT/Services/OutletCommandService.cs
@@ -18,7 +18,7 @@ public class OutletCommandService : IHostedService
     private readonly HiveMQClient mqtt;
     private readonly Config cfg;
     private readonly PDU pdu;
-    private readonly string commandFilter;
+    private readonly string[] commandFilters;
 
     public OutletCommandService(MQTTServiceDependencies deps)
     {
@@ -28,22 +28,29 @@ public class OutletCommandService : IHostedService
         cfg = deps.Cfg;
         pdu = deps.PDU;
 
-        // <ParentTopic>/+/outlets/+/set
-        commandFilter = MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", MqttPath.Outlets.ToJsonString(), "+", MqttPath.Set.ToJsonString());
+        // <ParentTopic>/+/outlets/+/{set,reboot}
+        commandFilters = new[]
+        {
+            MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", MqttPath.Outlets.ToJsonString(), "+", MqttPath.Set.ToJsonString()),
+            MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", MqttPath.Outlets.ToJsonString(), "+", MqttPath.Reboot.ToJsonString()),
+        };
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         mqtt.OnMessageReceived += OnMessageReceived;
 
-        var result = await mqtt.SubscribeAsync(commandFilter, QualityOfService.AtLeastOnceDelivery);
-        foreach (var sub in result.Subscriptions)
+        foreach (var filter in commandFilters)
         {
-            // SUBACK reason codes 0-2 are "granted QoS 0/1/2"; anything else is a failure/denial.
-            if ((int)sub.SubscribeReasonCode <= 2)
-                Log.Information($"Outlet command handler subscribed to {sub.TopicFilter.Topic} ({sub.SubscribeReasonCode}).");
-            else
-                Log.Error($"Outlet command subscription to {sub.TopicFilter.Topic} was NOT granted ({sub.SubscribeReasonCode}). Outlet control will not work - the MQTT account likely lacks subscribe permission on this topic.");
+            var result = await mqtt.SubscribeAsync(filter, QualityOfService.AtLeastOnceDelivery);
+            foreach (var sub in result.Subscriptions)
+            {
+                // SUBACK reason codes 0-2 are "granted QoS 0/1/2"; anything else is a failure/denial.
+                if ((int)sub.SubscribeReasonCode <= 2)
+                    Log.Information($"Outlet command handler subscribed to {sub.TopicFilter.Topic} ({sub.SubscribeReasonCode}).");
+                else
+                    Log.Error($"Outlet command subscription to {sub.TopicFilter.Topic} was NOT granted ({sub.SubscribeReasonCode}). Outlet control will not work - the MQTT account likely lacks subscribe permission on this topic.");
+            }
         }
     }
 
@@ -67,6 +74,15 @@ public class OutletCommandService : IHostedService
             var deviceId = parts[outletsIdx - 1];
             if (!int.TryParse(parts[outletsIdx + 1], out var outletIndex))
                 return;
+
+            // Trailing segment selects the action: "set" carries on/off, "reboot" power-cycles.
+            var command = parts[^1];
+
+            if (command.Equals(MqttPath.Reboot.ToJsonString(), StringComparison.OrdinalIgnoreCase))
+            {
+                await pdu.ControlOutletAsync(deviceId, outletIndex, "reboot", CancellationToken.None);
+                return;
+            }
 
             var payload = (e.PublishMessage.PayloadAsString ?? string.Empty).Trim();
             var on = payload.Equals("on", StringComparison.OrdinalIgnoreCase);

--- a/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
@@ -111,6 +111,59 @@ public abstract class baseDiscoveryService : baseMQTTService
     }
 
     /// <summary>
+    /// Build a writable numeric setting (Home Assistant number) bound to <paramref name="stateTopic"/>,
+    /// publishing the new value to <paramref name="commandTopic"/>.
+    /// </summary>
+    public NumberDiscovery BuildNumber(string id, string displayName, string stateTopic, string commandTopic,
+        DiscoveryDevice Parent, double? min = null, double? max = null, double? step = null, string? unit = null)
+    {
+        return new NumberDiscovery
+        {
+            ID = id,
+            Name = id,
+            DisplayName = displayName,
+
+            Device = Parent,
+            EntityType = Models.HomeAssistant.Enums.EntityType.Number,
+            EntityCategory = EntityCategory.Config,
+
+            StateTopic = stateTopic,
+            CommandTopic = commandTopic,
+            Min = min,
+            Max = max,
+            Step = step,
+            UnitOfMeasurement = unit,
+
+            AvailabilityTopic = Availability,
+        };
+    }
+
+    /// <summary>
+    /// Build a writable enumerated setting (Home Assistant select) bound to <paramref name="stateTopic"/>,
+    /// publishing the chosen option to <paramref name="commandTopic"/>.
+    /// </summary>
+    public SelectDiscovery BuildSelect(string id, string displayName, string stateTopic, string commandTopic,
+        IEnumerable<string> options, DiscoveryDevice Parent)
+    {
+        return new SelectDiscovery
+        {
+            ID = id,
+            Name = id,
+            DisplayName = displayName,
+
+            Device = Parent,
+            EntityType = Models.HomeAssistant.Enums.EntityType.Select,
+            EntityCategory = EntityCategory.Config,
+
+            StateTopic = stateTopic,
+            CommandTopic = commandTopic,
+            Options = options.ToList(),
+
+            AvailabilityTopic = Availability,
+        };
+    }
+
+    /// <summary>
     /// Build a "problem" binary sensor reflecting an entity's alarm state.
     /// </summary>
     public BinarySensorDiscovery BuildAlarm(NamedEntity item, DiscoveryDevice Parent)

--- a/rPDU2MQTT/Services/baseTypes/basePublishingService.cs
+++ b/rPDU2MQTT/Services/baseTypes/basePublishingService.cs
@@ -55,6 +55,19 @@ public abstract class basePublishingService : baseMQTTService
     }
 
     /// <summary>
+    /// Publish an outlet's writable config values (delays, power-on action) to the state topics
+    /// backing the Home Assistant number/select entities.
+    /// </summary>
+    protected async Task PublishOutletConfig(Outlet outlet, CancellationToken cancellationToken)
+    {
+        var basePath = outlet.GetTopicPath();
+        await PublishString(MQTTHelper.JoinPaths(basePath, "onDelay"), outlet.OnDelay.ToString(), cancellationToken);
+        await PublishString(MQTTHelper.JoinPaths(basePath, "offDelay"), outlet.OffDelay.ToString(), cancellationToken);
+        await PublishString(MQTTHelper.JoinPaths(basePath, "rebootDelay"), outlet.RebootDelay.ToString(), cancellationToken);
+        await PublishString(MQTTHelper.JoinPaths(basePath, "poaAction"), outlet.PoaAction ?? string.Empty, cancellationToken);
+    }
+
+    /// <summary>
     /// Publish entities state.
     /// </summary>
     /// <typeparam name="T"></typeparam>

--- a/rPDU2MQTT/Services/baseTypes/basePublishingService.cs
+++ b/rPDU2MQTT/Services/baseTypes/basePublishingService.cs
@@ -58,13 +58,16 @@ public abstract class basePublishingService : baseMQTTService
     /// Publish an outlet's writable config values (delays, power-on action) to the state topics
     /// backing the Home Assistant number/select entities.
     /// </summary>
-    protected async Task PublishOutletConfig(Outlet outlet, CancellationToken cancellationToken)
+    protected async Task PublishOutletConfig(string deviceId, Outlet outlet, CancellationToken cancellationToken)
     {
         var basePath = outlet.GetTopicPath();
-        await PublishString(MQTTHelper.JoinPaths(basePath, "onDelay"), outlet.OnDelay.ToString(), cancellationToken);
-        await PublishString(MQTTHelper.JoinPaths(basePath, "offDelay"), outlet.OffDelay.ToString(), cancellationToken);
-        await PublishString(MQTTHelper.JoinPaths(basePath, "rebootDelay"), outlet.RebootDelay.ToString(), cancellationToken);
-        await PublishString(MQTTHelper.JoinPaths(basePath, "poaAction"), outlet.PoaAction ?? string.Empty, cancellationToken);
+        var idx = outlet.Key;
+        string resolve(string field, string actual) => pdu.ResolveOutletConfig(deviceId, idx, field, actual);
+
+        await PublishString(MQTTHelper.JoinPaths(basePath, "onDelay"), resolve("onDelay", outlet.OnDelay.ToString()), cancellationToken);
+        await PublishString(MQTTHelper.JoinPaths(basePath, "offDelay"), resolve("offDelay", outlet.OffDelay.ToString()), cancellationToken);
+        await PublishString(MQTTHelper.JoinPaths(basePath, "rebootDelay"), resolve("rebootDelay", outlet.RebootDelay.ToString()), cancellationToken);
+        await PublishString(MQTTHelper.JoinPaths(basePath, "poaAction"), resolve("poaAction", outlet.PoaAction ?? string.Empty), cancellationToken);
     }
 
     /// <summary>

--- a/rPDU2MQTT/wwwroot/index.html
+++ b/rPDU2MQTT/wwwroot/index.html
@@ -235,8 +235,69 @@ function build() {
     }
     if (i === 0) link.click();
   });
+  addControlSection(nav, sections);
   addLiveDataSection(nav, sections);
   addExportSection(nav, sections);
+}
+
+// Direct outlet control (on/off/reboot). A convenient place to exercise write actions.
+function addControlSection(nav, sections) {
+  const link = document.createElement('a'); link.textContent = 'Control'; nav.appendChild(link);
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  const h = document.createElement('h2'); h.textContent = 'Outlet Control'; sec.appendChild(h);
+  const d = document.createElement('div'); d.className = 'desc';
+  d.textContent = 'Turn outlets on/off or reboot them directly. Requires write actions enabled (PDU.ActionsEnabled) and PDU credentials.';
+  sec.appendChild(d);
+
+  const bar = document.createElement('div'); bar.className = 'ld-toolbar';
+  const refresh = document.createElement('button'); refresh.className = 'small'; refresh.textContent = 'Refresh';
+  const filter = document.createElement('input'); filter.type = 'text'; filter.placeholder = 'Filter (device / outlet)…';
+  bar.appendChild(refresh); bar.appendChild(filter); sec.appendChild(bar);
+  const warn = document.createElement('div'); warn.className = 'desc'; warn.style.color = 'var(--bad)'; warn.style.display = 'none';
+  warn.textContent = 'Write actions are disabled (PDU.ActionsEnabled is false). Enable it in the PDU section and restart to control outlets.';
+  sec.appendChild(warn);
+  const tableWrap = document.createElement('div'); sec.appendChild(tableWrap);
+
+  let rows = [], enabled = false;
+  const act = async (o, action) => {
+    if (action === 'off' && !confirm('Turn OFF outlet ' + o.number + ' (' + o.name + ')?')) return;
+    if (action === 'reboot' && !confirm('Reboot outlet ' + o.number + ' (' + o.name + ')? Connected equipment will lose power briefly.')) return;
+    toast('Outlet ' + o.number + ': ' + action + '…', true);
+    const r = await api('/api/control/outlet', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ deviceId: o.deviceId, index: o.index, action }) });
+    toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
+    setTimeout(load, 800); // let the PDU apply, then re-read state
+  };
+  const draw = () => {
+    const f = filter.value.trim().toLowerCase();
+    const shown = f ? rows.filter(r => (r.device + ' ' + r.name + ' ' + r.number).toLowerCase().includes(f)) : rows;
+    const t = document.createElement('table'); t.className = 'ld';
+    const head = document.createElement('tr');
+    ['Device', 'Outlet', 'State', 'Actions'].forEach(x => { const th = document.createElement('th'); th.textContent = x; head.appendChild(th); });
+    const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
+    const tb = document.createElement('tbody');
+    shown.forEach(o => {
+      const tr = document.createElement('tr');
+      const tdDev = document.createElement('td'); tdDev.textContent = o.device; tr.appendChild(tdDev);
+      const tdName = document.createElement('td'); tdName.textContent = '#' + o.number + ' — ' + (o.name || ''); tr.appendChild(tdName);
+      const tdState = document.createElement('td');
+      const dot = document.createElement('span'); dot.className = 'dot ' + (o.state === 'on' ? 'good' : 'bad'); tdState.appendChild(dot);
+      tdState.appendChild(document.createTextNode(o.state || '?')); tr.appendChild(tdState);
+      const tdAct = document.createElement('td');
+      [['On', 'on'], ['Off', 'off'], ['Reboot', 'reboot']].forEach(([lab, a]) => {
+        const b = document.createElement('button'); b.className = 'small' + (a === 'off' ? ' danger' : '');
+        b.textContent = lab; b.disabled = !enabled; b.style.marginRight = '6px'; b.onclick = () => act(o, a); tdAct.appendChild(b);
+      });
+      tr.appendChild(tdAct); tb.appendChild(tr);
+    });
+    t.appendChild(tb); tableWrap.innerHTML = ''; tableWrap.appendChild(t);
+  };
+  const load = async () => {
+    const r = await api('/api/control/outlets');
+    if (!r.body.ok) { tableWrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load outlets.') + '</div>'; return; }
+    rows = r.body.outlets || []; enabled = !!r.body.actionsEnabled; warn.style.display = enabled ? 'none' : 'block'; draw();
+  };
+  refresh.onclick = load; filter.oninput = draw;
+  link.onclick = () => { activate(link, sec); load(); };
 }
 
 // A read-only view of the current readings being pulled from the PDU(s).

--- a/rPDU2MQTT/wwwroot/index.html
+++ b/rPDU2MQTT/wwwroot/index.html
@@ -262,6 +262,7 @@ function addControlSection(nav, sections) {
   const act = async (o, action) => {
     if (action === 'off' && !confirm('Turn OFF outlet ' + o.number + ' (' + o.name + ')?')) return;
     if (action === 'reboot' && !confirm('Reboot outlet ' + o.number + ' (' + o.name + ')? Connected equipment will lose power briefly.')) return;
+    if (action === 'resetstats' && !confirm('Reset statistics for outlet ' + o.number + ' (' + o.name + ')?')) return;
     toast('Outlet ' + o.number + ': ' + action + '…', true);
     const r = await api('/api/control/outlet', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ deviceId: o.deviceId, index: o.index, action }) });
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
@@ -278,12 +279,17 @@ function addControlSection(nav, sections) {
     shown.forEach(o => {
       const tr = document.createElement('tr');
       const tdDev = document.createElement('td'); tdDev.textContent = o.device; tr.appendChild(tdDev);
-      const tdName = document.createElement('td'); tdName.textContent = '#' + o.number + ' — ' + (o.name || ''); tr.appendChild(tdName);
+      const tdName = document.createElement('td');
+      tdName.appendChild(document.createTextNode('#' + o.number + ' — ' + (o.name || '')));
+      // Current write-action config, so changes made via HA are visible here.
+      const cfg = document.createElement('div'); cfg.className = 'ld-count';
+      cfg.textContent = 'delays: on ' + o.onDelay + 's / off ' + o.offDelay + 's / reboot ' + o.rebootDelay + 's · power-on: ' + (o.poaAction || '?');
+      tdName.appendChild(cfg); tr.appendChild(tdName);
       const tdState = document.createElement('td');
       const dot = document.createElement('span'); dot.className = 'dot ' + (o.state === 'on' ? 'good' : 'bad'); tdState.appendChild(dot);
       tdState.appendChild(document.createTextNode(o.state || '?')); tr.appendChild(tdState);
       const tdAct = document.createElement('td');
-      [['On', 'on'], ['Off', 'off'], ['Reboot', 'reboot']].forEach(([lab, a]) => {
+      [['On', 'on'], ['Off', 'off'], ['Reboot', 'reboot'], ['Reset Stats', 'resetstats']].forEach(([lab, a]) => {
         const b = document.createElement('button'); b.className = 'small' + (a === 'off' ? ' danger' : '');
         b.textContent = lab; b.disabled = !enabled; b.style.marginRight = '6px'; b.onclick = () => act(o, a); tdAct.appendChild(b);
       });


### PR DESCRIPTION
## Batch A — Outlet operations & config (write actions)

All gated behind **Enable Write Actions** (`PDU.ActionsEnabled`) + PDU credentials.

### Home Assistant entities (per outlet, when enabled)
| Entity | Type | Action |
| --- | --- | --- |
| Switch | `switch` | On / off |
| Reboot | `button` | Power-cycle |
| On / Off / Reboot Delay | `number` | Outlet timing (seconds) |
| Power-On Action | `select` | Behavior when power restored (`on`/`off`/`last`) |
| Reset Statistics | `button` | Reset accumulated energy |

### GUI
New **Control** tab: per-outlet On / Off / Reboot / Reset Stats with live state, current delays + power-on action shown, disabled with a warning when write actions are off.

### Internals
- Generalized PDU control path: `ControlOutletAsync(action)`, `SetOutletConfigAsync` (`cmd:"set"`), `ResetOutletStatsAsync` (`cmd:"reset"`, `target:"energy"`), via a shared command helper.
- New `NumberDiscovery` / `SelectDiscovery` types (+ `EntityType` number/select); `BuildNumber` / `BuildSelect`.
- `OutletCommandService` routes `<field>/set` and `resetStats` topics alongside on/off + reboot.
- Current config values published each poll, with a pending-state **latch** (mirrors on/off) so HA doesn't flap back to stale values while the PDU applies a change.
- GUI endpoints `/api/control/outlets` + `/api/control/outlet`; `actionsEnabled` in `/api/status`.

### Verification (on live hardware, incl. OneView cluster member via proxy port)
- ✅ On / Off / Reboot / Reboot Delay
- ✅ Power-On Action (`last`)
- ✅ Reset Statistics (`cmd:"reset"`, `target:"energy"`)
- ✅ Flap-back fixed via the config latch

🤖 Generated with [Claude Code](https://claude.com/claude-code)