### PR TITLE
Batch D: diagnostics & health (status page, restart, health probes, k8s logs/events)

### DIFF
--- a/charts/rpdu2mqtt/templates/deployment.yaml
+++ b/charts/rpdu2mqtt/templates/deployment.yaml
@@ -45,8 +45,14 @@ spec:
             - secretRef:
                 name: {{ include "rpdu2mqtt.secretName" . }}
           {{- end }}
-          {{- if .Values.kubernetesConfigSource.enabled }}
           env:
+            - name: RPDU2MQTT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: RPDU2MQTT_IMAGE
+              value: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            {{- if .Values.kubernetesConfigSource.enabled }}
             - name: RPDU2MQTT_CONFIG_SOURCE
               value: k8s
             - name: RPDU2MQTT_CR_NAME
@@ -55,7 +61,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          {{- end }}
+            {{- end }}
           ports:
             {{- if dig "Gui" "Enabled" false .Values.config }}
             - name: gui
@@ -65,6 +71,26 @@ spec:
             - name: metrics
               containerPort: {{ dig "Prometheus" "Port" 9184 .Values.config }}
             {{- end }}
+            {{- if dig "Health" "Enabled" true .Values.config }}
+            - name: health
+              containerPort: {{ dig "Health" "Port" 8081 .Values.config }}
+            {{- end }}
+          {{- if and .Values.healthProbes.enabled (dig "Health" "Enabled" true .Values.config) }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ dig "Health" "Port" 8081 .Values.config }}
+            {{- with .Values.healthProbes.liveness }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: {{ dig "Health" "Port" 8081 .Values.config }}
+            {{- with .Values.healthProbes.readiness }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
           {{- if not .Values.kubernetesConfigSource.enabled }}
           volumeMounts:
             - name: config

--- a/charts/rpdu2mqtt/templates/rbac.yaml
+++ b/charts/rpdu2mqtt/templates/rbac.yaml
@@ -12,6 +12,10 @@ rules:
   - apiGroups: ["rpdu2mqtt.xtremeownage.com"]
     resources: ["rpduconfigs/status"]
     verbs: ["get", "patch", "update"]
+  # Lets the GUI Diagnostics page show this pod's logs + recent events.
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -44,6 +44,9 @@ config:
     Username: admin
     # Set Gui.Password via .Values.config or, better, leave the GUI disabled in
     # Kubernetes (the ConfigMap mount is read-only, so Save is disabled anyway).
+  Health:
+    Enabled: true
+    Port: 8081
 
 # ---------------------------------------------------------------------------
 # Credentials, injected as RPDU2MQTT_* environment variables via a Secret so
@@ -107,6 +110,21 @@ ingress:
         - path: /
           pathType: Prefix
   tls: []
+
+# Liveness/readiness probes against the app's health endpoints (config.Health).
+# Liveness  -> /healthz (process is up); Readiness -> /readyz (MQTT connected + PDU polled recently).
+healthProbes:
+  enabled: true
+  liveness:
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3
 
 resources: {}
 podAnnotations: {}

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -421,6 +421,33 @@ source, and the GUI's **Export** view can render the current config as an `RpduC
 (secrets redacted) to commit back. Credentials are not stored in the CR — provide them via a Secret
 and the `RPDU2MQTT_*` env vars.
 
+### GUI Diagnostics page
+
+The GUI's **Diagnostics** tab shows runtime status — app version, container image, uptime, MQTT
+connection, last successful PDU poll, config source, and (in Kubernetes) the namespace/pod. It also
+has a **Restart bridge** button (stops the process so the container/host restarts it) and, when using
+the Kubernetes config source, on-demand **pod logs** and **recent events** (requires the RBAC the Helm
+chart grants — `pods`, `pods/log`, `events`).
+
+## Health Checks (Optional)
+
+The bridge exposes lightweight HTTP health endpoints for container/orchestrator probes, enabled by
+default on their own port:
+
+```yaml
+Health:
+  Enabled: true   # default
+  Port: 8081      # default
+```
+
+| Endpoint | Meaning |
+| --- | --- |
+| `GET /healthz` | **Liveness** — the process is up (always `200 OK` while running). |
+| `GET /readyz` | **Readiness** — `200` when MQTT is connected and the PDU has been polled recently; otherwise `503`. |
+
+The Helm chart wires these as `livenessProbe` / `readinessProbe` automatically (toggle with
+`healthProbes.enabled`, default on). For Docker Compose you can point a `healthcheck` at `/healthz`.
+
 ## Example Configurations
 
 Here- are a few example configuration files.

--- a/rPDU2MQTT/Classes/HealthState.cs
+++ b/rPDU2MQTT/Classes/HealthState.cs
@@ -1,0 +1,26 @@
+namespace rPDU2MQTT.Classes;
+
+/// <summary>
+/// Shared liveness/readiness signals: process start time and the last successful PDU poll,
+/// updated by the publishing loop and read by the health endpoints + the GUI diagnostics page.
+/// </summary>
+public sealed class HealthState
+{
+    public DateTime StartedUtc { get; } = DateTime.UtcNow;
+
+    private long lastPollTicks; // 0 = never polled successfully
+
+    /// <summary>Record a successful PDU poll (resets the readiness staleness window).</summary>
+    public void RecordPollSuccess() => Interlocked.Exchange(ref lastPollTicks, DateTime.UtcNow.Ticks);
+
+    public DateTime? LastPollUtc
+    {
+        get
+        {
+            var ticks = Interlocked.Read(ref lastPollTicks);
+            return ticks == 0 ? null : new DateTime(ticks, DateTimeKind.Utc);
+        }
+    }
+
+    public TimeSpan Uptime => DateTime.UtcNow - StartedUtc;
+}

--- a/rPDU2MQTT/Models/Config/Config.cs
+++ b/rPDU2MQTT/Models/Config/Config.cs
@@ -36,4 +36,7 @@ public class Config
 
     [YamlMember(Alias = "Gui", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Embedded configuration web GUI")]
     public GuiConfig Gui { get; set; } = new GuiConfig();
+
+    [YamlMember(Alias = "Health", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "HTTP health-check endpoints")]
+    public HealthConfig Health { get; set; } = new HealthConfig();
 }

--- a/rPDU2MQTT/Models/Config/HealthConfig.cs
+++ b/rPDU2MQTT/Models/Config/HealthConfig.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel;
+
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>
+/// Configuration for the HTTP health-check endpoints (liveness/readiness) used by container probes.
+/// </summary>
+public class HealthConfig
+{
+    [DefaultValue(true)]
+    [Description("Expose HTTP health-check endpoints: /healthz (liveness) and /readyz (readiness).")]
+    public bool Enabled { get; set; } = true;
+
+    [DefaultValue(8081)]
+    [Description("Port the health-check endpoints listen on.")]
+    public int Port { get; set; } = 8081;
+}

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using HiveMQtt.Client;
+using k8s;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -25,15 +27,19 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly PDU pdu;
     private readonly DiscoveryCoordinator discovery;
     private readonly IConfigSource configSource;
+    private readonly IHostApplicationLifetime lifetime;
+    private readonly HealthState health;
     private WebApplication? app;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health)
     {
         this.config = config;
         this.mqtt = mqtt;
         this.pdu = pdu;
         this.discovery = discovery;
         this.configSource = configSource;
+        this.lifetime = lifetime;
+        this.health = health;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -193,6 +199,88 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             mqttHost = $"{mqtt.Options.Host}:{mqtt.Options.Port}",
             actionsEnabled = config.PDU.ActionsEnabled,
         }, ConfigSchema.Json));
+
+        // Diagnostics: versions, uptime, runtime, and Kubernetes context for the Diagnostics page.
+        app.MapGet("/api/diagnostics", () =>
+        {
+            var k8s = configSource as KubernetesConfigSource;
+            return Results.Json(new
+            {
+                ok = true,
+                version = Version,
+                image = Environment.GetEnvironmentVariable("RPDU2MQTT_IMAGE"),
+                dotnet = Environment.Version.ToString(),
+                os = RuntimeInformation.OSDescription,
+                startedUtc = health.StartedUtc,
+                uptimeSeconds = (long)health.Uptime.TotalSeconds,
+                mqttConnected = mqtt.IsConnected(),
+                mqttHost = $"{mqtt.Options.Host}:{mqtt.Options.Port}",
+                configSource = configSource.Describe,
+                lastPollUtc = health.LastPollUtc,
+                kubernetes = k8s is not null,
+                pod = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME"),
+                ns = k8s?.Namespace,
+            }, ConfigSchema.Json);
+        });
+
+        // Stop the app so the container/host restarts it (same mechanism as the HA Restart button).
+        app.MapPost("/api/restart", () =>
+        {
+            Log.Information("Restart requested via GUI; stopping application.");
+            // Let the HTTP response flush before the host shuts down.
+            _ = Task.Run(async () => { await Task.Delay(300); lifetime.StopApplication(); });
+            return Results.Json(new { ok = true, message = "Restarting…" }, ConfigSchema.Json);
+        });
+
+        // Tail of this pod's container logs (Kubernetes config source only).
+        app.MapGet("/api/diagnostics/logs", async (HttpContext ctx) =>
+        {
+            if (configSource is not KubernetesConfigSource k8s)
+                return Results.Json(new { ok = false, message = "Logs are only available with the Kubernetes config source." }, ConfigSchema.Json);
+            var pod = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME");
+            if (string.IsNullOrEmpty(pod))
+                return Results.Json(new { ok = false, message = "Pod name unavailable (RPDU2MQTT_POD_NAME not set)." }, ConfigSchema.Json);
+            try
+            {
+                using var stream = await k8s.Client.CoreV1.ReadNamespacedPodLogAsync(pod, k8s.Namespace, tailLines: 200, cancellationToken: ctx.RequestAborted);
+                using var reader = new StreamReader(stream);
+                return Results.Json(new { ok = true, logs = await reader.ReadToEndAsync(ctx.RequestAborted) }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Could not read pod logs: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
+        // Recent Kubernetes events for this pod (Kubernetes config source only).
+        app.MapGet("/api/diagnostics/events", async (HttpContext ctx) =>
+        {
+            if (configSource is not KubernetesConfigSource k8s)
+                return Results.Json(new { ok = false, message = "Events are only available with the Kubernetes config source." }, ConfigSchema.Json);
+            try
+            {
+                var pod = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME");
+                var list = await k8s.Client.CoreV1.ListNamespacedEventAsync(k8s.Namespace,
+                    fieldSelector: string.IsNullOrEmpty(pod) ? null : $"involvedObject.name={pod}", cancellationToken: ctx.RequestAborted);
+                var events = list.Items
+                    .Select(e => new
+                    {
+                        time = e.LastTimestamp ?? e.EventTime ?? e.Metadata?.CreationTimestamp,
+                        type = e.Type,
+                        reason = e.Reason,
+                        message = e.Message,
+                        count = e.Count,
+                    })
+                    .OrderByDescending(e => e.time)
+                    .Take(50)
+                    .ToList();
+                return Results.Json(new { ok = true, events }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Could not read events: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
 
         app.MapPost("/api/test/mqtt", () =>
         {

--- a/rPDU2MQTT/Services/HealthService.cs
+++ b/rPDU2MQTT/Services/HealthService.cs
@@ -1,0 +1,75 @@
+using HiveMQtt.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Helpers;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Lightweight HTTP health endpoints for container probes, independent of the optional GUI:
+/// <c>/healthz</c> (liveness — the process is up) and <c>/readyz</c> (readiness — MQTT is connected
+/// and the PDU has been polled recently). Hosted on its own port when <c>Health.Enabled</c>.
+/// </summary>
+public sealed class HealthService : IHostedService, IAsyncDisposable
+{
+    private readonly Config cfg;
+    private readonly IHiveMQClient mqtt;
+    private readonly HealthState health;
+    private WebApplication? app;
+
+    public HealthService(Config cfg, IHiveMQClient mqtt, HealthState health)
+    {
+        this.cfg = cfg;
+        this.mqtt = mqtt;
+        this.health = health;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!cfg.Health.Enabled)
+            return;
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = Array.Empty<string>() });
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls($"http://*:{cfg.Health.Port}");
+
+        app = builder.Build();
+        app.MapGet("/healthz", () => Results.Text("OK"));
+        app.MapGet("/readyz", () => IsReady()
+            ? Results.Text("READY")
+            : Results.Text("NOT READY", "text/plain", statusCode: StatusCodes.Status503ServiceUnavailable));
+
+        await app.StartAsync(cancellationToken);
+        Log.Information($"Health endpoints listening on http://*:{cfg.Health.Port} (/healthz, /readyz).");
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (app is not null)
+            await app.StopAsync(cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (app is not null)
+            await app.DisposeAsync();
+    }
+
+    /// <summary>Ready when MQTT is connected and a poll has succeeded within the staleness window.</summary>
+    private bool IsReady()
+    {
+        if (!mqtt.IsConnected())
+            return false;
+
+        var last = health.LastPollUtc;
+        if (last is null)
+            return false;
+
+        var staleAfter = TimeSpan.FromSeconds(Math.Max(30, cfg.PDU.PollInterval * 3));
+        return DateTime.UtcNow - last.Value < staleAfter;
+    }
+}

--- a/rPDU2MQTT/Services/MQTTPublishingService.cs
+++ b/rPDU2MQTT/Services/MQTTPublishingService.cs
@@ -8,7 +8,12 @@ namespace rPDU2MQTT.Services;
 /// </summary>
 public class MQTTPublishingService : basePublishingService
 {
-    public MQTTPublishingService(MQTTServiceDependencies deps) : base(deps) { }
+    private readonly HealthState health;
+
+    public MQTTPublishingService(MQTTServiceDependencies deps, HealthState health) : base(deps)
+    {
+        this.health = health;
+    }
 
     protected override async Task Execute(CancellationToken cancellationToken)
     {
@@ -56,5 +61,8 @@ public class MQTTPublishingService : basePublishingService
                 await PublishOneViewGroupMeasurements(outlet.Measurements, cancellationToken);
             }
         }
+
+        // Reached here without throwing -> a healthy poll+publish cycle (drives readiness).
+        health.RecordPollSuccess();
     }
 }

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -114,6 +114,9 @@ public static class ServiceConfiguration
 
         services.AddSingleton<MQTTServiceDependencies>();
 
+        // Shared liveness/readiness signals (uptime + last successful poll).
+        services.AddSingleton<HealthState>();
+
         // Created hosted services.
         services.AddHostedService<MQTTPublishingService>();
 
@@ -137,6 +140,10 @@ public static class ServiceConfiguration
         }
         else
             Log.Warning($"Home Assistant Discovery Disabled.");
+
+        // Optional HTTP health endpoints for container probes.
+        if (cfg.Health.Enabled)
+            services.AddHostedService<HealthService>();
 
         // Optional embedded configuration GUI.
         if (cfg.Gui.Enabled)

--- a/rPDU2MQTT/wwwroot/index.html
+++ b/rPDU2MQTT/wwwroot/index.html
@@ -238,6 +238,79 @@ function build() {
   addControlSection(nav, sections);
   addLiveDataSection(nav, sections);
   addExportSection(nav, sections);
+  addDiagnosticsSection(nav, sections);
+}
+
+// Status / diagnostics: versions, uptime, restart, and (in Kubernetes) logs + events.
+function addDiagnosticsSection(nav, sections) {
+  const link = document.createElement('a'); link.textContent = 'Diagnostics'; nav.appendChild(link);
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  const h = document.createElement('h2'); h.textContent = 'Diagnostics'; sec.appendChild(h);
+  const d = document.createElement('div'); d.className = 'desc'; d.textContent = 'Runtime status and maintenance actions.'; sec.appendChild(d);
+
+  const bar = document.createElement('div'); bar.className = 'sec-actions';
+  const refresh = document.createElement('button'); refresh.className = 'small'; refresh.textContent = 'Refresh';
+  const restart = document.createElement('button'); restart.className = 'small danger'; restart.textContent = 'Restart bridge';
+  bar.appendChild(refresh); bar.appendChild(restart); sec.appendChild(bar);
+
+  const info = document.createElement('table'); info.className = 'ld'; sec.appendChild(info);
+  const k8sWrap = document.createElement('div'); sec.appendChild(k8sWrap);
+
+  const fmtUptime = s => { s = Math.floor(s); const d = Math.floor(s / 86400), h = Math.floor(s % 86400 / 3600), m = Math.floor(s % 3600 / 60); return (d ? d + 'd ' : '') + (h ? h + 'h ' : '') + m + 'm'; };
+  const row = (k, v) => { const tr = document.createElement('tr'); const a = document.createElement('td'); a.textContent = k; a.style.color = 'var(--muted)'; a.style.width = '220px'; const b = document.createElement('td'); b.textContent = (v == null || v === '') ? '—' : v; tr.appendChild(a); tr.appendChild(b); return tr; };
+
+  const load = async () => {
+    const r = await api('/api/diagnostics'); const b = r.body;
+    info.innerHTML = '';
+    info.appendChild(row('App version', b.version));
+    if (b.image) info.appendChild(row('Container image', b.image));
+    info.appendChild(row('Uptime', b.uptimeSeconds != null ? fmtUptime(b.uptimeSeconds) : null));
+    info.appendChild(row('Started (UTC)', b.startedUtc));
+    info.appendChild(row('MQTT', (b.mqttConnected ? 'connected' : 'disconnected') + ' — ' + b.mqttHost));
+    info.appendChild(row('Last PDU poll (UTC)', b.lastPollUtc));
+    info.appendChild(row('Config source', b.configSource));
+    info.appendChild(row('.NET', b.dotnet));
+    info.appendChild(row('OS', b.os));
+    info.appendChild(row('Kubernetes', b.kubernetes ? (b.ns + ' / ' + (b.pod || '?')) : 'no'));
+    k8sWrap.innerHTML = '';
+    if (b.kubernetes) buildK8sTools(k8sWrap);
+  };
+  refresh.onclick = load;
+  restart.onclick = async () => {
+    if (!confirm('Restart the bridge? It will disconnect briefly while the container restarts.')) return;
+    const r = await api('/api/restart', { method: 'POST' });
+    toast(r.body.message || 'Restarting…', r.ok && r.body.ok);
+  };
+  link.onclick = () => { activate(link, sec); load(); };
+}
+
+// Kubernetes-only: on-demand pod logs + recent events.
+function buildK8sTools(container) {
+  const tools = document.createElement('div'); tools.className = 'sec-actions';
+  const logsBtn = document.createElement('button'); logsBtn.className = 'small'; logsBtn.textContent = 'Load logs';
+  const evBtn = document.createElement('button'); evBtn.className = 'small'; evBtn.textContent = 'Load events';
+  tools.appendChild(logsBtn); tools.appendChild(evBtn); container.appendChild(tools);
+  const out = document.createElement('div'); container.appendChild(out);
+
+  logsBtn.onclick = async () => {
+    out.innerHTML = '<div class="desc">Loading logs…</div>';
+    const r = await api('/api/diagnostics/logs');
+    if (!r.body.ok) { out.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Failed.') + '</div>'; return; }
+    const ta = document.createElement('textarea'); ta.className = 'yaml'; ta.readOnly = true; ta.value = r.body.logs || '(empty)';
+    out.innerHTML = ''; out.appendChild(ta);
+  };
+  evBtn.onclick = async () => {
+    out.innerHTML = '<div class="desc">Loading events…</div>';
+    const r = await api('/api/diagnostics/events');
+    if (!r.body.ok) { out.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Failed.') + '</div>'; return; }
+    const t = document.createElement('table'); t.className = 'ld';
+    const head = document.createElement('tr'); ['Time', 'Type', 'Reason', 'Message', 'Count'].forEach(x => { const th = document.createElement('th'); th.textContent = x; head.appendChild(th); });
+    const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
+    const tb = document.createElement('tbody');
+    (r.body.events || []).forEach(e => { const tr = document.createElement('tr'); [e.time, e.type, e.reason, e.message, e.count].forEach(c => { const td = document.createElement('td'); td.textContent = c == null ? '' : c; tr.appendChild(td); }); tb.appendChild(tr); });
+    t.appendChild(tb); out.innerHTML = ''; out.appendChild(t);
+    if (!(r.body.events || []).length) out.innerHTML = '<div class="desc">No recent events.</div>';
+  };
 }
 
 // Direct outlet control (on/off/reboot). A convenient place to exercise write actions.


### PR DESCRIPTION
## Batch D — Diagnostics & health

### Health endpoints + probes
- New **`Health`** config (`Enabled` default true, `Port` 8081).
- `HealthService` hosts **`/healthz`** (liveness — process up) and **`/readyz`** (readiness — MQTT connected + a recent successful PDU poll), backed by a shared `HealthState` (uptime + last poll).
- Helm: `livenessProbe`/`readinessProbe` (toggle `healthProbes.enabled`, default on), a `health` containerPort, and `RPDU2MQTT_POD_NAME` / `RPDU2MQTT_IMAGE` env via the downward API.

### GUI Diagnostics page
- New **Diagnostics** tab: app version, container image, uptime, MQTT status, last PDU poll, config source, .NET/OS, and (in Kubernetes) namespace/pod.
- **Restart bridge** button → `/api/restart` (stops the process so the container/host restarts it — same mechanism as the HA Restart button).
- With the Kubernetes config source: on-demand **pod logs** + **recent events** viewers (`/api/diagnostics/logs`, `/api/diagnostics/events`).
- RBAC: grant `pods`, `pods/log`, `events` (get/list) when the k8s config source is enabled.

### Docs
- Health Checks + Diagnostics page sections in `Configuration.md`.

### Verification
- ✅ Compiles clean. Health endpoints + GUI Diagnostics testable locally (Restart, uptime, versions).
- ⚠️ Helm probes + k8s logs/events need a cluster deploy to verify (RBAC + downward API). Helm not available in my env to render — templates are straightforward but worth a `helm template` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)