### PR TITLE
fix(health): readiness never ready when group publish hiccups (#93)

### DIFF
--- a/rPDU2MQTT/Services/HealthService.cs
+++ b/rPDU2MQTT/Services/HealthService.cs
@@ -39,9 +39,13 @@ public sealed class HealthService : IHostedService, IAsyncDisposable
 
         app = builder.Build();
         app.MapGet("/healthz", () => Results.Text("OK"));
-        app.MapGet("/readyz", () => IsReady()
-            ? Results.Text("READY")
-            : Results.Text("NOT READY", "text/plain", statusCode: StatusCodes.Status503ServiceUnavailable));
+        app.MapGet("/readyz", () =>
+        {
+            var reason = NotReadyReason();
+            return reason is null
+                ? Results.Text("READY")
+                : Results.Text($"NOT READY: {reason}", "text/plain", statusCode: StatusCodes.Status503ServiceUnavailable);
+        });
 
         await app.StartAsync(cancellationToken);
         Log.Information($"Health endpoints listening on http://*:{cfg.Health.Port} (/healthz, /readyz).");
@@ -59,17 +63,24 @@ public sealed class HealthService : IHostedService, IAsyncDisposable
             await app.DisposeAsync();
     }
 
-    /// <summary>Ready when MQTT is connected and a poll has succeeded within the staleness window.</summary>
-    private bool IsReady()
+    /// <summary>
+    /// Ready when MQTT is connected and the PDU has been polled recently. Returns the reason it is
+    /// NOT ready, or <see langword="null"/> when ready.
+    /// </summary>
+    private string? NotReadyReason()
     {
         if (!mqtt.IsConnected())
-            return false;
+            return "MQTT not connected";
 
         var last = health.LastPollUtc;
         if (last is null)
-            return false;
+            return "no successful PDU poll yet";
 
         var staleAfter = TimeSpan.FromSeconds(Math.Max(30, cfg.PDU.PollInterval * 3));
-        return DateTime.UtcNow - last.Value < staleAfter;
+        var age = DateTime.UtcNow - last.Value;
+        if (age >= staleAfter)
+            return $"last PDU poll {age.TotalSeconds:0}s ago (> {staleAfter.TotalSeconds:0}s)";
+
+        return null;
     }
 }

--- a/rPDU2MQTT/Services/MQTTPublishingService.cs
+++ b/rPDU2MQTT/Services/MQTTPublishingService.cs
@@ -19,6 +19,10 @@ public class MQTTPublishingService : basePublishingService
     {
         var data = await pdu.GetRootData_Public(cancellationToken);
 
+        // A successful fetch is the readiness signal: we can reach the PDU. Record it before
+        // publishing so a later publish hiccup can't keep the pod permanently NotReady.
+        health.RecordPollSuccess();
+
         // Run through each device.
         foreach (var device in data.Devices)
         {
@@ -61,8 +65,5 @@ public class MQTTPublishingService : basePublishingService
                 await PublishOneViewGroupMeasurements(outlet.Measurements, cancellationToken);
             }
         }
-
-        // Reached here without throwing -> a healthy poll+publish cycle (drives readiness).
-        health.RecordPollSuccess();
     }
 }


### PR DESCRIPTION
## Fixes #93 — Helm health checks: container never enters ready state

### Root cause
`MQTTPublishingService.Execute` recorded the successful poll (the readiness signal) **only at the very end**, after publishing devices *and* OneView groups. Device data publishes first, so the container appears to run and data flows — but if anything in the later group publishing throws, `RecordPollSuccess()` is skipped, `/readyz` never sees a successful poll, and the pod stays **NotReady** forever.

### Fix
- Record the poll **immediately after a successful PDU fetch** — the true "we can reach the PDU" signal — independent of downstream publish quirks.
- `/readyz` now returns the **specific reason** when not ready (`MQTT not connected`, `no successful PDU poll yet`, or `last PDU poll Ns ago`), so it's diagnosable via `curl`/`kubectl describe`.

### Verification
- ✅ Builds clean, 38/38 tests pass.
- Please redeploy and confirm the pod reaches Ready; `curl /readyz` should return `READY` (or a clear reason if not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)