### PR TITLE
feat(helm): NetworkPolicy + Gateway API HTTPRoute (#102)

### DIFF
--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -53,6 +53,9 @@ credentials:
 | `serviceMonitor.enabled` | `false` | Create a Prometheus Operator `ServiceMonitor` for `/metrics`. |
 | `kubernetesConfigSource.enabled` | `false` | Store config in an `RpduConfig` CR (writable by the GUI) instead of a ConfigMap; creates the CR + RBAC and wires the app to read it. Requires the CRD (in this chart's `crds/`). |
 | `ingress.enabled` | `false` | Expose the GUI via an Ingress. |
+| `httpRoute.enabled` | `false` | Expose the GUI via a Gateway API `HTTPRoute` (set `httpRoute.parentRefs`/`hostnames`). Requires the Gateway API CRDs. |
+| `healthProbes.enabled` | `true` | Liveness/readiness probes against the app's health endpoints. |
+| `networkPolicy.enabled` | `false` | Restrict pod access: GUI/metrics ingress only from `networkPolicy.guiIngressFrom` / `metricsIngressFrom`; health probes always allowed. Optionally restrict egress with `restrictEgress` + `egress`. Requires a NetworkPolicy-enforcing CNI. |
 | `serviceAccount.create` | `true` | Create a ServiceAccount. |
 | `resources`, `nodeSelector`, `tolerations`, `affinity` | `{}` / `[]` | Standard pod scheduling/limits. |
 

--- a/charts/rpdu2mqtt/templates/httproute.yaml
+++ b/charts/rpdu2mqtt/templates/httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.httpRoute.enabled }}
+{{- $fullName := include "rpdu2mqtt.fullname" . -}}
+{{- $svcPort := dig "Gui" "Port" 8080 .Values.config -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "rpdu2mqtt.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- toYaml .Values.httpRoute.rules | nindent 4 }}
+    {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}-gui
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/rpdu2mqtt/templates/networkpolicy.yaml
+++ b/charts/rpdu2mqtt/templates/networkpolicy.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "rpdu2mqtt.fullname" . }}
+  labels:
+    {{- include "rpdu2mqtt.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "rpdu2mqtt.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if .Values.networkPolicy.restrictEgress }}
+    - Egress
+    {{- end }}
+  ingress:
+    {{- if dig "Health" "Enabled" true .Values.config }}
+    # Allow health probes (kubelet) to the health port from any source.
+    - ports:
+        - port: {{ dig "Health" "Port" 8081 .Values.config }}
+          protocol: TCP
+    {{- end }}
+    {{- if and (dig "Gui" "Enabled" false .Values.config) .Values.networkPolicy.guiIngressFrom }}
+    # Allow the GUI port only from the configured peers (e.g. your gateway/ingress controller).
+    - from:
+        {{- toYaml .Values.networkPolicy.guiIngressFrom | nindent 8 }}
+      ports:
+        - port: {{ dig "Gui" "Port" 8080 .Values.config }}
+          protocol: TCP
+    {{- end }}
+    {{- if and (dig "Prometheus" "Enabled" false .Values.config) .Values.networkPolicy.metricsIngressFrom }}
+    # Allow the metrics port only from the configured peers (e.g. Prometheus).
+    - from:
+        {{- toYaml .Values.networkPolicy.metricsIngressFrom | nindent 8 }}
+      ports:
+        - port: {{ dig "Prometheus" "Port" 9184 .Values.config }}
+          protocol: TCP
+    {{- end }}
+  {{- if .Values.networkPolicy.restrictEgress }}
+  egress:
+    # DNS resolution (always needed).
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- with .Values.networkPolicy.egress }}
+    # Caller-provided egress (MQTT broker, PDU, and the Kubernetes API server when using the
+    # Kubernetes config source). Without these, restricted egress will block the bridge.
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -111,6 +111,45 @@ ingress:
           pathType: Prefix
   tls: []
 
+# Gateway API HTTPRoute for the GUI Service (alternative to Ingress). Requires the
+# Gateway API CRDs and a Gateway. By default routes all traffic to the GUI Service.
+httpRoute:
+  enabled: false
+  # The Gateway(s) to attach to.
+  parentRefs:
+    - name: main-gateway
+      # namespace: gateway-namespace
+  hostnames:
+    - rpdu2mqtt.example.com
+  annotations: {}
+  # Override the default rule (route everything to the GUI Service) with custom matches if needed.
+  rules: []
+
+# NetworkPolicy to restrict pod access. When enabled, ingress to the GUI/metrics ports is allowed
+# only from the peers listed below (so users reach the GUI via Ingress/HTTPRoute, not the pod
+# directly); health probes are always allowed. Requires a CNI that enforces NetworkPolicy.
+networkPolicy:
+  enabled: false
+  # Peers (NetworkPolicyPeer: namespaceSelector / podSelector / ipBlock) allowed to reach the GUI
+  # port — e.g. your ingress controller or Gateway. Empty = no direct GUI ingress is permitted.
+  guiIngressFrom: []
+    # - namespaceSelector:
+    #     matchLabels:
+    #       kubernetes.io/metadata.name: ingress-nginx
+  # Peers allowed to scrape the metrics port (e.g. your Prometheus). Empty = none.
+  metricsIngressFrom: []
+  # Restrict egress to DNS + the rules below. When false, egress is unrestricted.
+  restrictEgress: false
+  # Extra egress rules (NetworkPolicyEgressRule) for your MQTT broker, PDU, and — with the
+  # Kubernetes config source — the API server. Required when restrictEgress is true.
+  egress: []
+    # - to:
+    #     - ipBlock:
+    #         cidr: 10.0.0.10/32   # MQTT broker
+    #   ports:
+    #     - port: 1883
+    #       protocol: TCP
+
 # Liveness/readiness probes against the app's health endpoints (config.Health).
 # Liveness  -> /healthz (process is up); Readiness -> /readyz (MQTT connected + PDU polled recently).
 healthProbes:


### PR DESCRIPTION
## Closes #102 — Helm chart enhancements

### HTTPRoute (Gateway API)
New optional `HTTPRoute` for the GUI Service, as an alternative to Ingress:
```yaml
httpRoute:
  enabled: true
  parentRefs:
    - name: main-gateway
      # namespace: cilium
  hostnames:
    - pdu.kube.example.com
```
Defaults to routing all traffic to the `*-gui` Service; override `httpRoute.rules` for custom matches. Requires the Gateway API CRDs.

### NetworkPolicy
New optional `NetworkPolicy` to block unexpected direct pod access:
- GUI ingress allowed **only** from `networkPolicy.guiIngressFrom` (e.g. your ingress controller / Gateway), so users reach the GUI via Ingress/HTTPRoute rather than the pod directly.
- Metrics ingress allowed only from `networkPolicy.metricsIngressFrom` (e.g. Prometheus).
- **Health probes always allowed** (so readiness/liveness keep working).
- Optional egress restriction (`restrictEgress` + `egress`); DNS always permitted. When restricting egress you must add rules for your MQTT broker, PDU, and (with the k8s config source) the API server.

Both default **disabled**. Documented in `values.yaml` + chart README (also added the missing `healthProbes` row).

### Verification
- ⚠️ Helm isn't available in my environment, so I couldn't `helm template`/`lint`. Template conditionals reviewed for balance. Please run `helm template` / a dry-run install to confirm rendering against your Gateway/CNI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)