### PR TITLE
feat(gui): Paths viewer + override path preview (#100)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -372,6 +372,9 @@ The GUI:
   (e.g. disabled ones) are still shown so they can be re-enabled.
 - **Live Data** — a read-only view of the current measurements being pulled from the PDU(s)
   (device / outlet / measurement / value / units), with a filter and optional 5-second auto-refresh.
+- **Paths** — shows the generated **MQTT topic**, **Prometheus metric**, and **EmonCMS key** for each
+  measurement (reflecting your overrides), with click-to-copy. Prometheus/EmonCMS columns appear only
+  when those exporters are enabled.
 - **Export YAML** — an "Export YAML" view renders the current form state (including unsaved edits) as
   the `config.yaml` that would be written, with a Copy button, for pasting into a ConfigMap, source
   control, etc.

--- a/rPDU2MQTT/Helpers/MetricsHelper.cs
+++ b/rPDU2MQTT/Helpers/MetricsHelper.cs
@@ -1,10 +1,11 @@
+using rPDU2MQTT.Extensions;
 using rPDU2MQTT.Models.PDU;
 using System.Globalization;
 
 namespace rPDU2MQTT.Helpers;
 
 /// <summary>A single numeric measurement, flattened for export to Prometheus / EmonCMS / etc.</summary>
-public readonly record struct MeasurementReading(string Device, string Source, string Type, double Value, string Units, string Identifier);
+public readonly record struct MeasurementReading(string Device, string Source, string Type, double Value, string Units, string Identifier, string Topic);
 
 public static class MetricsHelper
 {
@@ -30,6 +31,12 @@ public static class MetricsHelper
     {
         foreach (var m in measurements)
             if (double.TryParse(m.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
-                yield return new MeasurementReading(device, source, m.Type, value, m.Units, m.Entity_Identifier);
+                yield return new MeasurementReading(device, source, m.Type, value, m.Units, m.Entity_Identifier, m.GetTopicPath());
     }
+
+    /// <summary>The Prometheus gauge name for a measurement type (e.g. realPower -> rpdu2mqtt_realpower).</summary>
+    public static string PrometheusMetricName(string type) => $"rpdu2mqtt_{Sanitize(type)}";
+
+    private static string Sanitize(string value)
+        => new(value.Select(c => char.IsLetterOrDigit(c) ? char.ToLowerInvariant(c) : '_').ToArray());
 }

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -29,9 +29,10 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly IConfigSource configSource;
     private readonly IHostApplicationLifetime lifetime;
     private readonly HealthState health;
+    private readonly PduApiHandler pduApi;
     private WebApplication? app;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduApiHandler pduApi)
     {
         this.config = config;
         this.mqtt = mqtt;
@@ -40,6 +41,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         this.configSource = configSource;
         this.lifetime = lifetime;
         this.health = health;
+        this.pduApi = pduApi;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -399,25 +401,36 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             try
             {
                 var data = await pdu.GetRootData_Public(cts.Token);
-                var promEnabled = config.Prometheus.Exporter || config.Prometheus.Pushgateway.Enabled;
-                var emonEnabled = config.EmonCMS.Enabled;
-                var rows = MetricsHelper.EnumerateReadings(data)
-                    .OrderBy(r => r.Device).ThenBy(r => r.Source).ThenBy(r => r.Type)
-                    .Select(r => new
-                    {
-                        device = r.Device,
-                        source = r.Source,
-                        type = r.Type,
-                        mqtt = r.Topic,
-                        prometheus = promEnabled ? $"{MetricsHelper.PrometheusMetricName(r.Type)}{{device=\"{r.Device}\",source=\"{r.Source}\"}}" : null,
-                        emoncms = emonEnabled ? $"node={config.EmonCMS.Node} key={r.Identifier}" : null,
-                    })
-                    .ToList();
-                return Results.Json(new { ok = true, prometheusEnabled = promEnabled, emonEnabled, count = rows.Count, rows }, ConfigSchema.Json);
+                return Results.Json(BuildPaths(data, config), ConfigSchema.Json);
             }
             catch (Exception ex)
             {
                 return Results.Json(new { ok = false, message = $"Could not read live PDU data: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
+        // Preview the generated paths with the posted (unsaved) config applied, so the Overrides
+        // editor can show how edits change the HA/Prometheus/EmonCMS paths. Runs the real processing
+        // pipeline against a transient PDU so the result matches what would actually be published.
+        app.MapPost("/api/paths/preview", async (HttpContext ctx) =>
+        {
+            using var reader = new StreamReader(ctx.Request.Body);
+            var json = await reader.ReadToEndAsync();
+
+            Config parsed;
+            try { parsed = ConfigSchema.FromJson(json); }
+            catch (Exception ex) { return Results.BadRequest(new { ok = false, message = $"Invalid configuration: {ex.Message}" }); }
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(20));
+            try
+            {
+                var data = await new PDU(parsed, pduApi).GetRootData_Public(cts.Token);
+                return Results.Json(BuildPaths(data, parsed), ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Could not compute paths: {ex.Message}" }, ConfigSchema.Json);
             }
         });
 
@@ -518,6 +531,26 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
 
     /// <summary>Body of a POST /api/control/outlet request.</summary>
     private sealed record ControlRequest(string DeviceId, int Index, string Action);
+
+    /// <summary>Project a poll's measurements into the generated MQTT/Prometheus/EmonCMS paths.</summary>
+    private static object BuildPaths(Models.PDU.PduData data, Config config)
+    {
+        var promEnabled = config.Prometheus.Exporter || config.Prometheus.Pushgateway.Enabled;
+        var emonEnabled = config.EmonCMS.Enabled;
+        var rows = MetricsHelper.EnumerateReadings(data)
+            .OrderBy(r => r.Device).ThenBy(r => r.Source).ThenBy(r => r.Type)
+            .Select(r => new
+            {
+                device = r.Device,
+                source = r.Source,
+                type = r.Type,
+                mqtt = r.Topic,
+                prometheus = promEnabled ? $"{MetricsHelper.PrometheusMetricName(r.Type)}{{device=\"{r.Device}\",source=\"{r.Source}\"}}" : null,
+                emoncms = emonEnabled ? $"node={config.EmonCMS.Node} key={r.Identifier}" : null,
+            })
+            .ToList();
+        return new { ok = true, prometheusEnabled = promEnabled, emonEnabled, count = rows.Count, rows };
+    }
 
     private static string Version =>
         Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -390,6 +390,37 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             }
         });
 
+        // Generated integration paths per measurement (MQTT topic, Prometheus metric, EmonCMS key),
+        // reflecting the current overrides — for the GUI "Paths" view.
+        app.MapGet("/api/paths", async (HttpContext ctx) =>
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(20));
+            try
+            {
+                var data = await pdu.GetRootData_Public(cts.Token);
+                var promEnabled = config.Prometheus.Exporter || config.Prometheus.Pushgateway.Enabled;
+                var emonEnabled = config.EmonCMS.Enabled;
+                var rows = MetricsHelper.EnumerateReadings(data)
+                    .OrderBy(r => r.Device).ThenBy(r => r.Source).ThenBy(r => r.Type)
+                    .Select(r => new
+                    {
+                        device = r.Device,
+                        source = r.Source,
+                        type = r.Type,
+                        mqtt = r.Topic,
+                        prometheus = promEnabled ? $"{MetricsHelper.PrometheusMetricName(r.Type)}{{device=\"{r.Device}\",source=\"{r.Source}\"}}" : null,
+                        emoncms = emonEnabled ? $"node={config.EmonCMS.Node} key={r.Identifier}" : null,
+                    })
+                    .ToList();
+                return Results.Json(new { ok = true, prometheusEnabled = promEnabled, emonEnabled, count = rows.Count, rows }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Could not read live PDU data: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
         // Outlets available for control, with their current state (drives the Control tab).
         app.MapGet("/api/control/outlets", async (HttpContext ctx) =>
         {

--- a/rPDU2MQTT/Services/PrometheusExportService.cs
+++ b/rPDU2MQTT/Services/PrometheusExportService.cs
@@ -72,12 +72,9 @@ public class PrometheusExportService : baseMQTTService
     {
         if (!gauges.TryGetValue(type, out var gauge))
         {
-            gauge = Metrics.CreateGauge($"rpdu2mqtt_{Sanitize(type)}", $"rPDU2MQTT {type} measurement", "device", "source", "units");
+            gauge = Metrics.CreateGauge(MetricsHelper.PrometheusMetricName(type), $"rPDU2MQTT {type} measurement", "device", "source", "units");
             gauges[type] = gauge;
         }
         return gauge;
     }
-
-    private static string Sanitize(string value)
-        => new(value.Select(c => char.IsLetterOrDigit(c) ? char.ToLowerInvariant(c) : '_').ToArray());
 }

--- a/rPDU2MQTT/wwwroot/index.html
+++ b/rPDU2MQTT/wwwroot/index.html
@@ -218,10 +218,15 @@ function build() {
     if (acts) sec.appendChild(acts);
     if (node.key === 'Overrides') {
       // Bespoke, live-data-driven editor instead of the blind dictionary form.
+      const tools = document.createElement('div'); tools.className = 'sec-actions';
       const refresh = document.createElement('button'); refresh.className = 'small'; refresh.textContent = 'Refresh live data';
+      const preview = document.createElement('button'); preview.className = 'small'; preview.textContent = 'Preview generated paths (with unsaved edits)';
+      tools.appendChild(refresh); tools.appendChild(preview);
+      const pathsBox = document.createElement('div');
       const container = document.createElement('div');
       refresh.onclick = () => renderOverrides(container);
-      sec.appendChild(refresh); sec.appendChild(container);
+      preview.onclick = () => previewOverridePaths(pathsBox);
+      sec.appendChild(tools); sec.appendChild(pathsBox); sec.appendChild(container);
       link.onclick = () => { activate(link, sec); if (!container.dataset.loaded) renderOverrides(container); };
     } else {
       if (node.type === 'object') {
@@ -242,6 +247,35 @@ function build() {
   addDiagnosticsSection(nav, sections);
 }
 
+// A click-to-copy monospace table cell (used by the path tables).
+function pathCopyCell(text) {
+  const td = document.createElement('td');
+  if (!text) { td.textContent = '—'; td.style.color = 'var(--muted)'; return td; }
+  const code = document.createElement('span'); code.textContent = text; code.style.cursor = 'pointer';
+  code.style.fontFamily = 'ui-monospace,Consolas,monospace'; code.style.fontSize = '12px'; code.title = 'Click to copy';
+  code.onclick = () => { navigator.clipboard?.writeText(text); toast('Copied: ' + text, true); };
+  td.appendChild(code); return td;
+}
+
+// Build a paths table (Device / Outlet / Measurement / MQTT [/ Prometheus] [/ EmonCMS]).
+function pathsTable(rows, promOn, emonOn) {
+  const t = document.createElement('table'); t.className = 'ld';
+  const cols = ['Device', 'Outlet / entity', 'Measurement', 'MQTT topic'];
+  if (promOn) cols.push('Prometheus'); if (emonOn) cols.push('EmonCMS');
+  const head = document.createElement('tr'); cols.forEach(x => { const th = document.createElement('th'); th.textContent = x; head.appendChild(th); });
+  const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
+  const tb = document.createElement('tbody');
+  rows.forEach(r => {
+    const tr = document.createElement('tr');
+    [r.device, r.source, r.type].forEach(c => { const td = document.createElement('td'); td.textContent = c; tr.appendChild(td); });
+    tr.appendChild(pathCopyCell(r.mqtt));
+    if (promOn) tr.appendChild(pathCopyCell(r.prometheus));
+    if (emonOn) tr.appendChild(pathCopyCell(r.emoncms));
+    tb.appendChild(tr);
+  });
+  t.appendChild(tb); return t;
+}
+
 // Generated integration paths per measurement (MQTT topic, Prometheus metric, EmonCMS key).
 function addPathsSection(nav, sections) {
   const link = document.createElement('a'); link.textContent = 'Paths'; nav.appendChild(link);
@@ -259,33 +293,10 @@ function addPathsSection(nav, sections) {
   const tableWrap = document.createElement('div'); sec.appendChild(tableWrap);
 
   let rows = [], promOn = false, emonOn = false;
-  const copyCell = (text) => {
-    const td = document.createElement('td');
-    if (!text) { td.textContent = '—'; td.style.color = 'var(--muted)'; return td; }
-    const code = document.createElement('span'); code.textContent = text; code.style.cursor = 'pointer';
-    code.style.fontFamily = 'ui-monospace,Consolas,monospace'; code.style.fontSize = '12px';
-    code.title = 'Click to copy';
-    code.onclick = () => { navigator.clipboard?.writeText(text); toast('Copied: ' + text, true); };
-    td.appendChild(code); return td;
-  };
   const draw = () => {
     const f = filter.value.trim().toLowerCase();
     const shown = f ? rows.filter(r => (r.device + ' ' + r.source + ' ' + r.type + ' ' + r.mqtt + ' ' + (r.prometheus || '') + ' ' + (r.emoncms || '')).toLowerCase().includes(f)) : rows;
-    const t = document.createElement('table'); t.className = 'ld';
-    const cols = ['Device', 'Outlet / entity', 'Measurement', 'MQTT topic'];
-    if (promOn) cols.push('Prometheus'); if (emonOn) cols.push('EmonCMS');
-    const head = document.createElement('tr'); cols.forEach(x => { const th = document.createElement('th'); th.textContent = x; head.appendChild(th); });
-    const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
-    const tb = document.createElement('tbody');
-    shown.forEach(r => {
-      const tr = document.createElement('tr');
-      [r.device, r.source, r.type].forEach(c => { const td = document.createElement('td'); td.textContent = c; tr.appendChild(td); });
-      tr.appendChild(copyCell(r.mqtt));
-      if (promOn) tr.appendChild(copyCell(r.prometheus));
-      if (emonOn) tr.appendChild(copyCell(r.emoncms));
-      tb.appendChild(tr);
-    });
-    t.appendChild(tb); tableWrap.innerHTML = ''; tableWrap.appendChild(t);
+    tableWrap.innerHTML = ''; tableWrap.appendChild(pathsTable(shown, promOn, emonOn));
   };
   const load = async () => {
     const r = await api('/api/paths');
@@ -629,6 +640,20 @@ async function renderOverrides(container) {
     container.appendChild(groupHeader('OneView Groups', null));
     lv.groups.forEach(g => container.appendChild(overrideCard('Group: ' + (g.label || g.name || g.key), [['key', g.key], ['discovered as:', g.displayName]], ['OneviewGroups', 'Overrides', g.key], { name: g.displayName }, true)));
   }
+}
+
+// Show the generated paths produced by the current (unsaved) overrides, computed server-side
+// against the real processing pipeline so it matches what would actually be published.
+async function previewOverridePaths(box) {
+  box.innerHTML = '<div class="desc">Computing paths with your unsaved edits…</div>';
+  const r = await fetch('/api/paths/preview', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(exportData()) })
+    .then(async res => ({ ok: res.ok, body: await res.json().catch(() => ({})) }));
+  box.innerHTML = '';
+  if (!r.body.ok) { box.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not compute paths.') + '</div>'; return; }
+  const note = document.createElement('div'); note.className = 'desc';
+  note.innerHTML = 'Paths with unsaved overrides applied. Note: overrides change the <b>HA name/object_id</b> and <b>Prometheus device/source labels</b>; the <b>MQTT topic</b> and <b>EmonCMS key</b> derive from the PDU’s raw keys and are not affected.';
+  box.appendChild(note);
+  box.appendChild(pathsTable(r.body.rows || [], !!r.body.prometheusEnabled, !!r.body.emonEnabled));
 }
 
 // Strip empty override objects so untouched entries don't pollute the saved config.

--- a/rPDU2MQTT/wwwroot/index.html
+++ b/rPDU2MQTT/wwwroot/index.html
@@ -237,8 +237,65 @@ function build() {
   });
   addControlSection(nav, sections);
   addLiveDataSection(nav, sections);
+  addPathsSection(nav, sections);
   addExportSection(nav, sections);
   addDiagnosticsSection(nav, sections);
+}
+
+// Generated integration paths per measurement (MQTT topic, Prometheus metric, EmonCMS key).
+function addPathsSection(nav, sections) {
+  const link = document.createElement('a'); link.textContent = 'Paths'; nav.appendChild(link);
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  const h = document.createElement('h2'); h.textContent = 'Integration Paths'; sec.appendChild(h);
+  const d = document.createElement('div'); d.className = 'desc';
+  d.textContent = 'The MQTT topic, Prometheus metric, and EmonCMS key generated for each measurement (reflecting your overrides). Click a value to copy it.';
+  sec.appendChild(d);
+
+  const bar = document.createElement('div'); bar.className = 'ld-toolbar';
+  const refresh = document.createElement('button'); refresh.className = 'small'; refresh.textContent = 'Refresh';
+  const filter = document.createElement('input'); filter.type = 'text'; filter.placeholder = 'Filter (device / outlet / measurement / path)…';
+  const count = document.createElement('span'); count.className = 'ld-count';
+  bar.appendChild(refresh); bar.appendChild(filter); bar.appendChild(count); sec.appendChild(bar);
+  const tableWrap = document.createElement('div'); sec.appendChild(tableWrap);
+
+  let rows = [], promOn = false, emonOn = false;
+  const copyCell = (text) => {
+    const td = document.createElement('td');
+    if (!text) { td.textContent = '—'; td.style.color = 'var(--muted)'; return td; }
+    const code = document.createElement('span'); code.textContent = text; code.style.cursor = 'pointer';
+    code.style.fontFamily = 'ui-monospace,Consolas,monospace'; code.style.fontSize = '12px';
+    code.title = 'Click to copy';
+    code.onclick = () => { navigator.clipboard?.writeText(text); toast('Copied: ' + text, true); };
+    td.appendChild(code); return td;
+  };
+  const draw = () => {
+    const f = filter.value.trim().toLowerCase();
+    const shown = f ? rows.filter(r => (r.device + ' ' + r.source + ' ' + r.type + ' ' + r.mqtt + ' ' + (r.prometheus || '') + ' ' + (r.emoncms || '')).toLowerCase().includes(f)) : rows;
+    const t = document.createElement('table'); t.className = 'ld';
+    const cols = ['Device', 'Outlet / entity', 'Measurement', 'MQTT topic'];
+    if (promOn) cols.push('Prometheus'); if (emonOn) cols.push('EmonCMS');
+    const head = document.createElement('tr'); cols.forEach(x => { const th = document.createElement('th'); th.textContent = x; head.appendChild(th); });
+    const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
+    const tb = document.createElement('tbody');
+    shown.forEach(r => {
+      const tr = document.createElement('tr');
+      [r.device, r.source, r.type].forEach(c => { const td = document.createElement('td'); td.textContent = c; tr.appendChild(td); });
+      tr.appendChild(copyCell(r.mqtt));
+      if (promOn) tr.appendChild(copyCell(r.prometheus));
+      if (emonOn) tr.appendChild(copyCell(r.emoncms));
+      tb.appendChild(tr);
+    });
+    t.appendChild(tb); tableWrap.innerHTML = ''; tableWrap.appendChild(t);
+  };
+  const load = async () => {
+    const r = await api('/api/paths');
+    if (!r.body.ok) { tableWrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load paths.') + '</div>'; count.textContent = ''; return; }
+    rows = r.body.rows || []; promOn = !!r.body.prometheusEnabled; emonOn = !!r.body.emonEnabled;
+    count.textContent = rows.length + ' measurements';
+    draw();
+  };
+  refresh.onclick = load; filter.oninput = draw;
+  link.onclick = () => { activate(link, sec); load(); };
 }
 
 // Status / diagnostics: versions, uptime, restart, and (in Kubernetes) logs + events.


### PR DESCRIPTION
## Closes #100 — view (and copy) integration paths from the GUI, + preview override effects

### Paths tab
New **Paths** tab listing, per measurement, the generated:
- **MQTT topic** · **Prometheus metric** (name + `{device,source}` labels) · **EmonCMS key**

All reflect the current overrides, with **click-to-copy** and a filter. Prometheus/EmonCMS columns appear only when those exporters are enabled.

### Override path preview (the "see how edits change paths" ask)
The **Overrides** editor gains **"Preview generated paths (with unsaved edits)"** — it computes the resulting paths from the current, unsaved overrides by running the **real processing pipeline** against a transient PDU (`POST /api/paths/preview`), so it matches what would actually be published (no fragile client-side re-implementation).

It also surfaces an important truth discovered while building this: **overrides change the HA name/object_id and the Prometheus `device`/`source` labels, but the MQTT topic, HA unique_id, and EmonCMS key derive from the PDU's raw keys and are *not* affected.** (Making the Prometheus metric *name* / EmonCMS key customizable is #101.)

### Internals
- `MetricsHelper` carries the MQTT topic per reading and exposes `PrometheusMetricName` (shared with the exporter).
- `GET /api/paths` + `POST /api/paths/preview`; shared `BuildPaths` projection.

### Verification
- ✅ Build + 38 tests pass. Fully testable locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)