### PR TITLE
fix(helm): don't overwrite GUI-edited config on upgrade (#110)

### DIFF
--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -52,6 +52,7 @@ credentials:
 | `service.metrics.enabled` | `true` | Create a Service for `/metrics` (when `config.Prometheus.Enabled`). |
 | `serviceMonitor.enabled` | `false` | Create a Prometheus Operator `ServiceMonitor` for `/metrics`. |
 | `kubernetesConfigSource.enabled` | `false` | Store config in an `RpduConfig` CR (writable by the GUI) instead of a ConfigMap; creates the CR + RBAC and wires the app to read it. Requires the CRD (in this chart's `crds/`). |
+| `kubernetesConfigSource.preserveExisting` | `true` | Create-once: keep the live CR `spec` on upgrade so GUI edits aren't reverted (`values.config` only seeds it on install). Set `false` for declarative config. Under Argo CD, use an `ignoreDifferences` on the CR `spec` instead — see [KubernetesCRD.md](../../docs/KubernetesCRD.md#keeping-gui-edits-across-chart-upgrades--argo-syncs). |
 | `ingress.enabled` | `false` | Expose the GUI via an Ingress. |
 | `httpRoute.enabled` | `false` | Expose the GUI via a Gateway API `HTTPRoute` (set `httpRoute.parentRefs`/`hostnames`). Requires the Gateway API CRDs. |
 | `healthProbes.enabled` | `true` | Liveness/readiness probes against the app's health endpoints. |

--- a/charts/rpdu2mqtt/templates/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/templates/rpduconfig.yaml
@@ -1,10 +1,26 @@
 {{- if .Values.kubernetesConfigSource.enabled }}
-apiVersion: {{ printf "rpdu2mqtt.xtremeownage.com/v1alpha1" }}
+{{- $name := include "rpdu2mqtt.crName" . }}
+{{- /*
+  Create-once: when preserveExisting (default), keep the live CR's spec on upgrade so config edited
+  through the GUI isn't reverted; values.config only seeds the CR on first install. Relies on Helm's
+  `lookup`, which works for `helm upgrade` against a live cluster but returns nothing under
+  `helm template` / Argo CD — for Argo, add an ignoreDifferences for the RpduConfig spec (see the
+  chart README). Set preserveExisting: false to always apply values.config (declarative).
+*/}}
+{{- $existing := dict }}
+{{- if .Values.kubernetesConfigSource.preserveExisting }}
+{{- $existing = (lookup "rpdu2mqtt.xtremeownage.com/v1alpha1" "RpduConfig" .Release.Namespace $name) | default dict }}
+{{- end }}
+apiVersion: rpdu2mqtt.xtremeownage.com/v1alpha1
 kind: RpduConfig
 metadata:
-  name: {{ include "rpdu2mqtt.crName" . }}
+  name: {{ $name }}
   labels:
     {{- include "rpdu2mqtt.labels" . | nindent 4 }}
 spec:
+  {{- if $existing.spec }}
+  {{- toYaml $existing.spec | nindent 2 }}
+  {{- else }}
   {{- toYaml .Values.config | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -79,6 +79,11 @@ kubernetesConfigSource:
   enabled: false
   # Name of the RpduConfig resource (defaults to the release fullname).
   crName: ""
+  # Create-once: keep the live CR's spec on upgrade (so GUI edits aren't reverted); values.config
+  # only seeds it on first install. Set false to always apply values.config (declarative).
+  # NOTE: relies on Helm `lookup` — under Argo CD (helm template) it can't read the live CR, so use
+  # an Argo ignoreDifferences on the RpduConfig spec instead (see the chart README).
+  preserveExisting: true
 
 # Kubernetes Services for the GUI and /metrics endpoints. Created only when the
 # corresponding feature is enabled in `config` AND the toggle here is true.

--- a/docs/KubernetesCRD.md
+++ b/docs/KubernetesCRD.md
@@ -130,6 +130,31 @@ The CR can be the GitOps source of truth, so:
   ./charts/rpdu2mqtt` remains the canonical export — the GUI export focuses on the config/CR, which is
   the only thing it actually edits.
 
+### Keeping GUI edits across chart upgrades / Argo syncs
+
+Because the GUI writes the CR `spec` and a redeploy also renders the CR `spec` from `values.config`, a
+`helm upgrade` or Argo sync can otherwise **revert GUI changes**. To avoid that:
+
+- **Helm chart (`helm upgrade`):** the chart is **create-once** by default
+  (`kubernetesConfigSource.preserveExisting: true`) — it reads the live CR with Helm `lookup` and
+  re-emits its current `spec`, so `values.config` only seeds the CR on first install. Set
+  `preserveExisting: false` to manage the config declaratively (every upgrade applies `values.config`).
+- **Argo CD:** `lookup` returns nothing under `helm template`, so the rendered CR always carries
+  `values.config` and Argo would sync it. Tell Argo to ignore the CR `spec` so GUI edits stick:
+
+  ```yaml
+  # Argo CD Application
+  spec:
+    ignoreDifferences:
+      - group: rpdu2mqtt.xtremeownage.com
+        kind: RpduConfig
+        jsonPointers:
+          - /spec
+  ```
+
+  (Or keep config declarative in git and treat the GUI as view/test only — your choice of source of
+  truth. The GUI's Save already warns to update the GitOps source.)
+
 ### Reacting to changes & status (Phase 2)
 
 - **Watch** the CR; on change, the simplest correct behaviour is


### PR DESCRIPTION
## Closes #110 — Helm/Argo overwrites GUI-configured options

With the Kubernetes config source, the chart rendered the `RpduConfig` `spec` from `values.config` on **every** `helm upgrade` / Argo sync — clobbering anything the user changed through the GUI (which PATCHes the CR).

### Fix — create-once CR
`kubernetesConfigSource.preserveExisting` (default **true**): the chart now uses Helm `lookup` to read the live CR and re-emit its **current** `spec` on upgrade, so `values.config` only **seeds** the CR on first install. GUI edits survive `helm upgrade`.

Set `preserveExisting: false` to manage config declaratively (every upgrade applies `values.config`).

### Argo CD
`lookup` returns nothing under `helm template` (how Argo renders), so the create-once trick can't read the live CR there. Documented the Argo-native fix — an `ignoreDifferences` on the `RpduConfig` `/spec`:
```yaml
spec:
  ignoreDifferences:
    - group: rpdu2mqtt.xtremeownage.com
      kind: RpduConfig
      jsonPointers: [ /spec ]
```

### Notes
- Chart + docs only (no app code). Docs: `KubernetesCRD.md` (new "Keeping GUI edits…" section) + chart README values row.
- ⚠️ Helm isn't available in my env to `helm template`; please dry-run an upgrade to confirm the CR spec is preserved (and a fresh install still seeds from `values.config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)