### PR TITLE
feat(gui): pivoted/grouped Live Data view (#95)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -444,8 +444,10 @@ The GUI:
   discovered, each with Name/ID/Enabled fields, so you can see exactly what an override targets
   instead of typing keys blind. Existing overrides for entities that are not currently discovered
   (e.g. disabled ones) are still shown so they can be re-enabled.
-- **Live Data** — a read-only view of the current measurements being pulled from the PDU(s)
-  (device / outlet / measurement / value / units), with a filter and optional 5-second auto-refresh.
+- **Live Data** — a read-only view of the current measurements being pulled from the PDU(s). The
+  **Grouped** view pivots to one row per outlet/entity (grouped by device) with a column per
+  measurement type and the outlet on/off state; a **Flat** view lists one row per reading. Both have a
+  filter and optional 5-second auto-refresh.
 - **Paths** — shows the generated **MQTT topic**, **Prometheus metric**, and **EmonCMS key** for each
   measurement (reflecting your overrides), with click-to-copy. Prometheus/EmonCMS columns appear only
   when those exporters are enabled.

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -498,11 +498,30 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             try
             {
                 var data = await pdu.GetRootData_Public(cts.Token);
-                var readings = MetricsHelper.EnumerateReadings(data)
+                var readingList = MetricsHelper.EnumerateReadings(data)
                     .OrderBy(r => r.Device).ThenBy(r => r.Source).ThenBy(r => r.Type)
+                    .ToList();
+
+                var readings = readingList
                     .Select(r => new { device = r.Device, source = r.Source, type = r.Type, value = r.Value, units = r.Units })
                     .ToList();
-                return Results.Json(new { ok = true, count = readings.Count, readings }, ConfigSchema.Json);
+
+                // Pivoted view: one row per outlet/entity with its measurements as columns + state.
+                var types = readingList.Select(r => r.Type).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(t => t).ToList();
+                var units = readingList.GroupBy(r => r.Type, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(g => g.Key, g => g.Select(r => r.Units).FirstOrDefault(u => !string.IsNullOrEmpty(u)) ?? "", StringComparer.OrdinalIgnoreCase);
+
+                var entities = new List<object>();
+                foreach (var device in data.Devices)
+                {
+                    foreach (var o in device.Outlets.OrderBy(o => o.Key))
+                        entities.Add(BuildLiveEntity(device.Entity_DisplayName, o.Entity_DisplayName, "outlet", o.Key + 1,
+                            pdu.ResolveOutletState(device.Key, o.Key, o.State), o.Measurements));
+                    foreach (var e in device.Entity)
+                        entities.Add(BuildLiveEntity(device.Entity_DisplayName, e.Entity_DisplayName, "entity", null, null, e.Measurements));
+                }
+
+                return Results.Json(new { ok = true, count = readings.Count, readings, entities, types, units }, ConfigSchema.Json);
             }
             catch (Exception ex)
             {
@@ -649,6 +668,16 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
 
     /// <summary>Body of a POST /api/control/outlet request.</summary>
     private sealed record ControlRequest(string DeviceId, int Index, string Action);
+
+    /// <summary>One pivoted live-view row: an outlet/entity with its numeric measurements + state.</summary>
+    private static object BuildLiveEntity(string device, string source, string kind, int? number, string? state, IEnumerable<Models.PDU.Measurement> measurements)
+    {
+        var values = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        foreach (var m in measurements)
+            if (!string.IsNullOrEmpty(m.Type) && double.TryParse(m.Value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v))
+                values[m.Type] = v;
+        return new { device, source, kind, number, state, values };
+    }
 
     /// <summary>Project a poll's measurements into the generated MQTT/Prometheus/EmonCMS paths.</summary>
     private static object BuildPaths(Models.PDU.PduData data, Config config)

--- a/rPDU2MQTT/wwwroot/index.html
+++ b/rPDU2MQTT/wwwroot/index.html
@@ -504,39 +504,76 @@ function addLiveDataSection(nav, sections) {
 
   const bar = document.createElement('div'); bar.className = 'ld-toolbar';
   const refresh = document.createElement('button'); refresh.className = 'small'; refresh.textContent = 'Refresh';
+  const viewSel = document.createElement('select');
+  [['grouped', 'Grouped (by outlet)'], ['flat', 'Flat (one row per reading)']].forEach(([v, t]) => { const o = document.createElement('option'); o.value = v; o.textContent = t; viewSel.appendChild(o); });
   const filter = document.createElement('input'); filter.type = 'text'; filter.placeholder = 'Filter (device / outlet / measurement)…';
   const autoLab = document.createElement('label'); const auto = document.createElement('input'); auto.type = 'checkbox';
   autoLab.appendChild(auto); autoLab.appendChild(document.createTextNode('Auto-refresh (5s)'));
   const count = document.createElement('span'); count.className = 'ld-count';
-  bar.appendChild(refresh); bar.appendChild(filter); bar.appendChild(autoLab); bar.appendChild(count);
+  bar.appendChild(refresh); bar.appendChild(viewSel); bar.appendChild(filter); bar.appendChild(autoLab); bar.appendChild(count);
   sec.appendChild(bar);
   const tableWrap = document.createElement('div'); sec.appendChild(tableWrap);
 
-  let rows = [], timer = null;
-  const draw = () => {
+  let body = { entities: [], types: [], units: {}, readings: [] }, timer = null;
+
+  // Pivoted: one row per outlet/entity, a column per measurement type, grouped by device.
+  const drawGrouped = () => {
     const f = filter.value.trim().toLowerCase();
-    const shown = f ? rows.filter(r => (r.device + ' ' + r.source + ' ' + r.type).toLowerCase().includes(f)) : rows;
+    const types = body.types || [];
+    const ents = (body.entities || []).filter(e => !f || (e.device + ' ' + e.source + ' ' + types.join(' ')).toLowerCase().includes(f));
+    const t = document.createElement('table'); t.className = 'ld';
+    const head = document.createElement('tr');
+    const cols = ['Outlet / entity', 'State', ...types.map(ty => ty + (body.units[ty] ? ' (' + body.units[ty] + ')' : ''))];
+    cols.forEach((x, i) => { const th = document.createElement('th'); th.textContent = x; if (i >= 2) th.className = 'num'; head.appendChild(th); });
+    const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
+    const tb = document.createElement('tbody');
+    let lastDevice = null;
+    ents.forEach(e => {
+      if (e.device !== lastDevice) {
+        lastDevice = e.device;
+        const dr = document.createElement('tr'); const dtd = document.createElement('td'); dtd.colSpan = cols.length;
+        dtd.textContent = e.device; dtd.style.cssText = 'font-weight:600;background:var(--panel);color:var(--accent)';
+        dr.appendChild(dtd); tb.appendChild(dr);
+      }
+      const tr = document.createElement('tr');
+      const name = document.createElement('td'); name.textContent = (e.number ? '#' + e.number + ' ' : '') + (e.source || ''); tr.appendChild(name);
+      const st = document.createElement('td');
+      if (e.kind === 'outlet' && e.state) { const dot = document.createElement('span'); dot.className = 'dot ' + (e.state === 'on' ? 'good' : 'bad'); st.appendChild(dot); st.appendChild(document.createTextNode(e.state)); }
+      else { st.textContent = '—'; st.style.color = 'var(--muted)'; }
+      tr.appendChild(st);
+      types.forEach(ty => { const td = document.createElement('td'); td.className = 'num'; const v = (e.values || {})[ty]; td.textContent = (v == null) ? '' : formatNum(v); tr.appendChild(td); });
+      tb.appendChild(tr);
+    });
+    t.appendChild(tb); tableWrap.innerHTML = ''; tableWrap.appendChild(t);
+  };
+
+  const drawFlat = () => {
+    const f = filter.value.trim().toLowerCase();
+    const rows = (body.readings || []).filter(r => !f || (r.device + ' ' + r.source + ' ' + r.type).toLowerCase().includes(f));
     const t = document.createElement('table'); t.className = 'ld';
     const head = document.createElement('tr');
     ['Device', 'Outlet / entity', 'Measurement', 'Value', 'Units'].forEach(x => { const th = document.createElement('th'); th.textContent = x; head.appendChild(th); });
     const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
     const tb = document.createElement('tbody');
-    shown.forEach(r => {
+    rows.forEach(r => {
       const tr = document.createElement('tr');
-      const cells = [r.device, r.source, r.type, formatNum(r.value), r.units || ''];
-      cells.forEach((c, i) => { const td = document.createElement('td'); if (i === 3) td.className = 'num'; td.textContent = c; tr.appendChild(td); });
+      [r.device, r.source, r.type, formatNum(r.value), r.units || ''].forEach((c, i) => { const td = document.createElement('td'); if (i === 3) td.className = 'num'; td.textContent = c; tr.appendChild(td); });
       tb.appendChild(tr);
     });
-    t.appendChild(tb);
-    tableWrap.innerHTML = ''; tableWrap.appendChild(t);
+    t.appendChild(tb); tableWrap.innerHTML = ''; tableWrap.appendChild(t);
   };
+
+  const draw = () => viewSel.value === 'flat' ? drawFlat() : drawGrouped();
   const load = async () => {
     const r = await api('/api/livedata');
     if (!r.body.ok) { tableWrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load live data.') + '</div>'; count.textContent = ''; return; }
-    rows = r.body.readings || []; count.textContent = rows.length + ' readings'; draw();
+    body = r.body;
+    count.textContent = (body.entities || []).length + ' outlets/entities · ' + (body.readings || []).length + ' readings';
+    draw();
   };
   refresh.onclick = load;
   filter.oninput = draw;
+  viewSel.onchange = draw;
   auto.onchange = () => {
     clearInterval(timer);
     if (auto.checked) timer = setInterval(() => {


### PR DESCRIPTION
## Closes #95 — Live View enhancements (parity with the PDU UI)

The Live Data view was a long flat list (one row per reading). It now defaults to a **Grouped** layout matching the PDU's native table:

- **One row per outlet/entity**, grouped under a device header.
- **A column per measurement type** (header shows units), values aligned right.
- **Outlet on/off state** column (green/red dot).
- Filter + 5s auto-refresh as before.
- A **Flat** view (the old one-row-per-reading list) is still available via the view dropdown.

### Internals
- `/api/livedata` now also returns `entities` (per outlet/entity, with `state` + a `values` map), plus the ordered `types` and `units` for the pivot. `readings` is kept for the flat view.

### Verification
- ✅ Build + 44 tests pass. Please eyeball it against your PDU's screen — if you want specific columns ordered/renamed or extra fields, say so and I'll tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)