### PR TITLE
feat(gui): rename/clear outlet labels on the PDU (#98)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -161,7 +161,8 @@ When enabled, each outlet gains the following **outlet operations** in Home Assi
 
 The GUI **Control** tab is the easiest place to exercise these against a single outlet. It also
 shows each outlet's current delays and power-on action so changes made from Home Assistant are
-visible there.
+visible there, and lets you **rename the outlet's label on the PDU** (handy since the PDU's own web
+UI is slow) — also gated by write actions.
 
 > Power-On Action options are `on` / `off` / `last` (restore the pre-outage state).
 

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -588,6 +588,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                     index = o.Key,        // raw key the control API expects
                     number = o.Key + 1,   // 1-based, matching the PDU UI
                     name = o.Entity_DisplayName,
+                    label = o.Label,      // the editable label on the PDU itself
                     state = pdu.ResolveOutletState(d.Key, o.Key, o.State),
                     onDelay = o.OnDelay,
                     offDelay = o.OffDelay,
@@ -634,6 +635,31 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             }
         });
 
+        // Write an outlet's label on the PDU itself (cmd "set"). Gated by PDU.ActionsEnabled.
+        app.MapPost("/api/control/label", async (HttpContext ctx) =>
+        {
+            if (!config.PDU.ActionsEnabled)
+                return Results.Json(new { ok = false, message = "Write actions are disabled (PDU.ActionsEnabled is false)." }, statusCode: 409);
+
+            LabelRequest? req;
+            try { req = await ctx.Request.ReadFromJsonAsync<LabelRequest>(ctx.RequestAborted); }
+            catch { req = null; }
+            if (req is null || string.IsNullOrWhiteSpace(req.DeviceId))
+                return Results.BadRequest(new { ok = false, message = "deviceId, index and label are required." });
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(20));
+            try
+            {
+                await pdu.SetOutletConfigAsync(req.DeviceId, req.Index, new Dictionary<string, object> { ["label"] = req.Label ?? string.Empty }, cts.Token);
+                return Results.Json(new { ok = true, message = $"Outlet {req.Index + 1} label set." }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Set label failed: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
         // Render the current form state as YAML (for copy/paste into a ConfigMap, source control, etc.).
         app.MapPost("/api/config/yaml", async (HttpContext ctx) =>
         {
@@ -670,6 +696,9 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
 
     /// <summary>Body of a POST /api/control/outlet request.</summary>
     private sealed record ControlRequest(string DeviceId, int Index, string Action);
+
+    /// <summary>Body of a POST /api/control/label request.</summary>
+    private sealed record LabelRequest(string DeviceId, int Index, string Label);
 
     /// <summary>One pivoted live-view row: an outlet/entity with its numeric measurements + state.</summary>
     private static object BuildLiveEntity(string device, string source, string kind, int? number, string? state, IEnumerable<Models.PDU.Measurement> measurements)

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -588,12 +588,14 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                     index = o.Key,        // raw key the control API expects
                     number = o.Key + 1,   // 1-based, matching the PDU UI
                     name = o.Entity_DisplayName,
-                    label = o.Label,      // the editable label on the PDU itself
+                    // Resolve through the pending-write latch so a value just set here shows
+                    // immediately instead of reverting until the PDU/poll catches up.
+                    label = pdu.ResolveOutletConfig(d.Key, o.Key, "label", o.Label ?? ""),
                     state = pdu.ResolveOutletState(d.Key, o.Key, o.State),
-                    onDelay = o.OnDelay,
-                    offDelay = o.OffDelay,
-                    rebootDelay = o.RebootDelay,
-                    poaAction = o.PoaAction,
+                    onDelay = pdu.ResolveOutletConfig(d.Key, o.Key, "onDelay", o.OnDelay.ToString()),
+                    offDelay = pdu.ResolveOutletConfig(d.Key, o.Key, "offDelay", o.OffDelay.ToString()),
+                    rebootDelay = pdu.ResolveOutletConfig(d.Key, o.Key, "rebootDelay", o.RebootDelay.ToString()),
+                    poaAction = pdu.ResolveOutletConfig(d.Key, o.Key, "poaAction", o.PoaAction ?? ""),
                 })).ToList();
                 return Results.Json(new { ok = true, actionsEnabled = config.PDU.ActionsEnabled, outlets }, ConfigSchema.Json);
             }
@@ -651,7 +653,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
-                await pdu.SetOutletConfigAsync(req.DeviceId, req.Index, new Dictionary<string, object> { ["label"] = req.Label ?? string.Empty }, cts.Token);
+                await pdu.SetOutletConfigAsync(req.DeviceId, req.Index, new Dictionary<string, object> { ["label"] = (req.Label ?? string.Empty).Trim() }, cts.Token);
                 return Results.Json(new { ok = true, message = $"Outlet {req.Index + 1} label set." }, ConfigSchema.Json);
             }
             catch (Exception ex)

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -384,7 +384,14 @@ function addControlSection(nav, sections) {
       const lin = document.createElement('input'); lin.type = 'text'; lin.value = o.label || ''; lin.style.width = '150px'; lin.disabled = !enabled;
       const setBtn = document.createElement('button'); setBtn.className = 'small'; setBtn.textContent = 'Set'; setBtn.disabled = !enabled; setBtn.style.marginLeft = '6px';
       setBtn.onclick = () => setLabel(o, lin.value);
-      tdLabel.appendChild(lin); tdLabel.appendChild(setBtn); tr.appendChild(tdLabel);
+      tdLabel.appendChild(lin); tdLabel.appendChild(setBtn);
+      // Reset only shows when a label is actually set; clears it back to the PDU default.
+      if ((o.label || '').trim()) {
+        const resetBtn = document.createElement('button'); resetBtn.className = 'small danger'; resetBtn.textContent = 'Reset'; resetBtn.disabled = !enabled; resetBtn.style.marginLeft = '4px';
+        resetBtn.onclick = () => { if (confirm('Clear the label for outlet ' + o.number + '?')) setLabel(o, ''); };
+        tdLabel.appendChild(resetBtn);
+      }
+      tr.appendChild(tdLabel);
       const tdState = document.createElement('td');
       const dot = document.createElement('span'); dot.className = 'dot ' + (o.state === 'on' ? 'good' : 'bad'); tdState.appendChild(dot);
       tdState.appendChild(document.createTextNode(o.state || '?')); tr.appendChild(tdState);

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -333,7 +333,7 @@ function addControlSection(nav, sections) {
   const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
   const h = document.createElement('h2'); h.textContent = 'Outlet Control'; sec.appendChild(h);
   const d = document.createElement('div'); d.className = 'desc';
-  d.textContent = 'Turn outlets on/off or reboot them directly. Requires write actions enabled (PDU.ActionsEnabled) and PDU credentials.';
+  d.textContent = 'Turn outlets on/off, reboot, reset stats, or rename them on the PDU. Requires write actions enabled (PDU.ActionsEnabled) and PDU credentials.';
   sec.appendChild(d);
 
   const bar = document.createElement('div'); bar.className = 'ld-toolbar';
@@ -355,12 +355,18 @@ function addControlSection(nav, sections) {
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
     setTimeout(load, 800); // let the PDU apply, then re-read state
   };
+  const setLabel = async (o, value) => {
+    toast('Outlet ' + o.number + ': set label…', true);
+    const r = await api('/api/control/label', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ deviceId: o.deviceId, index: o.index, label: value }) });
+    toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
+    setTimeout(load, 800);
+  };
   const draw = () => {
     const f = filter.value.trim().toLowerCase();
     const shown = f ? rows.filter(r => (r.device + ' ' + r.name + ' ' + r.number).toLowerCase().includes(f)) : rows;
     const t = document.createElement('table'); t.className = 'ld';
     const head = document.createElement('tr');
-    ['Device', 'Outlet', 'State', 'Actions'].forEach(x => { const th = document.createElement('th'); th.textContent = x; head.appendChild(th); });
+    ['Device', 'Outlet', 'Label (on PDU)', 'State', 'Actions'].forEach(x => { const th = document.createElement('th'); th.textContent = x; head.appendChild(th); });
     const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
     const tb = document.createElement('tbody');
     shown.forEach(o => {
@@ -372,6 +378,12 @@ function addControlSection(nav, sections) {
       const cfg = document.createElement('div'); cfg.className = 'ld-count';
       cfg.textContent = 'delays: on ' + o.onDelay + 's / off ' + o.offDelay + 's / reboot ' + o.rebootDelay + 's · power-on: ' + (o.poaAction || '?');
       tdName.appendChild(cfg); tr.appendChild(tdName);
+      // Editable PDU label.
+      const tdLabel = document.createElement('td');
+      const lin = document.createElement('input'); lin.type = 'text'; lin.value = o.label || ''; lin.style.width = '150px'; lin.disabled = !enabled;
+      const setBtn = document.createElement('button'); setBtn.className = 'small'; setBtn.textContent = 'Set'; setBtn.disabled = !enabled; setBtn.style.marginLeft = '6px';
+      setBtn.onclick = () => setLabel(o, lin.value);
+      tdLabel.appendChild(lin); tdLabel.appendChild(setBtn); tr.appendChild(tdLabel);
       const tdState = document.createElement('td');
       const dot = document.createElement('span'); dot.className = 'dot ' + (o.state === 'on' ? 'good' : 'bad'); tdState.appendChild(dot);
       tdState.appendChild(document.createTextNode(o.state || '?')); tr.appendChild(tdState);

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -356,6 +356,7 @@ function addControlSection(nav, sections) {
     setTimeout(load, 800); // let the PDU apply, then re-read state
   };
   const setLabel = async (o, value) => {
+    value = (value || '').trim();
     toast('Outlet ' + o.number + ': set label…', true);
     const r = await api('/api/control/label', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ deviceId: o.deviceId, index: o.index, label: value }) });
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);


### PR DESCRIPTION
## Part of #98 — manage outlet labels on the PDU from rPDU2MQTT

The PDU's own web UI is slow to rename outlets. The GUI **Control** tab now manages the outlet **label on the PDU** directly.

### Features
- **Rename** — editable **"Label (on PDU)"** field per outlet with a **Set** button (writes `cmd:"set"` `data:{label:...}`, the same proven write path as the delay/power-on config).
- **Reset** — a per-outlet **Reset** button that appears **only when a label is set**; clears it back to the PDU default (with a confirm).
- **No lag** — the label, delays and power-on action on the Control tab are resolved through the pending-write latch, so a value just set shows immediately instead of reverting until the next poll.
- **Trimmed** — labels are trimmed client- and server-side before writing.
- Gated by `PDU.ActionsEnabled`; inputs/buttons disabled when write actions are off.

### API
- `/api/control/outlets` returns the (latched) raw PDU `label`.
- New `POST /api/control/label` sets it.

### Verified
- ✅ Build + 44 tests pass. Rename / reset confirmed working on live hardware (label sticks, updates immediately, trims).

### Follow-ups (rest of #98)
- **Circuit** and **PDU/device** labels (different API resources — need a trace).
- Optional **HA `text` entity** to edit labels from Home Assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)