### PR TITLE
feat: OneView group actions, member switches & rollups (#94)

### DIFF
--- a/docs/Aggregation.md
+++ b/docs/Aggregation.md
@@ -32,15 +32,17 @@ master via `via_device`.
 ## OneView groups
 
 OneView lets you define **groups** (e.g. all the outlets feeding one server). Each group is published
-as a Home Assistant device carrying **rollup sensors** — the group's aggregated measurements (sum
-across its outlets). The cluster-wide **"Total"** group is included too (its rollup comes from the
-PDU's `pduTotal`), giving you whole-cluster Power/Energy/etc. sensors.
+as a Home Assistant device carrying **rollup sensors** — the group's aggregated measurements as
+**Sum / Avg / Min / Max** (whichever the PDU reports). The cluster-wide **"Total"** group is included
+too (its rollup comes from the PDU's `pduTotal`), giving you whole-cluster Power/Energy/etc. sensors.
+The sensor names are overridable via `Overrides.OneviewGroups.Measurements.<type>.Name` (the
+"(Sum)/(Avg)/(Min)/(Max)" suffix is appended automatically).
 
-> **Group switches aren't possible.** The PDU's OneView API exposes a group only as *aggregate
-> measurements* — it does not list the group's member outlets, and the outlets themselves carry no
-> group membership. With no way to map a group to its outlets, the bridge cannot offer per-member or
-> "whole group" switches. Toggle the individual outlets on their own devices instead (they work
-> cluster-wide; see *Outlet control* below).
+> **Group actions** (`Pdu.ActionsEnabled`): OneView has no group control endpoint, but it *does*
+> expose per-outlet group membership (`groupMap`). The bridge resolves a group's member outlets from
+> that mapping and **fans out** the per-outlet control, so each group gets **All On / All Off /
+> Reboot All** (in the GUI Control tab and Home Assistant). It aborts if it can't resolve a group's
+> members, so it never acts on the wrong outlets.
 
 Customize groups under `Overrides.OneviewGroups`:
 

--- a/rPDU2MQTT/Classes/PDU.cs
+++ b/rPDU2MQTT/Classes/PDU.cs
@@ -69,11 +69,13 @@ public partial class PDU
     {
         var oneview = await api.GetAsync<OneViewRootData>("/oneview", cancellationToken);
 
-        var members = oneview.Hosts
-            .Where(h => string.Equals(h.Group, groupKey, StringComparison.OrdinalIgnoreCase))
-            .SelectMany(h => h.Cache?.Devices ?? new List<Device>())
-            .SelectMany(dev => (dev.Outlets ?? new List<Outlet>()).Select(o => (deviceId: dev.Key, index: o.Key)))
-            .ToList();
+        // Membership is per-outlet: host.groupMap.dev.<serial>.outlet.<index>.group == groupKey.
+        var members = new List<(string deviceId, int index)>();
+        foreach (var host in oneview.Hosts)
+            foreach (var (deviceId, dev) in host.GroupMap?.Dev ?? new())
+                foreach (var (indexStr, outlet) in dev.Outlet ?? new())
+                    if (string.Equals(outlet.Group, groupKey, StringComparison.OrdinalIgnoreCase) && int.TryParse(indexStr, out var index))
+                        members.Add((deviceId, index));
 
         if (members.Count == 0)
             throw new Exception($"No member outlets resolved for group '{groupKey}' from the OneView host→group mapping. Group control aborted.");

--- a/rPDU2MQTT/Classes/PDU.cs
+++ b/rPDU2MQTT/Classes/PDU.cs
@@ -68,14 +68,7 @@ public partial class PDU
     public async Task<int> ControlGroupAsync(string groupKey, string action, CancellationToken cancellationToken)
     {
         var oneview = await api.GetAsync<OneViewRootData>("/oneview", cancellationToken);
-
-        // Membership is per-outlet: host.groupMap.dev.<serial>.outlet.<index>.group == groupKey.
-        var members = new List<(string deviceId, int index)>();
-        foreach (var host in oneview.Hosts)
-            foreach (var (deviceId, dev) in host.GroupMap?.Dev ?? new())
-                foreach (var (indexStr, outlet) in dev.Outlet ?? new())
-                    if (string.Equals(outlet.Group, groupKey, StringComparison.OrdinalIgnoreCase) && int.TryParse(indexStr, out var index))
-                        members.Add((deviceId, index));
+        var members = ResolveGroupMembers(oneview, groupKey);
 
         if (members.Count == 0)
             throw new Exception($"No member outlets resolved for group '{groupKey}' from the OneView host→group mapping. Group control aborted.");
@@ -85,6 +78,21 @@ public partial class PDU
             await ControlOutletAsync(deviceId, index, action, cancellationToken);
 
         return members.Count;
+    }
+
+    /// <summary>
+    /// Resolve a group's member outlets (deviceSerial + index) from the OneView per-outlet group
+    /// mapping (host.groupMap.dev.&lt;serial&gt;.outlet.&lt;index&gt;.group == groupKey).
+    /// </summary>
+    internal static List<(string DeviceId, int Index)> ResolveGroupMembers(OneViewRootData oneview, string groupKey)
+    {
+        var members = new List<(string, int)>();
+        foreach (var host in oneview.Hosts)
+            foreach (var (deviceId, dev) in host.GroupMap?.Dev ?? new())
+                foreach (var (indexStr, outlet) in dev.Outlet ?? new())
+                    if (string.Equals(outlet.Group, groupKey, StringComparison.OrdinalIgnoreCase) && int.TryParse(indexStr, out var index))
+                        members.Add((deviceId, index));
+        return members;
     }
 
     /// <summary>Write outlet configuration fields (delays, power-on action) — PDU.ActionsEnabled only.</summary>
@@ -238,6 +246,13 @@ public partial class PDU
 
         // Process groups.
         await processOneViewGroups(data, data.Groups, cancellationToken);
+
+        // Resolve each group's member outlets from the per-outlet groupMap (for actions + member switches).
+        foreach (var group in data.Groups)
+        {
+            group.MemberOutlets.Clear();
+            group.MemberOutlets.AddRange(ResolveGroupMembers(data, group.Key));
+        }
 
 
         //Process individual hosts, as if they were stand-alone hosts.

--- a/rPDU2MQTT/Classes/PDU.cs
+++ b/rPDU2MQTT/Classes/PDU.cs
@@ -59,6 +59,32 @@ public partial class PDU
                 pendingOutletStates[$"{deviceId}/{outletIndex}"] = (action, DateTime.UtcNow.Add(PendingStateTimeout));
     }
 
+    /// <summary>
+    /// Apply a control action ("on"/"off"/"reboot") to every outlet in a OneView group. OneView has
+    /// no group control endpoint, so members are resolved from the host→group mapping and the existing
+    /// per-outlet control is fanned out. Aborts if no members resolve (so a bad mapping can't hit the
+    /// wrong outlets). Returns the number of outlets actioned. PDU.ActionsEnabled only.
+    /// </summary>
+    public async Task<int> ControlGroupAsync(string groupKey, string action, CancellationToken cancellationToken)
+    {
+        var oneview = await api.GetAsync<OneViewRootData>("/oneview", cancellationToken);
+
+        var members = oneview.Hosts
+            .Where(h => string.Equals(h.Group, groupKey, StringComparison.OrdinalIgnoreCase))
+            .SelectMany(h => h.Cache?.Devices ?? new List<Device>())
+            .SelectMany(dev => (dev.Outlets ?? new List<Outlet>()).Select(o => (deviceId: dev.Key, index: o.Key)))
+            .ToList();
+
+        if (members.Count == 0)
+            throw new Exception($"No member outlets resolved for group '{groupKey}' from the OneView host→group mapping. Group control aborted.");
+
+        Log.Information($"Group '{groupKey}' {action}: applying to {members.Count} outlet(s).");
+        foreach (var (deviceId, index) in members)
+            await ControlOutletAsync(deviceId, index, action, cancellationToken);
+
+        return members.Count;
+    }
+
     /// <summary>Write outlet configuration fields (delays, power-on action) — PDU.ActionsEnabled only.</summary>
     public async Task SetOutletConfigAsync(string deviceId, int outletIndex, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
     {

--- a/rPDU2MQTT/Models/Config/HomeAssistantConfig.cs
+++ b/rPDU2MQTT/Models/Config/HomeAssistantConfig.cs
@@ -48,4 +48,14 @@ public class HomeAssistantConfig
     [Description("Name template for a group's mirrored member switches. Placeholders: {device}, {outlet}, {number}, {group}.")]
     [TemplateVariables("device", "outlet", "number", "group")]
     public string GroupMemberNameTemplate { get; set; } = "{device} — Outlet {number} ({outlet})";
+
+    /// <summary>
+    /// Stable entity/object_id template for a group's mirrored member switches. Defaults to the PDU
+    /// serial + outlet number so it doesn't change when names/labels do. Lower-cased + slugified.
+    /// Placeholders: {serial}, {number}, {device}, {group}.
+    /// </summary>
+    [DefaultValue("{serial}_outlet_{number}")]
+    [Description("Stable entity/object_id template for a group's mirrored member switches. Placeholders: {serial}, {number}, {device}, {group}.")]
+    [TemplateVariables("serial", "number", "device", "group")]
+    public string GroupMemberObjectIdTemplate { get; set; } = "{serial}_outlet_{number}";
 }

--- a/rPDU2MQTT/Models/Config/HomeAssistantConfig.cs
+++ b/rPDU2MQTT/Models/Config/HomeAssistantConfig.cs
@@ -39,4 +39,13 @@ public class HomeAssistantConfig
     /// </summary>
     [Description("expire_after (seconds) applied to sensors; after this long without an update Home Assistant marks them unavailable.")]
     public int SensorExpireAfterSeconds { get; set; } = (int)TimeSpan.FromMinutes(5).TotalSeconds;
+
+    /// <summary>
+    /// Name template for the member-outlet switches mirrored onto a OneView group's device.
+    /// Placeholders: {device}, {outlet}, {number}, {group}.
+    /// </summary>
+    [DefaultValue("{device} — Outlet {number} ({outlet})")]
+    [Description("Name template for a group's mirrored member switches. Placeholders: {device}, {outlet}, {number}, {group}.")]
+    [TemplateVariables("device", "outlet", "number", "group")]
+    public string GroupMemberNameTemplate { get; set; } = "{device} — Outlet {number} ({outlet})";
 }

--- a/rPDU2MQTT/Models/PDU/OneView/OneViewGroup.cs
+++ b/rPDU2MQTT/Models/PDU/OneView/OneViewGroup.cs
@@ -25,4 +25,11 @@ public class OneViewGroup : EntityWithNameAndLabel, IDictionaryKey<string>
 
     [JsonPropertyName("entity")]
     public OneViewGroupEntities Entity { get; set; }
+
+    /// <summary>
+    /// Member outlets (deviceSerial + outlet index), resolved from the host <c>groupMap</c>. Used to
+    /// fan out group actions and to mirror member switches onto the group's Home Assistant device.
+    /// </summary>
+    [JsonIgnore]
+    public List<(string DeviceId, int OutletIndex)> MemberOutlets { get; } = new();
 }

--- a/rPDU2MQTT/Models/PDU/OneView/OneViewGroupMap.cs
+++ b/rPDU2MQTT/Models/PDU/OneView/OneViewGroupMap.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace rPDU2MQTT.Models.PDU.OneView;
+
+/// <summary>
+/// Per-outlet group assignment exposed by OneView under each host's <c>groupMap</c>:
+/// <c>groupMap.dev.&lt;deviceSerial&gt;.outlet.&lt;index&gt;.group</c> = the group key that outlet
+/// belongs to (null when unassigned). This is how a OneView group's member outlets are resolved.
+/// </summary>
+public class OneViewGroupMap
+{
+    [JsonPropertyName("dev")]
+    public Dictionary<string, OneViewGroupMapDevice>? Dev { get; set; }
+}
+
+public class OneViewGroupMapDevice
+{
+    [JsonPropertyName("outlet")]
+    public Dictionary<string, OneViewGroupMapOutlet>? Outlet { get; set; }
+}
+
+public class OneViewGroupMapOutlet
+{
+    [JsonPropertyName("group")]
+    public string? Group { get; set; }
+}

--- a/rPDU2MQTT/Models/PDU/OneView/OneViewHost.cs
+++ b/rPDU2MQTT/Models/PDU/OneView/OneViewHost.cs
@@ -14,9 +14,9 @@ public class OneViewHost : IDictionaryKey<string>
     [JsonPropertyName("snmpInstance")]
     public long SnmpInstance { get; set; }
 
-    // ToDo - Fix Later...
-    //[JsonPropertyName("groupMap")]
-    //public The0019850C269EGroupMap GroupMap { get; set; }
+    // Per-outlet group assignment: groupMap.dev.<serial>.outlet.<index>.group.
+    [JsonPropertyName("groupMap")]
+    public OneViewGroupMap? GroupMap { get; set; }
 
     [JsonPropertyName("type")]
     public string Type { get; set; }

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -597,11 +597,41 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                     rebootDelay = pdu.ResolveOutletConfig(d.Key, o.Key, "rebootDelay", o.RebootDelay.ToString()),
                     poaAction = pdu.ResolveOutletConfig(d.Key, o.Key, "poaAction", o.PoaAction ?? ""),
                 })).ToList();
-                return Results.Json(new { ok = true, actionsEnabled = config.PDU.ActionsEnabled, outlets }, ConfigSchema.Json);
+                var groups = data.Groups.Select(g => new { key = g.Key, name = g.Entity_DisplayName }).ToList();
+                return Results.Json(new { ok = true, actionsEnabled = config.PDU.ActionsEnabled, outlets, groups }, ConfigSchema.Json);
             }
             catch (Exception ex)
             {
                 return Results.Json(new { ok = false, message = $"Could not read live PDU data: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
+        // Apply a control action to every outlet in a OneView group (fan-out). Gated by ActionsEnabled.
+        app.MapPost("/api/control/group", async (HttpContext ctx) =>
+        {
+            if (!config.PDU.ActionsEnabled)
+                return Results.Json(new { ok = false, message = "Write actions are disabled (PDU.ActionsEnabled is false)." }, statusCode: 409);
+
+            GroupControlRequest? req;
+            try { req = await ctx.Request.ReadFromJsonAsync<GroupControlRequest>(ctx.RequestAborted); }
+            catch { req = null; }
+            if (req is null || string.IsNullOrWhiteSpace(req.GroupKey))
+                return Results.BadRequest(new { ok = false, message = "groupKey and action are required." });
+
+            var action = (req.Action ?? string.Empty).Trim().ToLowerInvariant();
+            if (action is not ("on" or "off" or "reboot"))
+                return Results.BadRequest(new { ok = false, message = "action must be on, off or reboot." });
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(60));
+            try
+            {
+                var n = await pdu.ControlGroupAsync(req.GroupKey, action, cts.Token);
+                return Results.Json(new { ok = true, message = $"Group {req.GroupKey} → {action} ({n} outlet(s))." }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Group control failed: {ex.Message}" }, ConfigSchema.Json);
             }
         });
 
@@ -701,6 +731,9 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
 
     /// <summary>Body of a POST /api/control/label request.</summary>
     private sealed record LabelRequest(string DeviceId, int Index, string Label);
+
+    /// <summary>Body of a POST /api/control/group request.</summary>
+    private sealed record GroupControlRequest(string GroupKey, string Action);
 
     /// <summary>One pivoted live-view row: an outlet/entity with its numeric measurements + state.</summary>
     private static object BuildLiveEntity(string device, string source, string kind, int? number, string? state, IEnumerable<Models.PDU.Measurement> measurements)

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -208,8 +208,7 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
         }
         else if (entity is GroupMeasurement groupMeasurement)
         {
-            if (BuildGroupMeasurement(groupMeasurement, parent) is { } sensor)
-                components.Add(sensor);
+            components.AddRange(BuildGroupMeasurements(groupMeasurement, parent));
         }
         else if (entity is OneViewGroup group)
         {

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -248,8 +248,12 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
                         var sw = BuildSwitch(member.Outlet, newParent);
                         sw.ID = group.Entity_Identifier + "_" + member.Outlet.Entity_Identifier + "_switch";
                         sw.Name = group.Entity_Identifier + "_" + member.Outlet.Entity_Name + "_switch";
-                        // Identify which PDU + outlet, since outlet names can repeat across members.
-                        sw.DisplayName = $"{member.Device.Entity_DisplayName} — Outlet {member.Outlet.Key + 1} ({member.Outlet.Entity_DisplayName})";
+                        // Identify which PDU + outlet (names can repeat across members); customizable.
+                        sw.DisplayName = (string.IsNullOrWhiteSpace(cfg.HASS.GroupMemberNameTemplate) ? "{device} — Outlet {number} ({outlet})" : cfg.HASS.GroupMemberNameTemplate)
+                            .Replace("{device}", member.Device.Entity_DisplayName)
+                            .Replace("{outlet}", member.Outlet.Entity_DisplayName)
+                            .Replace("{number}", (member.Outlet.Key + 1).ToString())
+                            .Replace("{group}", group.Entity_DisplayName);
                         components.Add(sw);
                     }
             }

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -18,6 +18,9 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
 {
     private readonly SemaphoreSlim discoveryLock = new(1, 1);
 
+    // Built each discovery run: "deviceKey/outletIndex" -> outlet, for mirroring group member switches.
+    private Dictionary<string, Outlet> memberOutletLookup = new();
+
     public HomeAssistantDiscoveryService(MQTTServiceDependencies deps, DiscoveryCoordinator coordinator) : base(deps)
     {
         // Allow the "Rediscover" diagnostic button to trigger an on-demand republish.
@@ -56,6 +59,11 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
 
             // Collect every entity, then publish one device-based discovery message per device.
             var components = new List<baseEntity>();
+
+            // Lookup (deviceKey/index -> outlet) so group devices can mirror their member switches.
+            memberOutletLookup = data.Devices
+                .SelectMany(d => d.Outlets.Select(o => (key: $"{d.Key}/{o.Key}", outlet: o)))
+                .ToDictionary(x => x.key, x => x.outlet);
 
             // Discover PDUs, Outlets, etc...
             foreach (rPDU nestedPDU in data.PDUs)
@@ -224,12 +232,24 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
 
             // Group actions (fan out to member outlets). The "Total"/"Unassigned" pseudo-groups have
             // no member mapping, so only offer actions on real groups.
-            if (cfg.PDU.ActionsEnabled && group.Entity.Outlets.Count > 0)
+            if (cfg.PDU.ActionsEnabled && group.MemberOutlets.Count > 0)
             {
                 var control = MQTTHelper.JoinPaths(group.GetTopicPath(), "control");
                 components.Add(BuildButton(group.Entity_Identifier + "_allOn", "All On", control, newParent, payloadPress: "on"));
                 components.Add(BuildButton(group.Entity_Identifier + "_allOff", "All Off", control, newParent, payloadPress: "off"));
                 components.Add(BuildButton(group.Entity_Identifier + "_rebootAll", "Reboot All", control, newParent, deviceClass: "restart", payloadPress: "reboot"));
+
+                // Mirror each member outlet's switch onto the group device (distinct id; shares the
+                // outlet's real state/command topics so it controls the actual outlet).
+                foreach (var (deviceId, index) in group.MemberOutlets)
+                    if (memberOutletLookup.TryGetValue($"{deviceId}/{index}", out var member))
+                    {
+                        var sw = BuildSwitch(member, newParent);
+                        sw.ID = group.Entity_Identifier + "_" + member.Entity_Identifier + "_switch";
+                        sw.Name = group.Entity_Identifier + "_" + member.Entity_Name + "_switch";
+                        sw.DisplayName = member.Entity_DisplayName;
+                        components.Add(sw);
+                    }
             }
         }
     }

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -18,8 +18,9 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
 {
     private readonly SemaphoreSlim discoveryLock = new(1, 1);
 
-    // Built each discovery run: "deviceKey/outletIndex" -> outlet, for mirroring group member switches.
-    private Dictionary<string, Outlet> memberOutletLookup = new();
+    // Built each discovery run: "deviceKey/outletIndex" -> (outlet, owning device), for mirroring
+    // group member switches with an identifying name.
+    private Dictionary<string, (Outlet Outlet, Device Device)> memberOutletLookup = new();
 
     public HomeAssistantDiscoveryService(MQTTServiceDependencies deps, DiscoveryCoordinator coordinator) : base(deps)
     {
@@ -62,8 +63,8 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
 
             // Lookup (deviceKey/index -> outlet) so group devices can mirror their member switches.
             memberOutletLookup = data.Devices
-                .SelectMany(d => d.Outlets.Select(o => (key: $"{d.Key}/{o.Key}", outlet: o)))
-                .ToDictionary(x => x.key, x => x.outlet);
+                .SelectMany(d => d.Outlets.Select(o => (key: $"{d.Key}/{o.Key}", value: (Outlet: o, Device: d))))
+                .ToDictionary(x => x.key, x => x.value);
 
             // Discover PDUs, Outlets, etc...
             foreach (rPDU nestedPDU in data.PDUs)
@@ -244,10 +245,11 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
                 foreach (var (deviceId, index) in group.MemberOutlets)
                     if (memberOutletLookup.TryGetValue($"{deviceId}/{index}", out var member))
                     {
-                        var sw = BuildSwitch(member, newParent);
-                        sw.ID = group.Entity_Identifier + "_" + member.Entity_Identifier + "_switch";
-                        sw.Name = group.Entity_Identifier + "_" + member.Entity_Name + "_switch";
-                        sw.DisplayName = member.Entity_DisplayName;
+                        var sw = BuildSwitch(member.Outlet, newParent);
+                        sw.ID = group.Entity_Identifier + "_" + member.Outlet.Entity_Identifier + "_switch";
+                        sw.Name = group.Entity_Identifier + "_" + member.Outlet.Entity_Name + "_switch";
+                        // Identify which PDU + outlet, since outlet names can repeat across members.
+                        sw.DisplayName = $"{member.Device.Entity_DisplayName} — Outlet {member.Outlet.Key + 1} ({member.Outlet.Entity_DisplayName})";
                         components.Add(sw);
                     }
             }

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -246,13 +246,21 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
                     if (memberOutletLookup.TryGetValue($"{deviceId}/{index}", out var member))
                     {
                         var sw = BuildSwitch(member.Outlet, newParent);
+                        // unique_id stays raw-key based (stable across renames).
                         sw.ID = group.Entity_Identifier + "_" + member.Outlet.Entity_Identifier + "_switch";
-                        sw.Name = group.Entity_Identifier + "_" + member.Outlet.Entity_Name + "_switch";
-                        // Identify which PDU + outlet (names can repeat across members); customizable.
+                        var number = (member.Outlet.Key + 1).ToString();
+                        // entity/object_id — stable + templated (defaults to serial_outlet_number).
+                        sw.Name = (string.IsNullOrWhiteSpace(cfg.HASS.GroupMemberObjectIdTemplate) ? "{serial}_outlet_{number}" : cfg.HASS.GroupMemberObjectIdTemplate)
+                            .Replace("{serial}", member.Device.Key)
+                            .Replace("{number}", number)
+                            .Replace("{device}", member.Device.Entity_DisplayName)
+                            .Replace("{group}", group.Entity_DisplayName)
+                            .FormatName();
+                        // Friendly display name (names can repeat across members); customizable.
                         sw.DisplayName = (string.IsNullOrWhiteSpace(cfg.HASS.GroupMemberNameTemplate) ? "{device} — Outlet {number} ({outlet})" : cfg.HASS.GroupMemberNameTemplate)
                             .Replace("{device}", member.Device.Entity_DisplayName)
                             .Replace("{outlet}", member.Outlet.Entity_DisplayName)
-                            .Replace("{number}", (member.Outlet.Key + 1).ToString())
+                            .Replace("{number}", number)
                             .Replace("{group}", group.Entity_DisplayName);
                         components.Add(sw);
                     }

--- a/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT/Services/HomeAssistantDiscoveryService.cs
@@ -221,6 +221,16 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
 
             // Discover measurements (per-group aggregate, and the cluster-wide PduTotal rollup).
             collectDiscovery(group.Entity.Outlets.Concat(group.Entity.PduTotal).SelectMany(o => o.Measurements), newParent, components);
+
+            // Group actions (fan out to member outlets). The "Total"/"Unassigned" pseudo-groups have
+            // no member mapping, so only offer actions on real groups.
+            if (cfg.PDU.ActionsEnabled && group.Entity.Outlets.Count > 0)
+            {
+                var control = MQTTHelper.JoinPaths(group.GetTopicPath(), "control");
+                components.Add(BuildButton(group.Entity_Identifier + "_allOn", "All On", control, newParent, payloadPress: "on"));
+                components.Add(BuildButton(group.Entity_Identifier + "_allOff", "All Off", control, newParent, payloadPress: "off"));
+                components.Add(BuildButton(group.Entity_Identifier + "_rebootAll", "Reboot All", control, newParent, deviceClass: "restart", payloadPress: "reboot"));
+            }
         }
     }
 

--- a/rPDU2MQTT/Services/OutletCommandService.cs
+++ b/rPDU2MQTT/Services/OutletCommandService.cs
@@ -37,8 +37,12 @@ public class OutletCommandService : IHostedService
             MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", outlets, "+", MqttPath.Reboot.ToJsonString()),
             MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", outlets, "+", ResetStatsCommand),
             MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, "+", outlets, "+", "+", MqttPath.Set.ToJsonString()),
+            // <ParentTopic>/Groups/<key>/control  (payload = on/off/reboot, fans out to members)
+            MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, MqttPath.Groups.ToJsonString(), "+", GroupControlCommand),
         };
     }
+
+    private const string GroupControlCommand = "control";
 
     // Command segment for the reset-statistics button, and the config fields settable via <field>/set.
     private const string ResetStatsCommand = "resetStats";
@@ -74,8 +78,19 @@ public class OutletCommandService : IHostedService
         var topic = e.PublishMessage.Topic ?? string.Empty;
         try
         {
-            // Expected topic: <parent>/<deviceId>/outlets/<index>/set
             var parts = topic.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+            // Group control: <parent>/Groups/<key>/control, payload on/off/reboot -> fan out to members.
+            var groupsIdx = Array.IndexOf(parts, MqttPath.Groups.ToJsonString());
+            if (groupsIdx >= 0 && parts.Length == groupsIdx + 3 && parts[^1].Equals(GroupControlCommand, StringComparison.OrdinalIgnoreCase))
+            {
+                var groupAction = (e.PublishMessage.PayloadAsString ?? string.Empty).Trim().ToLowerInvariant();
+                if (groupAction is "on" or "off" or "reboot")
+                    await pdu.ControlGroupAsync(parts[groupsIdx + 1], groupAction, CancellationToken.None);
+                return;
+            }
+
+            // Expected topic: <parent>/<deviceId>/outlets/<index>/set
             var outletsIdx = Array.IndexOf(parts, MqttPath.Outlets.ToJsonString());
             if (outletsIdx <= 0 || outletsIdx + 1 >= parts.Length)
                 return;

--- a/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
@@ -92,7 +92,7 @@ public abstract class baseDiscoveryService : baseMQTTService
     /// <summary>
     /// Build a stateless button entity that publishes to <paramref name="commandTopic"/> when pressed.
     /// </summary>
-    public ButtonDiscovery BuildButton(string id, string displayName, string commandTopic, DiscoveryDevice Parent, string? deviceClass = null)
+    public ButtonDiscovery BuildButton(string id, string displayName, string commandTopic, DiscoveryDevice Parent, string? deviceClass = null, string payloadPress = "PRESS")
     {
         return new ButtonDiscovery
         {
@@ -106,6 +106,7 @@ public abstract class baseDiscoveryService : baseMQTTService
             DeviceClass = deviceClass,
 
             CommandTopic = commandTopic,
+            PayloadPress = payloadPress,
             AvailabilityTopic = Availability,
         };
     }
@@ -196,12 +197,12 @@ public abstract class baseDiscoveryService : baseMQTTService
     /// </summary>
     protected IEnumerable<baseEntity> BuildGroupMeasurements(GroupMeasurement measurement, DiscoveryDevice Parent)
     {
-        // Primary sum sensor keeps the original id/name for continuity with existing installs.
-        if (BuildMeasurement(measurement, Parent, "{{ value_json.sum }}") is { } sum)
-            yield return sum;
-
+        // The display base ("(Sum)/(Avg)/(Min)/(Max)" appended) comes from Entity_DisplayName, which is
+        // overridable via Overrides.OneviewGroups.Measurements.<type>.Name.
         foreach (var (suffix, label, template, present) in new[]
         {
+            // Sum is always emitted; its id stays unsuffixed for continuity with existing installs.
+            ("sum", "Sum", "{{ value_json.sum }}", true),
             ("avg", "Avg", "{{ value_json.avg }}", !string.IsNullOrEmpty(measurement.AvgValue)),
             ("min", "Min", "{{ value_json.min }}", !string.IsNullOrEmpty(measurement.MinValue)),
             ("max", "Max", "{{ value_json.max }}", !string.IsNullOrEmpty(measurement.MaxValue)),
@@ -209,8 +210,11 @@ public abstract class baseDiscoveryService : baseMQTTService
         {
             if (!present || BuildMeasurement(measurement, Parent, template) is not SensorDiscovery s)
                 continue;
-            s.ID = measurement.Entity_Identifier + "_" + suffix;
-            s.Name = measurement.Entity_Name + "_" + suffix;
+            if (suffix != "sum")
+            {
+                s.ID = measurement.Entity_Identifier + "_" + suffix;
+                s.Name = measurement.Entity_Name + "_" + suffix;
+            }
             s.DisplayName = measurement.Entity_DisplayName + " (" + label + ")";
             yield return s;
         }

--- a/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseDiscoveryService.cs
@@ -191,10 +191,30 @@ public abstract class baseDiscoveryService : baseMQTTService
     }
 
     /// <summary>
-    /// Build a discovery for a group measurement, bound to its aggregated <c>sum</c> value.
+    /// Build discoveries for a group measurement: the aggregated <c>sum</c> (primary, kept under the
+    /// existing id), plus avg/min/max sensors when the PDU reports them.
     /// </summary>
-    protected baseEntity? BuildGroupMeasurement(GroupMeasurement measurement, DiscoveryDevice Parent)
-        => BuildMeasurement(measurement, Parent, "{{ value_json.sum }}");
+    protected IEnumerable<baseEntity> BuildGroupMeasurements(GroupMeasurement measurement, DiscoveryDevice Parent)
+    {
+        // Primary sum sensor keeps the original id/name for continuity with existing installs.
+        if (BuildMeasurement(measurement, Parent, "{{ value_json.sum }}") is { } sum)
+            yield return sum;
+
+        foreach (var (suffix, label, template, present) in new[]
+        {
+            ("avg", "Avg", "{{ value_json.avg }}", !string.IsNullOrEmpty(measurement.AvgValue)),
+            ("min", "Min", "{{ value_json.min }}", !string.IsNullOrEmpty(measurement.MinValue)),
+            ("max", "Max", "{{ value_json.max }}", !string.IsNullOrEmpty(measurement.MaxValue)),
+        })
+        {
+            if (!present || BuildMeasurement(measurement, Parent, template) is not SensorDiscovery s)
+                continue;
+            s.ID = measurement.Entity_Identifier + "_" + suffix;
+            s.Name = measurement.Entity_Name + "_" + suffix;
+            s.DisplayName = measurement.Entity_DisplayName + " (" + label + ")";
+            yield return s;
+        }
+    }
 
     private SensorDiscovery? BuildMeasurement(baseMeasurement measurement, DiscoveryDevice Parent, string valueTemplate)
     {

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -343,9 +343,34 @@ function addControlSection(nav, sections) {
   const warn = document.createElement('div'); warn.className = 'desc'; warn.style.color = 'var(--bad)'; warn.style.display = 'none';
   warn.textContent = 'Write actions are disabled (PDU.ActionsEnabled is false). Enable it in the PDU section and restart to control outlets.';
   sec.appendChild(warn);
+  const groupsWrap = document.createElement('div'); sec.appendChild(groupsWrap);
   const tableWrap = document.createElement('div'); sec.appendChild(tableWrap);
 
-  let rows = [], enabled = false;
+  let rows = [], groups = [], enabled = false;
+  const actGroup = async (g, action) => {
+    const verb = action === 'on' ? 'turn ON' : action === 'off' ? 'turn OFF' : 'reboot';
+    if (!confirm('Group "' + (g.name || g.key) + '": ' + verb + ' ALL member outlets?')) return;
+    toast('Group ' + (g.name || g.key) + ': ' + action + '…', true);
+    const r = await api('/api/control/group', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ groupKey: g.key, action }) });
+    toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
+    setTimeout(load, 1000);
+  };
+  const drawGroups = () => {
+    groupsWrap.innerHTML = '';
+    if (!groups.length) return;
+    const hh = document.createElement('div'); hh.className = 'desc'; hh.style.marginTop = '4px'; hh.textContent = 'Groups — act on all member outlets:'; groupsWrap.appendChild(hh);
+    const t = document.createElement('table'); t.className = 'ld'; const tb = document.createElement('tbody');
+    groups.forEach(g => {
+      const tr = document.createElement('tr');
+      const nameTd = document.createElement('td'); nameTd.textContent = g.name || g.key; tr.appendChild(nameTd);
+      const actTd = document.createElement('td');
+      [['All On', 'on'], ['All Off', 'off'], ['Reboot All', 'reboot']].forEach(([lab, a]) => {
+        const b = document.createElement('button'); b.className = 'small' + (a !== 'on' ? ' danger' : ''); b.textContent = lab; b.disabled = !enabled; b.style.marginRight = '6px'; b.onclick = () => actGroup(g, a); actTd.appendChild(b);
+      });
+      tr.appendChild(actTd); tb.appendChild(tr);
+    });
+    t.appendChild(tb); groupsWrap.appendChild(t);
+  };
   const act = async (o, action) => {
     if (action === 'off' && !confirm('Turn OFF outlet ' + o.number + ' (' + o.name + ')?')) return;
     if (action === 'reboot' && !confirm('Reboot outlet ' + o.number + ' (' + o.name + ')? Connected equipment will lose power briefly.')) return;
@@ -407,7 +432,8 @@ function addControlSection(nav, sections) {
   const load = async () => {
     const r = await api('/api/control/outlets');
     if (!r.body.ok) { tableWrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load outlets.') + '</div>'; return; }
-    rows = r.body.outlets || []; enabled = !!r.body.actionsEnabled; warn.style.display = enabled ? 'none' : 'block'; draw();
+    rows = r.body.outlets || []; groups = r.body.groups || []; enabled = !!r.body.actionsEnabled;
+    warn.style.display = enabled ? 'none' : 'block'; drawGroups(); draw();
   };
   refresh.onclick = load; filter.oninput = draw;
   link.onclick = () => { activate(link, sec); load(); };


### PR DESCRIPTION
## Closes #94 — group switches & actions

OneView has **no group control endpoint**, but it exposes per-outlet group membership under each host's **`groupMap`** (`dev.<serial>.outlet.<index>.group`). The bridge resolves a group's member outlets from that and **fans out** the existing per-outlet control — verified against the live `/oneview` (membership resolves correctly, spanning both PDUs).

### Group actions
- **GUI Control tab** → *Groups*: **All On / All Off / Reboot All** per group (confirm prompts).
- **Home Assistant** → each group device gets **All On / All Off / Reboot All** buttons.
- Resolution **aborts if no members resolve**, so a bad mapping can never hit the wrong outlets.
- `PDU.ControlGroupAsync` fans out; `OutletCommandService` handles `<parent>/Groups/<key>/control`.

### Member switches on the group device
Each group's HA device **mirrors a switch for every member outlet** (distinct unique_id, sharing the member outlet's real state/command topics), so the group view shows the individual switches alongside the rollups and buttons.

### Customizable, stable naming
- **`HomeAssistant.GroupMemberObjectIdTemplate`** (default `{serial}_outlet_{number}`) — stable entity/object_id (PDU serial + outlet number), placeholders `{serial}/{number}/{device}/{group}`.
- **`HomeAssistant.GroupMemberNameTemplate`** (default `{device} — Outlet {number} ({outlet})`) — friendly name, placeholders `{device}/{outlet}/{number}/{group}`.
- Both surface as draggable chips in the GUI.

### Rollup sensors
Group measurements now expose **Sum / Avg / Min / Max** consistently (base name overridable via `Overrides.OneviewGroups.Measurements.<type>.Name`); sum's entity id stays stable.

### Docs / tests
- `Aggregation.md` updated (group actions are possible via fan-out; rollups; naming).
- Build + 44 tests pass. Verified on live hardware (actions, member switches, naming).

> Note: changing a name/id template needs a **restart** to apply (config loads at startup) — republish alone re-sends the current in-memory config. A republish-time config reload is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)