### PR TITLE
feat(gui): hot-reload config on Republish discovery

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -438,8 +438,10 @@ The GUI:
   connectivity) and the PDU section a "Test PDU connection" button (fetches live data and reports the
   device/outlet counts).
 - **Home Assistant actions** — the Home Assistant section has "Republish discovery" and
-  "Clear discovery" buttons. Clear removes the retained discovery messages so the entities disappear
-  from Home Assistant (until discovery runs again).
+  "Clear discovery" buttons. **Republish** first **reloads the saved config from the source** and
+  re-reads the PDU, so discovery-affecting edits (overrides, names, templates) take effect without a
+  full restart. Clear removes the retained discovery messages so the entities disappear from Home
+  Assistant (until discovery runs again).
 - **Live-driven Overrides** — the Overrides section is populated from the **live PDU data**: it lists
   the actual devices, outlets (by index), measurement types, and OneView groups currently being
   discovered, each with Name/ID/Enabled fields, so you can see exactly what an override targets
@@ -455,8 +457,9 @@ The GUI:
 - **Export YAML** — an "Export YAML" view renders the current form state (including unsaved edits) as
   the `config.yaml` that would be written, with a Copy button, for pasting into a ConfigMap, source
   control, etc.
-- **Saves** back to this config file (keeping a `config.yaml.bak` copy). Changes apply on the next
-  restart, so restart the service after saving.
+- **Saves** back to this config file (keeping a `config.yaml.bak` copy). Discovery-affecting edits
+  (overrides, names, templates) can be applied by pressing **Republish discovery** (it reloads the
+  config); connection-level changes (MQTT/PDU host/port, GUI/Health ports) still need a restart.
 
 Notes:
 - Basic auth is sent in clear text, so only expose the GUI on a trusted network or behind a

--- a/rPDU2MQTT/Classes/DiscoveryCoordinator.cs
+++ b/rPDU2MQTT/Classes/DiscoveryCoordinator.cs
@@ -1,3 +1,5 @@
+using rPDU2MQTT.Startup.ConfigSources;
+
 namespace rPDU2MQTT.Classes;
 
 /// <summary>
@@ -6,6 +8,17 @@ namespace rPDU2MQTT.Classes;
 /// </summary>
 public sealed class DiscoveryCoordinator
 {
+    private readonly Config config;
+    private readonly IConfigSource configSource;
+    private readonly PDU pdu;
+
+    public DiscoveryCoordinator(Config config, IConfigSource configSource, PDU pdu)
+    {
+        this.config = config;
+        this.configSource = configSource;
+        this.pdu = pdu;
+    }
+
     /// <summary>Invoked when a rediscovery is requested. The discovery service subscribes to this.</summary>
     public event Func<CancellationToken, Task>? RediscoverRequested;
 
@@ -13,7 +26,26 @@ public sealed class DiscoveryCoordinator
     public event Func<CancellationToken, Task>? ClearRequested;
 
     public Task RequestRediscoverAsync(CancellationToken cancellationToken)
-        => RediscoverRequested?.Invoke(cancellationToken) ?? Task.CompletedTask;
+    {
+        // Hot-reload config from the source so saved override/template/name edits take effect on
+        // republish without a full restart (connection-level settings still need a restart).
+        ReloadConfig();
+        return RediscoverRequested?.Invoke(cancellationToken) ?? Task.CompletedTask;
+    }
+
+    private void ReloadConfig()
+    {
+        try
+        {
+            config.CopyFrom(configSource.Load());
+            pdu.InvalidateCache();
+            Log.Information("Reloaded configuration from source for rediscovery.");
+        }
+        catch (Exception ex)
+        {
+            Log.Warning($"Could not reload configuration for rediscovery ({ex.Message}); using the current configuration.");
+        }
+    }
 
     public Task RequestClearAsync(CancellationToken cancellationToken)
         => ClearRequested?.Invoke(cancellationToken) ?? Task.CompletedTask;

--- a/rPDU2MQTT/Classes/PDU.cs
+++ b/rPDU2MQTT/Classes/PDU.cs
@@ -188,6 +188,9 @@ public partial class PDU
     private PduData? cachedData;
     private DateTime cachedDataAtUtc;
 
+    /// <summary>Expire the cached poll so the next fetch re-reads + re-processes (e.g. after a config reload).</summary>
+    public void InvalidateCache() => cachedDataAtUtc = DateTime.MinValue;
+
     private async Task<PduData> FetchRootData(CancellationToken cancellationToken)
     {
         if (useOneView is null)

--- a/rPDU2MQTT/Models/Config/Config.cs
+++ b/rPDU2MQTT/Models/Config/Config.cs
@@ -39,4 +39,23 @@ public class Config
 
     [YamlMember(Alias = "Health", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "HTTP health-check endpoints")]
     public HealthConfig Health { get; set; } = new HealthConfig();
+
+    /// <summary>
+    /// Replace this instance's settings with another's. Used to hot-reload the shared singleton on
+    /// rediscovery (services read these sections live). Connection-level settings (MQTT/PDU host/port,
+    /// GUI/Health ports, command-topic filters) are bound at startup and still require a restart.
+    /// </summary>
+    public void CopyFrom(Config other)
+    {
+        MQTT = other.MQTT;
+        PDU = other.PDU;
+        HASS = other.HASS;
+        Overrides = other.Overrides;
+        Debug = other.Debug;
+        Prometheus = other.Prometheus;
+        EmonCMS = other.EmonCMS;
+        Logging = other.Logging;
+        Gui = other.Gui;
+        Health = other.Health;
+    }
 }

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -284,8 +284,8 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 await configSource.SaveAsync(parsed, ctx.RequestAborted);
                 Log.Information($"Configuration saved via GUI to {configSource.Describe}.");
                 var message = configSource.IsGitOpsManaged
-                    ? "Saved to the Kubernetes resource. Remember to update your GitOps source so it doesn't drift. Restart to apply."
-                    : "Saved. Restart the service to apply changes.";
+                    ? "Saved to the Kubernetes resource (remember to update your GitOps source so it doesn't drift). Press 'Republish discovery' to apply override/name/template changes; restart for connection changes."
+                    : "Saved. Press 'Republish discovery' to apply override/name/template changes; restart the service for connection changes (host/port).";
                 return Results.Json(new { ok = true, message, gitops = configSource.IsGitOpsManaged });
             }
             catch (Exception ex)


### PR DESCRIPTION
## Apply config edits without a full restart

Previously every config change (overrides, names, templates) required restarting the service. Now **Republish discovery** reloads the saved config and re-applies it.

### How
`DiscoveryCoordinator.RequestRediscoverAsync` now:
1. Reloads config from the source (file/CR) into the shared singleton (`Config.CopyFrom`).
2. **Invalidates the PDU poll cache** (`PDU.InvalidateCache`) so the next poll re-processes with the new overrides.
3. Re-runs discovery.

Covers both trigger paths — the GUI **Republish discovery** button and the Home Assistant **Rediscover** button.

### Applies on Republish (no restart)
- **Overrides** — names, object IDs, enabled/disabled, make/model
- HA discovery shaping — discovery topic/retain, `expire_after`, group member name/object_id templates, Prometheus metric-name template, LWT/availability
- EmonCMS node/path, Debug flags

### Still needs a restart (bound at startup)
- Connection settings (MQTT/PDU host/port/credentials), `MQTT.ParentTopic`, `PDU.ActionsEnabled`, poll/discovery intervals, GUI/Health ports + auth mode

### Misc
- Save toast updated to point at Republish for these edits.
- Docs (Configuration.md) updated.
- Build + 44 tests pass. Verified: edit an override/template → Save → Republish → applied without restart.

> Minor caveats: a renamed Prometheus metric leaves the old gauge until restart; HA fixes an entity's `entity_id` at creation, so a changed object_id template only affects newly-created entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)