### PR TITLE
fix(k8s): persist GUI secrets (incl. OIDC client secret) to a companion Secret (#123)

### DIFF
--- a/Examples/Configuration/environment-variables.md
+++ b/Examples/Configuration/environment-variables.md
@@ -23,6 +23,11 @@ handful of **environment variables** layered on top for secrets and to select th
 > So for a secret field: **`RPDU2MQTT_…_FILE` > `RPDU2MQTT_…` > value in the config file / CR**.
 > Everything else comes from the config source only.
 
+> **Kubernetes CRD source:** secrets are never stored in the `RpduConfig` CR. When you set them in the
+> GUI, they're written to a companion **Kubernetes Secret** (`RPDU2MQTT_SECRET_NAME`) that the chart also
+> mounts as env vars — so the precedence above still holds, and an explicit `RPDU2MQTT_*` env var still
+> wins. Credential changes apply on restart. See [KubernetesCRD.md](../../docs/KubernetesCRD.md).
+
 ## Variables
 
 ### Secrets (override the config source; each also has a `*_FILE` variant)
@@ -52,6 +57,7 @@ services:
 | --- | --- | --- |
 | `RPDU2MQTT_CONFIG_SOURCE` | `file` (default) or `k8s` / `kubernetes` to read from an `RpduConfig` CR | `file` |
 | `RPDU2MQTT_CR_NAME` | Name of the `RpduConfig` resource (required when source is `k8s`) | — |
+| `RPDU2MQTT_SECRET_NAME` | Companion Secret the GUI reads/writes credentials from (k8s source) | CR name |
 | `RPDU2MQTT_NAMESPACE` | Namespace of the CR; falls back to the pod's service-account namespace | service-account namespace |
 
 ### Set by the Helm chart (informational)

--- a/Examples/Kubernetes/argo/README.md
+++ b/Examples/Kubernetes/argo/README.md
@@ -16,8 +16,8 @@ It points `source` at `charts/rpdu2mqtt` in this repo and supplies values inline
 
 If you use the **RpduConfig config source** (`kubernetesConfigSource.enabled: true`) so the GUI's **Save**
 works, Argo would otherwise revert those edits on every sync — Argo renders with `helm template`, which
-can't read the live CR. The example includes an `ignoreDifferences` for the `RpduConfig` `/spec` to
-prevent that:
+can't read the live CR (or the live Secret the GUI writes credentials into). The example includes an
+`ignoreDifferences` for the `RpduConfig` `/spec` **and** the companion Secret's `/data` to prevent that:
 
 ```yaml
 ignoreDifferences:
@@ -25,6 +25,11 @@ ignoreDifferences:
     kind: RpduConfig
     jsonPointers:
       - /spec
+  - group: ""
+    kind: Secret
+    name: rpdu2mqtt          # the release Secret (RPDU2MQTT_SECRET_NAME)
+    jsonPointers:
+      - /data
 ```
 
 See [KubernetesCRD.md](../../../docs/KubernetesCRD.md) for the full discussion.

--- a/Examples/Kubernetes/argo/rpdu2mqtt-application.yaml
+++ b/Examples/Kubernetes/argo/rpdu2mqtt-application.yaml
@@ -40,11 +40,17 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-  # With the RpduConfig config source, let GUI edits to the CR persist instead of being
-  # reverted on every sync (Argo renders with `helm template`, which can't read the live CR).
-  # See docs/KubernetesCRD.md and issue #110.
+  # With the RpduConfig config source, let GUI edits persist instead of being reverted on every
+  # sync (Argo renders with `helm template`, which can't read the live CR or Secret). The CR holds
+  # the config; the GUI writes credentials (incl. the OIDC client secret) into the Secret.
+  # See docs/KubernetesCRD.md and issues #110, #123.
   ignoreDifferences:
     - group: rpdu2mqtt.xtremeownage.com
       kind: RpduConfig
       jsonPointers:
         - /spec
+    - group: ""
+      kind: Secret
+      name: rpdu2mqtt-credentials   # the Secret the GUI writes to (existingSecret / RPDU2MQTT_SECRET_NAME)
+      jsonPointers:
+        - /data

--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -36,7 +36,9 @@ credentials:
   — it is the single source of truth for app behaviour. See
   [docs/Configuration.md](../../docs/Configuration.md) for every option.
 - `credentials.*` (or `existingSecret`) become `RPDU2MQTT_*` env vars via a **Secret**, so passwords
-  stay out of the ConfigMap.
+  stay out of the ConfigMap. With `kubernetesConfigSource.enabled`, the GUI also writes credentials
+  (incl. the OIDC client secret) **into this Secret** — kept out of the CR `spec` — and the chart grants
+  the pod `get,patch,update` on just that Secret. Create-once preserves GUI-written values on upgrade.
 - The pod rolls automatically when the rendered config changes (config checksum annotation).
 
 ## Key values

--- a/charts/rpdu2mqtt/templates/deployment.yaml
+++ b/charts/rpdu2mqtt/templates/deployment.yaml
@@ -40,10 +40,11 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if include "rpdu2mqtt.hasSecret" . }}
+          {{- if or (include "rpdu2mqtt.hasSecret" .) .Values.kubernetesConfigSource.enabled }}
           envFrom:
             - secretRef:
                 name: {{ include "rpdu2mqtt.secretName" . }}
+                optional: true
           {{- end }}
           env:
             - name: RPDU2MQTT_POD_NAME
@@ -57,6 +58,9 @@ spec:
               value: k8s
             - name: RPDU2MQTT_CR_NAME
               value: {{ include "rpdu2mqtt.crName" . | quote }}
+            # Companion Secret the GUI writes credentials into (kept out of the CR spec).
+            - name: RPDU2MQTT_SECRET_NAME
+              value: {{ include "rpdu2mqtt.secretName" . | quote }}
             - name: RPDU2MQTT_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/rpdu2mqtt/templates/rbac.yaml
+++ b/charts/rpdu2mqtt/templates/rbac.yaml
@@ -16,6 +16,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events"]
     verbs: ["get", "list"]
+  # Lets the GUI persist credentials (incl. OIDC client secret) into the companion Secret,
+  # instead of the CR spec. Scoped to just that Secret (the chart pre-creates it).
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "patch", "update"]
+    resourceNames: ["{{ include "rpdu2mqtt.secretName" . }}"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/rpdu2mqtt/templates/secret.yaml
+++ b/charts/rpdu2mqtt/templates/secret.yaml
@@ -1,11 +1,26 @@
-{{- if and (not .Values.existingSecret) (include "rpdu2mqtt.hasSecret" .) }}
+{{- if and (not .Values.existingSecret) (or (include "rpdu2mqtt.hasSecret" .) .Values.kubernetesConfigSource.enabled) }}
+{{- $name := include "rpdu2mqtt.secretName" . }}
+{{- /*
+  With the CRD config source, the GUI writes credentials (MQTT/PDU/EmonCMS/GUI/OIDC) into this Secret.
+  Create-once (preserveExisting): keep the live Secret's data on upgrade so those GUI-written values
+  aren't reverted; values.credentials only seed it on first install. Relies on Helm `lookup` (empty
+  under `helm template` / Argo CD — add an Argo ignoreDifferences on this Secret's data; see the README).
+*/}}
+{{- $existing := dict }}
+{{- if and .Values.kubernetesConfigSource.enabled .Values.kubernetesConfigSource.preserveExisting }}
+{{- $existing = (lookup "v1" "Secret" .Release.Namespace $name) | default dict }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "rpdu2mqtt.fullname" . }}
+  name: {{ $name }}
   labels:
     {{- include "rpdu2mqtt.labels" . | nindent 4 }}
 type: Opaque
+{{- if $existing.data }}
+data:
+  {{- toYaml $existing.data | nindent 2 }}
+{{- else if include "rpdu2mqtt.hasSecret" . }}
 stringData:
   {{- with .Values.credentials.mqtt.username }}
   RPDU2MQTT_MQTT_USERNAME: {{ . | quote }}
@@ -25,4 +40,5 @@ stringData:
   {{- with .Values.credentials.oidcClientSecret }}
   RPDU2MQTT_OIDC_CLIENT_SECRET: {{ . | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -136,14 +136,19 @@ kubectl apply -f Examples/Kubernetes/argo/rpdu2mqtt-application.yaml
 ```
 
 That example also shows the **chart-here / values-in-your-repo** multi-source pattern. If you use the
-**`RpduConfig` config source** so the GUI's Save works, add an `ignoreDifferences` for the CR `/spec`
-so Argo doesn't revert GUI edits on sync (Argo renders with `helm template` and can't read the live CR):
+**`RpduConfig` config source** so the GUI's Save works, add `ignoreDifferences` for the CR `/spec` and
+the companion Secret's `/data` so Argo doesn't revert GUI edits (config) or GUI-saved credentials on
+sync (Argo renders with `helm template` and can't read the live CR/Secret):
 
 ```yaml
 ignoreDifferences:
   - group: rpdu2mqtt.xtremeownage.com
     kind: RpduConfig
     jsonPointers: [ /spec ]
+  - group: ""
+    kind: Secret
+    name: rpdu2mqtt          # RPDU2MQTT_SECRET_NAME
+    jsonPointers: [ /data ]
 ```
 
 ## Kubernetes — raw manifests

--- a/docs/KubernetesCRD.md
+++ b/docs/KubernetesCRD.md
@@ -111,10 +111,22 @@ IConfigSource
 
 ### Secrets (decided)
 
-When the Kubernetes config source is used, credentials live in a **Kubernetes Secret**, never inline in
-the CR `spec`. The CR references them (e.g. a `secretRef`/`secretName` field), and the existing
-`RPDU2MQTT_*` env overrides continue to populate them at runtime — so the secret-handling story is the
-same one the Helm chart already uses. GUI write-back **never** writes secret values into the CR.
+When the Kubernetes config source is used, credentials live in a **companion Kubernetes Secret**, never
+inline in the CR `spec`. GUI write-back **never** writes secret values into the CR — instead, on Save the
+app writes the secret fields (MQTT/PDU credentials, EmonCMS API key, GUI password, **OIDC client
+secret**) into that Secret, and reads them back at startup (the chart also mounts it via `envFrom`, so the
+existing `RPDU2MQTT_*` overrides still apply; an explicit env var still wins). This means enabling OIDC
+from the GUI just works — no hand-editing the CR.
+
+Mechanics:
+
+- The Secret name comes from **`RPDU2MQTT_SECRET_NAME`** (the chart sets it to the release Secret; it
+  defaults to the CR name otherwise).
+- The chart **pre-creates** the Secret (create-once, like the CR) so GUI-written values survive `helm
+  upgrade`, and grants the pod `get,patch,update` on **just that Secret**. Non-Helm/Argo deploys must
+  create the Secret, mount it, and grant the same RBAC (and add an Argo `ignoreDifferences` on its data).
+- Credential **changes apply on restart** (use the Diagnostics **Restart bridge** button) — the same as
+  any other connection change, and required for OIDC which is wired up at startup.
 
 ### GitOps & exporting manifests (decided)
 

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -284,7 +284,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 await configSource.SaveAsync(parsed, ctx.RequestAborted);
                 Log.Information($"Configuration saved via GUI to {configSource.Describe}.");
                 var message = configSource.IsGitOpsManaged
-                    ? "Saved to the Kubernetes resource (remember to update your GitOps source so it doesn't drift). Press 'Republish discovery' to apply override/name/template changes; restart for connection changes."
+                    ? "Saved to the Kubernetes resource (remember to update your GitOps source so it doesn't drift). Credentials are stored in the companion Secret. Press 'Republish discovery' to apply override/name/template changes; restart for connection/credential changes (incl. OIDC)."
                     : "Saved. Press 'Republish discovery' to apply override/name/template changes; restart the service for connection changes (host/port).";
                 return Results.Json(new { ok = true, message, gitops = configSource.IsGitOpsManaged });
             }

--- a/rPDU2MQTT/Startup/ConfigSources/KubernetesConfigSource.cs
+++ b/rPDU2MQTT/Startup/ConfigSources/KubernetesConfigSource.cs
@@ -1,5 +1,8 @@
+using System.Net;
+using System.Text;
 using System.Text.Json;
 using k8s;
+using k8s.Autorest;
 using k8s.Models;
 using rPDU2MQTT.Classes;
 using rPDU2MQTT.Services.Gui;
@@ -9,8 +12,9 @@ namespace rPDU2MQTT.Startup.ConfigSources;
 /// <summary>
 /// Reads (and writes) the configuration from a Kubernetes <c>RpduConfig</c> custom resource.
 /// The CR <c>spec</c> uses the same field names as the GUI config JSON (see <see cref="ConfigSchema"/>),
-/// so loading/saving reuses that round-trip. Secrets are never written to the CR — they come from the
-/// usual <c>RPDU2MQTT_*</c> env/Secret overrides.
+/// so loading/saving reuses that round-trip. Secrets are never written to the CR spec — they are stored
+/// in a companion Kubernetes <c>Secret</c> (<c>RPDU2MQTT_SECRET_NAME</c>) that the chart also mounts via
+/// <c>envFrom</c>, so GUI-entered credentials persist without hand-editing the CR.
 /// </summary>
 public sealed class KubernetesConfigSource : IConfigSource
 {
@@ -18,11 +22,31 @@ public sealed class KubernetesConfigSource : IConfigSource
     public string Name { get; }
     public string Namespace { get; }
 
+    /// <summary>Name of the companion Secret holding credentials (the chart mounts it via envFrom).</summary>
+    public string SecretName { get; }
+
+    /// <summary>
+    /// The secret config fields and the <c>RPDU2MQTT_*</c> keys they map to. Drives both reading secrets
+    /// out of the companion Secret and writing GUI-entered secrets back into it.
+    /// </summary>
+    private static readonly (string Key, Func<Config, string?> Get, Action<Config, string?> Set)[] SecretFields =
+    {
+        ("RPDU2MQTT_MQTT_USERNAME", c => c.MQTT.Credentials?.Username, (c, v) => (c.MQTT.Credentials ??= new()).Username = v),
+        ("RPDU2MQTT_MQTT_PASSWORD", c => c.MQTT.Credentials?.Password, (c, v) => (c.MQTT.Credentials ??= new()).Password = v),
+        ("RPDU2MQTT_PDU_USERNAME",  c => c.PDU.Credentials?.Username,  (c, v) => (c.PDU.Credentials  ??= new()).Username = v),
+        ("RPDU2MQTT_PDU_PASSWORD",  c => c.PDU.Credentials?.Password,  (c, v) => (c.PDU.Credentials  ??= new()).Password = v),
+        ("RPDU2MQTT_EMONCMS_APIKEY", c => c.EmonCMS.ApiKey, (c, v) => c.EmonCMS.ApiKey = v),
+        ("RPDU2MQTT_GUI_PASSWORD",   c => c.Gui.Password,   (c, v) => c.Gui.Password = v),
+        ("RPDU2MQTT_OIDC_CLIENT_SECRET", c => c.Gui.Oidc?.ClientSecret, (c, v) => (c.Gui.Oidc ??= new()).ClientSecret = v),
+    };
+
     public KubernetesConfigSource()
     {
         Name = Environment.GetEnvironmentVariable("RPDU2MQTT_CR_NAME")
             ?? throw new InvalidOperationException("RPDU2MQTT_CONFIG_SOURCE=k8s requires RPDU2MQTT_CR_NAME (the RpduConfig resource name).");
         Namespace = ResolveNamespace();
+        // Defaults to the CR name (the chart names both after the release); chart sets it explicitly.
+        SecretName = Environment.GetEnvironmentVariable("RPDU2MQTT_SECRET_NAME") ?? Name;
 
         var config = KubernetesClientConfiguration.BuildDefaultConfig();
         Client = new Kubernetes(config);
@@ -44,17 +68,87 @@ public sealed class KubernetesConfigSource : IConfigSource
             throw new InvalidOperationException($"RpduConfig {Namespace}/{Name} has no 'spec'.");
 
         var cfg = ConfigSchema.FromJson(spec.GetRawText());
-        // Apply defaults + RPDU2MQTT_* secret/env overrides, same as the file source.
+        // Secrets live in the companion Secret, not the CR spec; apply them before env overrides.
+        ApplyManagedSecret(cfg);
+        // Apply defaults + RPDU2MQTT_* env/secret overrides, same as the file source (env still wins).
         return YamlConfigLoader.Initialize(cfg);
     }
 
     public async Task SaveAsync(Config config, CancellationToken cancellationToken)
     {
+        // Persist secrets into the companion Secret first; the CR spec is always written redacted.
+        await WriteManagedSecretAsync(config, cancellationToken);
+
         var specJson = ConfigSchema.ToJson(ConfigSchema.RedactSecrets(config));
         // JSON Patch "add" on /spec replaces the whole spec (drops removed keys), unlike a merge patch.
         var patch = new V1Patch($"[{{\"op\":\"add\",\"path\":\"/spec\",\"value\":{specJson}}}]", V1Patch.PatchType.JsonPatch);
         await Client.CustomObjects.PatchNamespacedCustomObjectAsync(
             patch, RpduCrd.Group, RpduCrd.Version, Namespace, RpduCrd.Plural, Name, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>Fill the config's secret fields from the companion Secret (if it exists / is readable).</summary>
+    private void ApplyManagedSecret(Config config)
+    {
+        if (string.IsNullOrEmpty(SecretName))
+            return;
+
+        V1Secret secret;
+        try
+        {
+            secret = Client.CoreV1.ReadNamespacedSecretAsync(SecretName, Namespace).GetAwaiter().GetResult();
+        }
+        catch (HttpOperationException ex) when (ex.Response is { StatusCode: HttpStatusCode.NotFound })
+        {
+            return; // No companion Secret yet — secrets come from env / GUI save.
+        }
+        catch (Exception ex)
+        {
+            Log.Warning($"Could not read credentials Secret {Namespace}/{SecretName}: {ex.Message}");
+            return;
+        }
+
+        if (secret.Data is null)
+            return;
+
+        foreach (var (key, _, set) in SecretFields)
+            if (secret.Data.TryGetValue(key, out var bytes) && bytes is { Length: > 0 })
+                set(config, Encoding.UTF8.GetString(bytes));
+    }
+
+    /// <summary>Write the config's non-empty secret fields into the companion Secret (create or merge).</summary>
+    private async Task WriteManagedSecretAsync(Config config, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(SecretName))
+        {
+            Log.Warning("RPDU2MQTT_SECRET_NAME is not set; GUI-entered credentials were not persisted. Provide secrets via your Secret/env vars instead.");
+            return;
+        }
+
+        var stringData = new Dictionary<string, string>();
+        foreach (var (key, get, _) in SecretFields)
+        {
+            var value = get(config);
+            if (!string.IsNullOrEmpty(value))
+                stringData[key] = value;
+        }
+
+        if (stringData.Count == 0)
+            return;
+
+        var patch = new V1Patch(JsonSerializer.Serialize(new { stringData }), V1Patch.PatchType.MergePatch);
+        try
+        {
+            await Client.CoreV1.PatchNamespacedSecretAsync(patch, SecretName, Namespace, cancellationToken: cancellationToken);
+        }
+        catch (HttpOperationException ex) when (ex.Response is { StatusCode: HttpStatusCode.NotFound })
+        {
+            var secret = new V1Secret
+            {
+                Metadata = new V1ObjectMeta { Name = SecretName, NamespaceProperty = Namespace },
+                StringData = stringData,
+            };
+            await Client.CoreV1.CreateNamespacedSecretAsync(secret, Namespace, cancellationToken: cancellationToken);
+        }
     }
 
     /// <summary>Patch the CR's status subresource.</summary>


### PR DESCRIPTION
Fixes #123.

## Problem
With the **RpduConfig (k8s) config source**, secrets entered in the GUI were redacted on save and never persisted, so enabling OIDC required hand-editing the CR. This affected **all** secrets, not just OIDC — the chart-provided env vars just masked it for the others.

## Fix (GUI writes a Kubernetes Secret; CR stays secret-free)
- **App** — `KubernetesConfigSource` now writes the secret fields into a companion Secret (`RPDU2MQTT_SECRET_NAME`) on save (create-on-missing, else merge-patch) and reads them back at startup. A single `SecretFields` map drives both directions and matches `RedactSecrets`, so the CR `spec` stays secret-free and the two can't drift. Explicit `RPDU2MQTT_*` env vars still win.
- **Helm** — pre-creates the Secret (create-once, so GUI-written values survive `helm upgrade`) when the CRD source is enabled, mounts it via `envFrom`, passes `RPDU2MQTT_SECRET_NAME`, and grants the pod `get,patch,update` on **just that Secret** (resourceName-scoped).
- **Docs** — KubernetesCRD.md, env-vars reference (+`RPDU2MQTT_SECRET_NAME`), chart README, and Argo `ignoreDifferences` (now also covers the Secret `/data`).

Secrets covered: MQTT user/pass, PDU user/pass, EmonCMS API key, GUI password, OIDC client secret.

## Behavior notes
- Credential changes apply on **restart** (use Diagnostics → Restart bridge); required for OIDC, which is wired up at startup.
- With `existingSecret` set, the app patches that Secret (RBAC scoped to it) rather than a chart-created one.

## Testing
- `dotnet build` + all 44 tests pass.
- No `helm` available locally — manifests reviewed by inspection; verify with `helm template --set kubernetesConfigSource.enabled=true`.
- Not yet verified on a live cluster (will test in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)