### PR TITLE
feat(control): write PDU & circuit labels back to the PDU (#98)

### DIFF
--- a/rPDU2MQTT/Classes/PDU.cs
+++ b/rPDU2MQTT/Classes/PDU.cs
@@ -30,8 +30,9 @@ public partial class PDU
     // applies the change, during which it still reports the OLD state. Latch the commanded state
     // so polling doesn't flap Home Assistant back until the PDU actually catches up (or we time out).
     private readonly Dictionary<string, (string expected, DateTime expiresUtc)> pendingOutletStates = new();
-    // Same latch idea for writable config fields (delays / power-on action), keyed deviceId/index/field.
-    private readonly Dictionary<string, (string expected, DateTime expiresUtc)> pendingOutletConfig = new();
+    // Same latch idea for writable config fields (outlet delays/power-on, device & circuit labels),
+    // keyed by a resource-qualified path (see LatchPending / ResolvePending).
+    private readonly Dictionary<string, (string expected, DateTime expiresUtc)> pendingConfig = new();
     private readonly object pendingLock = new();
     private static readonly TimeSpan PendingStateTimeout = TimeSpan.FromSeconds(120);
 
@@ -95,29 +96,58 @@ public partial class PDU
         return members;
     }
 
-    /// <summary>Write outlet configuration fields (delays, power-on action) — PDU.ActionsEnabled only.</summary>
+    /// <summary>Write outlet configuration fields (delays, power-on action, label) — PDU.ActionsEnabled only.</summary>
     public async Task SetOutletConfigAsync(string deviceId, int outletIndex, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
     {
         await api.SetOutletConfigAsync(deviceId, outletIndex, fields, cancellationToken);
-
-        // Latch the new values so polling doesn't flap HA back to the stale config while the PDU applies.
-        lock (pendingLock)
-            foreach (var (field, value) in fields)
-                pendingOutletConfig[$"{deviceId}/{outletIndex}/{field}"] = (value?.ToString() ?? string.Empty, DateTime.UtcNow.Add(PendingStateTimeout));
+        LatchPending($"o/{deviceId}/{outletIndex}", fields);
     }
 
-    /// <summary>Report the latched value for a writable config field until the PDU catches up (or we time out).</summary>
+    /// <summary>Report the latched value for a writable outlet config field until the PDU catches up (or we time out).</summary>
     public string ResolveOutletConfig(string deviceId, int outletIndex, string field, string actual)
+        => ResolvePending($"o/{deviceId}/{outletIndex}/{field}", actual);
+
+    /// <summary>Write device (PDU) configuration fields (e.g. <c>label</c>) — PDU.ActionsEnabled only.</summary>
+    public async Task SetDeviceConfigAsync(string deviceId, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
+    {
+        await api.SetDeviceConfigAsync(deviceId, fields, cancellationToken);
+        LatchPending($"d/{deviceId}", fields);
+    }
+
+    /// <summary>Report the latched value for a writable device config field until the PDU catches up.</summary>
+    public string ResolveDeviceConfig(string deviceId, string field, string actual)
+        => ResolvePending($"d/{deviceId}/{field}", actual);
+
+    /// <summary>Write entity (circuit/phase/total) configuration fields (e.g. <c>label</c>) — PDU.ActionsEnabled only.</summary>
+    public async Task SetEntityConfigAsync(string deviceId, string entityKey, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
+    {
+        await api.SetEntityConfigAsync(deviceId, entityKey, fields, cancellationToken);
+        LatchPending($"e/{deviceId}/{entityKey}", fields);
+    }
+
+    /// <summary>Report the latched value for a writable entity config field until the PDU catches up.</summary>
+    public string ResolveEntityConfig(string deviceId, string entityKey, string field, string actual)
+        => ResolvePending($"e/{deviceId}/{entityKey}/{field}", actual);
+
+    /// <summary>Latch written config values (keyed <c>{prefix}/{field}</c>) so polling doesn't flap back to stale data.</summary>
+    private void LatchPending(string prefix, IReadOnlyDictionary<string, object> fields)
+    {
+        lock (pendingLock)
+            foreach (var (field, value) in fields)
+                pendingConfig[$"{prefix}/{field}"] = (value?.ToString() ?? string.Empty, DateTime.UtcNow.Add(PendingStateTimeout));
+    }
+
+    /// <summary>Report the latched value for a config field until the PDU catches up (or we time out).</summary>
+    private string ResolvePending(string key, string actual)
     {
         lock (pendingLock)
         {
-            var key = $"{deviceId}/{outletIndex}/{field}";
-            if (!pendingOutletConfig.TryGetValue(key, out var pending))
+            if (!pendingConfig.TryGetValue(key, out var pending))
                 return actual;
 
             if (string.Equals(actual, pending.expected, StringComparison.OrdinalIgnoreCase) || DateTime.UtcNow >= pending.expiresUtc)
             {
-                pendingOutletConfig.Remove(key);
+                pendingConfig.Remove(key);
                 return actual;
             }
 

--- a/rPDU2MQTT/Classes/PduApiHandler.cs
+++ b/rPDU2MQTT/Classes/PduApiHandler.cs
@@ -59,37 +59,47 @@ public class PduApiHandler
     /// outlet resource with the session token in the body. Only invoked when ActionsEnabled.
     /// </remarks>
     public Task ControlOutletAsync(string deviceId, int outletIndex, string action, CancellationToken cancellationToken)
-        => SendOutletCommandAsync(deviceId, outletIndex, "control", new { action, delay = false }, $"control '{action}'", cancellationToken);
+        => SendCommandAsync(deviceId, $"/outlet/{outletIndex}", "control", new { action, delay = false }, $"outlet {outletIndex} control '{action}'", cancellationToken);
 
     /// <summary>
     /// Write outlet configuration fields (e.g. onDelay/offDelay/rebootDelay/poaAction) via cmd "set".
     /// </summary>
     public Task SetOutletConfigAsync(string deviceId, int outletIndex, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
-        => SendOutletCommandAsync(deviceId, outletIndex, "set", fields, $"set {string.Join(",", fields.Keys)}", cancellationToken);
+        => SendCommandAsync(deviceId, $"/outlet/{outletIndex}", "set", fields, $"outlet {outletIndex} set {string.Join(",", fields.Keys)}", cancellationToken);
 
     /// <summary>
     /// Reset an outlet's accumulated energy statistics (cmd "reset", target "energy").
     /// </summary>
     public Task ResetOutletStatsAsync(string deviceId, int outletIndex, CancellationToken cancellationToken)
-        => SendOutletCommandAsync(deviceId, outletIndex, "reset", new { target = "energy" }, "reset statistics", cancellationToken);
+        => SendCommandAsync(deviceId, $"/outlet/{outletIndex}", "reset", new { target = "energy" }, $"outlet {outletIndex} reset statistics", cancellationToken);
+
+    /// <summary>Write device (PDU) configuration fields (e.g. <c>label</c>) via cmd "set".</summary>
+    public Task SetDeviceConfigAsync(string deviceId, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
+        => SendCommandAsync(deviceId, "", "set", fields, $"device set {string.Join(",", fields.Keys)}", cancellationToken);
+
+    /// <summary>Write entity (circuit/breaker, phase, total) configuration fields (e.g. <c>label</c>) via cmd "set".</summary>
+    public Task SetEntityConfigAsync(string deviceId, string entityKey, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
+        => SendCommandAsync(deviceId, $"/entity/{entityKey}", "set", fields, $"entity {entityKey} set {string.Join(",", fields.Keys)}", cancellationToken);
 
     /// <summary>
-    /// POST a command (control/set) to an outlet resource on the owning host, validating the result.
+    /// POST a command (control/set/reset) to a device resource (or a sub-resource like an outlet or
+    /// entity) on the owning host, validating the result.
     /// </summary>
     /// <remarks>
     /// Endpoint/auth match the Geist firmware (apiVersion 1.0.1): the session token travels in the
-    /// body, against the same /api/dev/{device}/outlet/{index} path as the read API (a proxy port
-    /// for cluster members). Only invoked when ActionsEnabled.
+    /// body, against the same /api/dev/{device}[/{sub}] path as the read API (a proxy port for cluster
+    /// members). <paramref name="resourceSuffix"/> is "" for the device itself, "/outlet/{i}" for an
+    /// outlet, or "/entity/{key}" for a circuit/phase/total. Only invoked when ActionsEnabled.
     /// </remarks>
-    private async Task SendOutletCommandAsync(string deviceId, int outletIndex, string cmd, object data, string description, CancellationToken cancellationToken)
+    private async Task SendCommandAsync(string deviceId, string resourceSuffix, string cmd, object data, string description, CancellationToken cancellationToken)
     {
         var webPort = await ResolveWebPortAsync(deviceId, cancellationToken);
         var token = await GetTokenAsync(webPort, cancellationToken);
 
-        var url = BuildUrl(webPort, $"/api/dev/{deviceId}/outlet/{outletIndex}");
+        var url = BuildUrl(webPort, $"/api/dev/{deviceId}{resourceSuffix}");
         var body = new { cmd, token, data };
 
-        Log.Information($"[PduApiHandler] Outlet {deviceId}/{outletIndex}: {description}");
+        Log.Information($"[PduApiHandler] {deviceId}: {description}");
         var response = await PostJsonWithRetryAsync(url, body, cancellationToken);
         var result = await response.Content.ReadFromJsonAsync<GetResponse<JsonElement>>(cancellationToken);
 
@@ -97,7 +107,7 @@ public class PduApiHandler
         {
             // A stale token is the most likely failure; drop it so the next call re-authenticates.
             tokensByPort.Remove(webPort);
-            throw new Exception($"[PduApiHandler] Outlet {description} failed (HTTP {(int)response.StatusCode}, retCode {result?.RetCode} {result?.RetMsg}).");
+            throw new Exception($"[PduApiHandler] {description} failed (HTTP {(int)response.StatusCode}, retCode {result?.RetCode} {result?.RetMsg}).");
         }
     }
 

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -598,7 +598,24 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                     poaAction = pdu.ResolveOutletConfig(d.Key, o.Key, "poaAction", o.PoaAction ?? ""),
                 })).ToList();
                 var groups = data.Groups.Select(g => new { key = g.Key, name = g.Entity_DisplayName }).ToList();
-                return Results.Json(new { ok = true, actionsEnabled = config.PDU.ActionsEnabled, outlets, groups }, ConfigSchema.Json);
+                // PDUs and their circuits (breaker entities), with editable labels — resolved through the
+                // pending-write latch like outlets so a just-set value shows immediately.
+                var devices = data.Devices.Select(d => new
+                {
+                    deviceId = d.Key,
+                    name = d.Entity_DisplayName,
+                    label = pdu.ResolveDeviceConfig(d.Key, "label", d.Label ?? ""),
+                    circuits = d.Entity
+                        .Where(e => e.Key.StartsWith("breaker", StringComparison.OrdinalIgnoreCase))
+                        .OrderBy(e => e.Key)
+                        .Select(e => new
+                        {
+                            key = e.Key,
+                            name = e.Entity_DisplayName ?? e.Name,
+                            label = pdu.ResolveEntityConfig(d.Key, e.Key, "label", e.Label ?? ""),
+                        }).ToList(),
+                }).ToList();
+                return Results.Json(new { ok = true, actionsEnabled = config.PDU.ActionsEnabled, outlets, groups, devices }, ConfigSchema.Json);
             }
             catch (Exception ex)
             {
@@ -677,14 +694,29 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             try { req = await ctx.Request.ReadFromJsonAsync<LabelRequest>(ctx.RequestAborted); }
             catch { req = null; }
             if (req is null || string.IsNullOrWhiteSpace(req.DeviceId))
-                return Results.BadRequest(new { ok = false, message = "deviceId, index and label are required." });
+                return Results.BadRequest(new { ok = false, message = "deviceId and label are required." });
+
+            var target = (req.Target ?? "outlet").Trim().ToLowerInvariant();
+            var label = new Dictionary<string, object> { ["label"] = (req.Label ?? string.Empty).Trim() };
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
-                await pdu.SetOutletConfigAsync(req.DeviceId, req.Index, new Dictionary<string, object> { ["label"] = (req.Label ?? string.Empty).Trim() }, cts.Token);
-                return Results.Json(new { ok = true, message = $"Outlet {req.Index + 1} label set." }, ConfigSchema.Json);
+                switch (target)
+                {
+                    case "device":
+                        await pdu.SetDeviceConfigAsync(req.DeviceId, label, cts.Token);
+                        return Results.Json(new { ok = true, message = "PDU label set." }, ConfigSchema.Json);
+                    case "entity":
+                        if (string.IsNullOrWhiteSpace(req.EntityKey))
+                            return Results.BadRequest(new { ok = false, message = "entityKey is required for an entity label." });
+                        await pdu.SetEntityConfigAsync(req.DeviceId, req.EntityKey, label, cts.Token);
+                        return Results.Json(new { ok = true, message = "Circuit label set." }, ConfigSchema.Json);
+                    default:
+                        await pdu.SetOutletConfigAsync(req.DeviceId, req.Index, label, cts.Token);
+                        return Results.Json(new { ok = true, message = $"Outlet {req.Index + 1} label set." }, ConfigSchema.Json);
+                }
             }
             catch (Exception ex)
             {
@@ -730,7 +762,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private sealed record ControlRequest(string DeviceId, int Index, string Action);
 
     /// <summary>Body of a POST /api/control/label request.</summary>
-    private sealed record LabelRequest(string DeviceId, int Index, string Label);
+    private sealed record LabelRequest(string DeviceId, string? Target, int Index, string? EntityKey, string Label);
 
     /// <summary>Body of a POST /api/control/group request.</summary>
     private sealed record GroupControlRequest(string GroupKey, string Action);

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -344,9 +344,10 @@ function addControlSection(nav, sections) {
   warn.textContent = 'Write actions are disabled (PDU.ActionsEnabled is false). Enable it in the PDU section and restart to control outlets.';
   sec.appendChild(warn);
   const groupsWrap = document.createElement('div'); sec.appendChild(groupsWrap);
+  const devicesWrap = document.createElement('div'); sec.appendChild(devicesWrap);
   const tableWrap = document.createElement('div'); sec.appendChild(tableWrap);
 
-  let rows = [], groups = [], enabled = false;
+  let rows = [], groups = [], devices = [], enabled = false;
   const actGroup = async (g, action) => {
     const verb = action === 'on' ? 'turn ON' : action === 'off' ? 'turn OFF' : 'reboot';
     if (!confirm('Group "' + (g.name || g.key) + '": ' + verb + ' ALL member outlets?')) return;
@@ -380,12 +381,39 @@ function addControlSection(nav, sections) {
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
     setTimeout(load, 800); // let the PDU apply, then re-read state
   };
-  const setLabel = async (o, value) => {
-    value = (value || '').trim();
-    toast('Outlet ' + o.number + ': set label…', true);
-    const r = await api('/api/control/label', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ deviceId: o.deviceId, index: o.index, label: value }) });
+  const postLabel = async (payload, desc) => {
+    toast(desc + ': set label…', true);
+    const r = await api('/api/control/label', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
     setTimeout(load, 800);
+  };
+  const setLabel = (o, value) => postLabel({ deviceId: o.deviceId, target: 'outlet', index: o.index, label: (value || '').trim() }, 'Outlet ' + o.number);
+  const drawDevices = () => {
+    devicesWrap.innerHTML = '';
+    if (!devices.length) return;
+    const hh = document.createElement('div'); hh.className = 'desc'; hh.style.marginTop = '4px';
+    hh.textContent = 'PDUs & circuits — labels are written to the PDU:'; devicesWrap.appendChild(hh);
+    const t = document.createElement('table'); t.className = 'ld';
+    const head = document.createElement('tr');
+    ['Type', 'Name', 'Label (on PDU)'].forEach(x => { const th = document.createElement('th'); th.textContent = x; head.appendChild(th); });
+    const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
+    const tb = document.createElement('tbody');
+    const labelRow = (kind, name, current, payload) => {
+      const tr = document.createElement('tr');
+      const td0 = document.createElement('td'); td0.textContent = kind; tr.appendChild(td0);
+      const td1 = document.createElement('td'); td1.textContent = name || ''; tr.appendChild(td1);
+      const td2 = document.createElement('td');
+      const lin = document.createElement('input'); lin.type = 'text'; lin.value = current || ''; lin.style.width = '150px'; lin.disabled = !enabled;
+      const setBtn = document.createElement('button'); setBtn.className = 'small'; setBtn.textContent = 'Set'; setBtn.disabled = !enabled; setBtn.style.marginLeft = '6px';
+      setBtn.onclick = () => postLabel(Object.assign({}, payload, { label: (lin.value || '').trim() }), kind + ' ' + (name || ''));
+      td2.appendChild(lin); td2.appendChild(setBtn); tr.appendChild(td2);
+      tb.appendChild(tr);
+    };
+    devices.forEach(d => {
+      labelRow('PDU', d.name, d.label, { deviceId: d.deviceId, target: 'device' });
+      (d.circuits || []).forEach(c => labelRow('Circuit', c.name, c.label, { deviceId: d.deviceId, target: 'entity', entityKey: c.key }));
+    });
+    t.appendChild(tb); devicesWrap.appendChild(t);
   };
   const draw = () => {
     const f = filter.value.trim().toLowerCase();
@@ -432,8 +460,8 @@ function addControlSection(nav, sections) {
   const load = async () => {
     const r = await api('/api/control/outlets');
     if (!r.body.ok) { tableWrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load outlets.') + '</div>'; return; }
-    rows = r.body.outlets || []; groups = r.body.groups || []; enabled = !!r.body.actionsEnabled;
-    warn.style.display = enabled ? 'none' : 'block'; drawGroups(); draw();
+    rows = r.body.outlets || []; groups = r.body.groups || []; devices = r.body.devices || []; enabled = !!r.body.actionsEnabled;
+    warn.style.display = enabled ? 'none' : 'block'; drawGroups(); drawDevices(); draw();
   };
   refresh.onclick = load; filter.oninput = draw;
   link.onclick = () => { activate(link, sec); load(); };


### PR DESCRIPTION
Closes #98.

## What
Outlet labels already write back to the PDU from the GUI; this extends the same to:
- the **PDU (device)** label, and
- **circuit** labels (the `breaker*` entities).

All gated behind **`PDU.ActionsEnabled`** (write actions), like the existing outlet controls.

## How
- **PduApiHandler** — generalized the outlet `set` command into `SendCommandAsync(deviceId, resourceSuffix, …)`; added `SetDeviceConfigAsync` (`POST /api/dev/{id}`) and `SetEntityConfigAsync` (`POST /api/dev/{id}/entity/{key}`). Same `{cmd:"set", token, data:{label}}` shape that already works for outlets.
- **PDU** — `SetDevice/EntityConfigAsync` with the same pending-write latch as outlet config (so a just-set label shows immediately instead of reverting until the next poll), refactored into a shared `LatchPending`/`ResolvePending` helper.
- **GUI** — `/api/control/label` now takes `target` (`device`|`entity`|`outlet`); `/api/control/outlets` also returns each PDU + its circuits with current labels; the Control tab gets a **"PDUs & circuits"** rename table above the outlets.

## Testing
- `dotnet build` + 44 tests pass.
- Verified against the live PDU that `/api` exposes the device label + `breaker*` circuits (read path), so the Control tab will list them.
- **Not yet verified on hardware:** the device/circuit label *write* (needs PDU credentials; the live-write probe was blocked as a prod change). It uses the identical command shape as the working outlet label write. Will confirm in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)