### PR TITLE
chore: default MQTT topic to rPDU2MQTT across installs (#114)

### DIFF
--- a/Examples/Configuration/config.spec.yaml
+++ b/Examples/Configuration/config.spec.yaml
@@ -8,7 +8,7 @@ Mqtt:
         Password: "password"
 
     # This will be the parent topic in MQTT, where keys are published to.
-    ParentTopic: "Rack_PDU"
+    ParentTopic: "rPDU2MQTT"
 
     # This is the client-ID used.
     ClientID: "rpdu2mqtt"

--- a/Examples/Configuration/recommended-configuration.yaml
+++ b/Examples/Configuration/recommended-configuration.yaml
@@ -6,7 +6,7 @@ Mqtt:
         Username: "admin"
         Password: "password"
 
-    ParentTopic: "Rack_PDU"
+    ParentTopic: "rPDU2MQTT"
 
 PDU:
     Connection:

--- a/Examples/Kubernetes/crd/rpduconfig-sample.yaml
+++ b/Examples/Kubernetes/crd/rpduconfig-sample.yaml
@@ -10,7 +10,7 @@ spec:
     Connection:
       Host: mqtt.lan
       Port: 1883
-    ParentTopic: Rack_PDU
+    ParentTopic: rPDU2MQTT
   PDU:
     Connection:
       Host: pdu.lan

--- a/Examples/Kubernetes/manifests.yaml
+++ b/Examples/Kubernetes/manifests.yaml
@@ -20,7 +20,7 @@ data:
             Username: "admin"
             Password: "password"
 
-        ParentTopic: "Rack_PDU"
+        ParentTopic: "rPDU2MQTT"
 
     PDU:
         Connection:        

--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -17,7 +17,7 @@ A minimal `my-values.yaml`:
 config:
   MQTT:
     Connection: { Host: mqtt.lan, Port: 1883 }
-    ParentTopic: Rack_PDU
+    ParentTopic: rPDU2MQTT
   PDU:
     Connection: { Host: pdu.lan, Port: 80 }
     PollInterval: 5

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -99,7 +99,7 @@ A minimal `my-values.yaml`:
 config:
   MQTT:
     Connection: { Host: mqtt.lan, Port: 1883 }
-    ParentTopic: Rack_PDU
+    ParentTopic: rPDU2MQTT
   PDU:
     Connection: { Host: pdu.lan, Port: 80 }
     PollInterval: 5

--- a/docs/KubernetesCRD.md
+++ b/docs/KubernetesCRD.md
@@ -55,7 +55,7 @@ spec:
   # Mirrors the existing Config model (MQTT, PDU, HomeAssistant, Overrides, Prometheus, EmonCMS, ...)
   MQTT:
     Connection: { Host: mqtt.example.com, Port: 1883 }
-    ParentTopic: Rack_PDU
+    ParentTopic: rPDU2MQTT
   PDU:
     Connection: { Host: rack-pdu-1.example.com, Port: 80 }
     PollInterval: 5


### PR DESCRIPTION
Closes #114.

The app's model default (`MQTTConfig.ParentTopic`) and the Helm chart `values.yaml` were already `rPDU2MQTT`. This aligns the remaining example/doc templates so **every** installation type shows the same default instead of the legacy `Rack_PDU`:

- `Examples/Configuration/recommended-configuration.yaml`, `config.spec.yaml`
- `Examples/Kubernetes/manifests.yaml`, `crd/rpduconfig-sample.yaml`
- `charts/rpdu2mqtt/README.md`, `docs/Deployment.md`, `docs/KubernetesCRD.md`

Left untouched: the maintainer's own `rPDU2MQTT/config.yaml` (live config) and a `HelperTests` input that just exercises the topic helper with an arbitrary value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)