### PR TITLE
feat(gui): OneView group rename, member states & rollups (#124, #125, #126)

### DIFF
--- a/rPDU2MQTT/Classes/PDU.cs
+++ b/rPDU2MQTT/Classes/PDU.cs
@@ -129,6 +129,17 @@ public partial class PDU
     public string ResolveEntityConfig(string deviceId, string entityKey, string field, string actual)
         => ResolvePending($"e/{deviceId}/{entityKey}/{field}", actual);
 
+    /// <summary>Write OneView group configuration fields (e.g. <c>label</c>) — PDU.ActionsEnabled only.</summary>
+    public async Task SetGroupConfigAsync(string groupKey, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
+    {
+        await api.SetGroupConfigAsync(groupKey, fields, cancellationToken);
+        LatchPending($"g/{groupKey}", fields);
+    }
+
+    /// <summary>Report the latched value for a writable group config field until the PDU catches up.</summary>
+    public string ResolveGroupConfig(string groupKey, string field, string actual)
+        => ResolvePending($"g/{groupKey}/{field}", actual);
+
     /// <summary>Latch written config values (keyed <c>{prefix}/{field}</c>) so polling doesn't flap back to stale data.</summary>
     private void LatchPending(string prefix, IReadOnlyDictionary<string, object> fields)
     {

--- a/rPDU2MQTT/Classes/PduApiHandler.cs
+++ b/rPDU2MQTT/Classes/PduApiHandler.cs
@@ -82,6 +82,28 @@ public class PduApiHandler
         => SendCommandAsync(deviceId, $"/entity/{entityKey}", "set", fields, $"entity {entityKey} set {string.Join(",", fields.Keys)}", cancellationToken);
 
     /// <summary>
+    /// Write OneView group configuration fields (e.g. <c>label</c>) via cmd "set". Groups are a master
+    /// (OneView) concept, reached at <c>/oneview/group/{key}</c> on the base host — not per-member.
+    /// </summary>
+    public async Task SetGroupConfigAsync(string groupKey, IReadOnlyDictionary<string, object> fields, CancellationToken cancellationToken)
+    {
+        var token = await GetTokenAsync(0, cancellationToken);
+        var url = BuildUrl(0, $"/oneview/group/{groupKey}");
+        var body = new { cmd = "set", token, data = fields };
+
+        var description = $"group {groupKey} set {string.Join(",", fields.Keys)}";
+        Log.Information($"[PduApiHandler] {description}");
+        var response = await PostJsonWithRetryAsync(url, body, cancellationToken);
+        var result = await response.Content.ReadFromJsonAsync<GetResponse<JsonElement>>(cancellationToken);
+
+        if (!response.IsSuccessStatusCode || result is null || result.RetCode != 0)
+        {
+            tokensByPort.Remove(0);
+            throw new Exception($"[PduApiHandler] {description} failed (HTTP {(int)response.StatusCode}, retCode {result?.RetCode} {result?.RetMsg}).");
+        }
+    }
+
+    /// <summary>
     /// POST a command (control/set/reset) to a device resource (or a sub-resource like an outlet or
     /// entity) on the owning host, validating the result.
     /// </summary>

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -523,7 +523,26 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                         entities.Add(BuildLiveEntity(device.Entity_DisplayName, e.Entity_DisplayName, "entity", null, null, e.Measurements));
                 }
 
-                return Results.Json(new { ok = true, count = readings.Count, readings, entities, types, units }, ConfigSchema.Json);
+                // OneView group rollups (Sum/Avg/Min/Max per measurement type). The group's aggregate
+                // measurements live on its single synthetic outlet (normal groups) or pduTotal (the Total group).
+                var groups = data.Groups.Select(g =>
+                {
+                    var src = g.Entity?.Outlets?.FirstOrDefault()?.Measurements
+                              ?? g.Entity?.PduTotal?.FirstOrDefault()?.Measurements
+                              ?? new List<Models.PDU.GroupMeasurement>();
+                    var measurements = src.Where(m => !string.IsNullOrEmpty(m.Type)).Select(m => new
+                    {
+                        type = m.Type,
+                        units = m.Units,
+                        sum = ParseMeasure(m.SumValue),
+                        avg = ParseMeasure(m.AvgValue),
+                        min = ParseMeasure(m.MinValue),
+                        max = ParseMeasure(m.MaxValue),
+                    }).ToList();
+                    return new { name = g.Entity_DisplayName, measurements };
+                }).Where(g => g.measurements.Count > 0).ToList();
+
+                return Results.Json(new { ok = true, count = readings.Count, readings, entities, groups, types, units }, ConfigSchema.Json);
             }
             catch (Exception ex)
             {
@@ -597,7 +616,26 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                     rebootDelay = pdu.ResolveOutletConfig(d.Key, o.Key, "rebootDelay", o.RebootDelay.ToString()),
                     poaAction = pdu.ResolveOutletConfig(d.Key, o.Key, "poaAction", o.PoaAction ?? ""),
                 })).ToList();
-                var groups = data.Groups.Select(g => new { key = g.Key, name = g.Entity_DisplayName }).ToList();
+                // Member-outlet lookup (deviceId, index) so each group can show per-member state.
+                var outletByKey = data.Devices
+                    .SelectMany(d => d.Outlets.Select(o => (dev: d, outlet: o)))
+                    .ToDictionary(x => (x.dev.Key, x.outlet.Key));
+                var groups = data.Groups.Select(g => new
+                {
+                    key = g.Key,
+                    name = g.Entity_DisplayName,
+                    label = pdu.ResolveGroupConfig(g.Key, "label", g.Label ?? ""),
+                    members = g.MemberOutlets.Select(m =>
+                    {
+                        outletByKey.TryGetValue((m.DeviceId, m.OutletIndex), out var hit);
+                        return new
+                        {
+                            number = m.OutletIndex + 1,
+                            name = hit.outlet?.Entity_DisplayName ?? $"#{m.OutletIndex + 1}",
+                            state = hit.outlet is null ? "unknown" : pdu.ResolveOutletState(m.DeviceId, m.OutletIndex, hit.outlet.State),
+                        };
+                    }).ToList(),
+                }).ToList();
                 // PDUs and their circuits (breaker entities), with editable labels — resolved through the
                 // pending-write latch like outlets so a just-set value shows immediately.
                 var devices = data.Devices.Select(d => new
@@ -693,10 +731,14 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             LabelRequest? req;
             try { req = await ctx.Request.ReadFromJsonAsync<LabelRequest>(ctx.RequestAborted); }
             catch { req = null; }
-            if (req is null || string.IsNullOrWhiteSpace(req.DeviceId))
-                return Results.BadRequest(new { ok = false, message = "deviceId and label are required." });
+            if (req is null)
+                return Results.BadRequest(new { ok = false, message = "A label request body is required." });
 
             var target = (req.Target ?? "outlet").Trim().ToLowerInvariant();
+            // Group labels target the OneView master, not a specific device; everything else needs a deviceId.
+            if (target != "group" && string.IsNullOrWhiteSpace(req.DeviceId))
+                return Results.BadRequest(new { ok = false, message = "deviceId is required." });
+
             var label = new Dictionary<string, object> { ["label"] = (req.Label ?? string.Empty).Trim() };
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
@@ -713,6 +755,11 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                             return Results.BadRequest(new { ok = false, message = "entityKey is required for an entity label." });
                         await pdu.SetEntityConfigAsync(req.DeviceId, req.EntityKey, label, cts.Token);
                         return Results.Json(new { ok = true, message = "Circuit label set." }, ConfigSchema.Json);
+                    case "group":
+                        if (string.IsNullOrWhiteSpace(req.GroupKey))
+                            return Results.BadRequest(new { ok = false, message = "groupKey is required for a group label." });
+                        await pdu.SetGroupConfigAsync(req.GroupKey, label, cts.Token);
+                        return Results.Json(new { ok = true, message = "Group label set." }, ConfigSchema.Json);
                     default:
                         await pdu.SetOutletConfigAsync(req.DeviceId, req.Index, label, cts.Token);
                         return Results.Json(new { ok = true, message = $"Outlet {req.Index + 1} label set." }, ConfigSchema.Json);
@@ -762,7 +809,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private sealed record ControlRequest(string DeviceId, int Index, string Action);
 
     /// <summary>Body of a POST /api/control/label request.</summary>
-    private sealed record LabelRequest(string DeviceId, string? Target, int Index, string? EntityKey, string Label);
+    private sealed record LabelRequest(string DeviceId, string? Target, int Index, string? EntityKey, string? GroupKey, string Label);
 
     /// <summary>Body of a POST /api/control/group request.</summary>
     private sealed record GroupControlRequest(string GroupKey, string Action);
@@ -776,6 +823,10 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 values[m.Type] = v;
         return new { device, source, kind, number, state, values };
     }
+
+    /// <summary>Parse a PDU measurement string to a number (null if missing/unparseable).</summary>
+    private static double? ParseMeasure(string? s)
+        => double.TryParse(s, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var v) ? v : null;
 
     /// <summary>Project a poll's measurements into the generated MQTT/Prometheus/EmonCMS paths.</summary>
     private static object BuildPaths(Models.PDU.PduData data, Config config)

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -560,30 +560,46 @@ function addLiveDataSection(nav, sections) {
     t.appendChild(tb); tableWrap.innerHTML = ''; tableWrap.appendChild(t);
   };
 
-  // OneView group rollups (Sum/Avg/Min/Max per measurement type) — one row per group/measurement.
+  // OneView group rollups — one row per group, a column per measurement type showing the group
+  // total (Sum, falling back to Avg); hover a cell for the full sum/avg/min/max breakdown.
   const drawGroupRollups = () => {
     groupsWrap.innerHTML = '';
     const gs = body.groups || [];
     if (!gs.length) return;
     const f = filter.value.trim().toLowerCase();
+    const shown = gs.filter(g => !f || (g.name || '').toLowerCase().includes(f));
+    if (!shown.length) return;
+    // Union of measurement types (+ units) across all groups, for stable columns.
+    const types = []; const units = {};
+    gs.forEach(g => (g.measurements || []).forEach(m => { if (!types.includes(m.type)) types.push(m.type); if (m.units && !units[m.type]) units[m.type] = m.units; }));
+    types.sort();
     const t = document.createElement('table'); t.className = 'ld';
     const head = document.createElement('tr');
-    ['OneView group', 'Measurement', 'Sum', 'Avg', 'Min', 'Max', 'Units'].forEach((x, i) => { const th = document.createElement('th'); th.textContent = x; if (i >= 2 && i <= 5) th.className = 'num'; head.appendChild(th); });
+    ['OneView group', ...types.map(ty => ty + (units[ty] ? ' (' + units[ty] + ')' : ''))].forEach((x, i) => { const th = document.createElement('th'); th.textContent = x; if (i >= 1) th.className = 'num'; head.appendChild(th); });
     const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
     const tb = document.createElement('tbody');
-    let any = false;
-    gs.forEach(g => {
-      const ms = (g.measurements || []).filter(m => !f || (g.name + ' ' + m.type).toLowerCase().includes(f));
-      ms.forEach((m, idx) => {
-        any = true;
-        const tr = document.createElement('tr');
-        const gtd = document.createElement('td'); gtd.textContent = idx === 0 ? g.name : ''; if (idx === 0) gtd.style.fontWeight = '600'; tr.appendChild(gtd);
-        [m.type, m.sum, m.avg, m.min, m.max, m.units || ''].forEach((c, i) => { const td = document.createElement('td'); if (i >= 1 && i <= 4) { td.className = 'num'; td.textContent = (c == null) ? '' : formatNum(c); } else td.textContent = c; tr.appendChild(td); });
-        tb.appendChild(tr);
+    shown.forEach(g => {
+      const byType = {}; (g.measurements || []).forEach(m => byType[m.type] = m);
+      const tr = document.createElement('tr');
+      const gtd = document.createElement('td'); gtd.textContent = g.name; gtd.style.fontWeight = '600'; tr.appendChild(gtd);
+      types.forEach(ty => {
+        const td = document.createElement('td'); td.className = 'num';
+        const m = byType[ty];
+        if (m) {
+          const v = (m.sum != null) ? m.sum : (m.avg != null ? m.avg : null);
+          td.textContent = (v == null) ? '' : formatNum(v);
+          const parts = [];
+          if (m.sum != null) parts.push('sum ' + formatNum(m.sum));
+          if (m.avg != null) parts.push('avg ' + formatNum(m.avg));
+          if (m.min != null) parts.push('min ' + formatNum(m.min));
+          if (m.max != null) parts.push('max ' + formatNum(m.max));
+          if (parts.length) td.title = ty + ': ' + parts.join(' · ');
+        }
+        tr.appendChild(td);
       });
+      tb.appendChild(tr);
     });
-    if (!any) return;
-    const hh = document.createElement('div'); hh.className = 'desc'; hh.style.marginTop = '12px'; hh.textContent = 'OneView groups (rollups):'; groupsWrap.appendChild(hh);
+    const hh = document.createElement('div'); hh.className = 'desc'; hh.style.marginTop = '12px'; hh.textContent = 'OneView groups (rollups — group totals; hover a value for sum/avg/min/max):'; groupsWrap.appendChild(hh);
     t.appendChild(tb); groupsWrap.appendChild(t);
   };
   const draw = () => { (viewSel.value === 'flat' ? drawFlat : drawGrouped)(); drawGroupRollups(); };

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -569,41 +569,44 @@ function addLiveDataSection(nav, sections) {
     const f = filter.value.trim().toLowerCase();
     const shown = gs.filter(g => !f || (g.name || '').toLowerCase().includes(f));
     if (!shown.length) return;
-    // Union of measurement types (+ units) across all groups, for stable columns.
-    const types = []; const units = {};
-    gs.forEach(g => (g.measurements || []).forEach(m => { if (!types.includes(m.type)) types.push(m.type); if (m.units && !units[m.type]) units[m.type] = m.units; }));
+    // Union of measurement types (+ units) across all groups, for stable columns. A type whose members
+    // vary gets Min/Max columns flanking its total (e.g. Min | realPower (W) | Max).
+    const types = []; const units = {}; const spread = {};
+    gs.forEach(g => (g.measurements || []).forEach(m => {
+      if (!types.includes(m.type)) types.push(m.type);
+      if (m.units && !units[m.type]) units[m.type] = m.units;
+      if (m.min != null && m.max != null) spread[m.type] = true;
+    }));
     types.sort();
+    // Flatten types into ordered columns.
+    const cols = [];
+    types.forEach(ty => {
+      if (spread[ty]) cols.push({ ty, kind: 'min', label: 'Min' });
+      cols.push({ ty, kind: 'val', label: ty + (units[ty] ? ' (' + units[ty] + ')' : '') });
+      if (spread[ty]) cols.push({ ty, kind: 'max', label: 'Max' });
+    });
     const t = document.createElement('table'); t.className = 'ld';
     const head = document.createElement('tr');
-    ['OneView group', ...types.map(ty => ty + (units[ty] ? ' (' + units[ty] + ')' : ''))].forEach((x, i) => { const th = document.createElement('th'); th.textContent = x; if (i >= 1) th.className = 'num'; head.appendChild(th); });
+    ['OneView group', ...cols.map(c => c.label)].forEach((x, i) => { const th = document.createElement('th'); th.textContent = x; if (i >= 1) th.className = 'num'; head.appendChild(th); });
     const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
     const tb = document.createElement('tbody');
     shown.forEach(g => {
       const byType = {}; (g.measurements || []).forEach(m => byType[m.type] = m);
       const tr = document.createElement('tr');
       const gtd = document.createElement('td'); gtd.textContent = g.name; gtd.style.fontWeight = '600'; tr.appendChild(gtd);
-      types.forEach(ty => {
+      cols.forEach(c => {
         const td = document.createElement('td'); td.className = 'num';
-        const m = byType[ty];
+        const m = byType[c.ty];
         if (m) {
-          const v = (m.sum != null) ? m.sum : (m.avg != null ? m.avg : null);
-          const main = document.createElement('div'); main.textContent = (v == null) ? '' : formatNum(v); td.appendChild(main);
-          // Show the per-member spread (min–max) under the group total when it varies.
-          if (m.min != null && m.max != null) {
-            const sub = document.createElement('div'); sub.className = 'ld-count'; sub.textContent = formatNum(m.min) + '–' + formatNum(m.max); td.appendChild(sub);
-          }
-          const parts = [];
-          if (m.sum != null) parts.push('sum ' + formatNum(m.sum));
-          if (m.avg != null) parts.push('avg ' + formatNum(m.avg));
-          if (m.min != null) parts.push('min ' + formatNum(m.min));
-          if (m.max != null) parts.push('max ' + formatNum(m.max));
-          if (parts.length) td.title = ty + ': ' + parts.join(' · ');
+          const v = c.kind === 'min' ? m.min : c.kind === 'max' ? m.max : (m.sum != null ? m.sum : m.avg);
+          td.textContent = (v == null) ? '' : formatNum(v);
+          if (c.kind === 'val' && m.avg != null) td.title = c.ty + ' avg ' + formatNum(m.avg);
         }
         tr.appendChild(td);
       });
       tb.appendChild(tr);
     });
-    const hh = document.createElement('div'); hh.className = 'desc'; hh.style.marginTop = '12px'; hh.textContent = 'OneView groups (rollups — group totals; hover a value for sum/avg/min/max):'; groupsWrap.appendChild(hh);
+    const hh = document.createElement('div'); hh.className = 'desc'; hh.style.marginTop = '12px'; hh.textContent = 'OneView groups (rollups — group totals, with per-member Min/Max):'; groupsWrap.appendChild(hh);
     t.appendChild(tb); groupsWrap.appendChild(t);
   };
   const draw = () => { (viewSel.value === 'flat' ? drawFlat : drawGrouped)(); drawGroupRollups(); };

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -356,14 +356,38 @@ function addControlSection(nav, sections) {
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
     setTimeout(load, 1000);
   };
+  const setGroupLabel = (g, value) => postLabel({ target: 'group', groupKey: g.key, label: (value || '').trim() }, 'Group ' + (g.name || g.key));
   const drawGroups = () => {
     groupsWrap.innerHTML = '';
     if (!groups.length) return;
-    const hh = document.createElement('div'); hh.className = 'desc'; hh.style.marginTop = '4px'; hh.textContent = 'Groups — act on all member outlets:'; groupsWrap.appendChild(hh);
-    const t = document.createElement('table'); t.className = 'ld'; const tb = document.createElement('tbody');
+    const hh = document.createElement('div'); hh.className = 'desc'; hh.style.marginTop = '4px'; hh.textContent = 'Groups — rename, see member states, and act on all member outlets:'; groupsWrap.appendChild(hh);
+    const t = document.createElement('table'); t.className = 'ld';
+    const head = document.createElement('tr');
+    ['Group', 'Label (on PDU)', 'Members', 'Actions'].forEach(x => { const th = document.createElement('th'); th.textContent = x; head.appendChild(th); });
+    const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
+    const tb = document.createElement('tbody');
     groups.forEach(g => {
       const tr = document.createElement('tr');
       const nameTd = document.createElement('td'); nameTd.textContent = g.name || g.key; tr.appendChild(nameTd);
+      // Editable group label (written to the PDU).
+      const labTd = document.createElement('td');
+      const lin = document.createElement('input'); lin.type = 'text'; lin.value = g.label || ''; lin.style.width = '140px'; lin.disabled = !enabled;
+      const setBtn = document.createElement('button'); setBtn.className = 'small'; setBtn.textContent = 'Set'; setBtn.disabled = !enabled; setBtn.style.marginLeft = '6px';
+      setBtn.onclick = () => setGroupLabel(g, lin.value);
+      labTd.appendChild(lin); labTd.appendChild(setBtn); tr.appendChild(labTd);
+      // Aggregate member state: a dot per member outlet + an "n/m on" summary.
+      const memTd = document.createElement('td');
+      const members = g.members || [];
+      const onCount = members.filter(m => m.state === 'on').length;
+      members.forEach(m => {
+        const dot = document.createElement('span');
+        dot.className = 'dot ' + (m.state === 'on' ? 'good' : m.state === 'off' ? 'bad' : 'muted');
+        dot.style.marginRight = '3px'; dot.title = (m.name || ('#' + m.number)) + ': ' + (m.state || '?');
+        memTd.appendChild(dot);
+      });
+      if (members.length) { const c = document.createElement('span'); c.className = 'ld-count'; c.style.marginLeft = '4px'; c.textContent = onCount + '/' + members.length + ' on'; memTd.appendChild(c); }
+      else { memTd.textContent = '—'; memTd.style.color = 'var(--muted)'; }
+      tr.appendChild(memTd);
       const actTd = document.createElement('td');
       [['All On', 'on'], ['All Off', 'off'], ['Reboot All', 'reboot']].forEach(([lab, a]) => {
         const b = document.createElement('button'); b.className = 'small' + (a !== 'on' ? ' danger' : ''); b.textContent = lab; b.disabled = !enabled; b.style.marginRight = '6px'; b.onclick = () => actGroup(g, a); actTd.appendChild(b);
@@ -485,8 +509,9 @@ function addLiveDataSection(nav, sections) {
   bar.appendChild(refresh); bar.appendChild(viewSel); bar.appendChild(filter); bar.appendChild(autoLab); bar.appendChild(count);
   sec.appendChild(bar);
   const tableWrap = document.createElement('div'); sec.appendChild(tableWrap);
+  const groupsWrap = document.createElement('div'); sec.appendChild(groupsWrap);
 
-  let body = { entities: [], types: [], units: {}, readings: [] }, timer = null;
+  let body = { entities: [], types: [], units: {}, readings: [], groups: [] }, timer = null;
 
   // Pivoted: one row per outlet/entity, a column per measurement type, grouped by device.
   const drawGrouped = () => {
@@ -535,12 +560,38 @@ function addLiveDataSection(nav, sections) {
     t.appendChild(tb); tableWrap.innerHTML = ''; tableWrap.appendChild(t);
   };
 
-  const draw = () => viewSel.value === 'flat' ? drawFlat() : drawGrouped();
+  // OneView group rollups (Sum/Avg/Min/Max per measurement type) — one row per group/measurement.
+  const drawGroupRollups = () => {
+    groupsWrap.innerHTML = '';
+    const gs = body.groups || [];
+    if (!gs.length) return;
+    const f = filter.value.trim().toLowerCase();
+    const t = document.createElement('table'); t.className = 'ld';
+    const head = document.createElement('tr');
+    ['OneView group', 'Measurement', 'Sum', 'Avg', 'Min', 'Max', 'Units'].forEach((x, i) => { const th = document.createElement('th'); th.textContent = x; if (i >= 2 && i <= 5) th.className = 'num'; head.appendChild(th); });
+    const thead = document.createElement('thead'); thead.appendChild(head); t.appendChild(thead);
+    const tb = document.createElement('tbody');
+    let any = false;
+    gs.forEach(g => {
+      const ms = (g.measurements || []).filter(m => !f || (g.name + ' ' + m.type).toLowerCase().includes(f));
+      ms.forEach((m, idx) => {
+        any = true;
+        const tr = document.createElement('tr');
+        const gtd = document.createElement('td'); gtd.textContent = idx === 0 ? g.name : ''; if (idx === 0) gtd.style.fontWeight = '600'; tr.appendChild(gtd);
+        [m.type, m.sum, m.avg, m.min, m.max, m.units || ''].forEach((c, i) => { const td = document.createElement('td'); if (i >= 1 && i <= 4) { td.className = 'num'; td.textContent = (c == null) ? '' : formatNum(c); } else td.textContent = c; tr.appendChild(td); });
+        tb.appendChild(tr);
+      });
+    });
+    if (!any) return;
+    const hh = document.createElement('div'); hh.className = 'desc'; hh.style.marginTop = '12px'; hh.textContent = 'OneView groups (rollups):'; groupsWrap.appendChild(hh);
+    t.appendChild(tb); groupsWrap.appendChild(t);
+  };
+  const draw = () => { (viewSel.value === 'flat' ? drawFlat : drawGrouped)(); drawGroupRollups(); };
   const load = async () => {
     const r = await api('/api/livedata');
-    if (!r.body.ok) { tableWrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load live data.') + '</div>'; count.textContent = ''; return; }
+    if (!r.body.ok) { tableWrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load live data.') + '</div>'; groupsWrap.innerHTML = ''; count.textContent = ''; return; }
     body = r.body;
-    count.textContent = (body.entities || []).length + ' outlets/entities · ' + (body.readings || []).length + ' readings';
+    count.textContent = (body.entities || []).length + ' outlets/entities · ' + (body.readings || []).length + ' readings · ' + (body.groups || []).length + ' groups';
     draw();
   };
   refresh.onclick = load;

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -561,7 +561,7 @@ function addLiveDataSection(nav, sections) {
   };
 
   // OneView group rollups — one row per group, a column per measurement type showing the group
-  // total (Sum, falling back to Avg); hover a cell for the full sum/avg/min/max breakdown.
+  // total (Sum, falling back to Avg), flanked by Min/Max columns for types whose members vary.
   const drawGroupRollups = () => {
     groupsWrap.innerHTML = '';
     const gs = body.groups || [];

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -587,7 +587,11 @@ function addLiveDataSection(nav, sections) {
         const m = byType[ty];
         if (m) {
           const v = (m.sum != null) ? m.sum : (m.avg != null ? m.avg : null);
-          td.textContent = (v == null) ? '' : formatNum(v);
+          const main = document.createElement('div'); main.textContent = (v == null) ? '' : formatNum(v); td.appendChild(main);
+          // Show the per-member spread (min–max) under the group total when it varies.
+          if (m.min != null && m.max != null) {
+            const sub = document.createElement('div'); sub.className = 'ld-count'; sub.textContent = formatNum(m.min) + '–' + formatNum(m.max); td.appendChild(sub);
+          }
           const parts = [];
           if (m.sum != null) parts.push('sum ' + formatNum(m.sum));
           if (m.avg != null) parts.push('avg ' + formatNum(m.avg));

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -631,7 +631,7 @@ function addLiveDataSection(nav, sections) {
   link.onclick = () => { activate(link, sec); load(); };
 }
 
-function formatNum(v) { return (typeof v === 'number' && Number.isFinite(v)) ? (Math.round(v * 1000) / 1000).toString() : String(v); }
+function formatNum(v) { return (typeof v === 'number' && Number.isFinite(v)) ? v.toLocaleString('en-US', { maximumFractionDigits: 3 }) : String(v); }
 
 function activate(link, sec) {
   document.querySelectorAll('nav a').forEach(a => a.classList.remove('active'));

--- a/rPDU2MQTT/wwwroot/styles.css
+++ b/rPDU2MQTT/wwwroot/styles.css
@@ -61,7 +61,7 @@
   table.ld { width:100%; border-collapse:collapse; font-size:13px; }
   table.ld th, table.ld td { text-align:left; padding:6px 12px; border-bottom:1px solid var(--line); }
   table.ld th { color:var(--muted); font-weight:600; position:sticky; top:53px; background:var(--bg); }
-  table.ld td.num { text-align:right; font-variant-numeric:tabular-nums; }
+  table.ld th.num, table.ld td.num { text-align:right; font-variant-numeric:tabular-nums; }
   table.ld tr:hover td { background:var(--panel); }
   .ro-note { color:var(--bad); font-size:12px; display:none; }
   .ro-note code { background:var(--panel2); padding:0 4px; border-radius:4px; }


### PR DESCRIPTION
Closes #124, closes #125, closes #126.

Three related OneView-group GUI improvements, all in one branch.

## #124 — Rename OneView groups
- `PduApiHandler.SetGroupConfigAsync` writes the group **label** to the PDU (`POST /oneview/group/{key}`, `cmd:"set"`), on the OneView master/base host. Same `{cmd,token,data}` shape as the existing outlet/device/circuit label writes, with the same pending-write latch (`PDU.SetGroupConfigAsync` / `ResolveGroupConfig`).
- `/api/control/label` gains a `group` target; the Control tab's Groups table gets a per-group rename input. Gated by `PDU.ActionsEnabled`.

## #125 — Group state
- `/api/control/outlets` groups now include their member outlets with current state.
- The Control tab shows a **red/green dot per member** outlet (hover for name/state) plus an **"n/m on"** summary — an at-a-glance aggregate view.

## #126 — Live Data page: groups
- `/api/livedata` returns per-group **rollups** (Sum/Avg/Min/Max per measurement type), read from each group's aggregate entity.
- The Live Data page renders a new **"OneView groups (rollups)"** table below the per-outlet data.

## Testing
- `dotnet build` + 44 tests pass.
- Verified against the live PDU that `/oneview` exposes group labels, member mappings (`groupMap`), and per-group rollup measurements — so #125/#126 have real data. (GUI runs OIDC locally, so the click-through is for prod.)
- **Needs hardware confirmation:** the #124 group-label **write** (`/oneview/group/{key}`). It mirrors the working outlet/device/circuit label writes; the live-write probe was blocked as a prod change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)