### PR TITLE
feat(emoncms): input templating, MQTT transport, test button & health (#112, #113)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -395,16 +395,34 @@ The Prometheus section in the GUI (with the metric-name template and Pushgateway
 ![GUI Prometheus configuration](images/gui-prometheus.webp)
 
 ### EmonCMS
-Pushes measurements to an EmonCMS server's `input/post` API (EmonCMS auto-creates the inputs).
+Pushes measurements to EmonCMS each poll (EmonCMS auto-creates the inputs). Delivery is either the
+HTTP `input/post` API or EmonCMS's **MQTT input** on the broker rPDU2MQTT already uses.
 
 ```yaml
 EmonCMS:
   Enabled: false
-  Url: "http://emoncms.example.com"   # required when enabled
-  ApiKey: "your-write-apikey"         # or set RPDU2MQTT_EMONCMS_APIKEY
+  Transport: Http                     # Http (input/post API) or Mqtt (publish to EmonCMS's MQTT input)
+  Url: "http://emoncms.example.com"   # required for the Http transport (or set RPDU2MQTT_EMONCMS_APIKEY)
+  ApiKey: "your-write-apikey"         # or set RPDU2MQTT_EMONCMS_APIKEY    (Http transport)
   Node: "rpdu2mqtt"
-  Path: "input/post"                  # API path (relative to Url) to post to
+  Path: "input/post"                  # API path (relative to Url) to post to (Http transport)
+  InputNameTemplate: "{device}_{source}_{type}"  # EmonCMS input key template (see below)
+  MqttBaseTopic: "emon"               # values published to <base>/<node> as JSON (Mqtt transport)
 ```
+
+**Input names (templating).** `InputNameTemplate` controls the per-measurement input key, the same way
+`Prometheus.MetricNameTemplate` does. Placeholders: `{device}`, `{source}` (a.k.a. `{outlet}`), `{type}`
+(honoring its `Overrides.Measurements` ID), and `{units}`. For example `{device}_{source}_{type}` →
+`rack_pdu_1_dell_md1200_realpower`. Leave it **blank** to fall back to the full raw identifier (the old,
+verbose default). The result is lower-cased with non-alphanumeric characters replaced by `_`.
+
+**MQTT transport.** With `Transport: Mqtt`, measurements are published as a JSON object to
+`<MqttBaseTopic>/<Node>` (e.g. `emon/rpdu2mqtt`) — point EmonCMS's [MQTT input](https://docs.openenergymonitor.org/emoncms/postingdata.html#sending-data-to-emoncms-using-mqtt)
+at the same broker. No `Url`/`ApiKey` needed.
+
+**Testing & health.** The GUI's EmonCMS section has a **Test EmonCMS connection** button (validates the
+server + API key for HTTP, or broker connectivity for MQTT), and the **Diagnostics** page shows the last
+export result (ok / error, transport, input count).
 
 The GUI's EmonCMS section, and the inputs/feeds it auto-creates in EmonCMS:
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -411,7 +411,8 @@ EmonCMS:
 ```
 
 **Input names (templating).** `InputNameTemplate` controls the per-measurement input key, the same way
-`Prometheus.MetricNameTemplate` does. Placeholders: `{device}`, `{source}` (a.k.a. `{outlet}`), `{type}`
+`Prometheus.MetricNameTemplate` does. Placeholders: `{device}`, `{source}` (object-id form), `{name}`
+(the formatted display name), `{number}` (outlet number; blank for circuits/phase/total), `{type}`
 (honoring its `Overrides.Measurements` ID), and `{units}`. For example `{device}_{source}_{type}` →
 `rack_pdu_1_dell_md1200_realpower`. Leave it **blank** to fall back to the full raw identifier (the old,
 verbose default). The result is lower-cased with non-alphanumeric characters replaced by `_`.

--- a/rPDU2MQTT.Tests/HelperTests.cs
+++ b/rPDU2MQTT.Tests/HelperTests.cs
@@ -115,6 +115,31 @@ public class MetricsHelperTests
     }
 
     [Fact]
+    public void EmonCmsInputName_DefaultTemplate_BuildsCleanKey()
+    {
+        var r = new MeasurementReading("rack-pdu-1", "dell-md1200", "realPower", 5, "W", "raw_identifier", "topic");
+        Assert.Equal("rack_pdu_1_dell_md1200_realpower", MetricsHelper.EmonCmsInputName(r, new Config()));
+    }
+
+    [Fact]
+    public void EmonCmsInputName_BlankTemplate_FallsBackToIdentifier()
+    {
+        var cfg = new Config();
+        cfg.EmonCMS.InputNameTemplate = "";
+        var r = new MeasurementReading("dev", "src", "realPower", 5, "W", "the_identifier", "topic");
+        Assert.Equal("the_identifier", MetricsHelper.EmonCmsInputName(r, cfg));
+    }
+
+    [Fact]
+    public void EmonCmsInputName_HonorsMeasurementIdOverride()
+    {
+        var cfg = new Config();
+        cfg.Overrides.Measurements["realPower"] = new EntityOverride { ID = "power" };
+        var r = new MeasurementReading("pdu", "kube02", "realPower", 5, "W", "id", "topic");
+        Assert.Equal("pdu_kube02_power", MetricsHelper.EmonCmsInputName(r, cfg));
+    }
+
+    [Fact]
     public void PrometheusMetricName_SupportsDeviceSourceUnitsPlaceholders()
     {
         var cfg = new Config();

--- a/rPDU2MQTT.Tests/HelperTests.cs
+++ b/rPDU2MQTT.Tests/HelperTests.cs
@@ -117,7 +117,7 @@ public class MetricsHelperTests
     [Fact]
     public void EmonCmsInputName_DefaultTemplate_BuildsCleanKey()
     {
-        var r = new MeasurementReading("rack-pdu-1", "dell-md1200", "realPower", 5, "W", "raw_identifier", "topic");
+        var r = new MeasurementReading("rack-pdu-1", "dell-md1200", "realPower", 5, "W", "raw_identifier", "topic", "Dell: MD1200", 7);
         Assert.Equal("rack_pdu_1_dell_md1200_realpower", MetricsHelper.EmonCmsInputName(r, new Config()));
     }
 
@@ -126,7 +126,7 @@ public class MetricsHelperTests
     {
         var cfg = new Config();
         cfg.EmonCMS.InputNameTemplate = "";
-        var r = new MeasurementReading("dev", "src", "realPower", 5, "W", "the_identifier", "topic");
+        var r = new MeasurementReading("dev", "src", "realPower", 5, "W", "the_identifier", "topic", "Src", 1);
         Assert.Equal("the_identifier", MetricsHelper.EmonCmsInputName(r, cfg));
     }
 
@@ -135,8 +135,17 @@ public class MetricsHelperTests
     {
         var cfg = new Config();
         cfg.Overrides.Measurements["realPower"] = new EntityOverride { ID = "power" };
-        var r = new MeasurementReading("pdu", "kube02", "realPower", 5, "W", "id", "topic");
+        var r = new MeasurementReading("pdu", "kube02", "realPower", 5, "W", "id", "topic", "Kube02", 5);
         Assert.Equal("pdu_kube02_power", MetricsHelper.EmonCmsInputName(r, cfg));
+    }
+
+    [Fact]
+    public void EmonCmsInputName_SupportsNameAndNumber()
+    {
+        var cfg = new Config();
+        cfg.EmonCMS.InputNameTemplate = "outlet{number}_{name}_{type}";
+        var r = new MeasurementReading("pdu", "src", "realPower", 5, "W", "id", "topic", "kube02", 3);
+        Assert.Equal("outlet3_kube02_realpower", MetricsHelper.EmonCmsInputName(r, cfg));
     }
 
     [Fact]

--- a/rPDU2MQTT/Helpers/MetricsHelper.cs
+++ b/rPDU2MQTT/Helpers/MetricsHelper.cs
@@ -6,7 +6,9 @@ using System.Globalization;
 namespace rPDU2MQTT.Helpers;
 
 /// <summary>A single numeric measurement, flattened for export to Prometheus / EmonCMS / etc.</summary>
-public readonly record struct MeasurementReading(string Device, string Source, string Type, double Value, string Units, string Identifier, string Topic);
+/// <param name="SourceName">The source's formatted display name (vs <paramref name="Source"/>'s object-id form).</param>
+/// <param name="Number">The 1-based outlet number, or null for non-outlet entities (circuits/phase/total).</param>
+public readonly record struct MeasurementReading(string Device, string Source, string Type, double Value, string Units, string Identifier, string Topic, string SourceName, int? Number);
 
 public static class MetricsHelper
 {
@@ -19,20 +21,20 @@ public static class MetricsHelper
         foreach (var device in data.Devices)
         {
             foreach (var outlet in device.Outlets)
-                foreach (var reading in ToReadings(device.Entity_Name, outlet.Entity_Name, outlet.Measurements))
+                foreach (var reading in ToReadings(device.Entity_Name, outlet.Entity_Name, outlet.Entity_DisplayName, outlet.Key + 1, outlet.Measurements))
                     yield return reading;
 
             foreach (var entity in device.Entity)
-                foreach (var reading in ToReadings(device.Entity_Name, entity.Entity_Name, entity.Measurements))
+                foreach (var reading in ToReadings(device.Entity_Name, entity.Entity_Name, entity.Entity_DisplayName, null, entity.Measurements))
                     yield return reading;
         }
     }
 
-    private static IEnumerable<MeasurementReading> ToReadings(string device, string source, IEnumerable<Measurement> measurements)
+    private static IEnumerable<MeasurementReading> ToReadings(string device, string source, string sourceName, int? number, IEnumerable<Measurement> measurements)
     {
         foreach (var m in measurements)
             if (double.TryParse(m.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
-                yield return new MeasurementReading(device, source, m.Type, value, m.Units, m.Entity_Identifier, m.GetTopicPath());
+                yield return new MeasurementReading(device, source, m.Type, value, m.Units, m.Entity_Identifier, m.GetTopicPath(), sourceName, number);
     }
 
     /// <summary>
@@ -85,6 +87,8 @@ public static class MetricsHelper
             .Replace("{device}", r.Device)
             .Replace("{source}", r.Source)
             .Replace("{outlet}", r.Source)
+            .Replace("{name}", r.SourceName ?? r.Source)
+            .Replace("{number}", r.Number?.ToString() ?? string.Empty)
             .Replace("{units}", r.Units);
 
         return Sanitize(name);

--- a/rPDU2MQTT/Helpers/MetricsHelper.cs
+++ b/rPDU2MQTT/Helpers/MetricsHelper.cs
@@ -65,6 +65,31 @@ public static class MetricsHelper
     public static string PrometheusMetricName(MeasurementReading r, Config config)
         => PrometheusMetricName(r.Type, r.Device, r.Source, r.Units, config);
 
+    /// <summary>
+    /// The EmonCMS input key for a reading, applying <c>EmonCMS.InputNameTemplate</c>. Placeholders:
+    /// <c>{type}</c> (honoring its Overrides.Measurements ID), <c>{device}</c>, <c>{source}</c> /
+    /// <c>{outlet}</c>, <c>{units}</c>. A blank template falls back to the full raw identifier.
+    /// </summary>
+    public static string EmonCmsInputName(MeasurementReading r, Config config)
+    {
+        var template = config.EmonCMS.InputNameTemplate;
+        if (string.IsNullOrWhiteSpace(template))
+            return r.Identifier;
+
+        var effectiveType = config.Overrides.Measurements.TryGetValue(r.Type, out var ov) && !string.IsNullOrWhiteSpace(ov?.ID)
+            ? ov!.ID!
+            : r.Type;
+
+        var name = template
+            .Replace("{type}", effectiveType)
+            .Replace("{device}", r.Device)
+            .Replace("{source}", r.Source)
+            .Replace("{outlet}", r.Source)
+            .Replace("{units}", r.Units);
+
+        return Sanitize(name);
+    }
+
     private static string Sanitize(string value)
         => new(value.Select(c => char.IsLetterOrDigit(c) ? char.ToLowerInvariant(c) : '_').ToArray());
 }

--- a/rPDU2MQTT/Models/Config/EmonCMSConfig.cs
+++ b/rPDU2MQTT/Models/Config/EmonCMSConfig.cs
@@ -11,12 +11,16 @@ public class EmonCMSConfig
     [Description("Push measurements to an EmonCMS server.")]
     public bool Enabled { get; set; }
 
+    [DefaultValue(EmonCmsTransport.Http)]
+    [Description("How to deliver measurements: Http (input/post API) or Mqtt (publish to EmonCMS's MQTT input on the same broker).")]
+    public EmonCmsTransport Transport { get; set; } = EmonCmsTransport.Http;
+
     /// <summary>Base URL of the EmonCMS server, e.g. "http://emoncms.example.com".</summary>
-    [Description("Base URL of the EmonCMS server, e.g. http://emoncms.example.com.")]
+    [Description("Base URL of the EmonCMS server, e.g. http://emoncms.example.com. (Http transport.)")]
     public string? Url { get; set; }
 
     /// <summary>EmonCMS write API key (can also be supplied via RPDU2MQTT_EMONCMS_APIKEY).</summary>
-    [Description("EmonCMS write API key (or set RPDU2MQTT_EMONCMS_APIKEY).")]
+    [Description("EmonCMS write API key (or set RPDU2MQTT_EMONCMS_APIKEY). (Http transport.)")]
     public string? ApiKey { get; set; }
 
     /// <summary>EmonCMS input node name.</summary>
@@ -26,6 +30,20 @@ public class EmonCMSConfig
 
     /// <summary>API path (relative to <see cref="Url"/>) that measurements are posted to.</summary>
     [DefaultValue("input/post")]
-    [Description("API path (relative to Url) that measurements are posted to.")]
+    [Description("API path (relative to Url) that measurements are posted to. (Http transport.)")]
     public string Path { get; set; } = "input/post";
+
+    /// <summary>
+    /// Template for the EmonCMS input key (per measurement). Placeholders: {device}, {source}/{outlet},
+    /// {type}, {units}. When blank, the full generated identifier is used (legacy behaviour).
+    /// </summary>
+    [DefaultValue("{device}_{source}_{type}")]
+    [Description("Template for EmonCMS input keys. Placeholders: {device}, {source} (a.k.a. {outlet}), {type}, {units}. e.g. '{device}_{source}_{type}' -> rack_pdu_1_dell_md1200_realpower. Leave blank to use the full raw identifier.")]
+    [TemplateVariables("device", "source", "type", "units")]
+    public string InputNameTemplate { get; set; } = "{device}_{source}_{type}";
+
+    /// <summary>Base MQTT topic for EmonCMS's MQTT input (the Mqtt transport publishes to base/node).</summary>
+    [DefaultValue("emon")]
+    [Description("Base MQTT topic for EmonCMS's MQTT input; values are published to <base>/<node> as JSON. (Mqtt transport.)")]
+    public string MqttBaseTopic { get; set; } = "emon";
 }

--- a/rPDU2MQTT/Models/Config/EmonCMSConfig.cs
+++ b/rPDU2MQTT/Models/Config/EmonCMSConfig.cs
@@ -38,8 +38,8 @@ public class EmonCMSConfig
     /// {type}, {units}. When blank, the full generated identifier is used (legacy behaviour).
     /// </summary>
     [DefaultValue("{device}_{source}_{type}")]
-    [Description("Template for EmonCMS input keys. Placeholders: {device}, {source} (a.k.a. {outlet}), {type}, {units}. e.g. '{device}_{source}_{type}' -> rack_pdu_1_dell_md1200_realpower. Leave blank to use the full raw identifier.")]
-    [TemplateVariables("device", "source", "type", "units")]
+    [Description("Template for EmonCMS input keys. Placeholders: {device}, {source} (object-id form), {name} (formatted display name), {number} (outlet number), {type}, {units}. e.g. '{device}_{source}_{type}' -> rack_pdu_1_dell_md1200_realpower. Leave blank to use the full raw identifier.")]
+    [TemplateVariables("device", "source", "name", "number", "type", "units")]
     public string InputNameTemplate { get; set; } = "{device}_{source}_{type}";
 
     /// <summary>Base MQTT topic for EmonCMS's MQTT input (the Mqtt transport publishes to base/node).</summary>

--- a/rPDU2MQTT/Models/Config/EmonCmsTransport.cs
+++ b/rPDU2MQTT/Models/Config/EmonCmsTransport.cs
@@ -1,0 +1,11 @@
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>How measurements are delivered to EmonCMS.</summary>
+public enum EmonCmsTransport
+{
+    /// <summary>POST to the EmonCMS <c>input/post</c> HTTP API (default).</summary>
+    Http,
+
+    /// <summary>Publish to EmonCMS's MQTT input (the broker rPDU2MQTT already connects to).</summary>
+    Mqtt,
+}

--- a/rPDU2MQTT/Services/EmonCmsExportService.cs
+++ b/rPDU2MQTT/Services/EmonCmsExportService.cs
@@ -1,27 +1,30 @@
 using rPDU2MQTT.Classes;
 using rPDU2MQTT.Helpers;
+using rPDU2MQTT.Models.Config;
 using rPDU2MQTT.Services.baseTypes;
 using System.Text.Json;
 
 namespace rPDU2MQTT.Services;
 
 /// <summary>
-/// Pushes PDU measurements to an EmonCMS server via its input/post API on each poll. EmonCMS
-/// auto-creates the inputs from the posted keys. Enabled via config.
+/// Pushes PDU measurements to EmonCMS on each poll, via either its HTTP input/post API or by
+/// publishing to its MQTT input. Input keys come from <c>EmonCMS.InputNameTemplate</c>. The outcome
+/// is recorded in <see cref="EmonCmsStatus"/> for the GUI health indicator. Enabled via config.
 /// </summary>
 public class EmonCmsExportService : baseMQTTService
 {
     private static readonly HttpClient http = new();
+    private readonly Config config;
+    private readonly EmonCMSConfig c;
+    private readonly EmonCmsStatus status;
     private readonly string postUrl;
-    private readonly string node;
-    private readonly string apiKey;
 
-    public EmonCmsExportService(MQTTServiceDependencies deps) : base(deps, deps.Cfg.PDU.PollInterval)
+    public EmonCmsExportService(MQTTServiceDependencies deps, EmonCmsStatus status) : base(deps, deps.Cfg.PDU.PollInterval)
     {
-        var c = deps.Cfg.EmonCMS;
+        config = deps.Cfg;
+        c = deps.Cfg.EmonCMS;
+        this.status = status;
         postUrl = (c.Url ?? string.Empty).TrimEnd('/') + "/" + (c.Path ?? "input/post").TrimStart('/');
-        node = c.Node;
-        apiKey = c.ApiKey ?? string.Empty;
     }
 
     protected override async Task Execute(CancellationToken cancellationToken)
@@ -30,24 +33,51 @@ public class EmonCmsExportService : baseMQTTService
 
         var values = new Dictionary<string, double>();
         foreach (var r in MetricsHelper.EnumerateReadings(data))
-            values[r.Identifier] = r.Value;
+            values[MetricsHelper.EmonCmsInputName(r, config)] = r.Value;
 
         if (values.Count == 0)
             return;
 
+        try
+        {
+            if (c.Transport == EmonCmsTransport.Mqtt)
+                await SendViaMqtt(values, cancellationToken);
+            else
+                await SendViaHttp(values, cancellationToken);
+
+            status.RecordSuccess(values.Count);
+        }
+        catch (Exception ex)
+        {
+            status.RecordFailure(ex.Message);
+            Log.Error($"EmonCMS export failed: {ex.Message}");
+        }
+    }
+
+    private async Task SendViaHttp(Dictionary<string, double> values, CancellationToken cancellationToken)
+    {
         var form = new Dictionary<string, string>
         {
-            ["node"] = node,
-            ["apikey"] = apiKey,
+            ["node"] = c.Node,
+            ["apikey"] = c.ApiKey ?? string.Empty,
             ["fulljson"] = JsonSerializer.Serialize(values),
         };
 
         using var content = new FormUrlEncodedContent(form);
         var response = await http.PostAsync(postUrl, content, cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
         if (!response.IsSuccessStatusCode)
-        {
-            var body = await response.Content.ReadAsStringAsync(cancellationToken);
-            Log.Error($"EmonCMS post failed (HTTP {(int)response.StatusCode}): {body}");
-        }
+            throw new Exception($"HTTP {(int)response.StatusCode}: {body}");
+        // EmonCMS answers 200 even on auth/permission failures, flagged in the JSON body.
+        if (body.Contains("\"success\":false", StringComparison.OrdinalIgnoreCase))
+            throw new Exception($"EmonCMS rejected the post: {body}");
+    }
+
+    private Task SendViaMqtt(Dictionary<string, double> values, CancellationToken cancellationToken)
+    {
+        // EmonCMS's MQTT input parses a JSON payload on <baseTopic>/<node>.
+        var topic = $"{(c.MqttBaseTopic ?? "emon").TrimEnd('/')}/{c.Node}";
+        return PublishString(topic, JsonSerializer.Serialize(values), cancellationToken);
     }
 }

--- a/rPDU2MQTT/Services/EmonCmsStatus.cs
+++ b/rPDU2MQTT/Services/EmonCmsStatus.cs
@@ -1,0 +1,53 @@
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Tracks the outcome of the most recent EmonCMS export so the GUI can show a health indicator.
+/// Thread-safe; a singleton shared by <see cref="EmonCmsExportService"/> (writer) and the GUI (reader).
+/// </summary>
+public sealed class EmonCmsStatus
+{
+    private readonly object gate = new();
+
+    public DateTime? LastAttemptUtc { get; private set; }
+    public DateTime? LastSuccessUtc { get; private set; }
+    public bool? LastOk { get; private set; }
+    public string? LastError { get; private set; }
+    public int LastCount { get; private set; }
+
+    public void RecordSuccess(int count)
+    {
+        lock (gate)
+        {
+            var now = DateTime.UtcNow;
+            LastAttemptUtc = now;
+            LastSuccessUtc = now;
+            LastOk = true;
+            LastError = null;
+            LastCount = count;
+        }
+    }
+
+    public void RecordFailure(string error)
+    {
+        lock (gate)
+        {
+            LastAttemptUtc = DateTime.UtcNow;
+            LastOk = false;
+            LastError = error;
+        }
+    }
+
+    /// <summary>A snapshot for serialization (e.g. the diagnostics endpoint).</summary>
+    public object Snapshot()
+    {
+        lock (gate)
+            return new
+            {
+                ok = LastOk,
+                lastAttemptUtc = LastAttemptUtc,
+                lastSuccessUtc = LastSuccessUtc,
+                lastError = LastError,
+                count = LastCount,
+            };
+    }
+}

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -37,9 +37,11 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly IHostApplicationLifetime lifetime;
     private readonly HealthState health;
     private readonly PduApiHandler pduApi;
+    private readonly EmonCmsStatus emonCmsStatus;
+    private static readonly HttpClient testHttp = new() { Timeout = TimeSpan.FromSeconds(15) };
     private WebApplication? app;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduApiHandler pduApi)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduApiHandler pduApi, EmonCmsStatus emonCmsStatus)
     {
         this.config = config;
         this.mqtt = mqtt;
@@ -49,6 +51,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         this.lifetime = lifetime;
         this.health = health;
         this.pduApi = pduApi;
+        this.emonCmsStatus = emonCmsStatus;
     }
 
     /// <summary>Authentication is turned off entirely (Gui.AuthType = None).</summary>
@@ -342,6 +345,9 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 kubernetes = k8s is not null,
                 pod = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME"),
                 ns = k8s?.Namespace,
+                emoncms = config.EmonCMS.Enabled
+                    ? new { enabled = true, transport = config.EmonCMS.Transport.ToString().ToLowerInvariant(), status = emonCmsStatus.Snapshot() }
+                    : new { enabled = false, transport = (string?)null, status = (object?)null },
             }, ConfigSchema.Json);
         });
 
@@ -434,6 +440,45 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             catch (Exception ex)
             {
                 return Results.Json(new { ok = false, message = $"PDU request failed: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
+        // Validate the EmonCMS configuration (HTTP: reach the server + check the API key; MQTT: broker up).
+        app.MapPost("/api/test/emoncms", async (HttpContext ctx) =>
+        {
+            var e = config.EmonCMS;
+            if (!e.Enabled)
+                return Results.Json(new { ok = false, message = "EmonCMS is disabled (EmonCMS.Enabled is false)." }, ConfigSchema.Json);
+
+            if (e.Transport == EmonCmsTransport.Mqtt)
+            {
+                var topic = $"{(e.MqttBaseTopic ?? "emon").TrimEnd('/')}/{e.Node}";
+                return mqtt.IsConnected()
+                    ? Results.Json(new { ok = true, message = $"MQTT broker connected; publishing to '{topic}'. (EmonCMS receipt can't be confirmed from here.)" }, ConfigSchema.Json)
+                    : Results.Json(new { ok = false, message = "MQTT broker is not connected — check the MQTT settings." }, ConfigSchema.Json);
+            }
+
+            if (string.IsNullOrWhiteSpace(e.Url))
+                return Results.Json(new { ok = false, message = "EmonCMS.Url is required for the HTTP transport." }, ConfigSchema.Json);
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(15));
+            try
+            {
+                var url = $"{e.Url.TrimEnd('/')}/feed/list.json?apikey={Uri.EscapeDataString(e.ApiKey ?? string.Empty)}";
+                using var resp = await testHttp.GetAsync(url, cts.Token);
+                var body = (await resp.Content.ReadAsStringAsync(cts.Token)).TrimStart();
+                if (!resp.IsSuccessStatusCode)
+                    return Results.Json(new { ok = false, message = $"EmonCMS returned HTTP {(int)resp.StatusCode}." }, ConfigSchema.Json);
+                if (body.StartsWith("["))
+                    return Results.Json(new { ok = true, message = "Reached EmonCMS and the API key was accepted." }, ConfigSchema.Json);
+                if (body.Contains("\"success\":false", StringComparison.OrdinalIgnoreCase) || body.Equals("false", StringComparison.OrdinalIgnoreCase) || body.Contains("invalid", StringComparison.OrdinalIgnoreCase))
+                    return Results.Json(new { ok = false, message = "Reached EmonCMS but the API key was rejected (a read/write key is required)." }, ConfigSchema.Json);
+                return Results.Json(new { ok = true, message = "Reached EmonCMS." }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Could not reach EmonCMS: {ex.Message}" }, ConfigSchema.Json);
             }
         });
 

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -116,6 +116,8 @@ public static class ServiceConfiguration
 
         // Shared liveness/readiness signals (uptime + last successful poll).
         services.AddSingleton<HealthState>();
+        // EmonCMS export health (last attempt/success/error) — read by the GUI even when disabled.
+        services.AddSingleton<Services.EmonCmsStatus>();
 
         // Created hosted services.
         services.AddHostedService<MQTTPublishingService>();
@@ -126,7 +128,9 @@ public static class ServiceConfiguration
 
         if (cfg.EmonCMS.Enabled)
         {
-            ThrowError.TestRequiredConfigurationSection(cfg.EmonCMS.Url, "EmonCMS.Url");
+            // Url is only needed for the HTTP transport; the MQTT transport uses the existing broker.
+            if (cfg.EmonCMS.Transport == Models.Config.EmonCmsTransport.Http)
+                ThrowError.TestRequiredConfigurationSection(cfg.EmonCMS.Url, "EmonCMS.Url");
             services.AddHostedService<EmonCmsExportService>();
         }
 

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -282,6 +282,14 @@ function addDiagnosticsSection(nav, sections) {
     info.appendChild(row('Started (UTC)', b.startedUtc));
     info.appendChild(row('MQTT', (b.mqttConnected ? 'connected' : 'disconnected') + ' — ' + b.mqttHost));
     info.appendChild(row('Last PDU poll (UTC)', b.lastPollUtc));
+    if (b.emoncms && b.emoncms.enabled) {
+      const s = b.emoncms.status || {};
+      let txt;
+      if (s.ok === true) txt = 'ok (' + b.emoncms.transport + ') — last sent ' + (s.lastSuccessUtc || '?') + (s.count ? ', ' + s.count + ' inputs' : '');
+      else if (s.ok === false) txt = 'error (' + b.emoncms.transport + ') — ' + (s.lastError || 'unknown');
+      else txt = 'enabled (' + b.emoncms.transport + ') — no export yet';
+      info.appendChild(row('EmonCMS', txt));
+    }
     info.appendChild(row('Config source', b.configSource));
     info.appendChild(row('.NET', b.dotnet));
     info.appendChild(row('OS', b.os));
@@ -811,6 +819,7 @@ function sectionActions(node) {
 
   if (node.key === 'MQTT') add('Test MQTT connection', testMqtt);
   else if (node.key === 'PDU') add('Test PDU connection', testPdu);
+  else if (node.key === 'EmonCMS') add('Test EmonCMS connection', testEmonCms);
   else if (node.key === 'HomeAssistant') {
     if ((data.HomeAssistant || {}).DiscoveryEnabled === false) return null;
     add('Republish discovery', rediscoverHa);
@@ -877,6 +886,7 @@ async function refreshStatus() {
 
 async function testMqtt() { const r = await api('/api/test/mqtt', { method: 'POST' }); toast(r.body.message, r.body.ok); refreshStatus(); }
 async function testPdu() { toast('Testing PDU…', true); const r = await api('/api/test/pdu', { method: 'POST' }); toast(r.body.message, r.body.ok); }
+async function testEmonCms() { toast('Testing EmonCMS…', true); const r = await api('/api/test/emoncms', { method: 'POST' }); toast(r.body.message, r.body.ok); refreshStatus(); }
 async function rediscoverHa() { toast('Requesting discovery…', true); const r = await api('/api/discovery/rediscover', { method: 'POST' }); toast(r.body.message, r.body.ok); }
 async function clearHa() {
   if (!confirm('Clear all Home Assistant discovery messages? The entities will disappear from Home Assistant until discovery runs again.')) return;


### PR DESCRIPTION
Closes #112, closes #113.

## #112 — Templating & data-input options
- **Input name templating** — `EmonCMS.InputNameTemplate` (placeholders `{device}`, `{source}`/`{outlet}`, `{type}`, `{units}`), mirroring `Prometheus.MetricNameTemplate`. Default `{device}_{source}_{type}` → e.g. `rack_pdu_1_dell_md1200_realpower` instead of the old verbose identifier. Blank = legacy full identifier. Honors `Overrides.Measurements` IDs; lower-cased + sanitized.
- **MQTT transport** — `EmonCMS.Transport: Http | Mqtt`. `Mqtt` publishes the readings as a JSON object to `<MqttBaseTopic>/<Node>` (e.g. `emon/rpdu2mqtt`) on the broker rPDU2MQTT already uses — point EmonCMS's [MQTT input](https://docs.openenergymonitor.org/emoncms/postingdata.html#sending-data-to-emoncms-using-mqtt) at it. `Url`/`ApiKey` only needed for HTTP.

## #113 — Health check
- **Test button** — `POST /api/test/emoncms` + a "Test EmonCMS connection" button in the GUI. HTTP: reaches the server and checks the API key (`feed/list.json`); MQTT: confirms broker connectivity.
- **Status indicator** — `EmonCmsStatus` records the last export outcome (ok/error, transport, input count); surfaced on the **Diagnostics** page.

## Testing
- `dotnet build` clean; **47 tests pass** (added 3 for `EmonCmsInputName`).
- HTTP path is the existing flow with templated keys; MQTT transport + the live test against a real EmonCMS are for prod verification.
- Docs: Configuration.md EmonCMS section updated (templating, MQTT transport, test/health).

Note: changing input names means EmonCMS will create new inputs; set `InputNameTemplate: ""` to keep the old identifiers. Screenshots in docs to be refreshed post-merge (per #112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)