### PR TITLE
fix(k8s): faster readiness probe defaults (#111)

### DIFF
--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -166,11 +166,14 @@ healthProbes:
     periodSeconds: 20
     timeoutSeconds: 3
     failureThreshold: 3
+  # Readiness becomes true once MQTT is connected + the first PDU poll succeeds (usually a few
+  # seconds). Poll frequently with a short initial delay so the pod is marked Ready promptly
+  # instead of waiting a full (long) period between checks.
   readiness:
-    initialDelaySeconds: 10
-    periodSeconds: 15
+    initialDelaySeconds: 3
+    periodSeconds: 5
     timeoutSeconds: 3
-    failureThreshold: 3
+    failureThreshold: 6
 
 resources: {}
 podAnnotations: {}

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -166,9 +166,7 @@ healthProbes:
     periodSeconds: 20
     timeoutSeconds: 3
     failureThreshold: 3
-  # Readiness becomes true once MQTT is connected + the first PDU poll succeeds (usually a few
-  # seconds). Poll frequently with a short initial delay so the pod is marked Ready promptly
-  # instead of waiting a full (long) period between checks.
+  # Poll frequently with a short initial delay so the pod is marked Ready promptly.
   readiness:
     initialDelaySeconds: 3
     periodSeconds: 5


### PR DESCRIPTION
Closes #111.

Readiness becomes true once MQTT is connected and the first PDU poll succeeds — typically a few seconds after start. The old probe defaults (`initialDelaySeconds: 10`, `periodSeconds: 15`) meant that if the app wasn't ready at the single t=10s check, the pod stayed `NotReady` until t=25s (or later).

Tightened the readiness cadence so it's marked Ready promptly:

| | before | after |
| --- | --- | --- |
| `initialDelaySeconds` | 10 | 3 |
| `periodSeconds` | 15 | 5 |
| `failureThreshold` | 3 | 6 |

(`failureThreshold` raised to keep roughly the same post-ready tolerance window with the shorter period.) Liveness is unchanged. Chart values only — verify with `helm template` / a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)