### PR TITLE
test: expand unit tests + add CI (tests + helm smoke) (#103)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - run: dotnet test --configuration Release
+
+  chart:
+    name: Helm chart smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+      - name: helm lint
+        run: helm lint charts/rpdu2mqtt
+      - name: helm template (defaults)
+        run: helm template rpdu2mqtt charts/rpdu2mqtt > /dev/null
+      - name: helm template (CRD config source)
+        run: helm template rpdu2mqtt charts/rpdu2mqtt --set kubernetesConfigSource.enabled=true > /dev/null

--- a/rPDU2MQTT.Tests/MappingAndSecretsTests.cs
+++ b/rPDU2MQTT.Tests/MappingAndSecretsTests.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.Config.Schemas;
+using rPDU2MQTT.Models.PDU;
+using rPDU2MQTT.Models.PDU.OneView;
+using rPDU2MQTT.Services.Gui;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>Secret redaction completeness (guards the k8s companion-Secret feature).</summary>
+public class SecretRedactionTests
+{
+    [Fact]
+    public void RedactSecrets_ClearsEverySecretField()
+    {
+        var cfg = new Config();
+        cfg.MQTT.Credentials = new Credentials { Username = "mqttUser", Password = "mqttPass" };
+        cfg.PDU.Credentials = new Credentials { Username = "pduUser", Password = "pduPass" };
+        cfg.EmonCMS.ApiKey = "emonKey";
+        cfg.Gui.Password = "guiPass";
+        cfg.Gui.Oidc.ClientSecret = "oidcSecret";
+
+        var redacted = ConfigSchema.RedactSecrets(cfg);
+
+        Assert.Null(redacted.MQTT.Credentials);
+        Assert.Null(redacted.PDU.Credentials);
+        Assert.Null(redacted.EmonCMS.ApiKey);
+        Assert.Null(redacted.Gui.Password);
+        Assert.Null(redacted.Gui.Oidc?.ClientSecret);
+    }
+
+    [Fact]
+    public void RedactSecrets_DoesNotMutateTheOriginal()
+    {
+        var cfg = new Config();
+        cfg.Gui.Oidc.ClientSecret = "keep-me";
+        cfg.MQTT.Credentials = new Credentials { Password = "keep-me" };
+
+        _ = ConfigSchema.RedactSecrets(cfg);
+
+        Assert.Equal("keep-me", cfg.Gui.Oidc.ClientSecret);
+        Assert.Equal("keep-me", cfg.MQTT.Credentials!.Password);
+    }
+}
+
+/// <summary>EmonCMS transport + templating config survives the JSON/YAML round-trips the GUI/CRD use.</summary>
+public class EmonCmsConfigTests
+{
+    [Fact]
+    public void TransportAndTemplate_JsonRoundTrips()
+    {
+        var cfg = new Config();
+        cfg.EmonCMS.Enabled = true;
+        cfg.EmonCMS.Transport = EmonCmsTransport.Mqtt;
+        cfg.EmonCMS.InputNameTemplate = "{name}_{number}_{type}";
+        cfg.EmonCMS.MqttBaseTopic = "emon";
+
+        var round = ConfigSchema.FromJson(ConfigSchema.ToJson(cfg));
+
+        Assert.Equal(EmonCmsTransport.Mqtt, round.EmonCMS.Transport);
+        Assert.Equal("{name}_{number}_{type}", round.EmonCMS.InputNameTemplate);
+        Assert.Equal("emon", round.EmonCMS.MqttBaseTopic);
+    }
+
+    [Fact]
+    public void Transport_DefaultsToHttp()
+        => Assert.Equal(EmonCmsTransport.Http, new Config().EmonCMS.Transport);
+}
+
+/// <summary>PDU JSON → model mapping (the dictionary-to-list + string-to-number converters).</summary>
+public class PduMappingTests
+{
+    [Fact]
+    public void OutletDictionary_DeserializesToListWithKeys()
+    {
+        const string json = """
+        { "outlet": { "0": { "label": "first" }, "1": { "label": "second" } } }
+        """;
+
+        var dev = JsonSerializer.Deserialize<Device>(json, Converter.Settings);
+
+        Assert.NotNull(dev);
+        Assert.Equal(2, dev!.Outlets.Count);
+        Assert.Contains(dev.Outlets, o => o.Key == 0 && o.Label == "first");
+        Assert.Contains(dev.Outlets, o => o.Key == 1 && o.Label == "second");
+    }
+
+    [Fact]
+    public void LifetimeEnergy_ParsesFromStringToLong()
+    {
+        var dev = JsonSerializer.Deserialize<Device>("""{ "lifetimeEnergy": "12345" }""", Converter.Settings);
+
+        Assert.NotNull(dev);
+        Assert.Equal(12345L, dev!.LifetimeEnergy);
+    }
+}
+
+/// <summary>Group member resolution from the OneView per-outlet group map (the group-control core).</summary>
+public class GroupMemberResolutionTests
+{
+    private static OneViewHost Host(string serial, params (string index, string group)[] outlets)
+        => new()
+        {
+            GroupMap = new OneViewGroupMap
+            {
+                Dev = new()
+                {
+                    [serial] = new OneViewGroupMapDevice
+                    {
+                        Outlet = outlets.ToDictionary(o => o.index, o => new OneViewGroupMapOutlet { Group = o.group }),
+                    },
+                },
+            },
+        };
+
+    [Fact]
+    public void ResolveGroupMembers_FindsMatchingOutletsAcrossHosts()
+    {
+        var oneview = new OneViewRootData
+        {
+            Hosts = new()
+            {
+                Host("SERIAL-A", ("0", "2"), ("1", "3"), ("2", "2")),
+                Host("SERIAL-B", ("5", "2"), ("6", "unassigned")),
+            },
+        };
+
+        var members = PDU.ResolveGroupMembers(oneview, "2");
+
+        Assert.Equal(3, members.Count);
+        Assert.Contains(("SERIAL-A", 0), members);
+        Assert.Contains(("SERIAL-A", 2), members);
+        Assert.Contains(("SERIAL-B", 5), members);
+        Assert.DoesNotContain(("SERIAL-A", 1), members);
+    }
+
+    [Fact]
+    public void ResolveGroupMembers_ReturnsEmptyForUnknownGroup()
+    {
+        var oneview = new OneViewRootData { Hosts = new() { Host("SERIAL-A", ("0", "2")) } };
+        Assert.Empty(PDU.ResolveGroupMembers(oneview, "nope"));
+    }
+}

--- a/rPDU2MQTT/rPDU2MQTT.csproj
+++ b/rPDU2MQTT/rPDU2MQTT.csproj
@@ -17,6 +17,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <!-- Expose internals (converters, ResolveGroupMembers, etc.) to the test project. -->
+	  <InternalsVisibleTo Include="rPDU2MQTT.Tests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<!-- Embedded configuration GUI (optional, gated by Gui.Enabled). -->
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 		<!-- GUI assets are embedded so the single binary serves them without a wwwroot on disk. -->


### PR DESCRIPTION
Closes #103.

## Unit tests (48 → 56)
Added `InternalsVisibleTo` for the test project and a new `MappingAndSecretsTests` covering high-value, previously-untested logic:
- **Secret redaction** — `RedactSecrets` clears *every* secret field (MQTT/PDU creds, EmonCMS key, GUI password, OIDC secret) and doesn't mutate the original. Guards the k8s companion-Secret feature (#123).
- **EmonCMS config** — `Transport`/`InputNameTemplate`/`MqttBaseTopic` JSON round-trip + default transport (#112).
- **PDU mapping** — dictionary→list (`outlet` map → keyed `Outlets`) and string→long (`lifetimeEnergy`) converters.
- **Group resolution** — `ResolveGroupMembers` resolves member outlets across hosts by group key and ignores non-matches (the OneView group-control core, #94).

## CI
Added `.github/workflows/ci.yml` — **nothing ran the tests in CI before**:
- `dotnet test` (Release)
- Helm **lint** + **template** smoke (defaults and `kubernetesConfigSource.enabled=true`)

All 56 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)