### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/charts/rpdu2mqtt/Chart.yaml
+++ b/charts/rpdu2mqtt/Chart.yaml
@@ -3,8 +3,8 @@ name: rpdu2mqtt
 description: Bridge a Vertiv/Geist rPDU to MQTT, with Home Assistant discovery and optional metrics exporters.
 type: application
 # Chart version (bump on chart changes); appVersion tracks the container image.
-version: 0.1.0
-appVersion: "0.4.0"
+version: 1.0.0
+appVersion: "1.0.0"
 home: https://github.com/XtremeOwnage/rPDU2MQTT
 sources:
   - https://github.com/XtremeOwnage/rPDU2MQTT

--- a/rPDU2MQTT/rPDU2MQTT.csproj
+++ b/rPDU2MQTT/rPDU2MQTT.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net10.0</TargetFramework>
-		<Version>0.4.0</Version>
+		<Version>1.0.0</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
Version bump for the **v1.0.0** release:

- `rPDU2MQTT.csproj`: `<Version>` 0.4.0 → 1.0.0 (drives the assembly version shown on the GUI/Diagnostics page).
- `charts/rpdu2mqtt/Chart.yaml`: chart `version` 0.1.0 → 1.0.0 and `appVersion` 0.4.0 → 1.0.0.

After this merges I'll tag/create the **v1.0.0** GitHub release with the prepared notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)