### PR TITLE
feat(v2): message bus + snapshot foundation (#127, phase 1)

### DIFF
--- a/rPDU2MQTT.Tests/MessageBusTests.cs
+++ b/rPDU2MQTT.Tests/MessageBusTests.cs
@@ -1,0 +1,73 @@
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+public class MessageBusTests
+{
+    private static PduSnapshot Snap(string id) => new(id, DateTime.UtcNow, new PduData());
+
+    [Fact]
+    public async Task Subscriber_ReceivesPublishedSnapshots()
+    {
+        var bus = new ChannelMessageBus();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var enumerator = bus.Subscribe(cancellationToken: cts.Token).GetAsyncEnumerator(cts.Token);
+
+        await bus.PublishAsync(Snap("pdu-1"));
+
+        Assert.True(await enumerator.MoveNextAsync());
+        Assert.Equal("pdu-1", enumerator.Current.InstanceId);
+
+        await enumerator.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task EverySubscriber_GetsEverySnapshot()
+    {
+        var bus = new ChannelMessageBus();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var a = bus.Subscribe(cancellationToken: cts.Token).GetAsyncEnumerator(cts.Token);
+        var b = bus.Subscribe(cancellationToken: cts.Token).GetAsyncEnumerator(cts.Token);
+
+        await bus.PublishAsync(Snap("pdu-1"));
+
+        Assert.True(await a.MoveNextAsync());
+        Assert.True(await b.MoveNextAsync());
+        Assert.Equal("pdu-1", a.Current.InstanceId);
+        Assert.Equal("pdu-1", b.Current.InstanceId);
+
+        await a.DisposeAsync();
+        await b.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Publish_WithNoSubscribers_DoesNotThrow()
+    {
+        var bus = new ChannelMessageBus();
+        await bus.PublishAsync(Snap("pdu-1"));
+    }
+
+    [Fact]
+    public async Task SlowSubscriber_DropsOldest_WithoutBlockingPublish()
+    {
+        var bus = new ChannelMessageBus();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        // Capacity 2, never read until after we over-publish: oldest snapshots are dropped, not blocked.
+        var enumerator = bus.Subscribe(capacity: 2, cancellationToken: cts.Token).GetAsyncEnumerator(cts.Token);
+
+        for (var i = 0; i < 5; i++)
+            await bus.PublishAsync(Snap($"pdu-{i}"));
+
+        Assert.True(await enumerator.MoveNextAsync());
+        var first = enumerator.Current.InstanceId;
+        Assert.True(await enumerator.MoveNextAsync());
+        var second = enumerator.Current.InstanceId;
+
+        // Only the two most-recent survived the bounded DropOldest buffer.
+        Assert.Equal(new[] { "pdu-3", "pdu-4" }, new[] { first, second });
+
+        await enumerator.DisposeAsync();
+    }
+}

--- a/rPDU2MQTT/Core/ChannelMessageBus.cs
+++ b/rPDU2MQTT/Core/ChannelMessageBus.cs
@@ -1,0 +1,60 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+
+namespace rPDU2MQTT.Core;
+
+/// <summary>
+/// In-process <see cref="IMessageBus"/> backed by <see cref="System.Threading.Channels"/>. Each
+/// subscriber gets its own bounded channel; publishing fans out with a non-blocking write so one slow
+/// consumer never stalls producers or other consumers (its buffer drops the oldest snapshot instead).
+/// </summary>
+public sealed class ChannelMessageBus : IMessageBus
+{
+    private readonly object gate = new();
+    private readonly List<Channel<PduSnapshot>> subscribers = new();
+
+    public ValueTask PublishAsync(PduSnapshot snapshot, CancellationToken cancellationToken = default)
+    {
+        Channel<PduSnapshot>[] targets;
+        lock (gate)
+            targets = subscribers.ToArray();
+
+        foreach (var channel in targets)
+            // DropOldest buffers: this always succeeds, evicting a stale snapshot for a lagging consumer.
+            channel.Writer.TryWrite(snapshot);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public IAsyncEnumerable<PduSnapshot> Subscribe(int capacity = 16, CancellationToken cancellationToken = default)
+    {
+        // Register eagerly (not lazily inside the iterator) so snapshots published between Subscribe()
+        // and the first read are buffered rather than dropped.
+        var channel = Channel.CreateBounded<PduSnapshot>(new BoundedChannelOptions(Math.Max(1, capacity))
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
+        lock (gate)
+            subscribers.Add(channel);
+
+        return Read(channel, cancellationToken);
+    }
+
+    private async IAsyncEnumerable<PduSnapshot> Read(Channel<PduSnapshot> channel, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (var item in channel.Reader.ReadAllAsync(cancellationToken))
+                yield return item;
+        }
+        finally
+        {
+            lock (gate)
+                subscribers.Remove(channel);
+            channel.Writer.TryComplete();
+        }
+    }
+}

--- a/rPDU2MQTT/Core/IMessageBus.cs
+++ b/rPDU2MQTT/Core/IMessageBus.cs
@@ -1,0 +1,18 @@
+namespace rPDU2MQTT.Core;
+
+/// <summary>
+/// The v2 producer/consumer bus: source pollers <see cref="PublishAsync"/> snapshots; each consumer
+/// <see cref="Subscribe"/>s and reads its own independent stream. This thin seam is the single point a
+/// different backend (e.g. a distributed one) would re-implement; see docs/v2-architecture.md.
+/// </summary>
+public interface IMessageBus
+{
+    /// <summary>Publish a snapshot to every current subscriber.</summary>
+    ValueTask PublishAsync(PduSnapshot snapshot, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Subscribe to the snapshot stream. Each call gets its own bounded buffer, so a slow consumer
+    /// can't stall others (and drops its own oldest items under sustained back-pressure).
+    /// </summary>
+    IAsyncEnumerable<PduSnapshot> Subscribe(int capacity = 16, CancellationToken cancellationToken = default);
+}

--- a/rPDU2MQTT/Core/PduSnapshot.cs
+++ b/rPDU2MQTT/Core/PduSnapshot.cs
@@ -1,0 +1,11 @@
+using rPDU2MQTT.Models.PDU;
+
+namespace rPDU2MQTT.Core;
+
+/// <summary>
+/// One poll's result from a single source, flowing producer → bus → consumers (v2 pipeline).
+/// </summary>
+/// <param name="InstanceId">Identifies the source PDU instance this snapshot came from.</param>
+/// <param name="TimestampUtc">When the snapshot was produced.</param>
+/// <param name="Data">The polled data (devices, outlets, entities, OneView groups).</param>
+public sealed record PduSnapshot(string InstanceId, DateTime TimestampUtc, PduData Data);

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -97,7 +97,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             // The GUI typically runs behind an ingress/gateway terminating TLS; honor the forwarded
             // scheme/host so OIDC builds the correct (https) redirect_uri.
             var fwd = new ForwardedHeadersOptions { ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost };
-            fwd.KnownNetworks.Clear();
+            fwd.KnownIPNetworks.Clear();
             fwd.KnownProxies.Clear();
             app.UseForwardedHeaders(fwd);
 
@@ -346,7 +346,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 pod = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME"),
                 ns = k8s?.Namespace,
                 emoncms = config.EmonCMS.Enabled
-                    ? new { enabled = true, transport = config.EmonCMS.Transport.ToString().ToLowerInvariant(), status = emonCmsStatus.Snapshot() }
+                    ? new { enabled = true, transport = (string?)config.EmonCMS.Transport.ToString().ToLowerInvariant(), status = (object?)emonCmsStatus.Snapshot() }
                     : new { enabled = false, transport = (string?)null, status = (object?)null },
             }, ConfigSchema.Json);
         });

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -60,7 +60,7 @@ public static class ServiceConfiguration
                 mqttBuilder.WithUserName(cfg.MQTT.Credentials.Username);
 
             if (cfg.MQTT.Credentials?.Password is not null)
-                mqttBuilder.WithPassword(cfg.MQTT.Credentials.Password);
+                mqttBuilder.WithPassword(ToSecureString(cfg.MQTT.Credentials.Password));
 
             // Return new client, with options applied.
             return new HiveMQClient(mqttBuilder.Build());
@@ -165,5 +165,15 @@ public static class ServiceConfiguration
             Log.Information("Outlet control is ENABLED (ActionsEnabled).");
             services.AddHostedService<OutletCommandService>();
         }
+    }
+
+    /// <summary>Wrap a plaintext secret as a read-only SecureString (for APIs that require one).</summary>
+    private static System.Security.SecureString ToSecureString(string value)
+    {
+        var secure = new System.Security.SecureString();
+        foreach (var c in value)
+            secure.AppendChar(c);
+        secure.MakeReadOnly();
+        return secure;
     }
 }

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -114,6 +114,9 @@ public static class ServiceConfiguration
 
         services.AddSingleton<MQTTServiceDependencies>();
 
+        // v2 producer/consumer pipeline bus (not yet wired to producers/consumers; see docs/v2-architecture.md).
+        services.AddSingleton<Core.IMessageBus, Core.ChannelMessageBus>();
+
         // Shared liveness/readiness signals (uptime + last successful poll).
         services.AddSingleton<HealthState>();
         // EmonCMS export health (last attempt/success/error) — read by the GUI even when disabled.


### PR DESCRIPTION
**Phase 1** of the v2.0 refactor ([docs/v2-architecture.md](../blob/main/docs/v2-architecture.md), #127). Lays the producer/consumer foundation with **no behavior change** — the bus is registered but not yet wired to producers/consumers (that's phases 2–3).

- **`Core/PduSnapshot`** — one poll's result from a source (`InstanceId`, `TimestampUtc`, `PduData`).
- **`Core/IMessageBus` + `ChannelMessageBus`** — `System.Threading.Channels`-backed pub/sub. Each subscriber gets its own **bounded `DropOldest`** buffer, so a slow/broken consumer can't stall producers or other consumers. Subscribers register eagerly so snapshots published between `Subscribe()` and first read aren't lost. This thin interface is the single seam an alternate backend would re-implement.
- Registered as a singleton in DI.
- **4 new unit tests** (fan-out to multiple subscribers, publish with no subscribers, slow-subscriber drop-oldest). Suite 56 → **60**, all green.

Next (phase 2): move polling into a `PduPoller` that publishes snapshots to this bus, with a shim so existing services keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)