### PR TITLE
feat(v2): PduPoller + SnapshotCache (#127, phase 2)

### DIFF
--- a/rPDU2MQTT.Tests/SnapshotCacheTests.cs
+++ b/rPDU2MQTT.Tests/SnapshotCacheTests.cs
@@ -1,0 +1,78 @@
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+public class SnapshotCacheTests
+{
+    private static PduSnapshot Snap(string id) => new(id, DateTime.UtcNow, new PduData());
+
+    private static async Task WaitUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+        Assert.Fail("Condition not met within timeout.");
+    }
+
+    [Fact]
+    public async Task Cache_TracksLatestAndPerInstance()
+    {
+        var bus = new ChannelMessageBus();
+        var cache = new SnapshotCache(bus);
+        await cache.StartAsync(CancellationToken.None);
+        try
+        {
+            await bus.PublishAsync(Snap("a"));
+            await bus.PublishAsync(Snap("b"));
+
+            await WaitUntil(() => cache.Get("a") is not null && cache.Get("b") is not null, TimeSpan.FromSeconds(2));
+
+            Assert.NotNull(cache.Get("a"));
+            Assert.NotNull(cache.Get("b"));
+            Assert.Equal("b", cache.Latest!.InstanceId);
+            Assert.Equal(2, cache.All.Count);
+        }
+        finally
+        {
+            await cache.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public async Task Cache_KeepsMostRecentPerInstance()
+    {
+        var bus = new ChannelMessageBus();
+        var cache = new SnapshotCache(bus);
+        await cache.StartAsync(CancellationToken.None);
+        try
+        {
+            var first = Snap("a");
+            await bus.PublishAsync(first);
+            await WaitUntil(() => cache.Get("a") is not null, TimeSpan.FromSeconds(2));
+
+            var second = Snap("a");
+            await bus.PublishAsync(second);
+            await WaitUntil(() => ReferenceEquals(cache.Get("a"), second), TimeSpan.FromSeconds(2));
+
+            Assert.Single(cache.All);
+            Assert.Same(second, cache.Get("a"));
+        }
+        finally
+        {
+            await cache.StopAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact]
+    public void Cache_StartsEmpty()
+    {
+        var cache = new SnapshotCache(new ChannelMessageBus());
+        Assert.Null(cache.Latest);
+        Assert.Empty(cache.All);
+    }
+}

--- a/rPDU2MQTT/Core/SnapshotCache.cs
+++ b/rPDU2MQTT/Core/SnapshotCache.cs
@@ -1,0 +1,44 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Hosting;
+
+namespace rPDU2MQTT.Core;
+
+/// <summary>Last-known snapshot per source, kept up to date from the bus.</summary>
+public interface ISnapshotCache
+{
+    /// <summary>The most recently received snapshot from any source, or null if none yet.</summary>
+    PduSnapshot? Latest { get; }
+
+    /// <summary>The latest snapshot for a specific source instance, or null if none yet.</summary>
+    PduSnapshot? Get(string instanceId);
+
+    /// <summary>The latest snapshot for every source seen so far.</summary>
+    IReadOnlyCollection<PduSnapshot> All { get; }
+}
+
+/// <summary>
+/// First v2 bus consumer: subscribes to the snapshot stream and keeps the latest per source so the
+/// API/GUI can serve last-known data without re-polling. (Phase 2 of docs/v2-architecture.md.)
+/// </summary>
+public sealed class SnapshotCache : BackgroundService, ISnapshotCache
+{
+    private readonly IAsyncEnumerable<PduSnapshot> stream;
+    private readonly ConcurrentDictionary<string, PduSnapshot> byInstance = new(StringComparer.OrdinalIgnoreCase);
+    private volatile PduSnapshot? latest;
+
+    // Subscribe at construction so the buffer captures snapshots published before ExecuteAsync runs.
+    public SnapshotCache(IMessageBus bus) => stream = bus.Subscribe();
+
+    public PduSnapshot? Latest => latest;
+    public PduSnapshot? Get(string instanceId) => byInstance.TryGetValue(instanceId, out var s) ? s : null;
+    public IReadOnlyCollection<PduSnapshot> All => byInstance.Values.ToArray();
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var snapshot in stream.WithCancellation(stoppingToken))
+        {
+            byInstance[snapshot.InstanceId] = snapshot;
+            latest = snapshot;
+        }
+    }
+}

--- a/rPDU2MQTT/Services/PduPoller.cs
+++ b/rPDU2MQTT/Services/PduPoller.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// v2 producer: polls the PDU on its interval and publishes a <see cref="PduSnapshot"/> to the bus.
+/// For now there is a single instance (today's one PDU); multi-instance comes in a later phase.
+/// Consumers still read the PDU directly until they are migrated onto the bus.
+/// </summary>
+public sealed class PduPoller : BackgroundService
+{
+    private readonly Config cfg;
+    private readonly PDU pdu;
+    private readonly IMessageBus bus;
+    private readonly string instanceId;
+
+    public PduPoller(Config cfg, PDU pdu, IMessageBus bus)
+    {
+        this.cfg = cfg;
+        this.pdu = pdu;
+        this.bus = bus;
+        instanceId = string.IsNullOrWhiteSpace(cfg.PDU?.Connection?.Host) ? "pdu" : cfg.PDU!.Connection!.Host!;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = TimeSpan.FromSeconds(Math.Max(1, cfg.PDU.PollInterval));
+        using var timer = new PeriodicTimer(interval);
+
+        while (true)
+        {
+            try
+            {
+                var data = await pdu.GetRootData_Public(stoppingToken);
+                await bus.PublishAsync(new PduSnapshot(instanceId, DateTime.UtcNow, data), stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"{nameof(PduPoller)} poll failed.");
+            }
+
+            try
+            {
+                if (!await timer.WaitForNextTickAsync(stoppingToken))
+                    break;
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+}

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -114,8 +114,13 @@ public static class ServiceConfiguration
 
         services.AddSingleton<MQTTServiceDependencies>();
 
-        // v2 producer/consumer pipeline bus (not yet wired to producers/consumers; see docs/v2-architecture.md).
+        // v2 producer/consumer pipeline (see docs/v2-architecture.md): the bus, a PDU poller (producer)
+        // and the snapshot cache (first consumer). Existing services still read the PDU directly for now.
         services.AddSingleton<Core.IMessageBus, Core.ChannelMessageBus>();
+        services.AddSingleton<Core.SnapshotCache>();
+        services.AddSingleton<Core.ISnapshotCache>(sp => sp.GetRequiredService<Core.SnapshotCache>());
+        services.AddHostedService(sp => sp.GetRequiredService<Core.SnapshotCache>());
+        services.AddHostedService<PduPoller>();
 
         // Shared liveness/readiness signals (uptime + last successful poll).
         services.AddSingleton<HealthState>();


### PR DESCRIPTION
**Phase 2** of #127 ([docs/v2-architecture.md](../blob/main/docs/v2-architecture.md)). First complete **producer → bus → consumer** slice, with **no change to existing services** (they still read the PDU directly; migrating them onto the bus is phase 3).

- **`Services/PduPoller`** — a `BackgroundService` that polls the PDU on `PollInterval` and publishes a `PduSnapshot` to the bus. Single instance for now (keyed by the PDU host); multi-instance is a later phase.
- **`Core/SnapshotCache`** — the first bus consumer: keeps the latest snapshot per source (`Latest`, `Get(id)`, `All`) so the API/GUI can serve last-known data without re-polling. **Subscribes in its constructor** so snapshots published before `ExecuteAsync` runs are buffered.
- Registered in DI; `ISnapshotCache` exposed.

### Note: caught a real bug
The first cut subscribed lazily inside `ExecuteAsync`. Because `PublishAsync` completes synchronously, publishes that happen right after startup ran **before** the subscription registered and were silently dropped (`All=[]`). A test reproduced it; the fix is the constructor-time subscribe above — which also protects any future consumer from the same trap.

63 tests (3 new), build warning-free.

Next (phase 3): migrate MQTT/Prometheus/EmonCMS/HA consumers to read from the bus instead of polling the PDU directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)