### PR TITLE
feat(v2): consumers read pipeline snapshots, not the PDU (#127, phase 3)

### DIFF
--- a/rPDU2MQTT.Tests/SnapshotCacheTests.cs
+++ b/rPDU2MQTT.Tests/SnapshotCacheTests.cs
@@ -76,3 +76,24 @@ public class SnapshotCacheTests
         Assert.Empty(cache.All);
     }
 }
+
+public class SnapshotFreshnessTests
+{
+    private static readonly DateTime Now = new(2026, 6, 23, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void FreshSnapshot_IsNotStale()
+        => Assert.False(SnapshotFreshness.IsStale(Now.AddSeconds(-5), pollIntervalSeconds: 5, Now));
+
+    [Fact]
+    public void OldSnapshot_IsStale()
+        => Assert.True(SnapshotFreshness.IsStale(Now.AddSeconds(-60), pollIntervalSeconds: 5, Now));
+
+    [Fact]
+    public void ShortInterval_HasA30sFloor()
+    {
+        // 1s poll -> 2.5s would be too twitchy; the 30s floor keeps it tolerant.
+        Assert.False(SnapshotFreshness.IsStale(Now.AddSeconds(-20), pollIntervalSeconds: 1, Now));
+        Assert.True(SnapshotFreshness.IsStale(Now.AddSeconds(-31), pollIntervalSeconds: 1, Now));
+    }
+}

--- a/rPDU2MQTT/Classes/MQTTServiceDependencies.cs
+++ b/rPDU2MQTT/Classes/MQTTServiceDependencies.cs
@@ -1,4 +1,5 @@
 ﻿using HiveMQtt.Client;
+using rPDU2MQTT.Core;
 
 namespace rPDU2MQTT.Classes;
 
@@ -7,15 +8,19 @@ namespace rPDU2MQTT.Classes;
 /// </summary>
 public class MQTTServiceDependencies
 {
-    public MQTTServiceDependencies(IHiveMQClient mqtt, Config cfg, PDU pdu)
+    public MQTTServiceDependencies(IHiveMQClient mqtt, Config cfg, PDU pdu, ISnapshotCache snapshotCache)
     {
         Mqtt = mqtt;
         Cfg = cfg;
         this.PDU = pdu;
+        SnapshotCache = snapshotCache;
     }
 
     public IHiveMQClient Mqtt { get; }
     public Config Cfg { get; }
 
     public PDU PDU { get; }
+
+    /// <summary>Latest pipeline snapshot per source (the PduPoller produces; consumers read).</summary>
+    public ISnapshotCache SnapshotCache { get; }
 }

--- a/rPDU2MQTT/Core/SnapshotFreshness.cs
+++ b/rPDU2MQTT/Core/SnapshotFreshness.cs
@@ -1,0 +1,16 @@
+namespace rPDU2MQTT.Core;
+
+/// <summary>
+/// When a pipeline snapshot is considered too old to act on. Consumers skip stale snapshots so a
+/// stalled producer (e.g. an unreachable PDU) surfaces downstream (HA expire_after) instead of being
+/// masked by republished last-known values.
+/// </summary>
+public static class SnapshotFreshness
+{
+    /// <summary>A snapshot older than ~2.5 polls (min 30s) is stale.</summary>
+    public static TimeSpan StaleAfter(int pollIntervalSeconds)
+        => TimeSpan.FromSeconds(Math.Max(30, pollIntervalSeconds * 2.5));
+
+    public static bool IsStale(DateTime timestampUtc, int pollIntervalSeconds, DateTime nowUtc)
+        => nowUtc - timestampUtc > StaleAfter(pollIntervalSeconds);
+}

--- a/rPDU2MQTT/Services/EmonCmsExportService.cs
+++ b/rPDU2MQTT/Services/EmonCmsExportService.cs
@@ -29,7 +29,9 @@ public class EmonCmsExportService : baseMQTTService
 
     protected override async Task Execute(CancellationToken cancellationToken)
     {
-        var data = await pdu.GetRootData_Public(cancellationToken);
+        var data = LatestFreshData();
+        if (data is null)
+            return;
 
         var values = new Dictionary<string, double>();
         foreach (var r in MetricsHelper.EnumerateReadings(data))

--- a/rPDU2MQTT/Services/MQTTPublishingService.cs
+++ b/rPDU2MQTT/Services/MQTTPublishingService.cs
@@ -8,20 +8,17 @@ namespace rPDU2MQTT.Services;
 /// </summary>
 public class MQTTPublishingService : basePublishingService
 {
-    private readonly HealthState health;
-
-    public MQTTPublishingService(MQTTServiceDependencies deps, HealthState health) : base(deps)
+    public MQTTPublishingService(MQTTServiceDependencies deps) : base(deps)
     {
-        this.health = health;
     }
 
     protected override async Task Execute(CancellationToken cancellationToken)
     {
-        var data = await pdu.GetRootData_Public(cancellationToken);
-
-        // A successful fetch is the readiness signal: we can reach the PDU. Record it before
-        // publishing so a later publish hiccup can't keep the pod permanently NotReady.
-        health.RecordPollSuccess();
+        // Consume the latest pipeline snapshot (the PduPoller is the sole PDU reader). Skip while it's
+        // stale/absent so a PDU outage surfaces via expire_after instead of republishing old values.
+        var data = LatestFreshData();
+        if (data is null)
+            return;
 
         // Run through each device.
         foreach (var device in data.Devices)

--- a/rPDU2MQTT/Services/PduPoller.cs
+++ b/rPDU2MQTT/Services/PduPoller.cs
@@ -14,13 +14,15 @@ public sealed class PduPoller : BackgroundService
     private readonly Config cfg;
     private readonly PDU pdu;
     private readonly IMessageBus bus;
+    private readonly HealthState health;
     private readonly string instanceId;
 
-    public PduPoller(Config cfg, PDU pdu, IMessageBus bus)
+    public PduPoller(Config cfg, PDU pdu, IMessageBus bus, HealthState health)
     {
         this.cfg = cfg;
         this.pdu = pdu;
         this.bus = bus;
+        this.health = health;
         instanceId = string.IsNullOrWhiteSpace(cfg.PDU?.Connection?.Host) ? "pdu" : cfg.PDU!.Connection!.Host!;
     }
 
@@ -35,6 +37,9 @@ public sealed class PduPoller : BackgroundService
             {
                 var data = await pdu.GetRootData_Public(stoppingToken);
                 await bus.PublishAsync(new PduSnapshot(instanceId, DateTime.UtcNow, data), stoppingToken);
+
+                // A successful poll is the readiness signal: we can reach the PDU.
+                health.RecordPollSuccess();
             }
             catch (OperationCanceledException)
             {

--- a/rPDU2MQTT/Services/PrometheusExportService.cs
+++ b/rPDU2MQTT/Services/PrometheusExportService.cs
@@ -60,12 +60,16 @@ public class PrometheusExportService : baseMQTTService
         }
     }
 
-    protected override async Task Execute(CancellationToken cancellationToken)
+    protected override Task Execute(CancellationToken cancellationToken)
     {
-        var data = await pdu.GetRootData_Public(cancellationToken);
+        var data = LatestFreshData();
+        if (data is null)
+            return Task.CompletedTask;
 
         foreach (var r in MetricsHelper.EnumerateReadings(data))
             GetGauge(MetricsHelper.PrometheusMetricName(r, cfg)).WithLabels(r.Device, r.Source, r.Units).Set(r.Value);
+
+        return Task.CompletedTask;
     }
 
     // Cached by the resolved metric name (the template may vary the name by device/source/units).

--- a/rPDU2MQTT/Services/baseTypes/baseMQTTService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseMQTTService.cs
@@ -18,6 +18,7 @@ public abstract class baseMQTTService : IHostedService, IDisposable
     private readonly CancellationTokenSource stoppingCts = new();
     protected Config cfg { get; }
     protected PDU pdu { get; }
+    private readonly Core.ISnapshotCache snapshotCache;
 
     protected System.Text.Json.JsonSerializerOptions jsonOptions { get; init; }
 
@@ -27,6 +28,7 @@ public abstract class baseMQTTService : IHostedService, IDisposable
         mqtt = dependencies.Mqtt;
         cfg = dependencies.Cfg;
         pdu = dependencies.PDU;
+        snapshotCache = dependencies.SnapshotCache;
 
         // If the interval is 0, don't create a timer.
         if (Interval <= 0)
@@ -162,6 +164,23 @@ public abstract class baseMQTTService : IHostedService, IDisposable
         // Disconnects are reported by MqttEventHandler and recovered via auto-reconnect;
         // publish failures surface in tick(). No need to check connectivity per message.
         return mqtt.PublishAsync(msg, cancellationToken);
+    }
+
+    /// <summary>
+    /// The most recent pipeline snapshot's data, or null if there is none or it has gone stale (the
+    /// PduPoller stopped producing — e.g. the PDU is unreachable). Returning null lets consumers skip
+    /// publishing so Home Assistant's expire_after can mark entities unavailable instead of us
+    /// republishing the last-known values forever.
+    /// </summary>
+    protected Models.PDU.PduData? LatestFreshData()
+    {
+        var snapshot = snapshotCache.Latest;
+        if (snapshot is null)
+            return null;
+
+        return Core.SnapshotFreshness.IsStale(snapshot.TimestampUtc, cfg.PDU.PollInterval, DateTime.UtcNow)
+            ? null
+            : snapshot.Data;
     }
 
     /// <summary>


### PR DESCRIPTION
**Phase 3** of #127 ([docs/v2-architecture.md](../blob/main/docs/v2-architecture.md)). The data exporters stop polling the PDU and instead consume the **PduPoller's** snapshots, so the poller is the single PDU reader.

- **`baseMQTTService.LatestFreshData()`** — returns the latest snapshot's data, or **null when it's stale/absent**. Consumers skip publishing in that case, so a PDU outage surfaces via Home Assistant's `expire_after` instead of us republishing last-known values forever. The staleness rule (`> 2.5 polls`, min 30s) is in `Core/SnapshotFreshness` and unit-tested.
- **MQTT / Prometheus / EmonCMS** `Execute()` now use `LatestFreshData()` instead of `pdu.GetRootData_Public()`.
- **Readiness** signal (`HealthState.RecordPollSuccess`) moved from the MQTT publisher into the **PduPoller** (the thing that actually reaches the PDU).
- **Home Assistant discovery is unchanged** — it runs on its own `DiscoveryInterval` (periodic config republish), which is a different cadence than per-measurement data, so it stays timer-based for now.

### Design note
I deliberately kept the timer-based consumer loop + a freshness-guarded cache read rather than converting the shared base to per-snapshot subscription. The discovery service shares `baseMQTTService` but needs the *discovery* cadence, so a full event-driven base split is a larger, riskier change best done once it can be runtime-verified. This step gets the decoupling + correct outage behavior safely. True per-snapshot subscription can be a follow-up.

66 tests (3 new), build warning-free. Can't runtime-test MQTT/HA here — worth a smoke on your side after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)