### PR TITLE
feat(v2): multi-PDU config model + v1 auto-migration (#127, phase 4.1)

### DIFF
--- a/rPDU2MQTT.Tests/MultiPduConfigTests.cs
+++ b/rPDU2MQTT.Tests/MultiPduConfigTests.cs
@@ -1,0 +1,38 @@
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Startup;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>v2 multi-PDU config groundwork: a v1 single-PDU config migrates into the Pdus instance map.</summary>
+public class MultiPduConfigTests
+{
+    [Fact]
+    public void Initialize_DerivesSingleInstanceFromPdu()
+    {
+        var cfg = new Config();
+        cfg.PDU.Connection.Host = "rack-pdu-1.example.com";
+        cfg.PDU.PollInterval = 7;
+
+        var result = YamlConfigLoader.Initialize(cfg);
+
+        var instance = Assert.Contains(Config.DefaultInstanceKey, result.Pdus);
+        Assert.Same(result.PDU, instance);
+        Assert.Equal("rack-pdu-1.example.com", instance.Connection.Host);
+        Assert.Equal(7, instance.PollInterval);
+    }
+
+    [Fact]
+    public void Initialize_PreservesAnAlreadyPopulatedInstanceMap()
+    {
+        var cfg = new Config();
+        var custom = new Models.Config.PduConfig();
+        custom.Connection.Host = "pdu-b.example.com";
+        cfg.Pdus = new() { ["b"] = custom };
+
+        var result = YamlConfigLoader.Initialize(cfg);
+
+        Assert.True(result.Pdus.ContainsKey("b"));
+        Assert.False(result.Pdus.ContainsKey(Config.DefaultInstanceKey));
+    }
+}

--- a/rPDU2MQTT/Models/Config/Config.cs
+++ b/rPDU2MQTT/Models/Config/Config.cs
@@ -15,6 +15,18 @@ public class Config
     [YamlMember(Alias = "PDU", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "PDU Configuration")]
     public PduConfig PDU { get; set; } = new PduConfig();
 
+    /// <summary>
+    /// v2 multi-PDU instance set, keyed by instance name. Derived from <see cref="PDU"/> on load for now
+    /// (a v1 single-PDU config migrates to a one-entry map under <see cref="DefaultInstanceKey"/>); not
+    /// yet persisted or shown in the GUI. The runtime moves onto this in a later phase (#127).
+    /// </summary>
+    [JsonIgnore]
+    [YamlIgnore]
+    public Dictionary<string, PduConfig> Pdus { get; set; } = new();
+
+    /// <summary>Instance key a migrated v1 single-PDU config is stored under.</summary>
+    public const string DefaultInstanceKey = "default";
+
     [YamlMember(Alias = "HomeAssistant", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Home Assistant Configuration")]
     [JsonPropertyName("HomeAssistant")]
     public HomeAssistantConfig HASS { get; set; } = new HomeAssistantConfig();
@@ -49,6 +61,7 @@ public class Config
     {
         MQTT = other.MQTT;
         PDU = other.PDU;
+        Pdus = other.Pdus;
         HASS = other.HASS;
         Overrides = other.Overrides;
         Debug = other.Debug;

--- a/rPDU2MQTT/Startup/YamlConfigLoader.cs
+++ b/rPDU2MQTT/Startup/YamlConfigLoader.cs
@@ -121,6 +121,11 @@ internal class YamlConfigLoader
         if (config.PDU.EnableActionsAlias.HasValue)
             config.PDU.ActionsEnabled = config.PDU.EnableActionsAlias.Value;
 
+        // v2 multi-PDU: derive the instance set from the single PDU config (auto-migrates v1 configs).
+        // Persisted Pdus / GUI management come in a later phase; for now this is in-memory groundwork.
+        if (config.Pdus is null || config.Pdus.Count == 0)
+            config.Pdus = new Dictionary<string, Models.Config.PduConfig> { [Config.DefaultInstanceKey] = config.PDU };
+
         // Backwards-compatible alias: the old Prometheus.Enabled meant "run the exporter".
         if (config.Prometheus.EnabledAlias == true)
             config.Prometheus.Exporter = true;


### PR DESCRIPTION
**Phase 4.1** of #127 — the multi-PDU foundation, kept **additive and non-breaking**.

- Adds **`Config.Pdus`** (instance map keyed by name) and derives it from the single `PDU` config on load, so a **v1 single-PDU config auto-migrates** into a one-entry map under `"default"`.
- It's **in-memory only** for now (`[JsonIgnore]`/`[YamlIgnore]`): not persisted, not shown in the GUI or CRD, and the **runtime still uses `Config.PDU`**. So nothing changes behaviourally — this is just the seam the next phases build on.
- `CopyFrom` carries `Pdus` so hot-reload stays consistent.

2 migration tests; suite 66 → **68**, build warning-free.

Next (4.2): an `InstanceManager` + per-instance `PDU`/handler factory that runs one poller per `Pdus` entry (one, for now). Then 4.3 fans consumers out across instances, and 4.4 surfaces `Pdus` in the GUI/CRD (the breaking change, with docs + upgrade notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)