### PR TITLE
feat(v2): InstanceManager + consumer fan-out (#127, phase 4.2+4.3)

### DIFF
--- a/rPDU2MQTT.Tests/SnapshotCacheTests.cs
+++ b/rPDU2MQTT.Tests/SnapshotCacheTests.cs
@@ -75,6 +75,31 @@ public class SnapshotCacheTests
         Assert.Null(cache.Latest);
         Assert.Empty(cache.All);
     }
+
+    [Fact]
+    public async Task FanOut_SelectsOnlyFreshSourcesAcrossInstances()
+    {
+        var bus = new ChannelMessageBus();
+        var cache = new SnapshotCache(bus);
+        await cache.StartAsync(CancellationToken.None);
+        try
+        {
+            var now = DateTime.UtcNow;
+            await bus.PublishAsync(new PduSnapshot("fresh", now, new PduData()));
+            await bus.PublishAsync(new PduSnapshot("stale", now.AddMinutes(-10), new PduData()));
+            await WaitUntil(() => cache.All.Count == 2, TimeSpan.FromSeconds(2));
+
+            // Mirrors baseMQTTService.FreshSnapshots(): keep only sources whose snapshot is still fresh.
+            var fresh = cache.All.Where(s => !SnapshotFreshness.IsStale(s.TimestampUtc, 5, now)).ToList();
+
+            Assert.Single(fresh);
+            Assert.Equal("fresh", fresh[0].InstanceId);
+        }
+        finally
+        {
+            await cache.StopAsync(CancellationToken.None);
+        }
+    }
 }
 
 public class SnapshotFreshnessTests

--- a/rPDU2MQTT/Services/EmonCmsExportService.cs
+++ b/rPDU2MQTT/Services/EmonCmsExportService.cs
@@ -29,13 +29,11 @@ public class EmonCmsExportService : baseMQTTService
 
     protected override async Task Execute(CancellationToken cancellationToken)
     {
-        var data = LatestFreshData();
-        if (data is null)
-            return;
-
+        // Aggregate readings across every fresh source into one post (input keys are unique per device).
         var values = new Dictionary<string, double>();
-        foreach (var r in MetricsHelper.EnumerateReadings(data))
-            values[MetricsHelper.EmonCmsInputName(r, config)] = r.Value;
+        foreach (var data in FreshSnapshots())
+            foreach (var r in MetricsHelper.EnumerateReadings(data))
+                values[MetricsHelper.EmonCmsInputName(r, config)] = r.Value;
 
         if (values.Count == 0)
             return;

--- a/rPDU2MQTT/Services/InstanceManager.cs
+++ b/rPDU2MQTT/Services/InstanceManager.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Owns the running PDU producers — one <see cref="PduPoller"/> per configured instance
+/// (<see cref="Config.Pdus"/>). The registry that later enables adding/removing instances at runtime.
+/// </summary>
+/// <remarks>
+/// Today every entry maps to the single shared <see cref="PDU"/> (Config.Pdus has one "default" entry
+/// derived from Config.PDU). Per-instance PDU construction (distinct connection/credentials) arrives
+/// when Config.Pdus becomes user-configurable; until then a second entry would re-poll the same PDU, so
+/// only the primary instance is started.
+/// </remarks>
+public sealed class InstanceManager : IHostedService
+{
+    private readonly Config cfg;
+    private readonly PDU primaryPdu;
+    private readonly IMessageBus bus;
+    private readonly HealthState health;
+    private readonly Dictionary<string, PduPoller> pollers = new(StringComparer.OrdinalIgnoreCase);
+
+    public InstanceManager(Config cfg, PDU primaryPdu, IMessageBus bus, HealthState health)
+    {
+        this.cfg = cfg;
+        this.primaryPdu = primaryPdu;
+        this.bus = bus;
+        this.health = health;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Start the primary instance. (Additional instances need per-instance PDU construction — wired
+        // up when Config.Pdus is user-configurable; see remarks.)
+        var (id, pduCfg) = cfg.Pdus.Count > 0
+            ? cfg.Pdus.First()
+            : new KeyValuePair<string, Models.Config.PduConfig>(Config.DefaultInstanceKey, cfg.PDU);
+
+        if (cfg.Pdus.Count > 1)
+            Log.Warning($"{cfg.Pdus.Count} PDU instances configured but only '{id}' is started; multi-instance polling is not enabled yet.");
+
+        StartInstance(id, pduCfg);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        foreach (var poller in pollers.Values)
+            await poller.StopAsync();
+        pollers.Clear();
+    }
+
+    private void StartInstance(string id, Models.Config.PduConfig pduCfg)
+    {
+        Log.Information($"Starting PDU instance '{id}'.");
+        var poller = new PduPoller(id, primaryPdu, pduCfg.PollInterval, bus, health);
+        poller.Start();
+        pollers[id] = poller;
+    }
+}

--- a/rPDU2MQTT/Services/MQTTPublishingService.cs
+++ b/rPDU2MQTT/Services/MQTTPublishingService.cs
@@ -14,52 +14,51 @@ public class MQTTPublishingService : basePublishingService
 
     protected override async Task Execute(CancellationToken cancellationToken)
     {
-        // Consume the latest pipeline snapshot (the PduPoller is the sole PDU reader). Skip while it's
-        // stale/absent so a PDU outage surfaces via expire_after instead of republishing old values.
-        var data = LatestFreshData();
-        if (data is null)
-            return;
-
-        // Run through each device.
-        foreach (var device in data.Devices)
+        // Publish every fresh source's data (a stale/absent source is skipped so a PDU outage surfaces
+        // via expire_after instead of republishing old values).
+        foreach (var data in FreshSnapshots())
         {
-            await PublishState(device, cancellationToken);
-            await PublishAlarm(device, device.Alarm, cancellationToken);
-
-            foreach (var entity in device.Entity)
+            // Run through each device.
+            foreach (var device in data.Devices)
             {
-                await PublishName(entity, cancellationToken);
-                await PublishUniqueIdentifier(entity, cancellationToken);
-                await PublishMeasurements(entity.Measurements, cancellationToken);
+                await PublishState(device, cancellationToken);
+                await PublishAlarm(device, device.Alarm, cancellationToken);
+
+                foreach (var entity in device.Entity)
+                {
+                    await PublishName(entity, cancellationToken);
+                    await PublishUniqueIdentifier(entity, cancellationToken);
+                    await PublishMeasurements(entity.Measurements, cancellationToken);
+                }
+                foreach (var outlet in device.Outlets)
+                {
+                    // While a control command is still pending, report the commanded state instead of
+                    // the stale polled one so HA doesn't flap back during the PDU's apply delay.
+                    // (Don't mutate the polled data; it may be shared via the data cache.)
+                    var state = pdu.ResolveOutletState(device.Key, outlet.Key, outlet.State);
+
+                    await PublishName(outlet, cancellationToken);
+                    await PublishUniqueIdentifier(outlet, cancellationToken);
+                    await PublishState(outlet, state, cancellationToken);
+                    await PublishAlarm(outlet, outlet.Alarm, cancellationToken);
+                    await PublishMeasurements(outlet.Measurements, cancellationToken);
+
+                    // Current values backing the writable delay/power-on entities (when control is enabled).
+                    if (cfg.PDU.ActionsEnabled)
+                        await PublishOutletConfig(device.Key, outlet, cancellationToken);
+                }
             }
-            foreach (var outlet in device.Outlets)
+
+            foreach (var group in data.Groups)
             {
-                // While a control command is still pending, report the commanded state instead of
-                // the stale polled one so HA doesn't flap back during the PDU's apply delay.
-                // (Don't mutate the polled data; it may be shared via the data cache.)
-                var state = pdu.ResolveOutletState(device.Key, outlet.Key, outlet.State);
+                await PublishName(group, cancellationToken);
+                await PublishUniqueIdentifier(group, cancellationToken);
 
-                await PublishName(outlet, cancellationToken);
-                await PublishUniqueIdentifier(outlet, cancellationToken);
-                await PublishState(outlet, state, cancellationToken);
-                await PublishAlarm(outlet, outlet.Alarm, cancellationToken);
-                await PublishMeasurements(outlet.Measurements, cancellationToken);
-
-                // Current values backing the writable delay/power-on entities (when control is enabled).
-                if (cfg.PDU.ActionsEnabled)
-                    await PublishOutletConfig(device.Key, outlet, cancellationToken);
-            }
-        }
-
-        foreach (var group in data.Groups)
-        {
-            await PublishName(group, cancellationToken);
-            await PublishUniqueIdentifier(group, cancellationToken);
-
-            // Per-group aggregates, plus the cluster-wide total (the "Total" group's pduTotal).
-            foreach (var outlet in group.Entity.Outlets.Concat(group.Entity.PduTotal))
-            {
-                await PublishOneViewGroupMeasurements(outlet.Measurements, cancellationToken);
+                // Per-group aggregates, plus the cluster-wide total (the "Total" group's pduTotal).
+                foreach (var outlet in group.Entity.Outlets.Concat(group.Entity.PduTotal))
+                {
+                    await PublishOneViewGroupMeasurements(outlet.Measurements, cancellationToken);
+                }
             }
         }
     }

--- a/rPDU2MQTT/Services/PduPoller.cs
+++ b/rPDU2MQTT/Services/PduPoller.cs
@@ -1,42 +1,50 @@
-using Microsoft.Extensions.Hosting;
 using rPDU2MQTT.Classes;
 using rPDU2MQTT.Core;
 
 namespace rPDU2MQTT.Services;
 
 /// <summary>
-/// v2 producer: polls the PDU on its interval and publishes a <see cref="PduSnapshot"/> to the bus.
-/// For now there is a single instance (today's one PDU); multi-instance comes in a later phase.
-/// Consumers still read the PDU directly until they are migrated onto the bus.
+/// v2 producer for a single PDU instance: polls on its interval and publishes a <see cref="PduSnapshot"/>
+/// (tagged with the instance id) to the bus. Created and owned by <see cref="InstanceManager"/>;
+/// Start/Stop map to loading/unloading the instance.
 /// </summary>
-public sealed class PduPoller : BackgroundService
+public sealed class PduPoller
 {
-    private readonly Config cfg;
+    private readonly string instanceId;
     private readonly PDU pdu;
+    private readonly int pollIntervalSeconds;
     private readonly IMessageBus bus;
     private readonly HealthState health;
-    private readonly string instanceId;
+    private readonly CancellationTokenSource cts = new();
+    private Task loop = Task.CompletedTask;
 
-    public PduPoller(Config cfg, PDU pdu, IMessageBus bus, HealthState health)
+    public PduPoller(string instanceId, PDU pdu, int pollIntervalSeconds, IMessageBus bus, HealthState health)
     {
-        this.cfg = cfg;
+        this.instanceId = instanceId;
         this.pdu = pdu;
+        this.pollIntervalSeconds = pollIntervalSeconds;
         this.bus = bus;
         this.health = health;
-        instanceId = string.IsNullOrWhiteSpace(cfg.PDU?.Connection?.Host) ? "pdu" : cfg.PDU!.Connection!.Host!;
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    public void Start() => loop = RunAsync(cts.Token);
+
+    public async Task StopAsync()
     {
-        var interval = TimeSpan.FromSeconds(Math.Max(1, cfg.PDU.PollInterval));
-        using var timer = new PeriodicTimer(interval);
+        await cts.CancelAsync();
+        try { await loop; } catch (OperationCanceledException) { /* expected */ }
+    }
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(Math.Max(1, pollIntervalSeconds)));
 
         while (true)
         {
             try
             {
-                var data = await pdu.GetRootData_Public(stoppingToken);
-                await bus.PublishAsync(new PduSnapshot(instanceId, DateTime.UtcNow, data), stoppingToken);
+                var data = await pdu.GetRootData_Public(cancellationToken);
+                await bus.PublishAsync(new PduSnapshot(instanceId, DateTime.UtcNow, data), cancellationToken);
 
                 // A successful poll is the readiness signal: we can reach the PDU.
                 health.RecordPollSuccess();
@@ -47,12 +55,12 @@ public sealed class PduPoller : BackgroundService
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"{nameof(PduPoller)} poll failed.");
+                Log.Error(ex, $"PduPoller '{instanceId}' poll failed.");
             }
 
             try
             {
-                if (!await timer.WaitForNextTickAsync(stoppingToken))
+                if (!await timer.WaitForNextTickAsync(cancellationToken))
                     break;
             }
             catch (OperationCanceledException)

--- a/rPDU2MQTT/Services/PrometheusExportService.cs
+++ b/rPDU2MQTT/Services/PrometheusExportService.cs
@@ -62,12 +62,9 @@ public class PrometheusExportService : baseMQTTService
 
     protected override Task Execute(CancellationToken cancellationToken)
     {
-        var data = LatestFreshData();
-        if (data is null)
-            return Task.CompletedTask;
-
-        foreach (var r in MetricsHelper.EnumerateReadings(data))
-            GetGauge(MetricsHelper.PrometheusMetricName(r, cfg)).WithLabels(r.Device, r.Source, r.Units).Set(r.Value);
+        foreach (var data in FreshSnapshots())
+            foreach (var r in MetricsHelper.EnumerateReadings(data))
+                GetGauge(MetricsHelper.PrometheusMetricName(r, cfg)).WithLabels(r.Device, r.Source, r.Units).Set(r.Value);
 
         return Task.CompletedTask;
     }

--- a/rPDU2MQTT/Services/baseTypes/baseMQTTService.cs
+++ b/rPDU2MQTT/Services/baseTypes/baseMQTTService.cs
@@ -167,20 +167,17 @@ public abstract class baseMQTTService : IHostedService, IDisposable
     }
 
     /// <summary>
-    /// The most recent pipeline snapshot's data, or null if there is none or it has gone stale (the
-    /// PduPoller stopped producing — e.g. the PDU is unreachable). Returning null lets consumers skip
-    /// publishing so Home Assistant's expire_after can mark entities unavailable instead of us
-    /// republishing the last-known values forever.
+    /// The latest data from every source whose snapshot is still fresh. Stale sources (a poller that
+    /// stopped producing — e.g. an unreachable PDU) are skipped, so Home Assistant's expire_after can
+    /// mark their entities unavailable instead of us republishing last-known values forever.
     /// </summary>
-    protected Models.PDU.PduData? LatestFreshData()
+    protected IReadOnlyList<Models.PDU.PduData> FreshSnapshots()
     {
-        var snapshot = snapshotCache.Latest;
-        if (snapshot is null)
-            return null;
-
-        return Core.SnapshotFreshness.IsStale(snapshot.TimestampUtc, cfg.PDU.PollInterval, DateTime.UtcNow)
-            ? null
-            : snapshot.Data;
+        var now = DateTime.UtcNow;
+        return snapshotCache.All
+            .Where(s => !Core.SnapshotFreshness.IsStale(s.TimestampUtc, cfg.PDU.PollInterval, now))
+            .Select(s => s.Data)
+            .ToList();
     }
 
     /// <summary>

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -120,7 +120,8 @@ public static class ServiceConfiguration
         services.AddSingleton<Core.SnapshotCache>();
         services.AddSingleton<Core.ISnapshotCache>(sp => sp.GetRequiredService<Core.SnapshotCache>());
         services.AddHostedService(sp => sp.GetRequiredService<Core.SnapshotCache>());
-        services.AddHostedService<PduPoller>();
+        // Owns the PDU producer(s) — one poller per configured instance.
+        services.AddHostedService<InstanceManager>();
 
         // Shared liveness/readiness signals (uptime + last successful poll).
         services.AddSingleton<HealthState>();


### PR DESCRIPTION
**Phases 4.2 + 4.3** of #127, combined into one PR.

### Producer side (4.2)
- **`PduPoller`** is now a managed per-instance runner (`Start()`/`StopAsync()` = load/unload), tagged with its instance id, instead of a hosted service.
- **`InstanceManager`** (hosted service) owns the pollers — one per `Config.Pdus` entry. It's the registry that will later support runtime add/remove. Today `Pdus` has the single `"default"` entry (== `Config.PDU`), so exactly one poller runs on the shared `PDU` — identical to current behaviour. Per-instance PDU construction (distinct connection/credentials/HttpClient) lands with **user-configurable `Pdus` in 4.4**; a >1-entry config logs a warning until then.

### Consumer side (4.3)
- **`baseMQTTService.FreshSnapshots()`** returns every non-stale source's data; MQTT / Prometheus / EmonCMS now process **all** instances (EmonCMS aggregates into a single post). Stale sources are skipped, so a PDU outage still surfaces via HA `expire_after`.

Single-instance behaviour is unchanged (one poller, consumers see one snapshot). 69 tests (incl. a fresh-only fan-out test); build warning-free.

Can't exercise true multi-instance here (one PDU, and `Pdus` isn't user-configurable until 4.4) — the structure + fan-out are unit-tested; full multi is validated once 4.4 makes instances configurable.

Next (4.4): make `Pdus` persisted + configurable (GUI/CRD), add the per-instance PDU factory, and the docs/upgrade notes (the breaking change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)