### PR TITLE
feat(v2): GUI multi-PDU instance selection + Inputs/Outputs nav (#127, phase 4.4 part 2)

### DIFF
--- a/rPDU2MQTT.Tests/MultiPduConfigTests.cs
+++ b/rPDU2MQTT.Tests/MultiPduConfigTests.cs
@@ -70,6 +70,31 @@ public class MultiPduConfigTests
     }
 
     [Fact]
+    public void Registry_SkipsInstancesMissingHost_AndKeepsValidOnes()
+    {
+        var cfg = new Config();
+        cfg.Pdus["default"] = new PduConfig(); cfg.Pdus["default"].Connection.Host = "10.0.0.1";
+        cfg.Pdus["new"] = new PduConfig(); // no Host — a half-configured GUI addition
+
+        var registry = new PduInstanceRegistry(cfg, new PduInstanceFactory(cfg));
+
+        Assert.True(registry.All.ContainsKey("default"));
+        Assert.False(registry.All.ContainsKey("new"));
+        // An unknown/skipped instance resolves to the primary instead of throwing.
+        Assert.Same(registry.Primary, registry.Get("new"));
+    }
+
+    [Fact]
+    public void Registry_ThrowsWhenNoInstanceHasAHost()
+    {
+        var cfg = new Config();
+        cfg.Pdus["a"] = new PduConfig(); // no Host
+        cfg.Pdus["b"] = new PduConfig(); // no Host
+
+        Assert.Throws<Exception>(() => new PduInstanceRegistry(cfg, new PduInstanceFactory(cfg)));
+    }
+
+    [Fact]
     public void Initialize_PrefersPdusOverDeprecatedPduWhenBothPresent()
     {
         var cfg = new Config { PDU = new PduConfig() };

--- a/rPDU2MQTT/Classes/PduInstanceRegistry.cs
+++ b/rPDU2MQTT/Classes/PduInstanceRegistry.cs
@@ -13,7 +13,19 @@ public sealed class PduInstanceRegistry
     {
         this.config = config;
         foreach (var (id, pduCfg) in config.Pdus)
+        {
+            // A half-configured instance (e.g. one just added in the GUI without a Host yet) must not
+            // take down the whole bridge; skip it with a warning so the valid instances still run.
+            if (string.IsNullOrWhiteSpace(pduCfg.Connection?.Host))
+            {
+                Log.Warning($"PDU instance '{id}' has no Connection.Host; skipping it. Set its host (or remove it) to enable polling.");
+                continue;
+            }
             instances[id] = factory.Create(pduCfg);
+        }
+
+        if (instances.Count == 0)
+            throw new Exception("No usable PDU instances configured — every entry in 'Pdus' is missing Connection.Host. Set at least one PDU host.");
     }
 
     public IReadOnlyDictionary<string, PDU> All => instances;

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -37,11 +37,12 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly IHostApplicationLifetime lifetime;
     private readonly HealthState health;
     private readonly PduInstanceFactory pduFactory;
+    private readonly PduInstanceRegistry registry;
     private readonly EmonCmsStatus emonCmsStatus;
     private static readonly HttpClient testHttp = new() { Timeout = TimeSpan.FromSeconds(15) };
     private WebApplication? app;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, EmonCmsStatus emonCmsStatus)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, EmonCmsStatus emonCmsStatus)
     {
         this.config = config;
         this.mqtt = mqtt;
@@ -51,7 +52,21 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         this.lifetime = lifetime;
         this.health = health;
         this.pduFactory = pduFactory;
+        this.registry = registry;
         this.emonCmsStatus = emonCmsStatus;
+    }
+
+    /// <summary>The instance id a request targets — a usable (registry) instance, else the primary's.</summary>
+    private string ResolveInstanceId(string? requested) =>
+        !string.IsNullOrEmpty(requested) && registry.All.ContainsKey(requested)
+            ? requested
+            : (registry.All.ContainsKey(Config.DefaultInstanceKey) ? Config.DefaultInstanceKey : registry.All.Keys.First());
+
+    /// <summary>Resolve the PDU + its config for a request, from <c>?instance=</c> (GET) or a body field (POST).</summary>
+    private (string Id, PDU Pdu, Models.Config.PduConfig Cfg) ResolveInstance(string? requested)
+    {
+        var id = ResolveInstanceId(requested);
+        return (id, registry.Get(id), config.Pdus[id]);
     }
 
     /// <summary>Authentication is turned off entirely (Gui.AuthType = None).</summary>
@@ -325,6 +340,20 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             user = UseOidc ? ctx.User?.Identity?.Name : null,
         }, ConfigSchema.Json));
 
+        // Configured PDU instances (the per-tab instance selector on Live Data / Control reads this).
+        app.MapGet("/api/instances", () =>
+        {
+            var primaryId = ResolveInstanceId(null);
+            // Only usable (pollable) instances — registry skips entries missing a Connection.Host.
+            var instances = registry.All.Keys.Select(id => new
+            {
+                id,
+                primary = string.Equals(id, primaryId, StringComparison.OrdinalIgnoreCase),
+                actionsEnabled = config.Pdus.TryGetValue(id, out var c) && c.ActionsEnabled,
+            }).ToList();
+            return Results.Json(new { ok = true, instances }, ConfigSchema.Json);
+        });
+
         // Diagnostics: versions, uptime, runtime, and Kubernetes context for the Diagnostics page.
         app.MapGet("/api/diagnostics", () =>
         {
@@ -428,6 +457,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
+                var pdu = ResolveInstance(ctx.Request.Query["instance"]).Pdu;
                 var data = await pdu.GetRootData_Public(cts.Token);
                 var devices = data.Devices?.Count ?? 0;
                 var outlets = data.Devices?.Sum(d => d.Outlets?.Count ?? 0) ?? 0;
@@ -490,6 +520,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
+                var pdu = ResolveInstance(ctx.Request.Query["instance"]).Pdu;
                 var data = await pdu.GetRootData_Public(cts.Token);
 
                 // Expose the raw PDU label/name plus the currently-discovered display name and
@@ -544,6 +575,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
+                var pdu = ResolveInstance(ctx.Request.Query["instance"]).Pdu;
                 var data = await pdu.GetRootData_Public(cts.Token);
                 var readingList = MetricsHelper.EnumerateReadings(data)
                     .OrderBy(r => r.Device).ThenBy(r => r.Source).ThenBy(r => r.Type)
@@ -603,6 +635,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
+                var pdu = ResolveInstance(ctx.Request.Query["instance"]).Pdu;
                 var data = await pdu.GetRootData_Public(cts.Token);
                 return Results.Json(BuildPaths(data, config), ConfigSchema.Json);
             }
@@ -644,6 +677,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
+                var (_, pdu, instanceCfg) = ResolveInstance(ctx.Request.Query["instance"]);
                 var data = await pdu.GetRootData_Public(cts.Token);
                 var outlets = data.Devices.SelectMany(d => d.Outlets.OrderBy(o => o.Key).Select(o => new
                 {
@@ -698,7 +732,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                             label = pdu.ResolveEntityConfig(d.Key, e.Key, "label", e.Label ?? ""),
                         }).ToList(),
                 }).ToList();
-                return Results.Json(new { ok = true, actionsEnabled = config.Primary.ActionsEnabled, outlets, groups, devices }, ConfigSchema.Json);
+                return Results.Json(new { ok = true, actionsEnabled = instanceCfg.ActionsEnabled, outlets, groups, devices }, ConfigSchema.Json);
             }
             catch (Exception ex)
             {
@@ -709,14 +743,15 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         // Apply a control action to every outlet in a OneView group (fan-out). Gated by ActionsEnabled.
         app.MapPost("/api/control/group", async (HttpContext ctx) =>
         {
-            if (!config.Primary.ActionsEnabled)
-                return Results.Json(new { ok = false, message = "Write actions are disabled (PDU.ActionsEnabled is false)." }, statusCode: 409);
-
             GroupControlRequest? req;
             try { req = await ctx.Request.ReadFromJsonAsync<GroupControlRequest>(ctx.RequestAborted); }
             catch { req = null; }
             if (req is null || string.IsNullOrWhiteSpace(req.GroupKey))
                 return Results.BadRequest(new { ok = false, message = "groupKey and action are required." });
+
+            var (_, pdu, instanceCfg) = ResolveInstance(req.Instance);
+            if (!instanceCfg.ActionsEnabled)
+                return Results.Json(new { ok = false, message = "Write actions are disabled for this PDU instance (ActionsEnabled is false)." }, statusCode: 409);
 
             var action = (req.Action ?? string.Empty).Trim().ToLowerInvariant();
             if (action is not ("on" or "off" or "reboot"))
@@ -738,14 +773,15 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         // Issue an outlet control action (on/off/reboot). Gated by PDU.ActionsEnabled.
         app.MapPost("/api/control/outlet", async (HttpContext ctx) =>
         {
-            if (!config.Primary.ActionsEnabled)
-                return Results.Json(new { ok = false, message = "Write actions are disabled (PDU.ActionsEnabled is false)." }, statusCode: 409);
-
             ControlRequest? req;
             try { req = await ctx.Request.ReadFromJsonAsync<ControlRequest>(ctx.RequestAborted); }
             catch { req = null; }
             if (req is null || string.IsNullOrWhiteSpace(req.DeviceId))
                 return Results.BadRequest(new { ok = false, message = "deviceId, index and action are required." });
+
+            var (_, pdu, instanceCfg) = ResolveInstance(req.Instance);
+            if (!instanceCfg.ActionsEnabled)
+                return Results.Json(new { ok = false, message = "Write actions are disabled for this PDU instance (ActionsEnabled is false)." }, statusCode: 409);
 
             var action = (req.Action ?? string.Empty).Trim().ToLowerInvariant();
             if (action is not ("on" or "off" or "reboot" or "resetstats"))
@@ -770,14 +806,15 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         // Write an outlet's label on the PDU itself (cmd "set"). Gated by PDU.ActionsEnabled.
         app.MapPost("/api/control/label", async (HttpContext ctx) =>
         {
-            if (!config.Primary.ActionsEnabled)
-                return Results.Json(new { ok = false, message = "Write actions are disabled (PDU.ActionsEnabled is false)." }, statusCode: 409);
-
             LabelRequest? req;
             try { req = await ctx.Request.ReadFromJsonAsync<LabelRequest>(ctx.RequestAborted); }
             catch { req = null; }
             if (req is null)
                 return Results.BadRequest(new { ok = false, message = "A label request body is required." });
+
+            var (_, pdu, instanceCfg) = ResolveInstance(req.Instance);
+            if (!instanceCfg.ActionsEnabled)
+                return Results.Json(new { ok = false, message = "Write actions are disabled for this PDU instance (ActionsEnabled is false)." }, statusCode: 409);
 
             var target = (req.Target ?? "outlet").Trim().ToLowerInvariant();
             // Group labels target the OneView master, not a specific device; everything else needs a deviceId.
@@ -851,13 +888,13 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     }
 
     /// <summary>Body of a POST /api/control/outlet request.</summary>
-    private sealed record ControlRequest(string DeviceId, int Index, string Action);
+    private sealed record ControlRequest(string DeviceId, int Index, string Action, string? Instance = null);
 
     /// <summary>Body of a POST /api/control/label request.</summary>
-    private sealed record LabelRequest(string DeviceId, string? Target, int Index, string? EntityKey, string? GroupKey, string Label);
+    private sealed record LabelRequest(string DeviceId, string? Target, int Index, string? EntityKey, string? GroupKey, string Label, string? Instance = null);
 
     /// <summary>Body of a POST /api/control/group request.</summary>
-    private sealed record GroupControlRequest(string GroupKey, string Action);
+    private sealed record GroupControlRequest(string GroupKey, string Action, string? Instance = null);
 
     /// <summary>One pivoted live-view row: an outlet/entity with its numeric measurements + state.</summary>
     private static object BuildLiveEntity(string device, string source, string kind, int? number, string? state, IEnumerable<Models.PDU.Measurement> measurements)

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -19,6 +19,35 @@ function el(tag, props, ...children) {
 // A small ".small" button (add a class like "danger"/"primary" via cls).
 function btn(label, cls) { return el('button', { class: 'small' + (cls ? ' ' + cls : ''), text: label }); }
 
+// --- Multi-PDU: per-tab instance selector ---
+let _instancesCache = null;
+async function getInstances() {
+  if (_instancesCache) return _instancesCache;
+  const r = await api('/api/instances');
+  _instancesCache = (r.body && r.body.ok) ? (r.body.instances || []) : [];
+  return _instancesCache;
+}
+// A per-tab PDU instance picker. Returns { wrap, get } — append `wrap` to a toolbar; `get()` is the
+// selected instance id. Stays hidden when only one instance is configured (single-PDU UX unchanged);
+// then get() === '' so the backend falls back to the primary. `onChange` fires when the user switches.
+function instanceSelector(onChange) {
+  const sel = el('select');
+  const wrap = el('label', { class: 'ld-inst', style: { display: 'none' } }, 'Instance ', sel);
+  getInstances().then(list => {
+    if (list.length <= 1) return;
+    list.forEach(i => sel.appendChild(el('option', { value: i.id, text: i.id + (i.primary ? ' (primary)' : '') })));
+    sel.value = (list.find(i => i.primary) || list[0]).id;
+    wrap.style.display = '';
+  });
+  sel.onchange = () => onChange && onChange(sel.value);
+  return { wrap, get: () => sel.value || '' };
+}
+// Append `?instance=<id>` to a path when an instance is selected (empty -> primary, omit the param).
+function withInstance(path, instSel) {
+  const v = instSel.get();
+  return v ? path + (path.includes('?') ? '&' : '?') + 'instance=' + encodeURIComponent(v) : path;
+}
+
 // === Config form (schema-driven rendering) ===
 function scalarInput(node, obj) {
   let el;
@@ -370,8 +399,9 @@ function addControlSection(nav, sections) {
 
   const bar = document.createElement('div'); bar.className = 'ld-toolbar';
   const refresh = btn('Refresh');
+  const instSel = instanceSelector(() => load());
   const filter = document.createElement('input'); filter.type = 'text'; filter.placeholder = 'Filter (device / outlet)…';
-  bar.appendChild(refresh); bar.appendChild(filter); sec.appendChild(bar);
+  bar.appendChild(refresh); bar.appendChild(instSel.wrap); bar.appendChild(filter); sec.appendChild(bar);
   const warn = document.createElement('div'); warn.className = 'desc'; warn.style.color = 'var(--bad)'; warn.style.display = 'none';
   warn.textContent = 'Write actions are disabled (PDU.ActionsEnabled is false). Enable it in the PDU section and restart to control outlets.';
   sec.appendChild(warn);
@@ -384,7 +414,7 @@ function addControlSection(nav, sections) {
     const verb = action === 'on' ? 'turn ON' : action === 'off' ? 'turn OFF' : 'reboot';
     if (!confirm('Group "' + (g.name || g.key) + '": ' + verb + ' ALL member outlets?')) return;
     toast('Group ' + (g.name || g.key) + ': ' + action + '…', true);
-    const r = await api('/api/control/group', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ groupKey: g.key, action }) });
+    const r = await api('/api/control/group', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ groupKey: g.key, action, instance: instSel.get() }) });
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
     setTimeout(load, 1000);
   };
@@ -433,13 +463,13 @@ function addControlSection(nav, sections) {
     if (action === 'reboot' && !confirm('Reboot outlet ' + o.number + ' (' + o.name + ')? Connected equipment will lose power briefly.')) return;
     if (action === 'resetstats' && !confirm('Reset statistics for outlet ' + o.number + ' (' + o.name + ')?')) return;
     toast('Outlet ' + o.number + ': ' + action + '…', true);
-    const r = await api('/api/control/outlet', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ deviceId: o.deviceId, index: o.index, action }) });
+    const r = await api('/api/control/outlet', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ deviceId: o.deviceId, index: o.index, action, instance: instSel.get() }) });
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
     setTimeout(load, 800); // let the PDU apply, then re-read state
   };
   const postLabel = async (payload, desc) => {
     toast(desc + ': set label…', true);
-    const r = await api('/api/control/label', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+    const r = await api('/api/control/label', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ...payload, instance: instSel.get() }) });
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
     setTimeout(load, 800);
   };
@@ -513,7 +543,7 @@ function addControlSection(nav, sections) {
     t.appendChild(tb); tableWrap.innerHTML = ''; tableWrap.appendChild(t);
   };
   const load = async () => {
-    const r = await api('/api/control/outlets');
+    const r = await api(withInstance('/api/control/outlets', instSel));
     if (!r.body.ok) { tableWrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load outlets.') + '</div>'; return; }
     rows = r.body.outlets || []; groups = r.body.groups || []; devices = r.body.devices || []; enabled = !!r.body.actionsEnabled;
     warn.style.display = enabled ? 'none' : 'block'; drawGroups(); drawDevices(); draw();
@@ -537,7 +567,8 @@ function addLiveDataSection(nav, sections) {
   const autoLab = document.createElement('label'); const auto = document.createElement('input'); auto.type = 'checkbox';
   autoLab.appendChild(auto); autoLab.appendChild(document.createTextNode('Auto-refresh (5s)'));
   const count = document.createElement('span'); count.className = 'ld-count';
-  bar.appendChild(refresh); bar.appendChild(viewSel); bar.appendChild(filter); bar.appendChild(autoLab); bar.appendChild(count);
+  const instSel = instanceSelector(() => load());
+  bar.appendChild(refresh); bar.appendChild(instSel.wrap); bar.appendChild(viewSel); bar.appendChild(filter); bar.appendChild(autoLab); bar.appendChild(count);
   sec.appendChild(bar);
   const tableWrap = document.createElement('div'); sec.appendChild(tableWrap);
   const groupsWrap = document.createElement('div'); sec.appendChild(groupsWrap);
@@ -642,7 +673,7 @@ function addLiveDataSection(nav, sections) {
   };
   const draw = () => { (viewSel.value === 'flat' ? drawFlat : drawGrouped)(); drawGroupRollups(); };
   const load = async () => {
-    const r = await api('/api/livedata');
+    const r = await api(withInstance('/api/livedata', instSel));
     if (!r.body.ok) { tableWrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load live data.') + '</div>'; groupsWrap.innerHTML = ''; count.textContent = ''; return; }
     body = r.body;
     count.textContent = (body.entities || []).length + ' outlets/entities · ' + (body.readings || []).length + ' readings · ' + (body.groups || []).length + ' groups';

--- a/rPDU2MQTT/wwwroot/app.js
+++ b/rPDU2MQTT/wwwroot/app.js
@@ -183,47 +183,81 @@ function renderList(node, arr) {
   return fs;
 }
 
+// Config sections grouped by role (mirrors the v2 producer/consumer model): data sources are Inputs,
+// data sinks are Outputs, shared transport/UI settings are General. Unlisted sections fall into General.
+const NAV_GROUPS = [
+  { title: 'Inputs', keys: ['Pdus'] },
+  { title: 'Outputs', keys: ['HomeAssistant', 'Prometheus', 'EmonCMS'] },
+  { title: 'General', keys: ['MQTT', 'Overrides', 'Gui', 'Health', 'Logging', 'Debug'] },
+];
+
+function navHeader(nav, title) { nav.appendChild(el('div', { class: 'nav-group', text: title })); }
+
+// Render one schema-driven config section (nav link + panel); returns the nav link.
+function renderConfigSection(node, nav, sections) {
+  const link = document.createElement('a'); link.textContent = node.label; nav.appendChild(link);
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  const h = document.createElement('h2'); h.textContent = node.label; sec.appendChild(h);
+  if (node.description) { const d = document.createElement('div'); d.className = 'desc'; d.textContent = node.description; sec.appendChild(d); }
+  // Section-specific actions belong with the section they act on, not on every page.
+  const acts = sectionActions(node);
+  if (acts) sec.appendChild(acts);
+  if (node.key === 'Overrides') {
+    // Bespoke, live-data-driven editor instead of the blind dictionary form.
+    const tools = document.createElement('div'); tools.className = 'sec-actions';
+    const refresh = btn('Refresh live data');
+    const preview = btn('Preview generated paths (with unsaved edits)');
+    tools.appendChild(refresh); tools.appendChild(preview);
+    const pathsBox = document.createElement('div');
+    const container = document.createElement('div');
+    refresh.onclick = () => renderOverrides(container);
+    preview.onclick = () => previewOverridePaths(pathsBox);
+    sec.appendChild(tools); sec.appendChild(pathsBox); sec.appendChild(container);
+    link.onclick = () => { activate(link, sec); if (!container.dataset.loaded) renderOverrides(container); };
+  } else {
+    if (node.type === 'object') {
+      ensure(data, node.key, {});
+      const grid = document.createElement('div'); grid.className = 'grid';
+      (node.properties || []).forEach(c => renderNode(c, data[node.key], grid));
+      sec.appendChild(grid);
+    }
+    else renderNode(node, data, sec);
+    if (node.key === 'Gui') wireGuiAuth(sec);
+    link.onclick = () => activate(link, sec);
+  }
+  return link;
+}
+
 function build() {
   const nav = document.getElementById('nav'); const sections = document.getElementById('sections');
   nav.innerHTML = ''; sections.innerHTML = '';
-  schema.forEach((node, i) => {
-    const link = document.createElement('a'); link.textContent = node.label; nav.appendChild(link);
-    const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
-    const h = document.createElement('h2'); h.textContent = node.label; sec.appendChild(h);
-    if (node.description) { const d = document.createElement('div'); d.className = 'desc'; d.textContent = node.description; sec.appendChild(d); }
-    // Section-specific actions belong with the section they act on, not on every page.
-    const acts = sectionActions(node);
-    if (acts) sec.appendChild(acts);
-    if (node.key === 'Overrides') {
-      // Bespoke, live-data-driven editor instead of the blind dictionary form.
-      const tools = document.createElement('div'); tools.className = 'sec-actions';
-      const refresh = btn('Refresh live data');
-      const preview = btn('Preview generated paths (with unsaved edits)');
-      tools.appendChild(refresh); tools.appendChild(preview);
-      const pathsBox = document.createElement('div');
-      const container = document.createElement('div');
-      refresh.onclick = () => renderOverrides(container);
-      preview.onclick = () => previewOverridePaths(pathsBox);
-      sec.appendChild(tools); sec.appendChild(pathsBox); sec.appendChild(container);
-      link.onclick = () => { activate(link, sec); if (!container.dataset.loaded) renderOverrides(container); };
-    } else {
-      if (node.type === 'object') {
-        ensure(data, node.key, {});
-        const grid = document.createElement('div'); grid.className = 'grid';
-        (node.properties || []).forEach(c => renderNode(c, data[node.key], grid));
-        sec.appendChild(grid);
-      }
-      else renderNode(node, data, sec);
-      if (node.key === 'Gui') wireGuiAuth(sec);
-      link.onclick = () => activate(link, sec);
+
+  const byKey = new Map(schema.map(n => [n.key, n]));
+  // Any schema section not explicitly grouped lands in General, so a new config section is never lost.
+  const known = new Set(NAV_GROUPS.flatMap(g => g.keys));
+  const general = NAV_GROUPS.find(g => g.title === 'General');
+  schema.forEach(n => { if (!known.has(n.key)) general.keys.push(n.key); });
+
+  let first = null;
+  for (const g of NAV_GROUPS) {
+    const nodes = g.keys.map(k => byKey.get(k)).filter(Boolean);
+    if (!nodes.length) continue;
+    navHeader(nav, g.title);
+    for (const node of nodes) {
+      const link = renderConfigSection(node, nav, sections);
+      if (!first) first = link;
     }
-    if (i === 0) link.click();
-  });
+  }
+
+  // Tools: the functional (non-config) tabs.
+  navHeader(nav, 'Tools');
   addControlSection(nav, sections);
   addLiveDataSection(nav, sections);
   addPathsSection(nav, sections);
   addExportSection(nav, sections);
   addDiagnosticsSection(nav, sections);
+
+  if (first) first.click();
 }
 
 // In the Gui section, grey out the auth fields that don't apply to the selected AuthType.

--- a/rPDU2MQTT/wwwroot/styles.css
+++ b/rPDU2MQTT/wwwroot/styles.css
@@ -8,6 +8,8 @@
   .dot.good { background:var(--good); } .dot.bad { background:var(--bad); }
   .layout { display:flex; min-height:calc(100vh - 53px); }
   nav { width:200px; border-right:1px solid var(--line); background:var(--panel); padding:10px 0; }
+  .nav-group { padding:14px 20px 4px; font-size:11px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; color:var(--muted); opacity:.65; }
+  .nav-group:first-child { padding-top:6px; }
   nav a { display:block; padding:8px 20px; color:var(--muted); cursor:pointer; border-left:3px solid transparent; }
   nav a:hover { color:var(--fg); }
   nav a.active { color:var(--fg); border-left-color:var(--accent); background:var(--panel2); }


### PR DESCRIPTION
**Phase 4.4 part 2** of #127 — the GUI catches up to the multi-PDU runtime landed in #148.

## GUI multi-PDU
- **Per-tab instance selector** on the **Live Data** and **Control** tabs (each remembers its own selection). Hidden when only one instance is configured, so the single-PDU UX is byte-identical.
- New `GET /api/instances` lists the *usable* (pollable) instances; the live/control/paths endpoints resolve `?instance=` (GET) or an `instance` body field (POST), defaulting to the primary.
- Control actions gate on the **target instance's own `ActionsEnabled`**, not the primary's.

## Robustness (fixes a real startup crash)
A half-configured instance — e.g. one just added in the GUI with no `Host` yet — used to throw at startup and take down the **whole** bridge (`Missing required configuration. Path: Pdus[].Connection.Host`). Now `PduInstanceRegistry` **skips** a hostless instance with a warning and only hard-fails if *no* instance has a host.
- Added `PduInstanceRegistry` bad-input tests (skips hostless / keeps valid; throws when none valid).

## Inputs/Outputs nav reorg
Config navigation is grouped to mirror the v2 producer/consumer model:
- **Inputs:** PDUs
- **Outputs:** Home Assistant, Prometheus, EmonCMS
- **General:** MQTT (shared transport), Overrides, GUI, Health, Logging, Debug
- **Tools:** Live Data, Control, Paths, Export, Diagnostics

`build()` renders grouped nav headers; per-section rendering extracted to `renderConfigSection()`. Any schema section not explicitly grouped falls into General, so a newly-added section is never dropped.

## Notes
- 75 tests green; `app.js` parses; verified the bridge boots against a real config (skips a blank instance, polls the valid one).
- GUI is OIDC-gated, so the new endpoints were validated via the build/tests + logic rather than unauthenticated curl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)