### PR TITLE
feat(v2): runtime add/remove of PDU instances (#127, phase 5)

### DIFF
--- a/rPDU2MQTT.Tests/MultiPduConfigTests.cs
+++ b/rPDU2MQTT.Tests/MultiPduConfigTests.cs
@@ -109,3 +109,126 @@ public class MultiPduConfigTests
         Assert.Null(result.PDU);
     }
 }
+
+/// <summary>Runtime reconcile planner (phase 5): what to start/stop when Config.Pdus changes.</summary>
+public class InstanceReconcileTests
+{
+    private static PduConfig Pdu(string host, int poll = 5)
+    {
+        var c = new PduConfig { PollInterval = poll };
+        c.Connection.Host = host;
+        return c;
+    }
+
+    [Fact]
+    public void Plan_StartsAddedInstances()
+    {
+        var running = new Dictionary<string, string> { ["default"] = InstanceReconcile.Signature(Pdu("a")) };
+        var desired = new Dictionary<string, PduConfig> { ["default"] = Pdu("a"), ["b"] = Pdu("b") };
+
+        var (toStop, toStart, primaryChanged) = InstanceReconcile.Plan(running, desired, "default");
+
+        Assert.Equal(new[] { "b" }, toStart);
+        Assert.Empty(toStop);
+        Assert.False(primaryChanged);
+    }
+
+    [Fact]
+    public void Plan_StopsRemovedInstances()
+    {
+        var running = new Dictionary<string, string>
+        {
+            ["default"] = InstanceReconcile.Signature(Pdu("a")),
+            ["b"] = InstanceReconcile.Signature(Pdu("b")),
+        };
+        var desired = new Dictionary<string, PduConfig> { ["default"] = Pdu("a") };
+
+        var (toStop, toStart, _) = InstanceReconcile.Plan(running, desired, "default");
+
+        Assert.Equal(new[] { "b" }, toStop);
+        Assert.Empty(toStart);
+    }
+
+    [Fact]
+    public void Plan_RebuildsChangedNonPrimary()
+    {
+        var running = new Dictionary<string, string>
+        {
+            ["default"] = InstanceReconcile.Signature(Pdu("a")),
+            ["b"] = InstanceReconcile.Signature(Pdu("b1")),
+        };
+        var desired = new Dictionary<string, PduConfig> { ["default"] = Pdu("a"), ["b"] = Pdu("b2") };
+
+        var (toStop, toStart, _) = InstanceReconcile.Plan(running, desired, "default");
+
+        Assert.Contains("b", toStop);
+        Assert.Contains("b", toStart);
+    }
+
+    [Fact]
+    public void Plan_PrimaryConnectionChange_FlagsRestart_AndIsNotStopped()
+    {
+        var running = new Dictionary<string, string> { ["default"] = InstanceReconcile.Signature(Pdu("a1")) };
+        var desired = new Dictionary<string, PduConfig> { ["default"] = Pdu("a2") };
+
+        var (toStop, toStart, primaryChanged) = InstanceReconcile.Plan(running, desired, "default");
+
+        Assert.True(primaryChanged);
+        Assert.Empty(toStop);
+        Assert.Empty(toStart);
+    }
+
+    [Fact]
+    public void Plan_IgnoresHostlessDesiredInstances()
+    {
+        var running = new Dictionary<string, string> { ["default"] = InstanceReconcile.Signature(Pdu("a")) };
+        var desired = new Dictionary<string, PduConfig> { ["default"] = Pdu("a"), ["b"] = new PduConfig() }; // b has no host
+
+        var (toStop, toStart, _) = InstanceReconcile.Plan(running, desired, "default");
+
+        Assert.Empty(toStart);
+        Assert.Empty(toStop);
+    }
+}
+
+/// <summary>Registry runtime add/remove (phase 5), keeping the primary fixed.</summary>
+public class PduInstanceRegistryRuntimeTests
+{
+    private static PduConfig Pdu(string host) { var c = new PduConfig(); c.Connection.Host = host; return c; }
+
+    private static PduInstanceRegistry Registry()
+    {
+        var cfg = new Config();
+        cfg.Pdus["default"] = Pdu("10.0.0.1");
+        return new PduInstanceRegistry(cfg, new PduInstanceFactory(cfg));
+    }
+
+    [Fact]
+    public void TryCreate_AddsAnInstance_AndRemoveDropsNonPrimary()
+    {
+        var registry = Registry();
+
+        Assert.NotNull(registry.TryCreate("b", Pdu("10.0.0.2")));
+        Assert.True(registry.All.ContainsKey("b"));
+        Assert.NotSame(registry.Primary, registry.Get("b"));
+
+        Assert.True(registry.Remove("b"));
+        Assert.False(registry.All.ContainsKey("b"));
+    }
+
+    [Fact]
+    public void Remove_RefusesToRemoveThePrimary()
+    {
+        var registry = Registry();
+        Assert.False(registry.Remove(registry.PrimaryId));
+        Assert.True(registry.All.ContainsKey(registry.PrimaryId));
+    }
+
+    [Fact]
+    public void TryCreate_SkipsHostlessInstance()
+    {
+        var registry = Registry();
+        Assert.Null(registry.TryCreate("b", new PduConfig())); // no host
+        Assert.False(registry.All.ContainsKey("b"));
+    }
+}

--- a/rPDU2MQTT/Classes/InstanceReconcile.cs
+++ b/rPDU2MQTT/Classes/InstanceReconcile.cs
@@ -1,0 +1,74 @@
+using rPDU2MQTT.Models.Config;
+
+namespace rPDU2MQTT.Classes;
+
+/// <summary>
+/// Pure reconciliation logic for the running PDU instances vs the desired <see cref="Config.Pdus"/>:
+/// what to stop (removed/changed) and (re)start (added/changed). Kept side-effect-free so it's unit-testable;
+/// <see cref="Services.InstanceManager"/> applies the plan.
+/// </summary>
+public static class InstanceReconcile
+{
+    /// <summary>
+    /// A signature of everything that requires rebuilding an instance's PDU/poller when it changes:
+    /// the connection target, TLS, timeout, credentials and poll cadence. (ActionsEnabled / Remap are
+    /// read live by the sinks &amp; discovery, so they don't need a poller rebuild.)
+    /// </summary>
+    public static string Signature(PduConfig c)
+    {
+        var con = c.Connection;
+        return string.Join('|',
+            con?.Host ?? "", con?.Port?.ToString() ?? "", con?.Scheme ?? "",
+            con?.TimeoutSecs?.ToString() ?? "", con?.ValidateCertificate?.ToString() ?? "",
+            c.Credentials?.Username ?? "", c.Credentials?.Password ?? "",
+            c.PollInterval.ToString());
+    }
+
+    /// <summary>
+    /// Plan the move from the currently-running instance signatures to the desired config. Returns the ids
+    /// to stop (removed or changed) and to start (added or changed); a changed non-primary instance appears
+    /// in both (rebuild). The primary is never stopped — it's the fixed DI singleton — so a changed primary
+    /// is surfaced via <c>primaryChanged</c> instead (needs a restart). Hostless desired entries are ignored.
+    /// </summary>
+    public static (List<string> toStop, List<string> toStart, bool primaryChanged) Plan(
+        IReadOnlyDictionary<string, string> running,
+        IReadOnlyDictionary<string, PduConfig> desired,
+        string primaryId)
+    {
+        var toStop = new List<string>();
+        var toStart = new List<string>();
+        var primaryChanged = false;
+
+        var desiredSig = desired
+            .Where(kv => !string.IsNullOrWhiteSpace(kv.Value.Connection?.Host))
+            .ToDictionary(kv => kv.Key, kv => Signature(kv.Value), StringComparer.OrdinalIgnoreCase);
+
+        bool IsPrimary(string id) => string.Equals(id, primaryId, StringComparison.OrdinalIgnoreCase);
+
+        // Removed or changed -> stop (the primary is never stopped).
+        foreach (var (id, sig) in running)
+        {
+            var wanted = desiredSig.TryGetValue(id, out var dsig);
+            var changed = wanted && dsig != sig;
+            if (wanted && !changed)
+                continue;
+            if (IsPrimary(id))
+            {
+                if (changed) primaryChanged = true;
+                continue;
+            }
+            toStop.Add(id);
+        }
+
+        // Added or changed -> start (the primary is never (re)started here).
+        foreach (var (id, dsig) in desiredSig)
+        {
+            if (IsPrimary(id))
+                continue;
+            if (!running.TryGetValue(id, out var rsig) || rsig != dsig)
+                toStart.Add(id);
+        }
+
+        return (toStop, toStart, primaryChanged);
+    }
+}

--- a/rPDU2MQTT/Classes/PduInstanceRegistry.cs
+++ b/rPDU2MQTT/Classes/PduInstanceRegistry.cs
@@ -1,38 +1,77 @@
+using rPDU2MQTT.Models.Config;
+
 namespace rPDU2MQTT.Classes;
 
 /// <summary>
-/// Holds the live <see cref="PDU"/> per configured instance (built once at startup from Config.Pdus).
-/// The pipeline polls every instance; GUI control/live/discovery use <see cref="Primary"/>.
+/// Holds the live <see cref="PDU"/> per configured instance. Built from <see cref="Config.Pdus"/> at
+/// startup; <see cref="TryCreate"/>/<see cref="Remove"/> let the <see cref="Services.InstanceManager"/>
+/// add/remove instances at runtime (phase 5). The pipeline polls every instance; GUI control/live/
+/// discovery use <see cref="Primary"/>.
 /// </summary>
+/// <remarks>
+/// <see cref="Primary"/> is fixed for the process lifetime — it's the DI-resolved <see cref="PDU"/> shared
+/// with the GUI / control / discovery, so runtime reconciliation never swaps it (a primary connection
+/// change still needs a restart). Reads/writes are guarded so reconciliation can run while the GUI reads.
+/// </remarks>
 public sealed class PduInstanceRegistry
 {
-    private readonly Config config;
+    private readonly PduInstanceFactory factory;
+    private readonly object gate = new();
     private readonly Dictionary<string, PDU> instances = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The fixed primary instance id (the DefaultInstanceKey entry, else the first at startup).</summary>
+    public string PrimaryId { get; }
 
     public PduInstanceRegistry(Config config, PduInstanceFactory factory)
     {
-        this.config = config;
+        this.factory = factory;
         foreach (var (id, pduCfg) in config.Pdus)
-        {
-            // A half-configured instance (e.g. one just added in the GUI without a Host yet) must not
-            // take down the whole bridge; skip it with a warning so the valid instances still run.
-            if (string.IsNullOrWhiteSpace(pduCfg.Connection?.Host))
-            {
-                Log.Warning($"PDU instance '{id}' has no Connection.Host; skipping it. Set its host (or remove it) to enable polling.");
-                continue;
-            }
-            instances[id] = factory.Create(pduCfg);
-        }
+            TryCreateInternal(id, pduCfg);
 
         if (instances.Count == 0)
             throw new Exception("No usable PDU instances configured — every entry in 'Pdus' is missing Connection.Host. Set at least one PDU host.");
+
+        PrimaryId = instances.ContainsKey(Config.DefaultInstanceKey) ? Config.DefaultInstanceKey : instances.Keys.First();
     }
 
-    public IReadOnlyDictionary<string, PDU> All => instances;
+    // Build + register an instance; skips (returns null) when it has no Host. Not locked — callers do.
+    private PDU? TryCreateInternal(string id, PduConfig pduCfg)
+    {
+        if (string.IsNullOrWhiteSpace(pduCfg.Connection?.Host))
+        {
+            Log.Warning($"PDU instance '{id}' has no Connection.Host; skipping it. Set its host (or remove it) to enable polling.");
+            return null;
+        }
+        var pdu = factory.Create(pduCfg);
+        instances[id] = pdu;
+        return pdu;
+    }
 
-    /// <summary>The primary instance's PDU (the DefaultInstanceKey entry, else the first).</summary>
-    public PDU Primary =>
-        instances.TryGetValue(Config.DefaultInstanceKey, out var p) ? p : instances.Values.First();
+    /// <summary>A snapshot of every live instance (safe to iterate while reconciliation mutates the set).</summary>
+    public IReadOnlyDictionary<string, PDU> All
+    {
+        get { lock (gate) return new Dictionary<string, PDU>(instances, StringComparer.OrdinalIgnoreCase); }
+    }
 
-    public PDU Get(string instanceId) => instances.TryGetValue(instanceId, out var p) ? p : Primary;
+    /// <summary>The primary instance's PDU (fixed for the process lifetime).</summary>
+    public PDU Primary { get { lock (gate) return instances[PrimaryId]; } }
+
+    public PDU Get(string instanceId)
+    {
+        lock (gate) return instances.TryGetValue(instanceId, out var p) ? p : instances[PrimaryId];
+    }
+
+    /// <summary>Build + register an instance at runtime (skips when hostless). Returns the PDU, or null if skipped.</summary>
+    public PDU? TryCreate(string id, PduConfig pduCfg)
+    {
+        lock (gate) return TryCreateInternal(id, pduCfg);
+    }
+
+    /// <summary>Remove an instance at runtime. Never removes the primary. Returns true if it was removed.</summary>
+    public bool Remove(string id)
+    {
+        if (string.Equals(id, PrimaryId, StringComparison.OrdinalIgnoreCase))
+            return false;
+        lock (gate) return instances.Remove(id);
+    }
 }

--- a/rPDU2MQTT/Services/Gui/GuiService.cs
+++ b/rPDU2MQTT/Services/Gui/GuiService.cs
@@ -38,11 +38,12 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly HealthState health;
     private readonly PduInstanceFactory pduFactory;
     private readonly PduInstanceRegistry registry;
+    private readonly InstanceManager instances;
     private readonly EmonCmsStatus emonCmsStatus;
     private static readonly HttpClient testHttp = new() { Timeout = TimeSpan.FromSeconds(15) };
     private WebApplication? app;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, EmonCmsStatus emonCmsStatus)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus)
     {
         this.config = config;
         this.mqtt = mqtt;
@@ -53,6 +54,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         this.health = health;
         this.pduFactory = pduFactory;
         this.registry = registry;
+        this.instances = instances;
         this.emonCmsStatus = emonCmsStatus;
     }
 
@@ -301,9 +303,25 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             {
                 await configSource.SaveAsync(parsed, ctx.RequestAborted);
                 Log.Information($"Configuration saved via GUI to {configSource.Describe}.");
-                var message = configSource.IsGitOpsManaged
-                    ? "Saved to the Kubernetes resource (remember to update your GitOps source so it doesn't drift). Credentials are stored in the companion Secret. Press 'Republish discovery' to apply override/name/template changes; restart for connection/credential changes (incl. OIDC)."
-                    : "Saved. Press 'Republish discovery' to apply override/name/template changes; restart the service for connection changes (host/port).";
+
+                // Apply PDU instance add/remove live: refresh the instance set from the saved config and
+                // reconcile the running pollers (a new PDU starts polling, a removed one stops) without a
+                // restart. Other live-read settings (overrides/names/templates) still apply on Republish.
+                var instanceMessage = "";
+                try
+                {
+                    config.Pdus = configSource.Load().Pdus;
+                    await instances.ReconcileAsync();
+                    instanceMessage = " PDU instances were applied live.";
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning($"Could not reconcile PDU instances after save ({ex.Message}); a restart will apply them.");
+                }
+
+                var message = (configSource.IsGitOpsManaged
+                    ? "Saved to the Kubernetes resource (remember to update your GitOps source so it doesn't drift). Credentials are stored in the companion Secret. Press 'Republish discovery' to apply override/name/template changes; restart for primary connection/credential changes (incl. OIDC)."
+                    : "Saved. Press 'Republish discovery' to apply override/name/template changes; restart the service for primary connection changes (host/port).") + instanceMessage;
                 return Results.Json(new { ok = true, message, gitops = configSource.IsGitOpsManaged });
             }
             catch (Exception ex)

--- a/rPDU2MQTT/Services/InstanceManager.cs
+++ b/rPDU2MQTT/Services/InstanceManager.cs
@@ -5,9 +5,12 @@ using rPDU2MQTT.Core;
 namespace rPDU2MQTT.Services;
 
 /// <summary>
-/// Owns the running PDU producers — one <see cref="PduPoller"/> per configured instance
-/// (<see cref="PduInstanceRegistry"/>). The registry that later enables adding/removing instances at
-/// runtime; for now it starts every instance once at startup.
+/// Owns the running PDU producers — one <see cref="PduPoller"/> per instance in the
+/// <see cref="PduInstanceRegistry"/>. Starts every instance at startup and, via <see cref="ReconcileAsync"/>,
+/// adds/removes/rebuilds pollers at runtime when <see cref="Config.Pdus"/> changes (phase 5) — so a PDU
+/// added or removed in the GUI takes effect without a restart. The primary instance is never torn down
+/// (its PDU is the DI singleton shared with the GUI/control/discovery); a primary connection change is
+/// logged as needing a restart.
 /// </summary>
 public sealed class InstanceManager : IHostedService
 {
@@ -16,6 +19,9 @@ public sealed class InstanceManager : IHostedService
     private readonly IMessageBus bus;
     private readonly HealthState health;
     private readonly Dictionary<string, PduPoller> pollers = new(StringComparer.OrdinalIgnoreCase);
+    // The config signature each running poller was started with, so reconciliation can detect changes.
+    private readonly Dictionary<string, string> runningSignatures = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SemaphoreSlim reconcileLock = new(1, 1);
 
     public InstanceManager(Config cfg, PduInstanceRegistry registry, IMessageBus bus, HealthState health)
     {
@@ -27,21 +33,68 @@ public sealed class InstanceManager : IHostedService
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        // Start a poller for each instance the registry built at startup.
         foreach (var (id, pdu) in registry.All)
-        {
-            var pollInterval = cfg.Pdus.TryGetValue(id, out var pduCfg) ? pduCfg.PollInterval : 5;
-            Log.Information($"Starting PDU instance '{id}' (poll every {pollInterval}s).");
-            var poller = new PduPoller(id, pdu, pollInterval, bus, health);
-            poller.Start();
-            pollers[id] = poller;
-        }
+            StartPoller(id, pdu);
         return Task.CompletedTask;
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        foreach (var poller in pollers.Values)
-            await poller.StopAsync();
-        pollers.Clear();
+        await reconcileLock.WaitAsync(cancellationToken);
+        try
+        {
+            foreach (var poller in pollers.Values)
+                await poller.StopAsync();
+            pollers.Clear();
+            runningSignatures.Clear();
+        }
+        finally { reconcileLock.Release(); }
+    }
+
+    /// <summary>
+    /// Bring the running pollers in line with the current <see cref="Config.Pdus"/>: start newly-added
+    /// instances, stop removed ones, and rebuild changed ones. Call after the config has been hot-reloaded.
+    /// </summary>
+    public async Task ReconcileAsync()
+    {
+        await reconcileLock.WaitAsync();
+        try
+        {
+            var (toStop, toStart, primaryChanged) = InstanceReconcile.Plan(runningSignatures, cfg.Pdus, registry.PrimaryId);
+
+            if (primaryChanged)
+                Log.Warning($"Connection/credential changes to the primary PDU instance '{registry.PrimaryId}' need a restart to take effect.");
+
+            foreach (var id in toStop)
+            {
+                Log.Information($"Stopping PDU instance '{id}' (removed or changed).");
+                if (pollers.Remove(id, out var poller))
+                    await poller.StopAsync();
+                registry.Remove(id);
+                runningSignatures.Remove(id);
+            }
+
+            foreach (var id in toStart)
+            {
+                if (!cfg.Pdus.TryGetValue(id, out var pduCfg))
+                    continue;
+                var pdu = registry.TryCreate(id, pduCfg);
+                if (pdu is null)
+                    continue; // hostless / not buildable — skip
+                StartPoller(id, pdu);
+            }
+        }
+        finally { reconcileLock.Release(); }
+    }
+
+    private void StartPoller(string id, PDU pdu)
+    {
+        var pollInterval = cfg.Pdus.TryGetValue(id, out var pduCfg) ? pduCfg.PollInterval : 5;
+        Log.Information($"Starting PDU instance '{id}' (poll every {pollInterval}s).");
+        var poller = new PduPoller(id, pdu, pollInterval, bus, health);
+        poller.Start();
+        pollers[id] = poller;
+        runningSignatures[id] = cfg.Pdus.TryGetValue(id, out var c) ? InstanceReconcile.Signature(c) : "";
     }
 }

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -84,8 +84,10 @@ public static class ServiceConfiguration
         services.AddSingleton<Core.SnapshotCache>();
         services.AddSingleton<Core.ISnapshotCache>(sp => sp.GetRequiredService<Core.SnapshotCache>());
         services.AddHostedService(sp => sp.GetRequiredService<Core.SnapshotCache>());
-        // Owns the PDU producer(s) — one poller per configured instance.
-        services.AddHostedService<InstanceManager>();
+        // Owns the PDU producer(s) — one poller per configured instance; reconciled at runtime when the
+        // GUI saves instance changes. Singleton + hosted-service facade so the GUI can trigger reconcile.
+        services.AddSingleton<InstanceManager>();
+        services.AddHostedService(sp => sp.GetRequiredService<InstanceManager>());
 
         // Shared liveness/readiness signals (uptime + last successful poll).
         services.AddSingleton<HealthState>();


### PR DESCRIPTION
**Phase 5** of #127 — live add/remove of PDU instances. Saving instance changes in the GUI now starts/stops pollers **without a restart**.

## What changed
- **`PduInstanceRegistry`** — thread-safe runtime `TryCreate`/`Remove` and a **fixed `PrimaryId`**. The primary PDU (the DI singleton shared with the GUI / control / discovery) is never swapped, so runtime reconciliation can't leave those holding a stale reference.
- **`InstanceReconcile`** (pure, unit-tested) — plans the move from the running instance signatures to the desired `Config.Pdus`: **start** added, **stop** removed, **rebuild** changed non-primary instances. A signature captures connection/TLS/timeout/credentials/poll-interval (the things that require a poller/PDU rebuild).
- **`InstanceManager.ReconcileAsync`** — applies the plan (serialized with a semaphore); a changed **primary** connection is logged as needing a restart rather than hot-swapped.
- **GUI save** (`POST /api/config`) refreshes `Config.Pdus` from the saved file and reconciles, so a PDU added/removed in the editor takes effect live. Override/name/template changes still apply on **Republish discovery** as before.

## Scope / tradeoff
- The **primary instance stays put** at runtime (it's the DI `PDU`); a primary host/credential change still needs a restart — matching today's documented behavior. Hot-swapping the primary can be a follow-up if wanted.
- Half-configured (hostless) instances are skipped, consistent with #149.

## Tests
83 (was 75): reconcile planner (add / remove / rebuild-changed / primary-change-flags-restart / ignore-hostless) and registry runtime add/remove (incl. refusing to remove the primary). Verified the bridge still boots cleanly against a real config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)