### PR TITLE
feat(v2): read-only REST API + OpenAPI/Scalar docs (#127, phase 6.1)

### DIFF
--- a/rPDU2MQTT/Models/Config/ApiConfig.cs
+++ b/rPDU2MQTT/Models/Config/ApiConfig.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel;
+
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>
+/// Configuration for the read-only REST API (and its OpenAPI/Scalar docs), hosted on its own port and
+/// independent of the GUI. Intended for monitoring/automation on a trusted network.
+/// </summary>
+public class ApiConfig
+{
+    [DefaultValue(false)]
+    [Description("Expose a read-only REST API (/api/v1/*) with OpenAPI + Scalar docs on its own port. Place it on a trusted network — it is unauthenticated, like the health endpoints.")]
+    public bool Enabled { get; set; } = false;
+
+    [DefaultValue(8082)]
+    [Description("Port the REST API + docs listen on.")]
+    public int Port { get; set; } = 8082;
+}

--- a/rPDU2MQTT/Models/Config/Config.cs
+++ b/rPDU2MQTT/Models/Config/Config.cs
@@ -66,6 +66,9 @@ public class Config
     [YamlMember(Alias = "Health", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "HTTP health-check endpoints")]
     public HealthConfig Health { get; set; } = new HealthConfig();
 
+    [YamlMember(Alias = "Api", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Read-only REST API + OpenAPI/Scalar docs")]
+    public ApiConfig Api { get; set; } = new ApiConfig();
+
     /// <summary>
     /// Replace this instance's settings with another's. Used to hot-reload the shared singleton on
     /// rediscovery (services read these sections live). Connection-level settings (MQTT/PDU host/port,
@@ -83,5 +86,6 @@ public class Config
         Logging = other.Logging;
         Gui = other.Gui;
         Health = other.Health;
+        Api = other.Api;
     }
 }

--- a/rPDU2MQTT/Services/ApiService.cs
+++ b/rPDU2MQTT/Services/ApiService.cs
@@ -1,0 +1,122 @@
+using HiveMQtt.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Helpers;
+using rPDU2MQTT.Models.Config;
+using Scalar.AspNetCore;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// A read-only REST API (<c>/api/v1/*</c>) with OpenAPI + a Scalar docs UI, hosted on its own port and
+/// independent of the GUI. Surfaces the v2 pipeline state — instances, latest snapshots, readings and
+/// health — for monitoring/automation. Unauthenticated like the health endpoints; gate by network.
+/// This is the seed of the eventual standalone <c>Api</c> project (phase 6).
+/// </summary>
+public sealed class ApiService : IHostedService, IAsyncDisposable
+{
+    private readonly Config cfg;
+    private readonly PduInstanceRegistry registry;
+    private readonly ISnapshotCache snapshots;
+    private readonly HealthState health;
+    private readonly IHiveMQClient mqtt;
+    private WebApplication? app;
+
+    public ApiService(Config cfg, PduInstanceRegistry registry, ISnapshotCache snapshots, HealthState health, IHiveMQClient mqtt)
+    {
+        this.cfg = cfg;
+        this.registry = registry;
+        this.snapshots = snapshots;
+        this.health = health;
+        this.mqtt = mqtt;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!cfg.Api.Enabled)
+            return;
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = Array.Empty<string>() });
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls($"http://*:{cfg.Api.Port}");
+        builder.Services.AddOpenApi();
+
+        app = builder.Build();
+        app.MapOpenApi();                       // /openapi/v1.json
+        app.MapScalarApiReference();            // /scalar/v1 (docs UI)
+        app.MapGet("/", () => Results.Redirect("/scalar/v1"));
+
+        MapV1(app);
+
+        await app.StartAsync(cancellationToken);
+        Log.Information($"REST API listening on http://*:{cfg.Api.Port} (docs at /scalar/v1).");
+    }
+
+    private void MapV1(WebApplication app)
+    {
+        var v1 = app.MapGroup("/api/v1").WithTags("rPDU2MQTT");
+
+        v1.MapGet("/instances", () =>
+            cfg.Pdus.Select(kv => new InstanceDto(
+                kv.Key,
+                string.Equals(kv.Key, registry.PrimaryId, StringComparison.OrdinalIgnoreCase),
+                kv.Value.Connection?.Host,
+                kv.Value.PollInterval,
+                kv.Value.ActionsEnabled)).ToList())
+            .WithName("ListInstances").WithSummary("List the configured PDU instances.");
+
+        v1.MapGet("/health", () => new HealthDto(
+                health.StartedUtc,
+                (long)health.Uptime.TotalSeconds,
+                mqtt.IsConnected(),
+                health.LastPollUtc))
+            .WithName("GetHealth").WithSummary("Bridge liveness: uptime, MQTT connectivity, last poll.");
+
+        v1.MapGet("/snapshots", () =>
+        {
+            var now = DateTime.UtcNow;
+            return snapshots.All
+                .Select(s => new SnapshotDto(s.InstanceId, s.TimestampUtc, (now - s.TimestampUtc).TotalSeconds))
+                .OrderBy(s => s.InstanceId)
+                .ToList();
+        }).WithName("ListSnapshots").WithSummary("Latest snapshot timestamp/age per instance.");
+
+        v1.MapGet("/readings", (string? instance) =>
+        {
+            var sources = string.IsNullOrEmpty(instance)
+                ? snapshots.All
+                : snapshots.All.Where(s => string.Equals(s.InstanceId, instance, StringComparison.OrdinalIgnoreCase));
+
+            return sources
+                .SelectMany(s => MetricsHelper.EnumerateReadings(s.Data)
+                    .Select(r => new ReadingDto(s.InstanceId, r.Device, r.Source, r.Type, r.Value, r.Units)))
+                .OrderBy(r => r.InstanceId).ThenBy(r => r.Device).ThenBy(r => r.Source).ThenBy(r => r.Type)
+                .ToList();
+        }).WithName("ListReadings").WithSummary("Flattened measurements from the latest snapshot(s); filter with ?instance=.");
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (app is not null)
+            await app.StopAsync(cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (app is not null)
+            await app.DisposeAsync();
+    }
+
+    // --- DTOs (named so they appear in the OpenAPI schema) ---
+    public record InstanceDto(string Id, bool Primary, string? Host, int PollInterval, bool ActionsEnabled);
+    public record HealthDto(DateTime StartedUtc, long UptimeSeconds, bool MqttConnected, DateTime? LastPollUtc);
+    public record SnapshotDto(string InstanceId, DateTime TimestampUtc, double AgeSeconds);
+    public record ReadingDto(string InstanceId, string Device, string Source, string Type, double Value, string Units);
+}

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -124,6 +124,10 @@ public static class ServiceConfiguration
         if (cfg.Health.Enabled)
             services.AddHostedService<HealthService>();
 
+        // Optional read-only REST API + OpenAPI/Scalar docs on its own port.
+        if (cfg.Api.Enabled)
+            services.AddHostedService<ApiService>();
+
         // Optional embedded configuration GUI.
         if (cfg.Gui.Enabled)
             services.AddHostedService<Services.Gui.GuiService>();

--- a/rPDU2MQTT/rPDU2MQTT.csproj
+++ b/rPDU2MQTT/rPDU2MQTT.csproj
@@ -34,8 +34,10 @@
 		<PackageReference Include="HiveMQtt" Version="0.44.0" />
 		<PackageReference Include="KubernetesClient" Version="19.0.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
 		<PackageReference Include="prometheus-net" Version="8.2.1" />
+		<PackageReference Include="Scalar.AspNetCore" Version="2.16.6" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />


### PR DESCRIPTION
**Phase 6 (part 1)** of #127 — the REST API/Swagger half, delivered first (the disruptive Core/Engine/Api/Web project split stays a separate later step).

A documented, machine-facing REST API for the v2 pipeline, on its own port (`Api.Enabled` / `Api.Port`, default `:8082`), independent of the GUI and reusing the existing registry / snapshot cache / health (no behavior change).

## Endpoints (`/api/v1`, read-only)
- `GET /instances` — configured PDU instances (id, primary, host, poll interval, actionsEnabled)
- `GET /health` — uptime, MQTT connectivity, last poll
- `GET /snapshots` — latest snapshot timestamp/age per instance
- `GET /readings` — flattened measurements from the latest snapshot(s); `?instance=` filter
- `GET /openapi/v1.json` (OpenAPI) + **Scalar docs UI** at `/scalar/v1` (`/` redirects there)

## Notes
- **Unauthenticated**, like the health endpoints — intended for a trusted network. (A richer auth story + write/control endpoints can follow.)
- New deps: `Microsoft.AspNetCore.OpenApi`, `Scalar.AspNetCore`.
- Read-only by design for this first cut; this is the seed of the eventual standalone `Api` project.
- 83 tests; smoke-verified every endpoint + the OpenAPI doc + Scalar UI return 200 against a live config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)