### PR TITLE
feat(v2): API write/control endpoints + API-key auth (#127, phase 6.1)

### DIFF
--- a/rPDU2MQTT.Tests/MappingAndSecretsTests.cs
+++ b/rPDU2MQTT.Tests/MappingAndSecretsTests.cs
@@ -21,6 +21,7 @@ public class SecretRedactionTests
         cfg.EmonCMS.ApiKey = "emonKey";
         cfg.Gui.Password = "guiPass";
         cfg.Gui.Oidc.ClientSecret = "oidcSecret";
+        cfg.Api.ApiKey = "apiKey";
 
         var redacted = ConfigSchema.RedactSecrets(cfg);
 
@@ -29,6 +30,7 @@ public class SecretRedactionTests
         Assert.Null(redacted.EmonCMS.ApiKey);
         Assert.Null(redacted.Gui.Password);
         Assert.Null(redacted.Gui.Oidc?.ClientSecret);
+        Assert.Null(redacted.Api.ApiKey);
     }
 
     [Fact]

--- a/rPDU2MQTT/Models/Config/ApiConfig.cs
+++ b/rPDU2MQTT/Models/Config/ApiConfig.cs
@@ -15,4 +15,8 @@ public class ApiConfig
     [DefaultValue(8082)]
     [Description("Port the REST API + docs listen on.")]
     public int Port { get; set; } = 8082;
+
+    [DefaultValue(null)]
+    [Description("Optional API key enabling the write/control endpoints. When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).")]
+    public string? ApiKey { get; set; } = null;
 }

--- a/rPDU2MQTT/Services/ApiService.cs
+++ b/rPDU2MQTT/Services/ApiService.cs
@@ -100,6 +100,69 @@ public sealed class ApiService : IHostedService, IAsyncDisposable
                 .OrderBy(r => r.InstanceId).ThenBy(r => r.Device).ThenBy(r => r.Source).ThenBy(r => r.Type)
                 .ToList();
         }).WithName("ListReadings").WithSummary("Flattened measurements from the latest snapshot(s); filter with ?instance=.");
+
+        // --- Write/control (opt-in: requires Api.ApiKey set + a matching X-Api-Key header) ---
+
+        v1.MapPost("/instances/{id}/outlets/{deviceId}/{index:int}/control", async (string id, string deviceId, int index, ControlBody body, HttpContext ctx) =>
+        {
+            if (Unauthorized(ctx) is { } authError) return authError;
+            if (Resolve(id, out var pdu, out var notFound) is false) return notFound!;
+            var action = (body.Action ?? "").Trim().ToLowerInvariant();
+            if (action is not ("on" or "off" or "reboot" or "resetstats"))
+                return Results.BadRequest(new { ok = false, message = "action must be on, off, reboot or resetstats." });
+
+            if (action == "resetstats")
+                await pdu!.ResetOutletStatsAsync(deviceId, index, ctx.RequestAborted);
+            else
+                await pdu!.ControlOutletAsync(deviceId, index, action, ctx.RequestAborted);
+            return Results.Ok(new { ok = true, message = $"Outlet {index + 1} on '{id}' -> {action}." });
+        }).WithName("ControlOutlet").WithSummary("Control an outlet (on/off/reboot/resetStats). Requires Api.ApiKey + ActionsEnabled.");
+
+        v1.MapPost("/instances/{id}/groups/{groupKey}/control", async (string id, string groupKey, ControlBody body, HttpContext ctx) =>
+        {
+            if (Unauthorized(ctx) is { } authError) return authError;
+            if (Resolve(id, out var pdu, out var notFound) is false) return notFound!;
+            var action = (body.Action ?? "").Trim().ToLowerInvariant();
+            if (action is not ("on" or "off" or "reboot"))
+                return Results.BadRequest(new { ok = false, message = "action must be on, off or reboot." });
+
+            var n = await pdu!.ControlGroupAsync(groupKey, action, ctx.RequestAborted);
+            return Results.Ok(new { ok = true, message = $"Group '{groupKey}' on '{id}' -> {action} ({n} outlet(s))." });
+        }).WithName("ControlGroup").WithSummary("Control every outlet in a group (on/off/reboot). Requires Api.ApiKey + ActionsEnabled.");
+    }
+
+    // Validate the instance exists (no silent fall-back to primary) and has write actions enabled.
+    private bool Resolve(string id, out PDU? pdu, out IResult? error)
+    {
+        pdu = null;
+        error = null;
+        if (!registry.All.ContainsKey(id))
+        {
+            error = Results.NotFound(new { ok = false, message = $"Unknown PDU instance '{id}'." });
+            return false;
+        }
+        if (!(cfg.Pdus.TryGetValue(id, out var c) && c.ActionsEnabled))
+        {
+            error = Results.Json(new { ok = false, message = $"Write actions are disabled for instance '{id}' (ActionsEnabled is false)." }, statusCode: StatusCodes.Status409Conflict);
+            return false;
+        }
+        pdu = registry.Get(id);
+        return true;
+    }
+
+    // Returns an error result when the request may not write (no key configured, or wrong/missing key); null when allowed.
+    private IResult? Unauthorized(HttpContext ctx)
+    {
+        if (string.IsNullOrEmpty(cfg.Api.ApiKey))
+            return Results.Json(new { ok = false, message = "Write endpoints are disabled. Set Api.ApiKey to enable control via the API." }, statusCode: StatusCodes.Status403Forbidden);
+
+        var provided = ctx.Request.Headers["X-Api-Key"].ToString();
+        var a = System.Text.Encoding.UTF8.GetBytes(provided);
+        var b = System.Text.Encoding.UTF8.GetBytes(cfg.Api.ApiKey);
+        if (a.Length != b.Length || !System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(a, b))
+            return Results.Json(new { ok = false, message = "Missing or invalid X-Api-Key." }, statusCode: StatusCodes.Status401Unauthorized);
+
+        return null;
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
@@ -119,4 +182,5 @@ public sealed class ApiService : IHostedService, IAsyncDisposable
     public record HealthDto(DateTime StartedUtc, long UptimeSeconds, bool MqttConnected, DateTime? LastPollUtc);
     public record SnapshotDto(string InstanceId, DateTime TimestampUtc, double AgeSeconds);
     public record ReadingDto(string InstanceId, string Device, string Source, string Type, double Value, string Units);
+    public record ControlBody(string Action);
 }

--- a/rPDU2MQTT/Services/Gui/ConfigSchema.cs
+++ b/rPDU2MQTT/Services/Gui/ConfigSchema.cs
@@ -187,6 +187,7 @@ public static class ConfigSchema
         clone.Gui.Password = null;
         if (clone.Gui.Oidc is not null)
             clone.Gui.Oidc.ClientSecret = null;
+        clone.Api.ApiKey = null;
         return clone;
     }
 


### PR DESCRIPTION
Builds on the read-only REST API (#151): adds **outlet & group control**, opt-in and guarded.

## Endpoints
- `POST /api/v1/instances/{id}/outlets/{deviceId}/{index}/control` — body `{ "action": "on|off|reboot|resetStats" }`
- `POST /api/v1/instances/{id}/groups/{groupKey}/control` — body `{ "action": "on|off|reboot" }`

Both route to the target instance's own PDU via the registry and reuse the existing, well-tested control paths (`PDU.ControlOutletAsync` / `ControlGroupAsync` / `ResetOutletStatsAsync`).

## Safety (the API port is unauthenticated)
- **Disabled unless `Api.ApiKey` is set** → `403`.
- Requires a matching **`X-Api-Key`** header (constant-time compare) → `401`.
- **Validates the instance exists** (no silent fall-back to primary) → `404`.
- Still honors each instance's **`ActionsEnabled`** → `409`.
- `Api.ApiKey` is redacted by `RedactSecrets` (GUI display + k8s companion-Secret hygiene).

## Verification
Smoke-tested every gate live: no-key→403, missing/wrong key→401, unknown instance→404, invalid action→400, reads still 200. The authorized happy-path was intentionally **not** run against the real PDU. 83 tests (added an `Api.ApiKey` redaction assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)