### PR TITLE
docs(v2): reshape examples/docs to Pdus + document the REST API (#127)

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -527,6 +527,20 @@ spec:
                     type: integer
                     description: Port the health-check endpoints listen on.
                 description: HTTP health-check endpoints
+              Api:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  Enabled:
+                    type: boolean
+                    description: Expose a read-only REST API (/api/v1/*) with OpenAPI + Scalar docs on its own port. Place it on a trusted network — it is unauthenticated, like the health endpoints.
+                  Port:
+                    type: integer
+                    description: Port the REST API + docs listen on.
+                  ApiKey:
+                    type: string
+                    description: Optional API key enabling the write/control endpoints. When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).
+                description: Read-only REST API + OpenAPI/Scalar docs
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/Examples/Kubernetes/crd/rpduconfig-sample.yaml
+++ b/Examples/Kubernetes/crd/rpduconfig-sample.yaml
@@ -11,11 +11,13 @@ spec:
       Host: mqtt.lan
       Port: 1883
     ParentTopic: rPDU2MQTT
-  PDU:
-    Connection:
-      Host: pdu.lan
-      Port: 80
-    PollInterval: 5
+  # One or more PDU instances, keyed by name. A single PDU is just one "default" entry.
+  Pdus:
+    default:
+      Connection:
+        Host: pdu.lan
+        Port: 80
+      PollInterval: 5
   HomeAssistant:
     DiscoveryEnabled: true
     DiscoveryTopic: homeassistant

--- a/Examples/Kubernetes/helm/values-example.yaml
+++ b/Examples/Kubernetes/helm/values-example.yaml
@@ -11,12 +11,14 @@ config:
       Host: mqtt.example.com
       Port: 1883
     ParentTopic: rPDU2MQTT
-  PDU:
-    Connection:
-      Host: pdu.example.com
-      Port: 80
-    PollInterval: 5
-    ActionsEnabled: false   # set true (+ credentials) to control outlets
+  # One or more PDU instances, keyed by name. A single PDU is just one "default" entry.
+  Pdus:
+    default:
+      Connection:
+        Host: pdu.example.com
+        Port: 80
+      PollInterval: 5
+      ActionsEnabled: false   # set true (+ credentials) to control outlets
   HomeAssistant:
     DiscoveryEnabled: true
     DiscoveryTopic: homeassistant

--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -18,9 +18,10 @@ config:
   MQTT:
     Connection: { Host: mqtt.lan, Port: 1883 }
     ParentTopic: rPDU2MQTT
-  PDU:
-    Connection: { Host: pdu.lan, Port: 80 }
-    PollInterval: 5
+  Pdus:
+    default:
+      Connection: { Host: pdu.lan, Port: 80 }
+      PollInterval: 5
   HomeAssistant:
     DiscoveryEnabled: true
     DiscoveryTopic: homeassistant

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -527,6 +527,20 @@ spec:
                     type: integer
                     description: Port the health-check endpoints listen on.
                 description: HTTP health-check endpoints
+              Api:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  Enabled:
+                    type: boolean
+                    description: Expose a read-only REST API (/api/v1/*) with OpenAPI + Scalar docs on its own port. Place it on a trusted network — it is unauthenticated, like the health endpoints.
+                  Port:
+                    type: integer
+                    description: Port the REST API + docs listen on.
+                  ApiKey:
+                    type: string
+                    description: Optional API key enabling the write/control endpoints. When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).
+                description: Read-only REST API + OpenAPI/Scalar docs
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -86,17 +86,40 @@ Everything is published under `ParentTopic` — here's the tree in MQTT Explorer
 
 ## PDU Configuration (Required)
 
+PDUs are configured under **`Pdus:`** — a map of named instances. A single PDU is just one entry
+named `default`; add more entries to bridge several PDUs from one deployment. Each instance is polled
+independently and published under its own MQTT/Home Assistant namespace (a lone instance is
+un-namespaced, identical to a single-PDU setup).
+
+```yaml
+Pdus:
+  default:                 # instance name (any key; "default" for a single PDU)
+    Connection:
+      Host: "10.0.0.10"
+      Port: 80
+    PollInterval: 5
+  rack-b:                  # add more instances as needed
+    Connection:
+      Host: "10.0.0.11"
+      Port: 80
+```
+
+> **Upgrading from v1:** the old single `PDU:` section is auto-migrated to `Pdus: { default: ... }`
+> on load (with a one-time warning), so existing configs keep working — but update to `Pdus:` to
+> silence it. The fields below apply **per instance** (under `Pdus.<name>`).
+
 ### Connection Details (Required)
 Set up the connection details to your Power Distribution Unit (PDU).
 
 ```yaml
-Pdu:
-  Connection:
-    Scheme: http         # http or https, based on your PDU's configuration
-    Host: "localhost"    # Replace with your PDU's IP or hostname
-    Port: 80             # Replace with your PDU's port number
-    Timeout: 15          # Request timeout in seconds
-    ValidateCertificate: true  # Set to false if using self-signed certificates
+Pdus:
+  default:
+    Connection:
+      Scheme: http         # http or https, based on your PDU's configuration
+      Host: "localhost"    # Replace with your PDU's IP or hostname
+      Port: 80             # Replace with your PDU's port number
+      Timeout: 15          # Request timeout in seconds
+      ValidateCertificate: true  # Set to false if using self-signed certificates
 ```
 
 The same options in the GUI's **PDU** section (note **Enable Write Actions** for outlet control):
@@ -107,10 +130,11 @@ The same options in the GUI's **PDU** section (note **Enable Write Actions** for
 Provide credentials if required to connect to the PDU.
 
 ```yaml
-Pdu:
-  Credentials:
-    Username: "actionsUser"  # Replace with your PDU username
-    Password: "actionsPass"  # Replace with your PDU password
+Pdus:
+  default:
+    Credentials:
+      Username: "actionsUser"  # Replace with your PDU username
+      Password: "actionsPass"  # Replace with your PDU password
 ```
 
 ### Credentials via environment / secrets (Optional)
@@ -145,8 +169,9 @@ services:
 Set how often the PDU sensors should be polled and published to MQTT (in seconds).
 
 ```yaml
-Pdu:
-  PollInterval: 5  # Adjust the polling interval as needed
+Pdus:
+  default:
+    PollInterval: 5  # Adjust the polling interval as needed
 ```
 
 ### Actions Enabled
@@ -154,8 +179,9 @@ Enable or disable the ability to perform write-actions on the PDU (e.g., togglin
 Requires PDU `Credentials`. Disabled by default.
 
 ```yaml
-Pdu:
-  ActionsEnabled: true  # Set to false to disable any changes on the PDU
+Pdus:
+  default:
+    ActionsEnabled: true  # Set to false to disable any changes on the PDU
 ```
 
 When enabled, each outlet gains the following **outlet operations** in Home Assistant
@@ -592,6 +618,44 @@ Health:
 
 The Helm chart wires these as `livenessProbe` / `readinessProbe` automatically (toggle with
 `healthProbes.enabled`, default on). For Docker Compose you can point a `healthcheck` at `/healthz`.
+
+## REST API (Optional)
+
+A read-only REST API with OpenAPI + a [Scalar](https://scalar.com/) docs UI, hosted on its own port
+and independent of the GUI. Off by default; intended for monitoring/automation on a **trusted
+network** (it is unauthenticated, like the health endpoints).
+
+```yaml
+Api:
+  Enabled: false        # default
+  Port: 8082            # default
+  ApiKey: ""            # optional; set to enable the write/control endpoints (see below)
+```
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /api/v1/instances` | Configured PDU instances (id, primary, host, poll interval, actions). |
+| `GET /api/v1/health` | Uptime, MQTT connectivity, last poll. |
+| `GET /api/v1/snapshots` | Latest snapshot timestamp/age per instance. |
+| `GET /api/v1/readings` | Flattened measurements from the latest snapshot(s); filter with `?instance=`. |
+| `GET /openapi/v1.json`, `/scalar/v1` | OpenAPI document + interactive docs UI. |
+
+### Control endpoints (opt-in)
+
+Outlet/group control is **disabled unless `Api.ApiKey` is set**. When set, write requests must send a
+matching `X-Api-Key` header, the target instance must exist, and that instance must have
+`ActionsEnabled: true`.
+
+| Endpoint | Body | Description |
+| --- | --- | --- |
+| `POST /api/v1/instances/{id}/outlets/{deviceId}/{index}/control` | `{ "action": "on\|off\|reboot\|resetStats" }` | Control one outlet on instance `id`. |
+| `POST /api/v1/instances/{id}/groups/{groupKey}/control` | `{ "action": "on\|off\|reboot" }` | Control every outlet in a OneView group. |
+
+```bash
+curl -X POST -H "X-Api-Key: $KEY" -H "Content-Type: application/json" \
+  -d '{"action":"reboot"}' \
+  http://rpdu2mqtt:8082/api/v1/instances/default/outlets/DEVICE/0/control
+```
 
 ## Example Configurations
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -100,9 +100,10 @@ config:
   MQTT:
     Connection: { Host: mqtt.lan, Port: 1883 }
     ParentTopic: rPDU2MQTT
-  PDU:
-    Connection: { Host: pdu.lan, Port: 80 }
-    PollInterval: 5
+  Pdus:
+    default:
+      Connection: { Host: pdu.lan, Port: 80 }
+      PollInterval: 5
   HomeAssistant:
     DiscoveryEnabled: true
     DiscoveryTopic: homeassistant
@@ -200,5 +201,5 @@ for you from `credentials.*` (or an `existingSecret`).
 | `MQTT broker refused the connection` | Bad MQTT credentials/permissions. Fix `MQTT.Credentials` or the `RPDU2MQTT_MQTT_*` vars. |
 | No data / can't reach PDU | PDU host/port wrong or unreachable from the container; for `https` PDUs set `PDU.Connection.Scheme: https` (and `ValidateCertificate: false` for self-signed). |
 | Nothing appears in Home Assistant | `HomeAssistant.DiscoveryEnabled` is false, or HA's MQTT discovery prefix differs from `DiscoveryTopic`. |
-| Outlet switches missing | Outlet control is opt-in: set `PDU.ActionsEnabled: true` (a.k.a. "Enable Write Actions") **and** provide PDU credentials. |
+| Outlet switches missing | Outlet control is opt-in: set `Pdus.<name>.ActionsEnabled: true` (a.k.a. "Enable Write Actions") **and** provide PDU credentials. |
 | GUI "Save" disabled in Kubernetes | The ConfigMap mount is read-only — use `helm upgrade`, or the [CRD config source](KubernetesCRD.md). |

--- a/docs/KubernetesCRD.md
+++ b/docs/KubernetesCRD.md
@@ -52,13 +52,14 @@ metadata:
   name: rack-pdu-1
   namespace: rpdu2mqtt
 spec:
-  # Mirrors the existing Config model (MQTT, PDU, HomeAssistant, Overrides, Prometheus, EmonCMS, ...)
+  # Mirrors the existing Config model (MQTT, Pdus, HomeAssistant, Overrides, Prometheus, EmonCMS, ...)
   MQTT:
     Connection: { Host: mqtt.example.com, Port: 1883 }
     ParentTopic: rPDU2MQTT
-  PDU:
-    Connection: { Host: rack-pdu-1.example.com, Port: 80 }
-    PollInterval: 5
+  Pdus:
+    default:
+      Connection: { Host: rack-pdu-1.example.com, Port: 80 }
+      PollInterval: 5
   HomeAssistant:
     DiscoveryEnabled: true
 status:

--- a/docs/v2-architecture.md
+++ b/docs/v2-architecture.md
@@ -110,16 +110,18 @@ InstanceManager ──manages──> PduPoller (×N)
 
 ## Migration plan (incremental — each step ships)
 
-1. **Introduce the bus + snapshot model** — add `IMessageBus` (Channels) and `PduSnapshot` in `Core`; no
-   behavior change yet.
-2. **Move polling into a `PduPoller`** — one poller wrapping today's single PDU; it publishes snapshots to
-   the bus. Existing services keep working via a temporary shim that reads the latest snapshot.
-3. **Move consumers onto the bus** — convert MQTT/Prometheus/EmonCMS/HA to bus subscribers, one at a time,
-   removing the shared-cache coupling.
-4. **Multi-instance config + `InstanceManager`** — `Config.Pdus`, with v1 auto-migration; add/remove
-   instances (still restart-applied at first).
-5. **Live add/remove** — the manager starts/stops pollers at runtime; GUI wired up.
-6. **Project split + REST API/Swagger** — extract `Core`/`Engine`/`Api`/`Web`; UI talks to the API.
+**Status: all phases complete (#127).** Each shipped as its own PR; the pipeline is in place.
+
+1. ✅ **Bus + snapshot model** — `IMessageBus` (Channels) + `PduSnapshot` in `Core`.
+2. ✅ **`PduPoller`** — polling moved into a producer publishing snapshots to the bus.
+3. ✅ **Consumers on the snapshot pipeline** — MQTT/Prometheus/EmonCMS/HA read the cached snapshots
+   (pull-cache) instead of polling the PDU directly.
+4. ✅ **Multi-instance config + `InstanceManager`** — `Config.Pdus` (with v1 `PDU:` auto-migration);
+   per-instance PDU construction + output namespacing; GUI per-tab instance selection.
+5. ✅ **Live add/remove** — `InstanceManager` reconciles pollers at runtime when instances are
+   saved in the GUI (the primary stays fixed; its connection change still needs a restart).
+6. ✅ **REST API + project split** — read + control REST API with OpenAPI/Scalar (`Api.*`); the code
+   is split into `rPDU2MQTT.Core` / `.Engine` / `.Api` / `.Web` + the host exe.
 
 Later (separate issues, built on this): energy-flow mapping (#128/#129), Tigo producer (#130),
 Sankey (#97).


### PR DESCRIPTION
Brings the docs and examples in line with the shipped v2 work (multi-PDU + REST API) — the follow-up tracked since #148.

## Examples reshaped to the `Pdus:` instance map
The old single `PDU:` block → `Pdus: { default: ... }` in:
- **`Examples/Kubernetes/crd/rpduconfig-sample.yaml`** — was **invalid** against the regenerated CRD schema.
- `Examples/Kubernetes/helm/values-example.yaml`, and the example blocks in `docs/Configuration.md`, `docs/Deployment.md`, `docs/KubernetesCRD.md`, `charts/rpdu2mqtt/README.md`.

## Docs
- **Configuration.md**: documents the `Pdus` instance map + multi-PDU namespacing, a **v1→v2 upgrade note** (`PDU:` auto-migrates with a one-time warning), and a new **REST API** section — read endpoints, opt-in control + `X-Api-Key`, OpenAPI/Scalar.
- **v2-architecture.md**: migration phases 1–6 marked ✅ complete.

## CRDs
Regenerated both copies (`Examples/.../crd.yaml`, `charts/.../crds/rpduconfig.yaml`) so they include the new `Api` section.

Docs/examples + generated CRDs only — no code change; build still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)