### PR TITLE
feat(flow): energy-flow graph + Sankey GUI tab (#97)

### DIFF
--- a/rPDU2MQTT.Api/ApiService.cs
+++ b/rPDU2MQTT.Api/ApiService.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using rPDU2MQTT.Classes;
 using rPDU2MQTT.Core;
+using rPDU2MQTT.Core.Flow;
 using rPDU2MQTT.Helpers;
 using rPDU2MQTT.Models.Config;
 using Scalar.AspNetCore;
@@ -100,6 +101,15 @@ public sealed class ApiService : IHostedService, IAsyncDisposable
                 .OrderBy(r => r.InstanceId).ThenBy(r => r.Device).ThenBy(r => r.Source).ThenBy(r => r.Type)
                 .ToList();
         }).WithName("ListReadings").WithSummary("Flattened measurements from the latest snapshot(s); filter with ?instance=.");
+
+        v1.MapGet("/flow", (string? instance, string? metric) =>
+        {
+            var snap = string.IsNullOrEmpty(instance) ? snapshots.Latest : snapshots.Get(instance);
+            if (snap is null)
+                return Results.NotFound(new { ok = false, message = "No snapshot available yet for that instance." });
+
+            return Results.Ok(FlowGraphBuilder.Build(snap.Data, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric));
+        }).WithName("GetFlow").WithSummary("Energy/power flow graph (PDU -> outlets) for a Sankey view; ?instance= and ?metric= (default realpower).");
 
         // --- Write/control (opt-in: requires Api.ApiKey set + a matching X-Api-Key header) ---
 

--- a/rPDU2MQTT.Core/Flow/FlowGraph.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraph.cs
@@ -1,0 +1,23 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>A node in an energy/power flow graph (a PDU, an outlet, a circuit, …).</summary>
+/// <param name="Id">Stable unique id (used to wire links).</param>
+/// <param name="Label">Human-readable display name.</param>
+/// <param name="Kind">Node kind: <c>pdu</c>, <c>outlet</c>, <c>circuit</c>, <c>total</c>, … (for styling/grouping).</param>
+public sealed record FlowNode(string Id, string Label, string Kind);
+
+/// <summary>A weighted link between two <see cref="FlowNode"/>s (energy flows Source → Target).</summary>
+public sealed record FlowLink(string Source, string Target, double Value);
+
+/// <summary>
+/// A directed, weighted flow graph (nodes + links) suitable for a Sankey diagram. Today it is derived
+/// automatically from a PDU snapshot (PDU → outlets, weighted by a measurement); user-defined / cross-
+/// source links (#129) can later be merged into the same shape.
+/// </summary>
+/// <param name="Metric">The measurement the link values represent (e.g. <c>realpower</c>).</param>
+/// <param name="Units">The units of the link values (e.g. <c>W</c>).</param>
+public sealed record FlowGraph(
+    IReadOnlyList<FlowNode> Nodes,
+    IReadOnlyList<FlowLink> Links,
+    string Metric,
+    string Units);

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -1,0 +1,51 @@
+using rPDU2MQTT.Models.PDU;
+
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// Builds a <see cref="FlowGraph"/> from a PDU snapshot. Today the flow is auto-derived as
+/// PDU → outlet, weighted by a per-outlet measurement (default <c>realpower</c>) — the structure that
+/// can be read straight from the data. Richer multi-level / cross-source flows (circuits, transfer
+/// switches, solar) come from the user-defined hierarchy (#129) layered onto this same model.
+/// </summary>
+public static class FlowGraphBuilder
+{
+    public const string DefaultMetric = "realpower";
+
+    public static FlowGraph Build(PduData data, string metric = DefaultMetric)
+    {
+        var nodes = new List<FlowNode>();
+        var links = new List<FlowLink>();
+        var units = "";
+
+        foreach (var device in data.Devices)
+        {
+            var pduId = $"pdu:{device.Entity_Name}";
+            var pduHasFlow = false;
+
+            foreach (var outlet in device.Outlets)
+            {
+                var m = outlet.Measurements.FirstOrDefault(x => string.Equals(x.Type, metric, StringComparison.OrdinalIgnoreCase));
+                if (m is null || !double.TryParse(m.Value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var value))
+                    continue;
+                if (value <= 0)
+                    continue; // a Sankey only shows actual flow
+
+                if (string.IsNullOrEmpty(units))
+                    units = m.Units;
+
+                var outletId = $"outlet:{device.Entity_Name}:{outlet.Key}";
+                nodes.Add(new FlowNode(outletId, outlet.Entity_DisplayName, "outlet"));
+                links.Add(new FlowLink(pduId, outletId, value));
+                pduHasFlow = true;
+            }
+
+            // Only surface PDUs that actually have measured flow, so the diagram isn't cluttered with
+            // idle/unmeasured devices.
+            if (pduHasFlow)
+                nodes.Insert(0, new FlowNode(pduId, device.Entity_DisplayName, "pdu"));
+        }
+
+        return new FlowGraph(nodes, links, metric, units);
+    }
+}

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -1,0 +1,61 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>FlowGraphBuilder: auto-derive a PDU -> outlet power-flow graph from a snapshot (#97).</summary>
+public class FlowGraphTests
+{
+    private static Outlet Outlet(int key, string name, string type, string value, string units = "W")
+    {
+        var o = new Outlet { Key = key, Entity_Name = $"o{key}", Entity_DisplayName = name };
+        o.Measurements.Add(new Measurement { Type = type, Value = value, Units = units });
+        return o;
+    }
+
+    private static PduData OnePdu(params Outlet[] outlets)
+    {
+        var device = new Device { Key = "pdu1", Entity_Name = "pdu1", Entity_DisplayName = "PDU 1" };
+        device.Outlets.AddRange(outlets);
+        var data = new PduData();
+        data.Devices.Add(device);
+        return data;
+    }
+
+    [Fact]
+    public void Build_LinksOutletsToTheirPdu_WeightedByRealpower()
+    {
+        var graph = FlowGraphBuilder.Build(OnePdu(
+            Outlet(0, "Outlet 1", "realpower", "100"),
+            Outlet(1, "Outlet 2", "realpower", "50")));
+
+        Assert.Equal("realpower", graph.Metric);
+        Assert.Equal("W", graph.Units);
+        Assert.Contains(graph.Nodes, n => n.Id == "pdu:pdu1" && n.Kind == "pdu");
+        Assert.Equal(2, graph.Nodes.Count(n => n.Kind == "outlet"));
+        Assert.Equal(100, graph.Links.Single(l => l.Target == "outlet:pdu1:0").Value);
+        Assert.All(graph.Links, l => Assert.Equal("pdu:pdu1", l.Source));
+    }
+
+    [Fact]
+    public void Build_SkipsZeroAndNonMatchingMeasurements()
+    {
+        var graph = FlowGraphBuilder.Build(OnePdu(
+            Outlet(0, "Active", "realpower", "30"),
+            Outlet(1, "Idle", "realpower", "0"),          // no flow -> skipped
+            Outlet(2, "OtherMetric", "current", "2.5")));  // not the requested metric -> skipped
+
+        Assert.Single(graph.Links);
+        Assert.Equal("outlet:pdu1:0", graph.Links[0].Target);
+        Assert.DoesNotContain(graph.Nodes, n => n.Id == "outlet:pdu1:1");
+    }
+
+    [Fact]
+    public void Build_OmitsPdusWithNoMeasuredFlow()
+    {
+        var graph = FlowGraphBuilder.Build(OnePdu(Outlet(0, "Idle", "realpower", "0")));
+        Assert.Empty(graph.Nodes);
+        Assert.Empty(graph.Links);
+    }
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core.Flow;
 using rPDU2MQTT.Helpers;
 using rPDU2MQTT.Models.Config;
 using rPDU2MQTT.Startup;
@@ -660,6 +661,25 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             catch (Exception ex)
             {
                 return Results.Json(new { ok = false, message = $"Could not read live PDU data: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
+        // Power/energy flow graph (PDU -> outlets) for the Sankey "Flow" tab.
+        app.MapGet("/api/flow", async (HttpContext ctx) =>
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(20));
+            try
+            {
+                var pdu = ResolveInstance(ctx.Request.Query["instance"]).Pdu;
+                var data = await pdu.GetRootData_Public(cts.Token);
+                var metric = ctx.Request.Query["metric"].ToString();
+                var graph = FlowGraphBuilder.Build(data, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric);
+                return Results.Json(new { ok = true, graph.Nodes, graph.Links, graph.Metric, graph.Units }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Could not build flow graph: {ex.Message}" }, ConfigSchema.Json);
             }
         });
 

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -253,6 +253,7 @@ function build() {
   navHeader(nav, 'Tools');
   addControlSection(nav, sections);
   addLiveDataSection(nav, sections);
+  addFlowSection(nav, sections);
   addPathsSection(nav, sections);
   addExportSection(nav, sections);
   addDiagnosticsSection(nav, sections);
@@ -728,6 +729,103 @@ function addLiveDataSection(nav, sections) {
 }
 
 function formatNum(v) { return (typeof v === 'number' && Number.isFinite(v)) ? v.toLocaleString('en-US', { maximumFractionDigits: 3 }) : String(v); }
+
+// SVG element helper (separate namespace from el()).
+function svgEl(tag, attrs) {
+  const e = document.createElementNS('http://www.w3.org/2000/svg', tag);
+  for (const [k, v] of Object.entries(attrs || {})) e.setAttribute(k, v);
+  return e;
+}
+
+// A read-only Sankey of power/energy flow (PDU -> outlets) from /api/flow.
+function addFlowSection(nav, sections) {
+  const link = document.createElement('a'); link.textContent = 'Flow'; nav.appendChild(link);
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  const h = document.createElement('h2'); h.textContent = 'Energy Flow'; sec.appendChild(h);
+  const d = document.createElement('div'); d.className = 'desc';
+  d.textContent = 'Power flow through each PDU to its outlets (live, from the latest poll). Link width is proportional to the measurement.';
+  sec.appendChild(d);
+
+  const bar = document.createElement('div'); bar.className = 'ld-toolbar';
+  const refresh = btn('Refresh');
+  const instSel = instanceSelector(() => load());
+  const count = document.createElement('span'); count.className = 'ld-count';
+  bar.appendChild(refresh); bar.appendChild(instSel.wrap); bar.appendChild(count); sec.appendChild(bar);
+  const wrap = document.createElement('div'); sec.appendChild(wrap);
+
+  const draw = (graph) => {
+    wrap.innerHTML = '';
+    const links = graph.links || [];
+    if (!links.length) { wrap.innerHTML = '<div class="desc" style="color:var(--muted)">No measured power flow to display.</div>'; count.textContent = ''; return; }
+
+    const units = graph.units || '';
+    const byId = Object.fromEntries((graph.nodes || []).map(n => [n.id, n]));
+    const pduIds = (graph.nodes || []).filter(n => n.kind === 'pdu').map(n => n.id);
+    const grand = links.reduce((s, l) => s + l.value, 0);
+    count.textContent = `${pduIds.length} PDU(s) · ${links.length} outlet(s) · ${formatNum(grand)} ${units}`;
+
+    // Geometry. One shared px-per-unit scale so widths line up across both columns.
+    const W = 920, padTop = 14, gap = 6, nodeW = 14, leftX = 170, rightX = W - 170;
+    const rows = links.length, pduGaps = Math.max(0, pduIds.length - 1);
+    const H = padTop * 2 + (rows - 1) * gap + pduGaps * gap;     // total node-stack gaps
+    const usable = 460;                                          // vertical px for the flow itself
+    const pxPerUnit = usable / grand;
+    const totalH = usable + (rows - 1) * gap + pduGaps * gap + padTop * 2;
+
+    const svg = svgEl('svg', { width: '100%', viewBox: `0 0 ${W} ${totalH}`, style: 'max-width:920px' });
+
+    let outletY = padTop;     // running y on the right (outlets)
+    let pduY = padTop;        // running y on the left (PDUs)
+    const colors = ['#4f9', '#49f', '#fa4', '#f49', '#9f4', '#4ff', '#f94'];
+
+    pduIds.forEach((pduId, pi) => {
+      const pduLinks = links.filter(l => l.source === pduId);
+      if (!pduLinks.length) return;
+      const pduTotal = pduLinks.reduce((s, l) => s + l.value, 0);
+      const pduH = pduTotal * pxPerUnit;
+      const color = colors[pi % colors.length];
+
+      // PDU node (left) + label.
+      svg.appendChild(svgEl('rect', { x: leftX, y: pduY, width: nodeW, height: Math.max(1, pduH), fill: color, rx: 2 }));
+      const plab = svgEl('text', { x: leftX - 8, y: pduY + pduH / 2, 'text-anchor': 'end', 'dominant-baseline': 'middle', fill: 'var(--fg)', 'font-size': '12', 'font-weight': '600' });
+      plab.textContent = `${byId[pduId]?.label || pduId} (${formatNum(pduTotal)} ${units})`;
+      svg.appendChild(plab);
+
+      let srcY = pduY;  // cumulative band on the PDU's right edge
+      pduLinks.sort((a, b) => b.value - a.value).forEach(l => {
+        const lh = Math.max(1, l.value * pxPerUnit);
+
+        // Ribbon: PDU right edge band [srcY..srcY+lh] -> outlet left edge band [outletY..outletY+lh].
+        const x1 = leftX + nodeW, x2 = rightX, xc = (x1 + x2) / 2;
+        const sTop = srcY, sBot = srcY + lh, tTop = outletY, tBot = outletY + lh;
+        const path = svgEl('path', {
+          d: `M${x1},${sTop} C${xc},${sTop} ${xc},${tTop} ${x2},${tTop} L${x2},${tBot} C${xc},${tBot} ${xc},${sBot} ${x1},${sBot} Z`,
+          fill: color, 'fill-opacity': '0.35',
+        });
+        svg.appendChild(path);
+
+        // Outlet node (right) + label.
+        svg.appendChild(svgEl('rect', { x: rightX, y: outletY, width: nodeW, height: lh, fill: color, rx: 2 }));
+        const olab = svgEl('text', { x: rightX + nodeW + 8, y: outletY + lh / 2, 'dominant-baseline': 'middle', fill: 'var(--fg)', 'font-size': '12' });
+        olab.textContent = `${byId[l.target]?.label || l.target} · ${formatNum(l.value)} ${units}`;
+        svg.appendChild(olab);
+
+        srcY += lh; outletY += lh + gap;
+      });
+      pduY += pduH + gap + gap;
+    });
+
+    wrap.appendChild(svg);
+  };
+
+  const load = async () => {
+    const r = await api(withInstance('/api/flow', instSel));
+    if (!r.body.ok) { wrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load flow data.') + '</div>'; count.textContent = ''; return; }
+    draw(r.body);
+  };
+  refresh.onclick = load;
+  link.onclick = () => { activate(link, sec); load(); };
+}
 
 function activate(link, sec) {
   document.querySelectorAll('nav a').forEach(a => a.classList.remove('active'));


### PR DESCRIPTION
A Sankey visualization of power flow through each PDU to its outlets — built on the snapshot data the v2 pipeline already produces. This is the first half of the energy-flow feature and the foundation the user-defined hierarchy (#129) layers onto.

## What's here
- **Core** — `FlowGraph { nodes, links, metric, units }` + `FlowGraphBuilder`: turns a `PduData` snapshot into **PDU → outlet** links weighted by a measurement (default `realpower`), skipping idle/unmeasured outlets and PDUs. A deliberately general `{nodes, links}` shape so #129 can merge user-defined / cross-source links (circuits, transfer switch, solar) into the **same** model + renderer.
- **API** — `GET /api/v1/flow?instance=&metric=` (read-only; in the OpenAPI/Scalar docs).
- **GUI** — `GET /api/flow` + a new **Flow** tab (under Tools) rendering an SVG Sankey: per-tab instance selector, ribbon widths proportional to power, outlet/PDU labels with values.

## Scope
For PDUs the flow (PDU → outlet) is auto-derivable from the data, so this needs **no configuration**. Multi-level / cross-source flows (PDU → circuit → outlet, inverter → string → panel, transfer switch → total) require the explicit hierarchy editor — that's **#129**, which will feed the same `FlowGraph`.

## Verification
- 3 `FlowGraphBuilder` tests (86 total); solution builds.
- Smoke-tested `GET /api/v1/flow` against **live PDUs** — produced a correct graph (both PDUs + named outlets, `realpower` link values).
- `app.js` parses; renderer is hand-rolled SVG (no new JS deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)