### PR TITLE
feat(flow): user-defined energy hierarchy + drag-drop editor (#129)

### DIFF
--- a/rPDU2MQTT.Api/ApiService.cs
+++ b/rPDU2MQTT.Api/ApiService.cs
@@ -108,7 +108,7 @@ public sealed class ApiService : IHostedService, IAsyncDisposable
             if (snap is null)
                 return Results.NotFound(new { ok = false, message = "No snapshot available yet for that instance." });
 
-            return Results.Ok(FlowGraphBuilder.Build(snap.Data, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric));
+            return Results.Ok(FlowGraphBuilder.Build(snap.Data, cfg.EnergyFlow, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric));
         }).WithName("GetFlow").WithSummary("Energy/power flow graph (PDU -> outlets) for a Sankey view; ?instance= and ?metric= (default realpower).");
 
         // --- Write/control (opt-in: requires Api.ApiKey set + a matching X-Api-Key header) ---

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -32,6 +32,43 @@ public static class FlowGraphBuilder
             list.Add(to);
         }
 
+        // Following the edges already added, can `a` reach `b`?
+        bool Reaches(string a, string b)
+        {
+            var stack = new Stack<string>();
+            stack.Push(a);
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            while (stack.Count > 0)
+            {
+                var x = stack.Pop();
+                if (!seen.Add(x)) continue;
+                if (outgoing.TryGetValue(x, out var kids))
+                    foreach (var k in kids)
+                    {
+                        if (string.Equals(k, b, StringComparison.OrdinalIgnoreCase)) return true;
+                        stack.Push(k);
+                    }
+            }
+            return false;
+        }
+
+        // Add an edge only if it keeps the graph acyclic. The editor blocks loops in the UI, but the
+        // config can be hand-edited to bypass that; dropping any self-loop or cycle-closing link here
+        // keeps the flow a DAG so aggregation terminates and the Sankey stays sane. Returns false if skipped.
+        bool AddEdgeSafe(string from, string to)
+        {
+            if (string.Equals(from, to, StringComparison.OrdinalIgnoreCase)) return false;  // self-loop
+            if (Reaches(to, from)) return false;                                            // would close a cycle
+            AddEdge(from, to);
+            return true;
+        }
+
+        // Nodes the user has explicitly wired a feeder for (via Links or legacy Parents) — their auto
+        // PDU → outlet link is suppressed so the custom wiring takes over.
+        var explicitlyFed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var l in flow.Links) if (!string.IsNullOrEmpty(l.To)) explicitlyFed.Add(l.To);
+        foreach (var child in flow.Parents.Keys) if (!string.IsNullOrEmpty(child)) explicitlyFed.Add(child);
+
         // Auto-derived base flow: each PDU feeds its outlets, weighted by the chosen measurement.
         foreach (var device in data.Devices)
         {
@@ -46,9 +83,8 @@ public static class FlowGraphBuilder
                 var outletId = $"outlet:{device.Entity_Name}:{outlet.Key}";
                 label[outletId] = outlet.Entity_DisplayName; kind[outletId] = "outlet"; leaf[outletId] = value;
                 label[pduId] = device.Entity_DisplayName; kind[pduId] = "pdu";
-                // Each node has exactly one feeder: skip the auto PDU link when the user has set an
-                // explicit parent for this outlet (the custom feeder overrides the auto-derived one).
-                if (!flow.Parents.ContainsKey(outletId))
+                // Skip the auto PDU link when the user has wired an explicit feeder for this outlet.
+                if (!explicitlyFed.Contains(outletId))
                     AddEdge(pduId, outletId);
             }
         }
@@ -63,32 +99,51 @@ public static class FlowGraphBuilder
                 if (n.Value is > 0) leaf[n.Id] = n.Value.Value;
             }
 
-        // Custom parent links (parent feeds child) — only when both endpoints are known nodes.
+        // Custom directed links (From feeds To) plus legacy Parents (parent feeds child) — only when both
+        // endpoints are known nodes. A node may gather several feeders (multi-parent) and a producer is
+        // simply a link pointing into what it powers (e.g. solar → inverter).
+        foreach (var l in flow.Links)
+            if (!string.IsNullOrEmpty(l.From) && !string.IsNullOrEmpty(l.To) && label.ContainsKey(l.From) && label.ContainsKey(l.To))
+                AddEdgeSafe(l.From, l.To);
         foreach (var (child, parent) in flow.Parents)
             if (!string.IsNullOrEmpty(child) && !string.IsNullOrEmpty(parent) && label.ContainsKey(child) && label.ContainsKey(parent))
-                AddEdge(parent, child);
+                AddEdgeSafe(parent, child);
 
-        // Each node's total = sum of leaf (outlet) measurements reachable downstream (memoized, cycle-guarded).
-        var memo = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
-        double DownstreamTotal(string id, HashSet<string> path)
+        // How many feeders does each node have? A node's demand is split equally among them so a node
+        // reachable by several paths (e.g. a panel fed both directly and via a sub-panel) isn't counted
+        // multiple times — otherwise the inflow inflates and the Sankey can't balance.
+        var inCount = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (_, kids) in outgoing)
+            foreach (var to in kids)
+                inCount[to] = inCount.GetValueOrDefault(to) + 1;
+
+        // Need(id): power this node must receive = its known value (outlet sink or producer), else the sum
+        // of the flows on its outgoing links. EdgeFlow: a producer supplies its measured generation; a
+        // demand link carries its share (target demand ÷ number of feeders). Memoized + cycle-guarded.
+        var needMemo = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        double Need(string id, HashSet<string> path)
         {
-            if (memo.TryGetValue(id, out var cached)) return cached;
+            if (needMemo.TryGetValue(id, out var cached)) return cached;
             if (!path.Add(id)) return 0;   // cycle guard
-            double sum = outgoing.TryGetValue(id, out var kids) && kids.Count > 0
-                ? kids.Sum(k => DownstreamTotal(k, path))
-                : (leaf.TryGetValue(id, out var lv) ? lv : 0);
+            double v = leaf.TryGetValue(id, out var lv)
+                ? lv
+                : (outgoing.TryGetValue(id, out var kids) ? kids.Sum(k => EdgeFlow(id, k, path)) : 0);
             path.Remove(id);
-            memo[id] = sum;
-            return sum;
+            needMemo[id] = v;
+            return v;
         }
+        double EdgeFlow(string from, string to, HashSet<string> path)
+            => leaf.TryGetValue(from, out var produced)
+                ? produced
+                : Need(to, path) / Math.Max(1, inCount.GetValueOrDefault(to));
 
-        // Emit links (value = downstream total of the target); collect the nodes that actually carry flow.
+        // Emit one link per edge, valued by the flow it carries.
         var links = new List<FlowLink>();
         var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var (from, kids) in outgoing)
             foreach (var to in kids)
             {
-                var value = DownstreamTotal(to, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                var value = EdgeFlow(from, to, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
                 if (value <= 0) continue;
                 links.Add(new FlowLink(from, to, value));
                 used.Add(from); used.Add(to);

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -46,7 +46,10 @@ public static class FlowGraphBuilder
                 var outletId = $"outlet:{device.Entity_Name}:{outlet.Key}";
                 label[outletId] = outlet.Entity_DisplayName; kind[outletId] = "outlet"; leaf[outletId] = value;
                 label[pduId] = device.Entity_DisplayName; kind[pduId] = "pdu";
-                AddEdge(pduId, outletId);
+                // Each node has exactly one feeder: skip the auto PDU link when the user has set an
+                // explicit parent for this outlet (the custom feeder overrides the auto-derived one).
+                if (!flow.Parents.ContainsKey(outletId))
+                    AddEdge(pduId, outletId);
             }
         }
 

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -1,50 +1,99 @@
+using rPDU2MQTT.Models.Config;
 using rPDU2MQTT.Models.PDU;
 
 namespace rPDU2MQTT.Core.Flow;
 
 /// <summary>
-/// Builds a <see cref="FlowGraph"/> from a PDU snapshot. Today the flow is auto-derived as
-/// PDU → outlet, weighted by a per-outlet measurement (default <c>realpower</c>) — the structure that
-/// can be read straight from the data. Richer multi-level / cross-source flows (circuits, transfer
-/// switches, solar) come from the user-defined hierarchy (#129) layered onto this same model.
+/// Builds a <see cref="FlowGraph"/> from a PDU snapshot, merged with the optional user-defined
+/// hierarchy (<see cref="EnergyFlowConfig"/>, #129). The base flow is auto-derived PDU → outlet,
+/// weighted by a per-outlet measurement (default <c>realpower</c>); custom upstream nodes/parents
+/// (breakers, transfer switch, "Total") are layered on top, and every link value aggregates up from the
+/// leaf (outlet) measurements.
 /// </summary>
 public static class FlowGraphBuilder
 {
     public const string DefaultMetric = "realpower";
 
     public static FlowGraph Build(PduData data, string metric = DefaultMetric)
+        => Build(data, null, metric);
+
+    public static FlowGraph Build(PduData data, EnergyFlowConfig? flow, string metric = DefaultMetric)
     {
-        var nodes = new List<FlowNode>();
-        var links = new List<FlowLink>();
+        flow ??= new EnergyFlowConfig();
+        var label = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var kind = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var leaf = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);   // outlet id -> measured value
+        var outgoing = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         var units = "";
 
+        void AddEdge(string from, string to)
+        {
+            if (!outgoing.TryGetValue(from, out var list)) outgoing[from] = list = new();
+            list.Add(to);
+        }
+
+        // Auto-derived base flow: each PDU feeds its outlets, weighted by the chosen measurement.
         foreach (var device in data.Devices)
         {
             var pduId = $"pdu:{device.Entity_Name}";
-            var pduHasFlow = false;
-
             foreach (var outlet in device.Outlets)
             {
                 var m = outlet.Measurements.FirstOrDefault(x => string.Equals(x.Type, metric, StringComparison.OrdinalIgnoreCase));
-                if (m is null || !double.TryParse(m.Value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var value))
+                if (m is null || !double.TryParse(m.Value, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var value) || value <= 0)
                     continue;
-                if (value <= 0)
-                    continue; // a Sankey only shows actual flow
-
-                if (string.IsNullOrEmpty(units))
-                    units = m.Units;
+                if (string.IsNullOrEmpty(units)) units = m.Units;
 
                 var outletId = $"outlet:{device.Entity_Name}:{outlet.Key}";
-                nodes.Add(new FlowNode(outletId, outlet.Entity_DisplayName, "outlet"));
-                links.Add(new FlowLink(pduId, outletId, value));
-                pduHasFlow = true;
+                label[outletId] = outlet.Entity_DisplayName; kind[outletId] = "outlet"; leaf[outletId] = value;
+                label[pduId] = device.Entity_DisplayName; kind[pduId] = "pdu";
+                AddEdge(pduId, outletId);
+            }
+        }
+
+        // Custom upstream nodes (#129). A node with a directly-known Value is a leaf source (the seam
+        // where external sensors — CT clamps, emoncms, Tigo, inverter ports — will bind their live value).
+        foreach (var n in flow.Nodes)
+            if (!string.IsNullOrEmpty(n.Id))
+            {
+                label[n.Id] = string.IsNullOrEmpty(n.Label) ? n.Id : n.Label;
+                if (!kind.ContainsKey(n.Id)) kind[n.Id] = "node";
+                if (n.Value is > 0) leaf[n.Id] = n.Value.Value;
             }
 
-            // Only surface PDUs that actually have measured flow, so the diagram isn't cluttered with
-            // idle/unmeasured devices.
-            if (pduHasFlow)
-                nodes.Insert(0, new FlowNode(pduId, device.Entity_DisplayName, "pdu"));
+        // Custom parent links (parent feeds child) — only when both endpoints are known nodes.
+        foreach (var (child, parent) in flow.Parents)
+            if (!string.IsNullOrEmpty(child) && !string.IsNullOrEmpty(parent) && label.ContainsKey(child) && label.ContainsKey(parent))
+                AddEdge(parent, child);
+
+        // Each node's total = sum of leaf (outlet) measurements reachable downstream (memoized, cycle-guarded).
+        var memo = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
+        double DownstreamTotal(string id, HashSet<string> path)
+        {
+            if (memo.TryGetValue(id, out var cached)) return cached;
+            if (!path.Add(id)) return 0;   // cycle guard
+            double sum = outgoing.TryGetValue(id, out var kids) && kids.Count > 0
+                ? kids.Sum(k => DownstreamTotal(k, path))
+                : (leaf.TryGetValue(id, out var lv) ? lv : 0);
+            path.Remove(id);
+            memo[id] = sum;
+            return sum;
         }
+
+        // Emit links (value = downstream total of the target); collect the nodes that actually carry flow.
+        var links = new List<FlowLink>();
+        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (from, kids) in outgoing)
+            foreach (var to in kids)
+            {
+                var value = DownstreamTotal(to, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+                if (value <= 0) continue;
+                links.Add(new FlowLink(from, to, value));
+                used.Add(from); used.Add(to);
+            }
+
+        var nodes = used
+            .Select(id => new FlowNode(id, label.TryGetValue(id, out var l) ? l : id, kind.TryGetValue(id, out var k) ? k : "node"))
+            .ToList();
 
         return new FlowGraph(nodes, links, metric, units);
     }

--- a/rPDU2MQTT.Core/Models/Config/Config.cs
+++ b/rPDU2MQTT.Core/Models/Config/Config.cs
@@ -69,6 +69,9 @@ public class Config
     [YamlMember(Alias = "Api", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Read-only REST API + OpenAPI/Scalar docs")]
     public ApiConfig Api { get; set; } = new ApiConfig();
 
+    [YamlMember(Alias = "EnergyFlow", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "User-defined energy-flow hierarchy (Flow/Sankey view)")]
+    public EnergyFlowConfig EnergyFlow { get; set; } = new EnergyFlowConfig();
+
     /// <summary>
     /// Replace this instance's settings with another's. Used to hot-reload the shared singleton on
     /// rediscovery (services read these sections live). Connection-level settings (MQTT/PDU host/port,
@@ -87,5 +90,6 @@ public class Config
         Gui = other.Gui;
         Health = other.Health;
         Api = other.Api;
+        EnergyFlow = other.EnergyFlow;
     }
 }

--- a/rPDU2MQTT.Core/Models/Config/Config.cs
+++ b/rPDU2MQTT.Core/Models/Config/Config.cs
@@ -69,7 +69,7 @@ public class Config
     [YamlMember(Alias = "Api", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Read-only REST API + OpenAPI/Scalar docs")]
     public ApiConfig Api { get; set; } = new ApiConfig();
 
-    [YamlMember(Alias = "EnergyFlow", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "User-defined energy-flow hierarchy (Flow/Sankey view)")]
+    [YamlMember(Alias = "EnergyFlow", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Virtual upstream nodes (breakers, transfer switches, a “Total”) and their feeder wiring for the energy-flow hierarchy. Edited visually on the Flow tab.")]
     public EnergyFlowConfig EnergyFlow { get; set; } = new EnergyFlowConfig();
 
     /// <summary>

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>
+/// User-defined energy-flow hierarchy (#129). Lets you place the auto-derived PDU/outlet nodes (and
+/// future producers) under custom upstream nodes — breakers, transfer-switch outputs, a "Total" root —
+/// so the flow/Sankey shows the whole path (outlet → PDU → breaker → transfer switch → total). Optional;
+/// when empty, only the auto-derived PDU → outlet flow is shown.
+/// </summary>
+public class EnergyFlowConfig
+{
+    /// <summary>
+    /// Custom upstream nodes that aren't auto-derived from a PDU (e.g. a breaker, a transfer-switch
+    /// output, the grid "Total"). Auto nodes use ids like <c>pdu:&lt;name&gt;</c> / <c>outlet:&lt;pdu&gt;:&lt;n&gt;</c>.
+    /// </summary>
+    [Description("Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.")]
+    public List<EnergyFlowNode> Nodes { get; set; } = new();
+
+    /// <summary>
+    /// Maps a node id to the id of the node that **feeds** it (its upstream parent). Keys/values may be
+    /// custom node ids or auto ids. Energy flows parent → child; values aggregate up from the leaf
+    /// (outlet) measurements.
+    /// </summary>
+    [Description("child node id -> parent (feeder) node id. Energy flows parent -> child.")]
+    public Dictionary<string, string> Parents { get; set; } = new();
+}
+
+/// <summary>A custom flow node (see <see cref="EnergyFlowConfig.Nodes"/>).</summary>
+public class EnergyFlowNode
+{
+    [Description("Stable unique id used to wire parents/children.")]
+    public string Id { get; set; } = "";
+
+    [Description("Human-readable label shown in the flow diagram.")]
+    public string Label { get; set; } = "";
+
+    /// <summary>
+    /// A directly-known value for this node, used when it has no children (a leaf). The seam where
+    /// external sensors will bind: today it's a manual/known figure (e.g. an untracked load, or a panel
+    /// you're modelling before its CT clamp is ingested); later a node can instead bind to a live
+    /// measurement from any producer (CT clamps over MQTT/emoncms, Tigo solar, inverter ports, …).
+    /// Ignored when the node aggregates children.
+    /// </summary>
+    [Description("Optional directly-known value for a leaf node (used until a live sensor is bound).")]
+    public double? Value { get; set; }
+}

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -18,12 +18,30 @@ public class EnergyFlowConfig
     public List<EnergyFlowNode> Nodes { get; set; } = new();
 
     /// <summary>
-    /// Maps a node id to the id of the node that **feeds** it (its upstream parent). Keys/values may be
-    /// custom node ids or auto ids. Energy flows parent → child; values aggregate up from the leaf
-    /// (outlet) measurements.
+    /// Directed energy-flow links — each entry means energy flows <c>From</c> → <c>To</c>. A node may be
+    /// the <c>To</c> of several links (multiple feeders, e.g. a transfer switch fed by grid + generator +
+    /// inverter), and a producer is just a link pointing into the thing it powers (solar → inverter).
+    /// Endpoints may be custom node ids or auto ids (<c>pdu:…</c> / <c>outlet:…</c>).
     /// </summary>
-    [Description("child node id -> parent (feeder) node id. Energy flows parent -> child.")]
+    [Description("Directed energy-flow links (From feeds To). Allows multiple feeders per node and producer inputs.")]
+    public List<EnergyFlowLink> Links { get; set; } = new();
+
+    /// <summary>
+    /// Legacy single-feeder map (child id → parent id), superseded by <see cref="Links"/>. Still honored on
+    /// load (each entry behaves like a link parent → child) so older configs keep working.
+    /// </summary>
+    [Description("Legacy single-feeder map (child id -> parent id). Prefer Links; still honored for back-compat.")]
     public Dictionary<string, string> Parents { get; set; } = new();
+}
+
+/// <summary>A directed energy-flow link: energy flows <see cref="From"/> → <see cref="To"/>.</summary>
+public class EnergyFlowLink
+{
+    [Description("Source node id — energy flows out of here.")]
+    public string From { get; set; } = "";
+
+    [Description("Target node id — energy flows into here.")]
+    public string To { get; set; } = "";
 }
 
 /// <summary>A custom flow node (see <see cref="EnergyFlowConfig.Nodes"/>).</summary>

--- a/rPDU2MQTT.Tests/ConfigSchemaTests.cs
+++ b/rPDU2MQTT.Tests/ConfigSchemaTests.cs
@@ -1,6 +1,8 @@
 using rPDU2MQTT.Classes;
+using rPDU2MQTT.Models.Config;
 using rPDU2MQTT.Models.Config.Schemas;
 using rPDU2MQTT.Services.Gui;
+using rPDU2MQTT.Startup;
 using Xunit;
 
 namespace rPDU2MQTT.Tests;
@@ -57,6 +59,30 @@ public class ConfigSchemaTests
 
         var mqtt = ConfigSchema.Build().Single(n => n.Key == "MQTT");
         Assert.Contains("LastWill", mqtt.Properties!.Select(n => n.Key));
+    }
+
+    [Fact]
+    public void EnergyFlow_SurvivesTheSaveThenReloadRoundTrip()
+    {
+        // The GUI saves a hierarchy edit and the app re-reads it live (config.EnergyFlow = source.Load()),
+        // which only reflects the change if EnergyFlow survives the exact serialization path: the browser
+        // posts JSON -> the endpoint parses it -> SaveAsync writes YAML -> Load() parses YAML back.
+        var posted = new Config();
+        posted.EnergyFlow.Nodes.Add(new EnergyFlowNode { Id = "gridboss", Label = "Grid Boss", Value = 1234 });
+        posted.EnergyFlow.Links.Add(new EnergyFlowLink { From = "grid", To = "gridboss" });
+        posted.EnergyFlow.Links.Add(new EnergyFlowLink { From = "gridboss", To = "main_panel" });
+
+        var parsed = ConfigSchema.FromJson(ConfigSchema.ToJson(posted));   // browser -> endpoint
+        var yaml = ConfigSchema.ToYaml(parsed);                            // endpoint -> disk (SaveAsync)
+        var reloaded = YamlConfigLoader.DeserializeString(yaml);           // disk -> memory (Load)
+
+        var node = Assert.Single(reloaded.EnergyFlow.Nodes);
+        Assert.Equal("gridboss", node.Id);
+        Assert.Equal("Grid Boss", node.Label);
+        Assert.Equal(1234, node.Value);
+        Assert.Equal(2, reloaded.EnergyFlow.Links.Count);
+        Assert.Contains(reloaded.EnergyFlow.Links, l => l.From == "grid" && l.To == "gridboss");
+        Assert.Contains(reloaded.EnergyFlow.Links, l => l.From == "gridboss" && l.To == "main_panel");
     }
 
     [Fact]

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -102,6 +102,25 @@ public class FlowGraphTests
     }
 
     [Fact]
+    public void Build_ExplicitParentOverridesAutoPduLink_OneFeederPerNode()
+    {
+        // Reparenting an outlet onto a custom breaker must suppress its auto PDU->outlet link,
+        // so the outlet ends up with exactly one feeder (the bug: it had both).
+        var data = OnePdu(Outlet(0, "Server", "realpower", "60"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes = { new EnergyFlowNode { Id = "breaker", Label = "Breaker 15" } },
+            Parents = { ["outlet:pdu1:0"] = "breaker" },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.DoesNotContain(graph.Links, l => l.Source == "pdu:pdu1" && l.Target == "outlet:pdu1:0");
+        Assert.Equal(60, graph.Links.Single(l => l.Source == "breaker" && l.Target == "outlet:pdu1:0").Value);
+        Assert.Single(graph.Links, l => l.Target == "outlet:pdu1:0");
+    }
+
+    [Fact]
     public void Build_IgnoresParentLinksToUnknownNodes()
     {
         var data = OnePdu(Outlet(0, "A", "realpower", "10"));

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -1,4 +1,5 @@
 using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
 using rPDU2MQTT.Models.PDU;
 using Xunit;
 
@@ -57,5 +58,57 @@ public class FlowGraphTests
         var graph = FlowGraphBuilder.Build(OnePdu(Outlet(0, "Idle", "realpower", "0")));
         Assert.Empty(graph.Nodes);
         Assert.Empty(graph.Links);
+    }
+
+    [Fact]
+    public void Build_MergesCustomHierarchy_AndPropagatesValuesUp()
+    {
+        var data = OnePdu(Outlet(0, "A", "realpower", "60"), Outlet(1, "B", "realpower", "40"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes = { new EnergyFlowNode { Id = "total", Label = "Total" }, new EnergyFlowNode { Id = "breaker", Label = "Breaker 15" } },
+            // outlets -> PDU (auto); PDU -> breaker -> total (custom). Energy flows parent -> child.
+            Parents = { ["pdu:pdu1"] = "breaker", ["breaker"] = "total" },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        // The custom upstream links carry the aggregated downstream power (60 + 40 = 100).
+        Assert.Equal(100, graph.Links.Single(l => l.Source == "total" && l.Target == "breaker").Value);
+        Assert.Equal(100, graph.Links.Single(l => l.Source == "breaker" && l.Target == "pdu:pdu1").Value);
+        Assert.Equal(60, graph.Links.Single(l => l.Target == "outlet:pdu1:0").Value);
+        Assert.Contains(graph.Nodes, n => n.Id == "total" && n.Label == "Total");
+    }
+
+    [Fact]
+    public void Build_UsesManualLeafValueForSensorlessNodes_AndAggregatesWithPduFlow()
+    {
+        // A panel fed by the PDU (60W of outlets) plus an untracked-but-known 40W load, under "Total".
+        var data = OnePdu(Outlet(0, "Server", "realpower", "60"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "total", Label = "Panel" },
+                new EnergyFlowNode { Id = "lights", Label = "Lights (known)", Value = 40 },
+            },
+            Parents = { ["pdu:pdu1"] = "total", ["lights"] = "total" },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal(40, graph.Links.Single(l => l.Target == "lights").Value);   // manual leaf value
+        Assert.Equal(100, graph.Links.Single(l => l.Target == "pdu:pdu1").Value + graph.Links.Single(l => l.Target == "lights").Value);
+    }
+
+    [Fact]
+    public void Build_IgnoresParentLinksToUnknownNodes()
+    {
+        var data = OnePdu(Outlet(0, "A", "realpower", "10"));
+        var flow = new EnergyFlowConfig { Parents = { ["pdu:pdu1"] = "ghost" } }; // 'ghost' has no node def
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.DoesNotContain(graph.Nodes, n => n.Id == "ghost");
+        Assert.DoesNotContain(graph.Links, l => l.Source == "ghost");
     }
 }

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -130,4 +130,129 @@ public class FlowGraphTests
         Assert.DoesNotContain(graph.Nodes, n => n.Id == "ghost");
         Assert.DoesNotContain(graph.Links, l => l.Source == "ghost");
     }
+
+    [Fact]
+    public void Build_DirectedLinks_AllowMultipleFeedersIntoOneNode()
+    {
+        // A transfer switch ("gridboss") fed by both grid and generator, then feeding the PDU.
+        var data = OnePdu(Outlet(0, "Server", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "gridboss", Label = "Grid Boss" },
+                new EnergyFlowNode { Id = "grid", Label = "Grid", Value = 70 },
+                new EnergyFlowNode { Id = "gen", Label = "Generator", Value = 30 },
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "gridboss", To = "pdu:pdu1" }, // gridboss powers the PDU (demand-driven)
+                new EnergyFlowLink { From = "grid", To = "gridboss" },     // two feeders into one node
+                new EnergyFlowLink { From = "gen", To = "gridboss" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal(2, graph.Links.Count(l => l.Target == "gridboss")); // multi-parent
+        Assert.Equal(70, graph.Links.Single(l => l.Source == "grid").Value);  // measured producer values
+        Assert.Equal(30, graph.Links.Single(l => l.Source == "gen").Value);
+        Assert.Equal(100, graph.Links.Single(l => l.Source == "gridboss").Value); // demand-driven downstream
+    }
+
+    [Fact]
+    public void Build_ProducerLink_CarriesGenerationIntoWhatItFeeds()
+    {
+        // Solar (a producer with a known value) feeds the PDU's upstream node; the link width is the generation.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "20"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes = { new EnergyFlowNode { Id = "solar", Label = "Solar", Value = 500 } },
+            Links = { new EnergyFlowLink { From = "solar", To = "pdu:pdu1" } },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal(500, graph.Links.Single(l => l.Source == "solar" && l.Target == "pdu:pdu1").Value);
+        Assert.Contains(graph.Nodes, n => n.Id == "solar" && n.Label == "Solar");
+    }
+
+    [Fact]
+    public void Build_DiamondPaths_SplitDemandAmongFeeders_NoDoubleCount()
+    {
+        // A panel reachable from the boss both directly AND via a sub-panel (a diamond). The 100W of real
+        // load must not be counted twice: the panel's two feeder links carry 50W each, and the boss totals 100W.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "boss", Label = "Boss" },
+                new EnergyFlowNode { Id = "panel", Label = "Panel" },
+                new EnergyFlowNode { Id = "sub", Label = "Sub" },
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "boss", To = "panel" },   // direct feeder
+                new EnergyFlowLink { From = "boss", To = "sub" },
+                new EnergyFlowLink { From = "sub", To = "panel" },    // second feeder into the same panel
+                new EnergyFlowLink { From = "panel", To = "pdu:pdu1" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal(50, graph.Links.Single(l => l.Source == "boss" && l.Target == "panel").Value);
+        Assert.Equal(50, graph.Links.Single(l => l.Source == "sub" && l.Target == "panel").Value);
+        Assert.Equal(100, graph.Links.Single(l => l.Source == "panel" && l.Target == "pdu:pdu1").Value);
+        // The boss carries the real load once: 50 (direct) + 50 (via sub) = 100, not 200.
+        Assert.Equal(100, graph.Links.Where(l => l.Source == "boss").Sum(l => l.Value));
+    }
+
+    // Walk the emitted links; true if they contain a directed cycle.
+    private static bool HasCycle(FlowGraph graph)
+    {
+        var adj = graph.Links.GroupBy(l => l.Source, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.Select(l => l.Target).ToList(), StringComparer.OrdinalIgnoreCase);
+        var state = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase); // 1 = on stack, 2 = done
+        bool Visit(string n)
+        {
+            state[n] = 1;
+            if (adj.TryGetValue(n, out var kids))
+                foreach (var k in kids)
+                {
+                    if (state.GetValueOrDefault(k) == 1) return true;
+                    if (state.GetValueOrDefault(k) == 0 && Visit(k)) return true;
+                }
+            state[n] = 2;
+            return false;
+        }
+        return graph.Nodes.Any(n => state.GetValueOrDefault(n.Id) == 0 && Visit(n.Id));
+    }
+
+    [Fact]
+    public void Build_BreaksLoops_WhenConfigBypassesTheEditorGuard()
+    {
+        // A hand-edited config wires a cycle (a → b → a) and a self-loop. The builder must not hang and
+        // must drop the loop-closing edges, leaving a clean DAG that still carries the real outlet load.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes = { new EnergyFlowNode { Id = "a", Label = "A" }, new EnergyFlowNode { Id = "b", Label = "B" } },
+            Links =
+            {
+                new EnergyFlowLink { From = "a", To = "b" },
+                new EnergyFlowLink { From = "b", To = "a" },          // closes a 2-cycle -> dropped
+                new EnergyFlowLink { From = "a", To = "a" },          // self-loop -> dropped
+                new EnergyFlowLink { From = "a", To = "pdu:pdu1" },   // gives 'a' real downstream flow
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.False(HasCycle(graph));                                                  // no loops survive
+        Assert.DoesNotContain(graph.Links, l => l.Source == l.Target);                  // no self-loop
+        Assert.DoesNotContain(graph.Links, l => l.Source == "b" && l.Target == "a");    // the cycle-closing edge is gone
+        Assert.Equal(100, graph.Links.Single(l => l.Source == "a" && l.Target == "pdu:pdu1").Value);
+    }
 }

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -674,7 +674,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 var pdu = ResolveInstance(ctx.Request.Query["instance"]).Pdu;
                 var data = await pdu.GetRootData_Public(cts.Token);
                 var metric = ctx.Request.Query["metric"].ToString();
-                var graph = FlowGraphBuilder.Build(data, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric);
+                var graph = FlowGraphBuilder.Build(data, config.EnergyFlow, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric);
                 return Results.Json(new { ok = true, graph.Nodes, graph.Links, graph.Metric, graph.Units }, ConfigSchema.Json);
             }
             catch (Exception ex)

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -305,13 +305,19 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 await configSource.SaveAsync(parsed, ctx.RequestAborted);
                 Log.Information($"Configuration saved via GUI to {configSource.Describe}.");
 
+                // Re-read the just-saved config so live-readable settings take effect without a restart.
+                var reloaded = configSource.Load();
+                // The energy-flow hierarchy is read fresh on every /api/flow request, so applying it here
+                // makes Flow/Sankey edits show up on the next refresh (previously they needed a restart).
+                config.EnergyFlow = reloaded.EnergyFlow;
+
                 // Apply PDU instance add/remove live: refresh the instance set from the saved config and
                 // reconcile the running pollers (a new PDU starts polling, a removed one stops) without a
                 // restart. Other live-read settings (overrides/names/templates) still apply on Republish.
                 var instanceMessage = "";
                 try
                 {
-                    config.Pdus = configSource.Load().Pdus;
+                    config.Pdus = reloaded.Pdus;
                     await instances.ReconcileAsync();
                     instanceMessage = " PDU instances were applied live.";
                 }

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -828,82 +828,129 @@ function addFlowSection(nav, sections) {
     wrap.appendChild(svg);
   };
 
-  // --- Drag-and-drop hierarchy editor (edits data.EnergyFlow, persisted via the config save) ---
+  // --- Node-graph hierarchy editor: drag nodes to arrange, drag a node's port onto another to set
+  //     its feeder (parent->child). Positions persist per-instance in localStorage. ---
+  const NW = 172, NH = 46;
+  const posKey = () => 'rpdu-flowpos:' + (instSel.get() || 'default');
+  const loadPos = () => { try { return JSON.parse(localStorage.getItem(posKey())) || {}; } catch { return {}; } };
+  const savePos = p => { try { localStorage.setItem(posKey(), JSON.stringify(p)); } catch { /* ignore */ } };
+
   const renderEditor = () => {
+    if (ed._cleanup) ed._cleanup();
     const flow = ensure(data, 'EnergyFlow', {});
     const customNodes = ensure(flow, 'Nodes', []);
     const parents = ensure(flow, 'Parents', {});
     ed.innerHTML = '';
 
     ed.appendChild(el('h3', { text: 'Hierarchy', style: { margin: '4px 0' } }));
-    ed.appendChild(el('div', { class: 'desc', text: 'Drag a node onto its upstream feeder (or use the parent dropdown). Drop onto “(top / grid)” to clear.' }));
+    ed.appendChild(el('div', { class: 'desc', text: 'Drag a node by its body to arrange it. Drag from a node’s right ● onto another node to make it the feeder (parent → child). Click ✕ on a link to remove it.' }));
 
-    // Add a custom upstream/leaf node.
     const addBar = el('div', { class: 'ld-toolbar' });
     const idIn = el('input', { type: 'text', placeholder: 'id (e.g. panel-main)' });
     const labIn = el('input', { type: 'text', placeholder: 'label (e.g. Main Panel)' });
     const valIn = el('input', { type: 'number', placeholder: 'known value (optional)', style: { width: '150px' } });
     const addBtn = btn('Add node', 'primary');
-    addBtn.onclick = () => {
-      const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
-      if (customNodes.some(n => n.Id === id) || (lastGraph && lastGraph.nodes.some(n => n.id === id))) { toast('That id already exists.', false); return; }
-      const node = { Id: id, Label: (labIn.value || '').trim() || id };
-      if (valIn.value !== '' && !isNaN(+valIn.value)) node.Value = +valIn.value;
-      customNodes.push(node); idIn.value = labIn.value = valIn.value = ''; renderEditor();
-    };
-    addBar.append(idIn, labIn, valIn, addBtn); ed.appendChild(addBar);
+    const save = btn('Save hierarchy', 'primary');
+    addBar.append(idIn, labIn, valIn, addBtn, save); ed.appendChild(addBar);
 
-    // Candidate nodes: everything currently in the graph + custom nodes (deduped).
+    // Candidate nodes (graph + custom) and the edges between them.
     const cand = new Map();
     (lastGraph?.nodes || []).forEach(n => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
     customNodes.forEach(n => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: 'node', custom: true }));
-    const setParent = (child, parent) => { if (!parent) delete parents[child]; else if (parent !== child) parents[child] = parent; renderEditor(); };
 
-    // "Top / grid" drop zone clears a node's parent.
-    const root = el('div', { class: 'flow-card', style: { borderStyle: 'dashed', opacity: '0.8' }, text: '⤴ (top / grid) — drop here to clear a feeder' });
-    root.ondragover = e => e.preventDefault();
-    root.ondrop = e => { e.preventDefault(); setParent(e.dataTransfer.getData('text/plain'), ''); };
-    ed.appendChild(root);
+    const autoParent = id => { const m = /^outlet:(.+):\d+$/.exec(id); return m ? 'pdu:' + m[1] : null; };
+    const parentOf = id => parents[id] || autoParent(id);
+    const depth = (id, seen) => { seen = seen || new Set(); if (seen.has(id)) return 0; seen.add(id); const p = parentOf(id); return (p && cand.has(p)) ? depth(p, seen) + 1 : 0; };
 
-    const list = el('div', { class: 'flow-cards' });
+    // Auto-layout any node without a saved position (column = depth, stacked per column).
+    const pos = loadPos();
+    const perCol = {};
     [...cand.values()].forEach(c => {
-      const card = el('div', { class: 'flow-card', draggable: 'true' });
-      card.ondragstart = e => e.dataTransfer.setData('text/plain', c.id);
-      card.ondragover = e => e.preventDefault();
-      card.ondrop = e => { e.preventDefault(); const dragged = e.dataTransfer.getData('text/plain'); if (dragged) setParent(dragged, c.id); };
-
-      card.appendChild(el('span', { class: 'flow-card-title', text: c.label }));
-      card.appendChild(el('span', { class: 'flow-card-id', text: c.id + (c.custom ? '' : ' · ' + c.kind) }));
-
-      // Parent dropdown (accessible alternative to dragging).
-      const sel = el('select');
-      sel.appendChild(el('option', { value: '', text: 'feeder: (top / grid)' }));
-      [...cand.values()].filter(o => o.id !== c.id).forEach(o => sel.appendChild(el('option', { value: o.id, text: 'feeder: ' + o.label })));
-      sel.value = parents[c.id] || '';
-      sel.onchange = () => setParent(c.id, sel.value);
-      card.appendChild(sel);
-
-      if (c.custom) {
-        const rm = btn('✕', 'danger');
-        rm.onclick = () => {
-          const i = customNodes.findIndex(n => n.Id === c.id); if (i >= 0) customNodes.splice(i, 1);
-          delete parents[c.id];
-          Object.keys(parents).forEach(k => { if (parents[k] === c.id) delete parents[k]; });
-          renderEditor();
-        };
-        card.appendChild(rm);
-      }
-      list.appendChild(card);
+      if (!pos[c.id]) { const dc = depth(c.id); const r = (perCol[dc] = perCol[dc] || 0); pos[c.id] = { x: 24 + dc * (NW + 90), y: 20 + r * (NH + 22) }; perCol[dc] = r + 1; }
     });
-    ed.appendChild(list);
 
-    const save = btn('Save hierarchy', 'primary');
+    const edges = [];
+    cand.forEach(c => { const ap = autoParent(c.id); if (ap && cand.has(ap)) edges.push({ from: ap, to: c.id, custom: false }); });
+    Object.entries(parents).forEach(([child, par]) => { if (cand.has(child) && cand.has(par)) edges.push({ from: par, to: child, custom: true }); });
+
+    const allX = [...cand.values()].map(c => pos[c.id].x), allY = [...cand.values()].map(c => pos[c.id].y);
+    const W = Math.max(600, Math.max(...allX, 0) + NW + 40), H = Math.max(280, Math.max(...allY, 0) + NH + 40);
+    const scroll = el('div', { style: { overflow: 'auto', border: '1px solid var(--line)', borderRadius: '6px', marginTop: '10px', maxHeight: '640px' } });
+    const svg = svgEl('svg', { width: W, height: H, style: 'background:var(--panel2)' });
+    scroll.appendChild(svg); ed.appendChild(scroll);
+    const edgeLayer = svgEl('g', {}); svg.appendChild(edgeLayer);
+    const nodeLayer = svgEl('g', {}); svg.appendChild(nodeLayer);
+    const colors = ['#49f', '#4f9', '#fa4', '#f49', '#9f4', '#4ff'];
+
+    const edgeD = e => { const a = pos[e.from], b = pos[e.to], x1 = a.x + NW, y1 = a.y + NH / 2, x2 = b.x, y2 = b.y + NH / 2, xc = (x1 + x2) / 2; return `M${x1},${y1} C${xc},${y1} ${xc},${y2} ${x2},${y2}`; };
+    const edgeEls = [];
+    edges.forEach(e => {
+      const p = svgEl('path', { d: edgeD(e), fill: 'none', stroke: e.custom ? '#5ab0ff' : 'var(--line)', 'stroke-width': e.custom ? 2 : 1.5, 'stroke-dasharray': e.custom ? '' : '4 3' });
+      edgeLayer.appendChild(p); edgeEls.push({ e, p });
+      if (e.custom) {
+        const a = pos[e.from], b = pos[e.to], mx = (a.x + NW + b.x) / 2, my = (a.y + b.y) / 2 + NH / 2;
+        const del = svgEl('text', { x: mx, y: my, 'text-anchor': 'middle', 'dominant-baseline': 'middle', fill: 'var(--bad)', 'font-size': '15', style: 'cursor:pointer' });
+        del.textContent = '✕'; del.onclick = () => { delete parents[e.to]; renderEditor(); };
+        edgeLayer.appendChild(del);
+      }
+    });
+
+    const nodeG = {};
+    [...cand.values()].forEach(c => {
+      const g = svgEl('g', { transform: `translate(${pos[c.id].x},${pos[c.id].y})`, style: 'cursor:grab' }); g.dataset.id = c.id;
+      const color = colors[depth(c.id) % colors.length];
+      g.appendChild(svgEl('rect', { width: NW, height: NH, rx: 7, fill: 'var(--panel)', stroke: color, 'stroke-width': 2 }));
+      const t1 = svgEl('text', { x: 11, y: 19, fill: 'var(--fg)', 'font-size': '12', 'font-weight': '600' }); t1.textContent = c.label.length > 24 ? c.label.slice(0, 23) + '…' : c.label; g.appendChild(t1);
+      const t2 = svgEl('text', { x: 11, y: 35, fill: 'var(--muted)', 'font-size': '10' }); t2.textContent = c.id; g.appendChild(t2);
+      g.appendChild(svgEl('circle', { cx: NW, cy: NH / 2, r: 7, fill: color, style: 'cursor:crosshair', 'data-port': c.id }));
+      if (c.custom) {
+        const rm = svgEl('text', { x: NW - 12, y: 15, fill: 'var(--bad)', 'font-size': '13', style: 'cursor:pointer', 'data-rm': c.id }); rm.textContent = '✕'; g.appendChild(rm);
+      }
+      nodeLayer.appendChild(g); nodeG[c.id] = g;
+    });
+
+    // Interactions.
+    const rect = () => svg.getBoundingClientRect();
+    let drag = null, linkFrom = null, tempLine = null;
+    const onDown = e => {
+      const portId = e.target.getAttribute && e.target.getAttribute('data-port');
+      const rmId = e.target.getAttribute && e.target.getAttribute('data-rm');
+      if (rmId) { const i = customNodes.findIndex(n => n.Id === rmId); if (i >= 0) customNodes.splice(i, 1); delete parents[rmId]; Object.keys(parents).forEach(k => { if (parents[k] === rmId) delete parents[k]; }); renderEditor(); return; }
+      if (portId) { linkFrom = portId; tempLine = svgEl('path', { d: '', fill: 'none', stroke: '#5ab0ff', 'stroke-width': 2, 'stroke-dasharray': '4 3' }); edgeLayer.appendChild(tempLine); e.preventDefault(); return; }
+      const g = e.target.closest && e.target.closest('g[data-id]');
+      if (g) { const r = rect(); drag = { id: g.dataset.id, ox: (e.clientX - r.left) - pos[g.dataset.id].x, oy: (e.clientY - r.top) - pos[g.dataset.id].y }; e.preventDefault(); }
+    };
+    const onMove = e => {
+      const r = rect(), mx = e.clientX - r.left, my = e.clientY - r.top;
+      if (drag) { pos[drag.id] = { x: Math.max(0, mx - drag.ox), y: Math.max(0, my - drag.oy) }; nodeG[drag.id].setAttribute('transform', `translate(${pos[drag.id].x},${pos[drag.id].y})`); edgeEls.forEach(({ e, p }) => { if (e.from === drag.id || e.to === drag.id) p.setAttribute('d', edgeD(e)); }); }
+      else if (linkFrom) { const a = pos[linkFrom]; tempLine.setAttribute('d', `M${a.x + NW},${a.y + NH / 2} L${mx},${my}`); }
+    };
+    const onUp = e => {
+      if (drag) { savePos(pos); drag = null; }
+      else if (linkFrom) {
+        const hit = document.elementFromPoint(e.clientX, e.clientY);
+        const gn = hit && hit.closest && hit.closest('g[data-id]');
+        if (gn && gn.dataset.id !== linkFrom) { parents[gn.dataset.id] = linkFrom; renderEditor(); return; }
+        if (tempLine) tempLine.remove(); linkFrom = null;
+      }
+    };
+    svg.addEventListener('mousedown', onDown);
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    ed._cleanup = () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); };
+
+    addBtn.onclick = () => {
+      const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
+      if (cand.has(id)) { toast('That id already exists.', false); return; }
+      const node = { Id: id, Label: (labIn.value || '').trim() || id };
+      if (valIn.value !== '' && !isNaN(+valIn.value)) node.Value = +valIn.value;
+      customNodes.push(node); renderEditor();
+    };
     save.onclick = async () => {
       const r = await api('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(exportData()) });
       toast(r.body.message || (r.ok ? 'Saved.' : 'Save failed.'), r.ok && r.body.ok);
       if (r.ok && r.body.ok) load();
     };
-    const sbar = el('div', { class: 'ld-toolbar', style: { marginTop: '10px' } }); sbar.appendChild(save); ed.appendChild(sbar);
   };
 
   const load = async () => {

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -843,7 +843,7 @@ function addFlowSection(nav, sections) {
     ed.innerHTML = '';
 
     ed.appendChild(el('h3', { text: 'Hierarchy', style: { margin: '4px 0' } }));
-    ed.appendChild(el('div', { class: 'desc', text: 'Drag a node by its body to arrange it. Drag from a node’s right ● onto another node to make it the feeder (parent → child). Click ✕ on a link to remove it.' }));
+    ed.appendChild(el('div', { class: 'desc', text: 'Drag a node by its body to arrange it. To set what feeds a node, drag from the feeder’s right ● onto the target node (it highlights green) — each node has exactly one feeder, so this replaces any existing one. Click ✕ on a link to clear it (an outlet reverts to its own PDU).' }));
 
     const addBar = el('div', { class: 'ld-toolbar' });
     const idIn = el('input', { type: 'text', placeholder: 'id (e.g. panel-main)' });
@@ -869,9 +869,14 @@ function addFlowSection(nav, sections) {
       if (!pos[c.id]) { const dc = depth(c.id); const r = (perCol[dc] = perCol[dc] || 0); pos[c.id] = { x: 24 + dc * (NW + 90), y: 20 + r * (NH + 22) }; perCol[dc] = r + 1; }
     });
 
+    // One feeder per node: an explicit (custom) parent replaces the auto-derived PDU link.
     const edges = [];
-    cand.forEach(c => { const ap = autoParent(c.id); if (ap && cand.has(ap)) edges.push({ from: ap, to: c.id, custom: false }); });
-    Object.entries(parents).forEach(([child, par]) => { if (cand.has(child) && cand.has(par)) edges.push({ from: par, to: child, custom: true }); });
+    cand.forEach(c => {
+      const cp = parents[c.id];
+      if (cp && cand.has(cp)) { edges.push({ from: cp, to: c.id, custom: true }); return; }
+      const ap = autoParent(c.id);
+      if (ap && cand.has(ap)) edges.push({ from: ap, to: c.id, custom: false });
+    });
 
     const allX = [...cand.values()].map(c => pos[c.id].x), allY = [...cand.values()].map(c => pos[c.id].y);
     const W = Math.max(600, Math.max(...allX, 0) + NW + 40), H = Math.max(280, Math.max(...allY, 0) + NH + 40);
@@ -885,7 +890,7 @@ function addFlowSection(nav, sections) {
     const edgeD = e => { const a = pos[e.from], b = pos[e.to], x1 = a.x + NW, y1 = a.y + NH / 2, x2 = b.x, y2 = b.y + NH / 2, xc = (x1 + x2) / 2; return `M${x1},${y1} C${xc},${y1} ${xc},${y2} ${x2},${y2}`; };
     const edgeEls = [];
     edges.forEach(e => {
-      const p = svgEl('path', { d: edgeD(e), fill: 'none', stroke: e.custom ? '#5ab0ff' : 'var(--line)', 'stroke-width': e.custom ? 2 : 1.5, 'stroke-dasharray': e.custom ? '' : '4 3' });
+      const p = svgEl('path', { d: edgeD(e), fill: 'none', stroke: e.custom ? '#5ab0ff' : 'var(--line)', 'stroke-width': e.custom ? 2 : 1.5, 'stroke-dasharray': e.custom ? '' : '4 3', 'pointer-events': 'none' });
       edgeLayer.appendChild(p); edgeEls.push({ e, p });
       if (e.custom) {
         const a = pos[e.from], b = pos[e.to], mx = (a.x + NW + b.x) / 2, my = (a.y + b.y) / 2 + NH / 2;
@@ -911,27 +916,37 @@ function addFlowSection(nav, sections) {
 
     // Interactions.
     const rect = () => svg.getBoundingClientRect();
-    let drag = null, linkFrom = null, tempLine = null;
+    let drag = null, linkFrom = null, tempLine = null, hovered = null;
+    // Walking up the feeder chain from `parent`, do we hit `child`? (prevents loops)
+    const wouldCycle = (child, parent) => { let p = parent, g = 0; while (p && g++ < 1000) { if (p === child) return true; p = parents[p] || autoParent(p); } return false; };
+    const highlight = id => {
+      if (id === hovered) return;
+      if (hovered && nodeG[hovered]) { const rc = nodeG[hovered].querySelector('rect'); rc.setAttribute('stroke', colors[depth(hovered) % colors.length]); rc.setAttribute('stroke-width', '2'); }
+      hovered = id;
+      if (hovered && nodeG[hovered]) { const rc = nodeG[hovered].querySelector('rect'); rc.setAttribute('stroke', '#46c46a'); rc.setAttribute('stroke-width', '3'); }
+    };
+    const targetUnder = (cx, cy) => { const hit = document.elementFromPoint(cx, cy); const gn = hit && hit.closest && hit.closest('g[data-id]'); return gn && gn.dataset.id !== linkFrom ? gn.dataset.id : null; };
     const onDown = e => {
       const portId = e.target.getAttribute && e.target.getAttribute('data-port');
       const rmId = e.target.getAttribute && e.target.getAttribute('data-rm');
       if (rmId) { const i = customNodes.findIndex(n => n.Id === rmId); if (i >= 0) customNodes.splice(i, 1); delete parents[rmId]; Object.keys(parents).forEach(k => { if (parents[k] === rmId) delete parents[k]; }); renderEditor(); return; }
-      if (portId) { linkFrom = portId; tempLine = svgEl('path', { d: '', fill: 'none', stroke: '#5ab0ff', 'stroke-width': 2, 'stroke-dasharray': '4 3' }); edgeLayer.appendChild(tempLine); e.preventDefault(); return; }
+      if (portId) { linkFrom = portId; tempLine = svgEl('path', { d: '', fill: 'none', stroke: '#5ab0ff', 'stroke-width': 2, 'stroke-dasharray': '4 3', 'pointer-events': 'none' }); edgeLayer.appendChild(tempLine); e.preventDefault(); return; }
       const g = e.target.closest && e.target.closest('g[data-id]');
       if (g) { const r = rect(); drag = { id: g.dataset.id, ox: (e.clientX - r.left) - pos[g.dataset.id].x, oy: (e.clientY - r.top) - pos[g.dataset.id].y }; e.preventDefault(); }
     };
     const onMove = e => {
       const r = rect(), mx = e.clientX - r.left, my = e.clientY - r.top;
       if (drag) { pos[drag.id] = { x: Math.max(0, mx - drag.ox), y: Math.max(0, my - drag.oy) }; nodeG[drag.id].setAttribute('transform', `translate(${pos[drag.id].x},${pos[drag.id].y})`); edgeEls.forEach(({ e, p }) => { if (e.from === drag.id || e.to === drag.id) p.setAttribute('d', edgeD(e)); }); }
-      else if (linkFrom) { const a = pos[linkFrom]; tempLine.setAttribute('d', `M${a.x + NW},${a.y + NH / 2} L${mx},${my}`); }
+      else if (linkFrom) { const a = pos[linkFrom]; tempLine.setAttribute('d', `M${a.x + NW},${a.y + NH / 2} L${mx},${my}`); highlight(targetUnder(e.clientX, e.clientY)); }
     };
     const onUp = e => {
-      if (drag) { savePos(pos); drag = null; }
-      else if (linkFrom) {
-        const hit = document.elementFromPoint(e.clientX, e.clientY);
-        const gn = hit && hit.closest && hit.closest('g[data-id]');
-        if (gn && gn.dataset.id !== linkFrom) { parents[gn.dataset.id] = linkFrom; renderEditor(); return; }
-        if (tempLine) tempLine.remove(); linkFrom = null;
+      if (drag) { savePos(pos); drag = null; return; }
+      if (linkFrom) {
+        const src = linkFrom, tgt = targetUnder(e.clientX, e.clientY);
+        if (tempLine) tempLine.remove(); linkFrom = null; highlight(null);
+        if (!tgt) return;
+        if (wouldCycle(tgt, src)) { toast('That would create a feeder loop.', false); return; }
+        parents[tgt] = src; renderEditor();
       }
     };
     svg.addEventListener('mousedown', onDown);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -743,7 +743,7 @@ function addFlowSection(nav, sections) {
   const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
   const h = document.createElement('h2'); h.textContent = 'Energy Flow'; sec.appendChild(h);
   const d = document.createElement('div'); d.className = 'desc';
-  d.textContent = 'Power flow through each PDU to its outlets (live, from the latest poll). Link width is proportional to the measurement.';
+  d.textContent = 'Live power flow (from the latest poll). Outlet→PDU is auto-derived; add upstream nodes (panels, breakers, a “Total”) and drag to set each node’s feeder to model the full hierarchy. Link width is proportional to the measurement.';
   sec.appendChild(d);
 
   const bar = document.createElement('div'); bar.className = 'ld-toolbar';
@@ -752,76 +752,166 @@ function addFlowSection(nav, sections) {
   const count = document.createElement('span'); count.className = 'ld-count';
   bar.appendChild(refresh); bar.appendChild(instSel.wrap); bar.appendChild(count); sec.appendChild(bar);
   const wrap = document.createElement('div'); sec.appendChild(wrap);
+  const ed = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
+  let lastGraph = null;
 
+  // Layered Sankey: columns = longest path from a root (energy flows left->right, parent->child).
   const draw = (graph) => {
     wrap.innerHTML = '';
-    const links = graph.links || [];
-    if (!links.length) { wrap.innerHTML = '<div class="desc" style="color:var(--muted)">No measured power flow to display.</div>'; count.textContent = ''; return; }
+    const links = (graph.links || []).slice();
+    const nodes = graph.nodes || [];
+    if (!links.length) { wrap.innerHTML = '<div class="desc" style="color:var(--muted)">No measured power flow to display. Define an EnergyFlow hierarchy, or check that outlets report power.</div>'; count.textContent = ''; return; }
 
     const units = graph.units || '';
-    const byId = Object.fromEntries((graph.nodes || []).map(n => [n.id, n]));
-    const pduIds = (graph.nodes || []).filter(n => n.kind === 'pdu').map(n => n.id);
-    const grand = links.reduce((s, l) => s + l.value, 0);
-    count.textContent = `${pduIds.length} PDU(s) · ${links.length} outlet(s) · ${formatNum(grand)} ${units}`;
+    const incoming = {}, outgoing = {};
+    nodes.forEach(n => { incoming[n.id] = []; outgoing[n.id] = []; });
+    links.forEach(l => { (outgoing[l.source] = outgoing[l.source] || []).push(l); (incoming[l.target] = incoming[l.target] || []).push(l); });
+    const sumv = arr => (arr || []).reduce((s, l) => s + l.value, 0);
+    const nodeValue = id => Math.max(sumv(incoming[id]), sumv(outgoing[id]));
 
-    // Geometry. One shared px-per-unit scale so widths line up across both columns.
-    const W = 920, padTop = 14, gap = 6, nodeW = 14, leftX = 170, rightX = W - 170;
-    const rows = links.length, pduGaps = Math.max(0, pduIds.length - 1);
-    const H = padTop * 2 + (rows - 1) * gap + pduGaps * gap;     // total node-stack gaps
-    const usable = 460;                                          // vertical px for the flow itself
-    const pxPerUnit = usable / grand;
-    const totalH = usable + (rows - 1) * gap + pduGaps * gap + padTop * 2;
+    // Column index = longest path from a root (a node with no incoming links).
+    const colMemo = {};
+    const col = (id, seen) => {
+      if (colMemo[id] != null) return colMemo[id];
+      seen = seen || new Set();
+      if (seen.has(id)) return 0;
+      seen.add(id);
+      const ins = incoming[id] || [];
+      const c = ins.length ? Math.max(...ins.map(l => col(l.source, seen) + 1)) : 0;
+      seen.delete(id);
+      return colMemo[id] = c;
+    };
+    nodes.forEach(n => col(n.id));
+    const maxCol = Math.max(0, ...nodes.map(n => colMemo[n.id]));
 
-    const svg = svgEl('svg', { width: '100%', viewBox: `0 0 ${W} ${totalH}`, style: 'max-width:920px' });
+    const cols = [];
+    nodes.forEach(n => { const c = colMemo[n.id]; (cols[c] = cols[c] || []).push(n); });
 
-    let outletY = padTop;     // running y on the right (outlets)
-    let pduY = padTop;        // running y on the left (PDUs)
-    const colors = ['#4f9', '#49f', '#fa4', '#f49', '#9f4', '#4ff', '#f94'];
+    const W = 960, padTop = 22, gap = 8, nodeW = 12, usableH = 520;
+    const maxTotal = Math.max(1, ...cols.map(cn => cn.reduce((s, n) => s + nodeValue(n.id), 0)));
+    const pxPerUnit = usableH / maxTotal;
+    const colX = c => 150 + (maxCol > 0 ? c * ((W - 320) / maxCol) : 0);
 
-    pduIds.forEach((pduId, pi) => {
-      const pduLinks = links.filter(l => l.source === pduId);
-      if (!pduLinks.length) return;
-      const pduTotal = pduLinks.reduce((s, l) => s + l.value, 0);
-      const pduH = pduTotal * pxPerUnit;
-      const color = colors[pi % colors.length];
-
-      // PDU node (left) + label.
-      svg.appendChild(svgEl('rect', { x: leftX, y: pduY, width: nodeW, height: Math.max(1, pduH), fill: color, rx: 2 }));
-      const plab = svgEl('text', { x: leftX - 8, y: pduY + pduH / 2, 'text-anchor': 'end', 'dominant-baseline': 'middle', fill: 'var(--fg)', 'font-size': '12', 'font-weight': '600' });
-      plab.textContent = `${byId[pduId]?.label || pduId} (${formatNum(pduTotal)} ${units})`;
-      svg.appendChild(plab);
-
-      let srcY = pduY;  // cumulative band on the PDU's right edge
-      pduLinks.sort((a, b) => b.value - a.value).forEach(l => {
-        const lh = Math.max(1, l.value * pxPerUnit);
-
-        // Ribbon: PDU right edge band [srcY..srcY+lh] -> outlet left edge band [outletY..outletY+lh].
-        const x1 = leftX + nodeW, x2 = rightX, xc = (x1 + x2) / 2;
-        const sTop = srcY, sBot = srcY + lh, tTop = outletY, tBot = outletY + lh;
-        const path = svgEl('path', {
-          d: `M${x1},${sTop} C${xc},${sTop} ${xc},${tTop} ${x2},${tTop} L${x2},${tBot} C${xc},${tBot} ${xc},${sBot} ${x1},${sBot} Z`,
-          fill: color, 'fill-opacity': '0.35',
-        });
-        svg.appendChild(path);
-
-        // Outlet node (right) + label.
-        svg.appendChild(svgEl('rect', { x: rightX, y: outletY, width: nodeW, height: lh, fill: color, rx: 2 }));
-        const olab = svgEl('text', { x: rightX + nodeW + 8, y: outletY + lh / 2, 'dominant-baseline': 'middle', fill: 'var(--fg)', 'font-size': '12' });
-        olab.textContent = `${byId[l.target]?.label || l.target} · ${formatNum(l.value)} ${units}`;
-        svg.appendChild(olab);
-
-        srcY += lh; outletY += lh + gap;
-      });
-      pduY += pduH + gap + gap;
+    const pos = {};
+    cols.forEach((cn, c) => {
+      cn.sort((a, b) => nodeValue(b.id) - nodeValue(a.id));
+      let y = padTop;
+      cn.forEach(n => { const h = Math.max(2, nodeValue(n.id) * pxPerUnit); pos[n.id] = { x: colX(c), y, h, outOff: 0, inOff: 0 }; y += h + gap; });
     });
 
+    const totalH = padTop * 2 + usableH;
+    const svg = svgEl('svg', { width: '100%', viewBox: `0 0 ${W} ${totalH}`, style: 'max-width:960px' });
+    const colors = ['#49f', '#4f9', '#fa4', '#f49', '#9f4', '#4ff', '#f94', '#a9f'];
+
+    // Ribbons (filled bezier bands), stacked on each node edge by target order.
+    links.sort((a, b) => pos[a.target].y - pos[b.target].y).forEach(l => {
+      const s = pos[l.source], t = pos[l.target];
+      if (!s || !t) return;
+      const h = Math.max(1, l.value * pxPerUnit);
+      const x1 = s.x + nodeW, x2 = t.x, xc = (x1 + x2) / 2;
+      const sTop = s.y + s.outOff, tTop = t.y + t.inOff;
+      const color = colors[colMemo[l.source] % colors.length];
+      svg.appendChild(svgEl('path', { d: `M${x1},${sTop} C${xc},${sTop} ${xc},${tTop} ${x2},${tTop} L${x2},${tTop + h} C${xc},${tTop + h} ${xc},${sTop + h} ${x1},${sTop + h} Z`, fill: color, 'fill-opacity': '0.3' }));
+      s.outOff += h; t.inOff += h;
+    });
+
+    // Nodes + labels (above each node).
+    nodes.forEach(n => {
+      const p = pos[n.id]; if (!p) return;
+      svg.appendChild(svgEl('rect', { x: p.x, y: p.y, width: nodeW, height: p.h, rx: 2, fill: colors[colMemo[n.id] % colors.length] }));
+      const lab = svgEl('text', { x: p.x, y: p.y - 4, fill: 'var(--fg)', 'font-size': '11', 'font-weight': n.kind === 'outlet' ? '400' : '600' });
+      lab.textContent = `${n.label} · ${formatNum(nodeValue(n.id))} ${units}`;
+      svg.appendChild(lab);
+    });
+
+    count.textContent = `${nodes.length} node(s) · ${links.length} link(s)`;
     wrap.appendChild(svg);
+  };
+
+  // --- Drag-and-drop hierarchy editor (edits data.EnergyFlow, persisted via the config save) ---
+  const renderEditor = () => {
+    const flow = ensure(data, 'EnergyFlow', {});
+    const customNodes = ensure(flow, 'Nodes', []);
+    const parents = ensure(flow, 'Parents', {});
+    ed.innerHTML = '';
+
+    ed.appendChild(el('h3', { text: 'Hierarchy', style: { margin: '4px 0' } }));
+    ed.appendChild(el('div', { class: 'desc', text: 'Drag a node onto its upstream feeder (or use the parent dropdown). Drop onto “(top / grid)” to clear.' }));
+
+    // Add a custom upstream/leaf node.
+    const addBar = el('div', { class: 'ld-toolbar' });
+    const idIn = el('input', { type: 'text', placeholder: 'id (e.g. panel-main)' });
+    const labIn = el('input', { type: 'text', placeholder: 'label (e.g. Main Panel)' });
+    const valIn = el('input', { type: 'number', placeholder: 'known value (optional)', style: { width: '150px' } });
+    const addBtn = btn('Add node', 'primary');
+    addBtn.onclick = () => {
+      const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
+      if (customNodes.some(n => n.Id === id) || (lastGraph && lastGraph.nodes.some(n => n.id === id))) { toast('That id already exists.', false); return; }
+      const node = { Id: id, Label: (labIn.value || '').trim() || id };
+      if (valIn.value !== '' && !isNaN(+valIn.value)) node.Value = +valIn.value;
+      customNodes.push(node); idIn.value = labIn.value = valIn.value = ''; renderEditor();
+    };
+    addBar.append(idIn, labIn, valIn, addBtn); ed.appendChild(addBar);
+
+    // Candidate nodes: everything currently in the graph + custom nodes (deduped).
+    const cand = new Map();
+    (lastGraph?.nodes || []).forEach(n => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
+    customNodes.forEach(n => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: 'node', custom: true }));
+    const setParent = (child, parent) => { if (!parent) delete parents[child]; else if (parent !== child) parents[child] = parent; renderEditor(); };
+
+    // "Top / grid" drop zone clears a node's parent.
+    const root = el('div', { class: 'flow-card', style: { borderStyle: 'dashed', opacity: '0.8' }, text: '⤴ (top / grid) — drop here to clear a feeder' });
+    root.ondragover = e => e.preventDefault();
+    root.ondrop = e => { e.preventDefault(); setParent(e.dataTransfer.getData('text/plain'), ''); };
+    ed.appendChild(root);
+
+    const list = el('div', { class: 'flow-cards' });
+    [...cand.values()].forEach(c => {
+      const card = el('div', { class: 'flow-card', draggable: 'true' });
+      card.ondragstart = e => e.dataTransfer.setData('text/plain', c.id);
+      card.ondragover = e => e.preventDefault();
+      card.ondrop = e => { e.preventDefault(); const dragged = e.dataTransfer.getData('text/plain'); if (dragged) setParent(dragged, c.id); };
+
+      card.appendChild(el('span', { class: 'flow-card-title', text: c.label }));
+      card.appendChild(el('span', { class: 'flow-card-id', text: c.id + (c.custom ? '' : ' · ' + c.kind) }));
+
+      // Parent dropdown (accessible alternative to dragging).
+      const sel = el('select');
+      sel.appendChild(el('option', { value: '', text: 'feeder: (top / grid)' }));
+      [...cand.values()].filter(o => o.id !== c.id).forEach(o => sel.appendChild(el('option', { value: o.id, text: 'feeder: ' + o.label })));
+      sel.value = parents[c.id] || '';
+      sel.onchange = () => setParent(c.id, sel.value);
+      card.appendChild(sel);
+
+      if (c.custom) {
+        const rm = btn('✕', 'danger');
+        rm.onclick = () => {
+          const i = customNodes.findIndex(n => n.Id === c.id); if (i >= 0) customNodes.splice(i, 1);
+          delete parents[c.id];
+          Object.keys(parents).forEach(k => { if (parents[k] === c.id) delete parents[k]; });
+          renderEditor();
+        };
+        card.appendChild(rm);
+      }
+      list.appendChild(card);
+    });
+    ed.appendChild(list);
+
+    const save = btn('Save hierarchy', 'primary');
+    save.onclick = async () => {
+      const r = await api('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(exportData()) });
+      toast(r.body.message || (r.ok ? 'Saved.' : 'Save failed.'), r.ok && r.body.ok);
+      if (r.ok && r.body.ok) load();
+    };
+    const sbar = el('div', { class: 'ld-toolbar', style: { marginTop: '10px' } }); sbar.appendChild(save); ed.appendChild(sbar);
   };
 
   const load = async () => {
     const r = await api(withInstance('/api/flow', instSel));
-    if (!r.body.ok) { wrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load flow data.') + '</div>'; count.textContent = ''; return; }
+    if (!r.body.ok) { wrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load flow data.') + '</div>'; count.textContent = ''; lastGraph = null; renderEditor(); return; }
+    lastGraph = r.body;
     draw(r.body);
+    renderEditor();
   };
   refresh.onclick = load;
   link.onclick = () => { activate(link, sec); load(); };

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -72,6 +72,21 @@ function scalarInput(node, obj) {
   return el;
 }
 
+// Render an object's child properties into `container`: scalar fields flow into a multi-column grid
+// (compact), while nested lists/dicts/objects are tall unbreakable blocks, so they render full-width
+// and stacked — otherwise the CSS column-balancer shoves them into one lopsided column.
+function renderObjectBody(properties, target, container) {
+  const isComplex = c => c.type === 'object' || c.type === 'list' || c.type === 'dictionary';
+  const scalars = (properties || []).filter(c => !isComplex(c));
+  const complex = (properties || []).filter(isComplex);
+  if (scalars.length) {
+    const grid = document.createElement('div'); grid.className = 'grid';
+    scalars.forEach(child => renderNode(child, target, grid));
+    container.appendChild(grid);
+  }
+  complex.forEach(child => renderNode(child, target, container));
+}
+
 // Render an arbitrary node bound to obj[node.key] (the value lives under its key on obj).
 function renderNode(node, obj, container) {
   if (node.type === 'object') {
@@ -79,10 +94,7 @@ function renderNode(node, obj, container) {
     const fs = document.createElement('fieldset');
     const lg = document.createElement('legend'); lg.textContent = node.label; fs.appendChild(lg);
     if (node.description) { const d = document.createElement('div'); d.className = 'desc'; d.textContent = node.description; fs.appendChild(d); }
-    // Lay nested fields out in columns to use the horizontal space.
-    const grid = document.createElement('div'); grid.className = 'grid';
-    (node.properties || []).forEach(child => renderNode(child, target, grid));
-    fs.appendChild(grid);
+    renderObjectBody(node.properties, target, fs);
     container.appendChild(fs);
   } else if (node.type === 'dictionary') {
     container.appendChild(renderMap(node, ensure(obj, node.key, {})));
@@ -128,10 +140,8 @@ function renderValue(valueSchema, holder, keyName, container) {
   const node = Object.assign({}, valueSchema, { key: keyName, label: 'value' });
   if (node.type === 'object') {
     const target = ensure(holder, keyName, {});
-    // Multi-column layout for a dictionary/list entry's fields (e.g. each PDU instance).
-    const grid = document.createElement('div'); grid.className = 'grid';
-    (node.properties || []).forEach(child => renderNode(child, target, grid));
-    container.appendChild(grid);
+    // A dictionary/list entry's fields (e.g. each PDU instance): scalars in columns, collections full-width.
+    renderObjectBody(node.properties, target, container);
   } else {
     renderNode(node, holder, container);
   }
@@ -217,9 +227,7 @@ function renderConfigSection(node, nav, sections) {
   } else {
     if (node.type === 'object') {
       ensure(data, node.key, {});
-      const grid = document.createElement('div'); grid.className = 'grid';
-      (node.properties || []).forEach(c => renderNode(c, data[node.key], grid));
-      sec.appendChild(grid);
+      renderObjectBody(node.properties, data[node.key], sec);
     }
     else renderNode(node, data, sec);
     if (node.key === 'Gui') wireGuiAuth(sec);
@@ -233,10 +241,12 @@ function build() {
   nav.innerHTML = ''; sections.innerHTML = '';
 
   const byKey = new Map(schema.map(n => [n.key, n]));
-  // Any schema section not explicitly grouped lands in General, so a new config section is never lost.
+  // EnergyFlow has a dedicated visual editor on the Flow tab, so its raw schema form is hidden here.
+  const HIDDEN = new Set(['EnergyFlow']);
+  // Any schema section not explicitly grouped (and not hidden) lands in General, so a new config section is never lost.
   const known = new Set(NAV_GROUPS.flatMap(g => g.keys));
   const general = NAV_GROUPS.find(g => g.title === 'General');
-  schema.forEach(n => { if (!known.has(n.key)) general.keys.push(n.key); });
+  schema.forEach(n => { if (!known.has(n.key) && !HIDDEN.has(n.key)) general.keys.push(n.key); });
 
   let first = null;
   for (const g of NAV_GROUPS) {
@@ -425,7 +435,7 @@ function buildK8sTools(container) {
 
 // Direct outlet control (on/off/reboot). A convenient place to exercise write actions.
 function addControlSection(nav, sections) {
-  const link = document.createElement('a'); link.textContent = 'Control'; nav.appendChild(link);
+  const link = document.createElement('a'); link.textContent = 'PDU Control'; nav.appendChild(link);
   const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
   const h = document.createElement('h2'); h.textContent = 'Outlet Control'; sec.appendChild(h);
   const d = document.createElement('div'); d.className = 'desc';
@@ -737,6 +747,28 @@ function svgEl(tag, attrs) {
   return e;
 }
 
+// Mouse-wheel zoom for an SVG inside a scroll container. The SVG must carry a viewBox of its base size;
+// we scale by setting its width/height and keep the point under the cursor fixed. Returns a detach fn.
+function attachZoom(scroll, svg, baseW, baseH) {
+  let z = 1; const min = 0.25, max = 6;
+  const apply = () => { svg.setAttribute('width', Math.round(baseW * z)); svg.setAttribute('height', Math.round(baseH * z)); };
+  apply();
+  const onWheel = e => {
+    e.preventDefault();
+    const r = scroll.getBoundingClientRect();
+    const cx = scroll.scrollLeft + (e.clientX - r.left), cy = scroll.scrollTop + (e.clientY - r.top);
+    const prev = z;
+    z = Math.min(max, Math.max(min, z * (e.deltaY < 0 ? 1.1 : 1 / 1.1)));
+    if (z === prev) return;
+    apply();
+    const k = z / prev;
+    scroll.scrollLeft = cx * k - (e.clientX - r.left);
+    scroll.scrollTop = cy * k - (e.clientY - r.top);
+  };
+  scroll.addEventListener('wheel', onWheel, { passive: false });
+  return () => scroll.removeEventListener('wheel', onWheel);
+}
+
 // A read-only Sankey of power/energy flow (PDU -> outlets) from /api/flow.
 function addFlowSection(nav, sections) {
   const link = document.createElement('a'); link.textContent = 'Flow'; nav.appendChild(link);
@@ -788,19 +820,26 @@ function addFlowSection(nav, sections) {
     nodes.forEach(n => { const c = colMemo[n.id]; (cols[c] = cols[c] || []).push(n); });
 
     const W = 960, padTop = 22, gap = 8, nodeW = 12, usableH = 520;
+    // Labels sit to the right of each node, so reserve a right gutter for them and only a small left pad.
+    const leftPad = 16, rightGutter = 232;
     const maxTotal = Math.max(1, ...cols.map(cn => cn.reduce((s, n) => s + nodeValue(n.id), 0)));
     const pxPerUnit = usableH / maxTotal;
-    const colX = c => 150 + (maxCol > 0 ? c * ((W - 320) / maxCol) : 0);
+    const colX = c => leftPad + (maxCol > 0 ? c * ((W - leftPad - rightGutter - nodeW) / maxCol) : 0);
 
     const pos = {};
+    // Barycenter: a node's preferred y is the value-weighted mean of its (already positioned) feeders.
+    const bary = id => { let w = 0, s = 0; (incoming[id] || []).forEach(l => { const sp = pos[l.source]; if (sp) { s += (sp.y + sp.h / 2) * l.value; w += l.value; } }); return w ? s / w : Infinity; };
     cols.forEach((cn, c) => {
-      cn.sort((a, b) => nodeValue(b.id) - nodeValue(a.id));
+      // Roots stack by size; downstream columns follow their feeder's order (groups children, avoids crossings).
+      if (c === 0) cn.sort((a, b) => nodeValue(b.id) - nodeValue(a.id));
+      else cn.sort((a, b) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
       let y = padTop;
       cn.forEach(n => { const h = Math.max(2, nodeValue(n.id) * pxPerUnit); pos[n.id] = { x: colX(c), y, h, outOff: 0, inOff: 0 }; y += h + gap; });
     });
 
-    const totalH = padTop * 2 + usableH;
-    const svg = svgEl('svg', { width: '100%', viewBox: `0 0 ${W} ${totalH}`, style: 'max-width:960px' });
+    // Fit the viewBox to the tallest column (stacking gaps push it past usableH), so nothing clips.
+    const totalH = Math.ceil(Math.max(padTop + usableH, ...nodes.map(n => pos[n.id] ? pos[n.id].y + pos[n.id].h : 0))) + padTop;
+    const svg = svgEl('svg', { viewBox: `0 0 ${W} ${totalH}`, width: W, height: totalH, style: 'display:block' });
     const colors = ['#49f', '#4f9', '#fa4', '#f49', '#9f4', '#4ff', '#f94', '#a9f'];
 
     // Ribbons (filled bezier bands), stacked on each node edge by target order.
@@ -815,113 +854,148 @@ function addFlowSection(nav, sections) {
       s.outOff += h; t.inOff += h;
     });
 
-    // Nodes + labels (above each node).
+    // Nodes + labels (to the right of each node, vertically centered; a bg halo keeps them legible
+    // where they cross a ribbon).
     nodes.forEach(n => {
       const p = pos[n.id]; if (!p) return;
       svg.appendChild(svgEl('rect', { x: p.x, y: p.y, width: nodeW, height: p.h, rx: 2, fill: colors[colMemo[n.id] % colors.length] }));
-      const lab = svgEl('text', { x: p.x, y: p.y - 4, fill: 'var(--fg)', 'font-size': '11', 'font-weight': n.kind === 'outlet' ? '400' : '600' });
+      const lab = svgEl('text', {
+        x: p.x + nodeW + 6, y: p.y + p.h / 2, fill: 'var(--fg)', 'font-size': '11', 'font-weight': n.kind === 'outlet' ? '400' : '600',
+        'dominant-baseline': 'middle', 'paint-order': 'stroke', stroke: 'var(--panel2)', 'stroke-width': '3', 'stroke-linejoin': 'round',
+      });
       lab.textContent = `${n.label} · ${formatNum(nodeValue(n.id))} ${units}`;
       svg.appendChild(lab);
     });
 
     count.textContent = `${nodes.length} node(s) · ${links.length} link(s)`;
-    wrap.appendChild(svg);
+    const scroll = el('div', { style: { overflow: 'auto', maxHeight: '74vh', border: '1px solid var(--line)', borderRadius: '6px' } });
+    scroll.appendChild(svg); wrap.appendChild(scroll);
+    attachZoom(scroll, svg, W, totalH);  // scroll-into-view container is replaced on each draw(), so no leak.
   };
 
-  // --- Node-graph hierarchy editor: drag nodes to arrange, drag a node's port onto another to set
-  //     its feeder (parent->child). Positions persist per-instance in localStorage. ---
-  const NW = 172, NH = 46;
-  const posKey = () => 'rpdu-flowpos:' + (instSel.get() || 'default');
-  const loadPos = () => { try { return JSON.parse(localStorage.getItem(posKey())) || {}; } catch { return {}; } };
-  const savePos = p => { try { localStorage.setItem(posKey(), JSON.stringify(p)); } catch { /* ignore */ } };
+  // --- Hierarchy editor: a layered, left→right arrow graph (energy flows source → target). Drag from a
+  //     node's right ● output port onto another node to add a directed feed. A node can have many feeders
+  //     (a transfer switch fed by grid + generator + inverter) and producers are just feeds pointing into
+  //     what they power (solar → inverter). Columns are auto-laid-out by depth to minimise crossings. ---
+  const colors = ['#4f8cff', '#46c46a', '#fa4', '#f49', '#9f4', '#4ff'];
+  const NW = 190, NH = 46;
 
   const renderEditor = () => {
     if (ed._cleanup) ed._cleanup();
     const flow = ensure(data, 'EnergyFlow', {});
     const customNodes = ensure(flow, 'Nodes', []);
-    const parents = ensure(flow, 'Parents', {});
+    const links = ensure(flow, 'Links', []);
+    const legacy = ensure(flow, 'Parents', {});
+    // One-time migration: fold any legacy single-feeder Parents (child→parent) into directed Links.
+    if (Object.keys(legacy).length) {
+      Object.entries(legacy).forEach(([child, parent]) => { if (parent && child && !links.some(l => l.From === parent && l.To === child)) links.push({ From: parent, To: child }); });
+      Object.keys(legacy).forEach(k => delete legacy[k]);
+    }
     ed.innerHTML = '';
 
     ed.appendChild(el('h3', { text: 'Hierarchy', style: { margin: '4px 0' } }));
-    ed.appendChild(el('div', { class: 'desc', text: 'Drag a node by its body to arrange it. To set what feeds a node, drag from the feeder’s right ● onto the target node (it highlights green) — each node has exactly one feeder, so this replaces any existing one. Click ✕ on a link to clear it (an outlet reverts to its own PDU).' }));
+    ed.appendChild(el('div', { class: 'desc', text: 'Energy flows left → right. Drag from a node’s right ● onto another node to add a feed (source powers target). A node can have several feeders, and a producer is just a feed into what it powers — e.g. drag from Solar onto your inverter. The target highlights green when in range; click ✕ on a link to remove it. PDU → outlet links are auto-derived (dashed) until you wire an explicit feeder.' }));
 
     const addBar = el('div', { class: 'ld-toolbar' });
-    const idIn = el('input', { type: 'text', placeholder: 'id (e.g. panel-main)' });
-    const labIn = el('input', { type: 'text', placeholder: 'label (e.g. Main Panel)' });
+    const idIn = el('input', { type: 'text', placeholder: 'id (e.g. gridboss)' });
+    const labIn = el('input', { type: 'text', placeholder: 'label (e.g. Grid Boss)' });
     const valIn = el('input', { type: 'number', placeholder: 'known value (optional)', style: { width: '150px' } });
     const addBtn = btn('Add node', 'primary');
     const save = btn('Save hierarchy', 'primary');
     addBar.append(idIn, labIn, valIn, addBtn, save); ed.appendChild(addBar);
 
-    // Candidate nodes (graph + custom) and the edges between them.
+    // Candidate nodes (from the built graph + custom defs).
     const cand = new Map();
     (lastGraph?.nodes || []).forEach(n => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
     customNodes.forEach(n => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: 'node', custom: true }));
+    const nm = id => (cand.get(id) || {}).label || id;
+    const byLabel = (a, b) => (cand.get(a).label || a).localeCompare(cand.get(b).label || b);
 
     const autoParent = id => { const m = /^outlet:(.+):\d+$/.exec(id); return m ? 'pdu:' + m[1] : null; };
-    const parentOf = id => parents[id] || autoParent(id);
-    const depth = (id, seen) => { seen = seen || new Set(); if (seen.has(id)) return 0; seen.add(id); const p = parentOf(id); return (p && cand.has(p)) ? depth(p, seen) + 1 : 0; };
 
-    // Auto-layout any node without a saved position (column = depth, stacked per column).
-    const pos = loadPos();
-    const perCol = {};
-    [...cand.values()].forEach(c => {
-      if (!pos[c.id]) { const dc = depth(c.id); const r = (perCol[dc] = perCol[dc] || 0); pos[c.id] = { x: 24 + dc * (NW + 90), y: 20 + r * (NH + 22) }; perCol[dc] = r + 1; }
-    });
-
-    // One feeder per node: an explicit (custom) parent replaces the auto-derived PDU link.
+    // Edges: explicit directed Links, plus the auto PDU → outlet feed (suppressed once an outlet is
+    // explicitly fed). `custom` edges are user links (deletable); auto edges are dashed and fixed.
+    const customTo = new Set(links.map(l => l.To));
     const edges = [];
-    cand.forEach(c => {
-      const cp = parents[c.id];
-      if (cp && cand.has(cp)) { edges.push({ from: cp, to: c.id, custom: true }); return; }
-      const ap = autoParent(c.id);
-      if (ap && cand.has(ap)) edges.push({ from: ap, to: c.id, custom: false });
+    cand.forEach(c => { const ap = autoParent(c.id); if (ap && cand.has(ap) && !customTo.has(c.id)) edges.push({ from: ap, to: c.id, custom: false }); });
+    links.forEach(l => { if (cand.has(l.From) && cand.has(l.To)) edges.push({ from: l.From, to: l.To, custom: true, ref: l }); });
+
+    // Adjacency + column = longest path from a root (every edge therefore points strictly rightward).
+    const incoming = {}, outgoing = {};
+    cand.forEach((_, id) => { incoming[id] = []; outgoing[id] = []; });
+    edges.forEach(e => { outgoing[e.from].push(e); incoming[e.to].push(e); });
+    const colMemo = {};
+    const col = (id, seen) => {
+      if (colMemo[id] != null) return colMemo[id];
+      seen = seen || new Set(); if (seen.has(id)) return 0; seen.add(id);
+      const ins = incoming[id] || [];
+      const c = ins.length ? Math.max(...ins.map(e => col(e.from, seen) + 1)) : 0;
+      seen.delete(id); return colMemo[id] = c;
+    };
+    [...cand.keys()].forEach(id => col(id));
+    // Would adding from→to create a loop? (can `to` already reach `from`?)
+    const reaches = (a, b) => { const stack = [a], seen = new Set(); while (stack.length) { const x = stack.pop(); if (x === b) return true; if (seen.has(x)) continue; seen.add(x); (outgoing[x] || []).forEach(e => stack.push(e.to)); } return false; };
+
+    // Layout: stack each column top-to-bottom; order downstream columns by feeder barycenter.
+    const padX = 22, padY = 18, rowGap = 16, step = NW + 96;
+    const cols = [];
+    [...cand.keys()].forEach(id => { const c = col(id); (cols[c] = cols[c] || []).push(id); });
+    const pos = {};
+    const bary = id => { const ins = incoming[id] || []; if (!ins.length) return 1e9; let s = 0, w = 0; ins.forEach(e => { const p = pos[e.from]; if (p) { s += p.y + NH / 2; w++; } }); return w ? s / w : 1e9; };
+    cols.forEach((ids, c) => {
+      if (c === 0) ids.sort((a, b) => (cand.get(a).kind === 'pdu' ? 0 : 1) - (cand.get(b).kind === 'pdu' ? 0 : 1) || byLabel(a, b));
+      else ids.sort((a, b) => (bary(a) - bary(b)) || byLabel(a, b));
+      let y = padY;
+      ids.forEach(id => { pos[id] = { x: padX + c * step, y }; y += NH + rowGap; });
     });
 
-    const allX = [...cand.values()].map(c => pos[c.id].x), allY = [...cand.values()].map(c => pos[c.id].y);
-    const W = Math.max(600, Math.max(...allX, 0) + NW + 40), H = Math.max(280, Math.max(...allY, 0) + NH + 40);
-    const scroll = el('div', { style: { overflow: 'auto', border: '1px solid var(--line)', borderRadius: '6px', marginTop: '10px', maxHeight: '640px' } });
-    const svg = svgEl('svg', { width: W, height: H, style: 'background:var(--panel2)' });
+    const W = Math.max(640, ...[...cand.keys()].map(id => pos[id].x + NW + padX));
+    const H = Math.max(260, ...[...cand.keys()].map(id => pos[id].y + NH + padY));
+    const scroll = el('div', { style: { overflow: 'auto', border: '1px solid var(--line)', borderRadius: '6px', marginTop: '10px', maxHeight: '72vh' } });
+    const svg = svgEl('svg', { viewBox: `0 0 ${W} ${H}`, width: W, height: H, style: 'background:var(--panel2); display:block' });
     scroll.appendChild(svg); ed.appendChild(scroll);
+    const detachZoom = attachZoom(scroll, svg, W, H);
+    const defs = svgEl('defs', {}); svg.appendChild(defs);
+    [['fh-arrow', 'var(--line)'], ['fh-arrow-c', '#5ab0ff']].forEach(([id, fill]) => {
+      const mk = svgEl('marker', { id, viewBox: '0 0 10 10', refX: '9', refY: '5', markerWidth: '7', markerHeight: '7', orient: 'auto-start-reverse' });
+      mk.appendChild(svgEl('path', { d: 'M0,0 L10,5 L0,10 z', fill })); defs.appendChild(mk);
+    });
     const edgeLayer = svgEl('g', {}); svg.appendChild(edgeLayer);
     const nodeLayer = svgEl('g', {}); svg.appendChild(nodeLayer);
-    const colors = ['#49f', '#4f9', '#fa4', '#f49', '#9f4', '#4ff'];
 
-    const edgeD = e => { const a = pos[e.from], b = pos[e.to], x1 = a.x + NW, y1 = a.y + NH / 2, x2 = b.x, y2 = b.y + NH / 2, xc = (x1 + x2) / 2; return `M${x1},${y1} C${xc},${y1} ${xc},${y2} ${x2},${y2}`; };
-    const edgeEls = [];
+    const edgeD = (a, b) => { const x1 = a.x + NW, y1 = a.y + NH / 2, x2 = b.x, y2 = b.y + NH / 2, xc = (x1 + x2) / 2; return `M${x1},${y1} C${xc},${y1} ${xc},${y2} ${x2},${y2}`; };
     edges.forEach(e => {
-      const p = svgEl('path', { d: edgeD(e), fill: 'none', stroke: e.custom ? '#5ab0ff' : 'var(--line)', 'stroke-width': e.custom ? 2 : 1.5, 'stroke-dasharray': e.custom ? '' : '4 3', 'pointer-events': 'none' });
-      edgeLayer.appendChild(p); edgeEls.push({ e, p });
+      const a = pos[e.from], b = pos[e.to];
+      edgeLayer.appendChild(svgEl('path', { d: edgeD(a, b), fill: 'none', stroke: e.custom ? '#5ab0ff' : 'var(--line)', 'stroke-width': e.custom ? 2 : 1.5, 'stroke-dasharray': e.custom ? '' : '4 3', 'marker-end': `url(#${e.custom ? 'fh-arrow-c' : 'fh-arrow'})`, 'pointer-events': 'none' }));
       if (e.custom) {
-        const a = pos[e.from], b = pos[e.to], mx = (a.x + NW + b.x) / 2, my = (a.y + b.y) / 2 + NH / 2;
+        // Drifting dashes along the link, hinting at flow direction.
+        edgeLayer.appendChild(svgEl('path', { class: 'flow-line', d: edgeD(a, b), fill: 'none', stroke: '#cfe8ff', 'stroke-opacity': '0.85', 'stroke-width': '2.6', 'stroke-linecap': 'round', 'stroke-dasharray': '7 11', 'pointer-events': 'none' }));
+        const mx = (a.x + NW + b.x) / 2, my = (a.y + b.y) / 2 + NH / 2;
         const del = svgEl('text', { x: mx, y: my, 'text-anchor': 'middle', 'dominant-baseline': 'middle', fill: 'var(--bad)', 'font-size': '15', style: 'cursor:pointer' });
-        del.textContent = '✕'; del.onclick = () => { delete parents[e.to]; renderEditor(); };
+        del.textContent = '✕'; del.onclick = () => { const i = links.indexOf(e.ref); if (i >= 0) links.splice(i, 1); toast(`${nm(e.from)} → ${nm(e.to)} removed.`, true); renderEditor(); };
         edgeLayer.appendChild(del);
       }
     });
 
     const nodeG = {};
     [...cand.values()].forEach(c => {
-      const g = svgEl('g', { transform: `translate(${pos[c.id].x},${pos[c.id].y})`, style: 'cursor:grab' }); g.dataset.id = c.id;
-      const color = colors[depth(c.id) % colors.length];
+      const p = pos[c.id], color = colors[col(c.id) % colors.length];
+      const g = svgEl('g', { transform: `translate(${p.x},${p.y})`, style: 'cursor:default' }); g.dataset.id = c.id;
       g.appendChild(svgEl('rect', { width: NW, height: NH, rx: 7, fill: 'var(--panel)', stroke: color, 'stroke-width': 2 }));
-      const t1 = svgEl('text', { x: 11, y: 19, fill: 'var(--fg)', 'font-size': '12', 'font-weight': '600' }); t1.textContent = c.label.length > 24 ? c.label.slice(0, 23) + '…' : c.label; g.appendChild(t1);
+      const t1 = svgEl('text', { x: 11, y: 19, fill: 'var(--fg)', 'font-size': '12', 'font-weight': '600' }); t1.textContent = c.label.length > 26 ? c.label.slice(0, 25) + '…' : c.label; g.appendChild(t1);
       const t2 = svgEl('text', { x: 11, y: 35, fill: 'var(--muted)', 'font-size': '10' }); t2.textContent = c.id; g.appendChild(t2);
       g.appendChild(svgEl('circle', { cx: NW, cy: NH / 2, r: 7, fill: color, style: 'cursor:crosshair', 'data-port': c.id }));
-      if (c.custom) {
-        const rm = svgEl('text', { x: NW - 12, y: 15, fill: 'var(--bad)', 'font-size': '13', style: 'cursor:pointer', 'data-rm': c.id }); rm.textContent = '✕'; g.appendChild(rm);
-      }
+      if (c.custom) { const rm = svgEl('text', { x: NW - 13, y: 15, fill: 'var(--bad)', 'font-size': '13', style: 'cursor:pointer', 'data-rm': c.id }); rm.textContent = '✕'; g.appendChild(rm); }
       nodeLayer.appendChild(g); nodeG[c.id] = g;
     });
 
-    // Interactions.
-    const rect = () => svg.getBoundingClientRect();
-    let drag = null, linkFrom = null, tempLine = null, hovered = null;
-    // Walking up the feeder chain from `parent`, do we hit `child`? (prevents loops)
-    const wouldCycle = (child, parent) => { let p = parent, g = 0; while (p && g++ < 1000) { if (p === child) return true; p = parents[p] || autoParent(p); } return false; };
+    // Interactions: drag a node's output port onto another node to add a directed feed. Map screen
+    // coords through the SVG CTM so the drag line stays correct under zoom/scroll.
+    const toUser = (cx, cy) => new DOMPoint(cx, cy).matrixTransform(svg.getScreenCTM().inverse());
+    let linkFrom = null, tempLine = null, hovered = null;
     const highlight = id => {
       if (id === hovered) return;
-      if (hovered && nodeG[hovered]) { const rc = nodeG[hovered].querySelector('rect'); rc.setAttribute('stroke', colors[depth(hovered) % colors.length]); rc.setAttribute('stroke-width', '2'); }
+      if (hovered && nodeG[hovered]) { const rc = nodeG[hovered].querySelector('rect'); rc.setAttribute('stroke', colors[col(hovered) % colors.length]); rc.setAttribute('stroke-width', '2'); }
       hovered = id;
       if (hovered && nodeG[hovered]) { const rc = nodeG[hovered].querySelector('rect'); rc.setAttribute('stroke', '#46c46a'); rc.setAttribute('stroke-width', '3'); }
     };
@@ -929,30 +1003,30 @@ function addFlowSection(nav, sections) {
     const onDown = e => {
       const portId = e.target.getAttribute && e.target.getAttribute('data-port');
       const rmId = e.target.getAttribute && e.target.getAttribute('data-rm');
-      if (rmId) { const i = customNodes.findIndex(n => n.Id === rmId); if (i >= 0) customNodes.splice(i, 1); delete parents[rmId]; Object.keys(parents).forEach(k => { if (parents[k] === rmId) delete parents[k]; }); renderEditor(); return; }
-      if (portId) { linkFrom = portId; tempLine = svgEl('path', { d: '', fill: 'none', stroke: '#5ab0ff', 'stroke-width': 2, 'stroke-dasharray': '4 3', 'pointer-events': 'none' }); edgeLayer.appendChild(tempLine); e.preventDefault(); return; }
-      const g = e.target.closest && e.target.closest('g[data-id]');
-      if (g) { const r = rect(); drag = { id: g.dataset.id, ox: (e.clientX - r.left) - pos[g.dataset.id].x, oy: (e.clientY - r.top) - pos[g.dataset.id].y }; e.preventDefault(); }
+      if (rmId) { const i = customNodes.findIndex(n => n.Id === rmId); if (i >= 0) customNodes.splice(i, 1); for (let j = links.length - 1; j >= 0; j--) if (links[j].From === rmId || links[j].To === rmId) links.splice(j, 1); renderEditor(); return; }
+      if (portId) { linkFrom = portId; tempLine = svgEl('path', { d: '', fill: 'none', stroke: '#5ab0ff', 'stroke-width': 2, 'stroke-dasharray': '4 3', 'pointer-events': 'none' }); edgeLayer.appendChild(tempLine); e.preventDefault(); }
     };
     const onMove = e => {
-      const r = rect(), mx = e.clientX - r.left, my = e.clientY - r.top;
-      if (drag) { pos[drag.id] = { x: Math.max(0, mx - drag.ox), y: Math.max(0, my - drag.oy) }; nodeG[drag.id].setAttribute('transform', `translate(${pos[drag.id].x},${pos[drag.id].y})`); edgeEls.forEach(({ e, p }) => { if (e.from === drag.id || e.to === drag.id) p.setAttribute('d', edgeD(e)); }); }
-      else if (linkFrom) { const a = pos[linkFrom]; tempLine.setAttribute('d', `M${a.x + NW},${a.y + NH / 2} L${mx},${my}`); highlight(targetUnder(e.clientX, e.clientY)); }
+      if (!linkFrom) return;
+      const u = toUser(e.clientX, e.clientY), a = pos[linkFrom];
+      tempLine.setAttribute('d', `M${a.x + NW},${a.y + NH / 2} L${u.x},${u.y}`);
+      highlight(targetUnder(e.clientX, e.clientY));
     };
     const onUp = e => {
-      if (drag) { savePos(pos); drag = null; return; }
-      if (linkFrom) {
-        const src = linkFrom, tgt = targetUnder(e.clientX, e.clientY);
-        if (tempLine) tempLine.remove(); linkFrom = null; highlight(null);
-        if (!tgt) return;
-        if (wouldCycle(tgt, src)) { toast('That would create a feeder loop.', false); return; }
-        parents[tgt] = src; renderEditor();
-      }
+      if (!linkFrom) return;
+      const src = linkFrom, tgt = targetUnder(e.clientX, e.clientY);
+      if (tempLine) tempLine.remove(); linkFrom = null; highlight(null);
+      if (!tgt || src === tgt) return;
+      if (reaches(tgt, src)) { toast('That would create a feeder loop.', false); return; }
+      if (links.some(l => l.From === src && l.To === tgt)) { toast('That feed already exists.', false); return; }
+      links.push({ From: src, To: tgt });
+      toast(`${nm(src)} → ${nm(tgt)} added.`, true);
+      renderEditor();
     };
     svg.addEventListener('mousedown', onDown);
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
-    ed._cleanup = () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); };
+    ed._cleanup = () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); detachZoom(); };
 
     addBtn.onclick = () => {
       const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }

--- a/rPDU2MQTT.Web/wwwroot/styles.css
+++ b/rPDU2MQTT.Web/wwwroot/styles.css
@@ -70,3 +70,8 @@
   .actions { position:sticky; bottom:0; background:var(--panel); border-top:1px solid var(--line); padding:12px 28px; display:flex; gap:10px; align-items:center; margin:24px -28px -24px; }
   .toast { margin-left:auto; font-size:13px; } .toast.good { color:var(--good); } .toast.bad { color:var(--bad); }
   .tools button { margin-right:8px; }
+
+  /* Subtle "energy flowing" effect: dashes drift source -> target along each link's centerline. */
+  @keyframes rpdu-flow { to { stroke-dashoffset:-18; } }
+  .flow-line { animation:rpdu-flow 1s linear infinite; }
+  @media (prefers-reduced-motion: reduce) { .flow-line { animation:none; } }

--- a/rPDU2MQTT.Web/wwwroot/styles.css
+++ b/rPDU2MQTT.Web/wwwroot/styles.css
@@ -70,3 +70,8 @@
   .actions { position:sticky; bottom:0; background:var(--panel); border-top:1px solid var(--line); padding:12px 28px; display:flex; gap:10px; align-items:center; margin:24px -28px -24px; }
   .toast { margin-left:auto; font-size:13px; } .toast.good { color:var(--good); } .toast.bad { color:var(--bad); }
   .tools button { margin-right:8px; }
+  .flow-cards { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; }
+  .flow-card { display:flex; align-items:center; gap:8px; padding:6px 10px; border:1px solid var(--line); border-radius:6px; background:var(--panel); cursor:grab; }
+  .flow-card[draggable=true]:active { cursor:grabbing; }
+  .flow-card-title { font-weight:600; }
+  .flow-card-id { color:var(--muted); font-size:11px; }

--- a/rPDU2MQTT.Web/wwwroot/styles.css
+++ b/rPDU2MQTT.Web/wwwroot/styles.css
@@ -70,8 +70,3 @@
   .actions { position:sticky; bottom:0; background:var(--panel); border-top:1px solid var(--line); padding:12px 28px; display:flex; gap:10px; align-items:center; margin:24px -28px -24px; }
   .toast { margin-left:auto; font-size:13px; } .toast.good { color:var(--good); } .toast.bad { color:var(--bad); }
   .tools button { margin-right:8px; }
-  .flow-cards { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; }
-  .flow-card { display:flex; align-items:center; gap:8px; padding:6px 10px; border:1px solid var(--line); border-radius:6px; background:var(--panel); cursor:grab; }
-  .flow-card[draggable=true]:active { cursor:grabbing; }
-  .flow-card-title { font-weight:600; }
-  .flow-card-id { color:var(--muted); font-size:11px; }


### PR DESCRIPTION
The other half of the energy-flow feature (with #97): define how nodes feed each other so the Sankey shows the **full path** — `outlet → PDU → panel → transfer switch → grid` — not just PDU → outlet. Foundation for #128 (HA energy hierarchy).

Models a real homelab supply: a transfer switch ("Grid Boss") fed by **grid + generator + inverter**, with **solar producing into** the inverter — i.e. a directed graph, not a tree.

## Model
- `EnergyFlowConfig`: custom **`Nodes`** (panels, breakers, transfer-switch outputs, a "Total", producers like solar/grid) + a directed **`Links`** list (`From → To`, energy flows that way).
  - A node can be the `To` of **several links** (multiple feeders). A **producer** is just a link into what it powers (`solar → inverter`). Legacy single-feeder `Parents` are still honored and folded into `Links` on load.
- A node may carry an optional **`Value`** — a directly-known leaf figure. This is the **seam where external sensors bind**: today a manual/known figure (model panels *before* their CT clamps are ingested); later a node binds to a live measurement from any producer.

## Builder (`FlowGraphBuilder`)
Merges custom nodes/links with the auto-derived PDU → outlet flow, then values every link:
- **Demand is split among a node's feeders**, so a node reachable by several paths (a diamond) isn't double-counted and the Sankey balances (in = out).
- **Measured producers** carry their generation onto the link.
- **Loop guard**: any link that would form a self-loop or close a cycle is dropped at build time, so the graph stays a DAG even if the config is hand-edited to bypass the editor.

Wired into `GET /api/v1/flow` (REST) and `GET /api/flow` (GUI).

## GUI
- **Flow tab** — a **layered Sankey** (labels right of each node, fit-to-content, barycenter-ordered to reduce crossings) above a **layered arrow-graph hierarchy editor**: drag a node's output port onto another to add a directed feed (multi-feeder + producers supported), click ✕ to remove, ✕ a node to delete it. Animated flow lines on custom links.
- **Mouse-wheel zoom** (cursor-anchored) on both the Sankey and the editor.
- **Live apply on save** — hierarchy edits now take effect on the next refresh instead of needing a restart (`/api/flow` reads `config.EnergyFlow`, which the save handler now refreshes in memory).
- Hid the redundant raw `EnergyFlow` config form (the Flow tab is the editor); renamed **Control → PDU Control**; fixed nested list/dict config sections being crammed into a multi-column grid.

## Source-agnostic by design
Serves the v2.0 end goal — managing the **complete** energy flow across heterogeneous sources. PDU is just the first leaf source; planned producers (CT clamps over MQTT/emoncms, Tigo solar → strings → MPPT → inverter) plug into the **same** graph + editor + Sankey.

## Verification
**95 tests**, incl. multi-feeder, producer values, diamond demand-split, a hand-edited **cyclic config** (must not hang; loop-closing edges dropped), and the **save → reload** serialization round-trip behind the live-apply fix. Solution builds clean (0 warnings); `app.js` parses.

> Note: the save → live-reload path is covered by a serialization round-trip test; the HTTP handler itself is verified by inspection — worth a quick manual round-trip against live PDUs before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
