### PR TITLE
fix(flow): split a producer's generation across its consumers (#129)

### DIFF
--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -118,8 +118,7 @@ public static class FlowGraphBuilder
                 inCount[to] = inCount.GetValueOrDefault(to) + 1;
 
         // Need(id): power this node must receive = its known value (outlet sink or producer), else the sum
-        // of the flows on its outgoing links. EdgeFlow: a producer supplies its measured generation; a
-        // demand link carries its share (target demand ÷ number of feeders). Memoized + cycle-guarded.
+        // of the flows on its outgoing links. Memoized + cycle-guarded.
         var needMemo = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
         double Need(string id, HashSet<string> path)
         {
@@ -132,10 +131,20 @@ public static class FlowGraphBuilder
             needMemo[id] = v;
             return v;
         }
+        // EdgeFlow(from -> to): a demand link carries the target's demand split among its feeders. A
+        // producer supplies its measured generation, divided across the things it powers in proportion to
+        // their downstream demand (equal split if none draw anything) — so a producer feeding several
+        // consumers isn't counted once per link.
         double EdgeFlow(string from, string to, HashSet<string> path)
-            => leaf.TryGetValue(from, out var produced)
-                ? produced
-                : Need(to, path) / Math.Max(1, inCount.GetValueOrDefault(to));
+        {
+            if (!leaf.TryGetValue(from, out var produced))
+                return Need(to, path) / Math.Max(1, inCount.GetValueOrDefault(to));
+
+            var kids = outgoing.TryGetValue(from, out var k) ? k : new List<string>();
+            if (kids.Count <= 1) return produced;
+            var totalDemand = kids.Sum(c => Need(c, path));
+            return totalDemand > 0 ? produced * Need(to, path) / totalDemand : produced / kids.Count;
+        }
 
         // Emit one link per edge, valued by the flow it carries.
         var links = new List<FlowLink>();

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -178,6 +178,63 @@ public class FlowGraphTests
     }
 
     [Fact]
+    public void Build_ProducerFeedingMultipleConsumers_SplitsGenerationByDemand()
+    {
+        // Solar powers two PDUs drawing 100W and 300W. Its 800W generation must split 1:3 across the two
+        // links (200 / 600), not show 800 on each — i.e. the producer isn't counted once per consumer.
+        var d1 = new Device { Key = "pdu1", Entity_Name = "pdu1", Entity_DisplayName = "PDU 1" };
+        d1.Outlets.Add(Outlet(0, "LoadA", "realpower", "100"));
+        var d2 = new Device { Key = "pdu2", Entity_Name = "pdu2", Entity_DisplayName = "PDU 2" };
+        d2.Outlets.Add(Outlet(0, "LoadB", "realpower", "300"));
+        var data = new PduData();
+        data.Devices.Add(d1);
+        data.Devices.Add(d2);
+
+        var flow = new EnergyFlowConfig
+        {
+            Nodes = { new EnergyFlowNode { Id = "solar", Label = "Solar", Value = 800 } },
+            Links =
+            {
+                new EnergyFlowLink { From = "solar", To = "pdu:pdu1" },
+                new EnergyFlowLink { From = "solar", To = "pdu:pdu2" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal(200, graph.Links.Single(l => l.Source == "solar" && l.Target == "pdu:pdu1").Value);
+        Assert.Equal(600, graph.Links.Single(l => l.Source == "solar" && l.Target == "pdu:pdu2").Value);
+        Assert.Equal(800, graph.Links.Where(l => l.Source == "solar").Sum(l => l.Value)); // total generation preserved
+    }
+
+    [Fact]
+    public void Build_ProducerFeedingConsumersWithNoDemand_SplitsEqually()
+    {
+        // No downstream load yet (modelling before sensors bind): fall back to an even split of generation.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "10"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "solar", Label = "Solar", Value = 900 },
+                new EnergyFlowNode { Id = "a", Label = "A" },
+                new EnergyFlowNode { Id = "b", Label = "B" },
+                new EnergyFlowNode { Id = "c", Label = "C" },
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "solar", To = "a" },
+                new EnergyFlowLink { From = "solar", To = "b" },
+                new EnergyFlowLink { From = "solar", To = "c" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.All(new[] { "a", "b", "c" }, t => Assert.Equal(300, graph.Links.Single(l => l.Source == "solar" && l.Target == t).Value));
+    }
+
+    [Fact]
     public void Build_DiamondPaths_SplitDemandAmongFeeders_NoDoubleCount()
     {
         // A panel reachable from the boss both directly AND via a sub-panel (a diamond). The 100W of real


### PR DESCRIPTION
Follow-up to #156 (energy hierarchy). Fixes the producer-split limitation noted in that PR.

## Problem
A **producer** node — one with a known `Value` that *feeds* other nodes (solar, generator, grid) — put its **full value on every outgoing link**. So a producer feeding several consumers was counted once per link: solar (800 W) → inverter A + inverter B showed 800 W on *each*, i.e. 1600 W of phantom generation.

## Fix
`FlowGraphBuilder` now divides a producer's generation across the things it powers, **in proportion to each consumer's downstream demand** (even split when nothing draws yet). Total generation is preserved, not multiplied.

- Single-consumer producers: unchanged (full value on the one link).
- Demand-driven (non-producer) links: unchanged — still split a node's demand among its feeders (#156).

Example — solar 800 W feeding PDUs that draw 100 W and 300 W now emits **200 W** and **600 W** (1:3), summing to 800 W.

## Tests
`Build_ProducerFeedingMultipleConsumers_SplitsGenerationByDemand` (proportional) and `Build_ProducerFeedingConsumersWithNoDemand_SplitsEqually` (even fallback). **97 tests pass**, builds clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
