### PR TITLE
feat(host): role-selectable startup (worker/api/ui), default all (#127)

### DIFF
--- a/rPDU2MQTT.Tests/HostRoleTests.cs
+++ b/rPDU2MQTT.Tests/HostRoleTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Configuration;
+using rPDU2MQTT.Startup;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>HostRoles.Resolve: which workload(s) a process runs, from --role / RPDU2MQTT_ROLE.</summary>
+public class HostRoleTests
+{
+    private static IConfiguration Cfg(params (string key, string val)[] kv)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(kv.Select(x => new KeyValuePair<string, string?>(x.key, x.val)))
+            .Build();
+
+    [Fact]
+    public void DefaultsToAll_WhenUnset() => Assert.Equal(HostRole.All, HostRoles.Resolve(Cfg()));
+
+    [Theory]
+    [InlineData("worker", HostRole.Worker)]
+    [InlineData("engine", HostRole.Worker)]
+    [InlineData("data", HostRole.Worker)]
+    [InlineData("api", HostRole.Api)]
+    [InlineData("ui", HostRole.Ui)]
+    [InlineData("gui", HostRole.Ui)]
+    [InlineData("web", HostRole.Ui)]
+    [InlineData("all", HostRole.All)]
+    public void ParsesSingleRole(string raw, HostRole expected) => Assert.Equal(expected, HostRoles.Resolve(Cfg(("role", raw))));
+
+    [Fact]
+    public void ParsesCommaSeparatedList() => Assert.Equal(HostRole.Api | HostRole.Ui, HostRoles.Resolve(Cfg(("role", "api, ui"))));
+
+    [Fact]
+    public void UnknownRoleFallsBackToAll() => Assert.Equal(HostRole.All, HostRoles.Resolve(Cfg(("role", "bogus"))));
+
+    [Fact]
+    public void ReadsEnvironmentKey() => Assert.Equal(HostRole.Worker, HostRoles.Resolve(Cfg(("RPDU2MQTT_ROLE", "worker"))));
+
+    [Fact]
+    public void CommandLineRoleTakesPrecedenceOverEnv() => Assert.Equal(HostRole.Api, HostRoles.Resolve(Cfg(("role", "api"), ("RPDU2MQTT_ROLE", "worker"))));
+}

--- a/rPDU2MQTT/Startup/HostRole.cs
+++ b/rPDU2MQTT/Startup/HostRole.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Configuration;
+
+namespace rPDU2MQTT.Startup;
+
+/// <summary>
+/// Which workload(s) this process runs. The components live in one solution and one executable; the
+/// active role(s) decide which hosted services start. Default is <see cref="All"/> — a single node that
+/// does everything — but the same binary can run a single role per process to scale out (e.g. several
+/// <see cref="Worker"/>s behind one <see cref="Ui"/>). Cross-role communication is in-process today;
+/// a message-bus transport (the existing MQTT broker) is the planned seam for a distributed deployment.
+/// </summary>
+[Flags]
+public enum HostRole
+{
+    None = 0,
+    /// <summary>Automation / data processing: PDU pollers, MQTT publish, exporters, discovery, control.</summary>
+    Worker = 1,
+    /// <summary>Middle tier: the read-only REST API.</summary>
+    Api = 2,
+    /// <summary>The configuration GUI.</summary>
+    Ui = 4,
+    All = Worker | Api | Ui,
+}
+
+public static class HostRoles
+{
+    /// <summary>
+    /// Resolve the active role(s) from <c>--role</c> (command line) or <c>RPDU2MQTT_ROLE</c> (env),
+    /// accepting a comma/space/semicolon-separated list (e.g. <c>api,ui</c>). Unset or unrecognised
+    /// falls back to <see cref="HostRole.All"/> so a plain install just runs everything.
+    /// </summary>
+    public static HostRole Resolve(IConfiguration config)
+    {
+        var raw = config["role"] ?? config["RPDU2MQTT_ROLE"];
+        if (string.IsNullOrWhiteSpace(raw)) return HostRole.All;
+
+        var roles = HostRole.None;
+        foreach (var token in raw.Split(new[] { ',', ' ', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            roles |= token.ToLowerInvariant() switch
+            {
+                "all" => HostRole.All,
+                "worker" or "engine" or "data" => HostRole.Worker,
+                "api" => HostRole.Api,
+                "ui" or "gui" or "web" => HostRole.Ui,
+                _ => HostRole.None,
+            };
+
+        return roles == HostRole.None ? HostRole.All : roles;
+    }
+}

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -23,6 +23,16 @@ public static class ServiceConfiguration
 
         Config cfg = configSource.Load() ?? throw new Exception("Unable to load configuration");
 
+        // Which workload(s) this process runs. Default All = a single node that does everything. Singletons
+        // (the object graph) are always registered; only the hosted services (the actual work) are gated by
+        // role, so the default deployment is unchanged and a single role can be run per process to scale out.
+        var roles = HostRoles.Resolve(context.Configuration);
+        services.AddSingleton(typeof(HostRole), roles);
+        Log.Information($"Active host role(s): {roles}.");
+        bool worker = roles.HasFlag(HostRole.Worker);
+        bool api = roles.HasFlag(HostRole.Api);
+        bool ui = roles.HasFlag(HostRole.Ui);
+
         // Bind Configuration + the source it came from (the GUI uses it to save).
         services.AddSingleton(cfg);
         services.AddSingleton(configSource);
@@ -83,64 +93,73 @@ public static class ServiceConfiguration
         services.AddSingleton<Core.IMessageBus, Core.ChannelMessageBus>();
         services.AddSingleton<Core.SnapshotCache>();
         services.AddSingleton<Core.ISnapshotCache>(sp => sp.GetRequiredService<Core.SnapshotCache>());
-        services.AddHostedService(sp => sp.GetRequiredService<Core.SnapshotCache>());
         // Owns the PDU producer(s) — one poller per configured instance; reconciled at runtime when the
         // GUI saves instance changes. Singleton + hosted-service facade so the GUI can trigger reconcile.
         services.AddSingleton<InstanceManager>();
-        services.AddHostedService(sp => sp.GetRequiredService<InstanceManager>());
+        // Data production runs in the Worker role; the cache/bus singletons stay registered so the API/GUI
+        // can read them in-process (a single-node 'all' deployment). Splitting these across processes is the
+        // job of the planned message-bus transport.
+        if (worker)
+        {
+            services.AddHostedService(sp => sp.GetRequiredService<Core.SnapshotCache>());
+            services.AddHostedService(sp => sp.GetRequiredService<InstanceManager>());
+        }
 
         // Shared liveness/readiness signals (uptime + last successful poll).
         services.AddSingleton<HealthState>();
         // EmonCMS export health (last attempt/success/error) — read by the GUI even when disabled.
         services.AddSingleton<Services.EmonCmsStatus>();
 
-        // Created hosted services.
-        services.AddHostedService<MQTTPublishingService>();
-
-        // Optional metric exporters.
-        if (cfg.Prometheus.Exporter || cfg.Prometheus.Pushgateway.Enabled)
-            services.AddHostedService<PrometheusExportService>();
-
-        if (cfg.EmonCMS.Enabled)
-        {
-            // Url is only needed for the HTTP transport; the MQTT transport uses the existing broker.
-            if (cfg.EmonCMS.Transport == Models.Config.EmonCmsTransport.Http)
-                ThrowError.TestRequiredConfigurationSection(cfg.EmonCMS.Url, "EmonCMS.Url");
-            services.AddHostedService<EmonCmsExportService>();
-        }
-
         // Coordinates on-demand rediscovery (the "Rediscover" diagnostic button).
         services.AddSingleton<DiscoveryCoordinator>();
 
-        if (cfg.HASS.DiscoveryEnabled)
+        // ---- Worker role: the data-processing workload (publish, export, discovery, control). ----
+        if (worker)
         {
-            services.AddHostedService<HomeAssistantDiscoveryService>();
-            services.AddHostedService<DiagnosticService>();
-        }
-        else
-            Log.Warning($"Home Assistant Discovery Disabled.");
+            services.AddHostedService<MQTTPublishingService>();
 
-        // Optional HTTP health endpoints for container probes.
+            // Optional metric exporters.
+            if (cfg.Prometheus.Exporter || cfg.Prometheus.Pushgateway.Enabled)
+                services.AddHostedService<PrometheusExportService>();
+
+            if (cfg.EmonCMS.Enabled)
+            {
+                // Url is only needed for the HTTP transport; the MQTT transport uses the existing broker.
+                if (cfg.EmonCMS.Transport == Models.Config.EmonCmsTransport.Http)
+                    ThrowError.TestRequiredConfigurationSection(cfg.EmonCMS.Url, "EmonCMS.Url");
+                services.AddHostedService<EmonCmsExportService>();
+            }
+
+            if (cfg.HASS.DiscoveryEnabled)
+            {
+                services.AddHostedService<HomeAssistantDiscoveryService>();
+                services.AddHostedService<DiagnosticService>();
+            }
+            else
+                Log.Warning($"Home Assistant Discovery Disabled.");
+
+            // Outlet control is opt-in; only subscribe to command topics when explicitly enabled.
+            if (cfg.Primary.ActionsEnabled)
+            {
+                if (string.IsNullOrEmpty(cfg.Primary.Credentials?.Username) || string.IsNullOrEmpty(cfg.Primary.Credentials?.Password))
+                    Log.Warning("PDU.ActionsEnabled is true, but PDU credentials are not set. Outlet on/off control will fail until Pdu.Credentials (or RPDU2MQTT_PDU_USERNAME / RPDU2MQTT_PDU_PASSWORD) are provided.");
+
+                Log.Information("Outlet control is ENABLED (ActionsEnabled).");
+                services.AddHostedService<OutletCommandService>();
+            }
+        }
+
+        // Optional HTTP health endpoints for container probes — useful in any role.
         if (cfg.Health.Enabled)
             services.AddHostedService<HealthService>();
 
-        // Optional read-only REST API + OpenAPI/Scalar docs on its own port.
-        if (cfg.Api.Enabled)
+        // ---- Api role: the read-only REST API + OpenAPI/Scalar docs on its own port. ----
+        if (api && cfg.Api.Enabled)
             services.AddHostedService<ApiService>();
 
-        // Optional embedded configuration GUI.
-        if (cfg.Gui.Enabled)
+        // ---- Ui role: the embedded configuration GUI. ----
+        if (ui && cfg.Gui.Enabled)
             services.AddHostedService<Services.Gui.GuiService>();
-
-        // Outlet control is opt-in; only subscribe to command topics when explicitly enabled.
-        if (cfg.Primary.ActionsEnabled)
-        {
-            if (string.IsNullOrEmpty(cfg.Primary.Credentials?.Username) || string.IsNullOrEmpty(cfg.Primary.Credentials?.Password))
-                Log.Warning("PDU.ActionsEnabled is true, but PDU credentials are not set. Outlet on/off control will fail until Pdu.Credentials (or RPDU2MQTT_PDU_USERNAME / RPDU2MQTT_PDU_PASSWORD) are provided.");
-
-            Log.Information("Outlet control is ENABLED (ActionsEnabled).");
-            services.AddHostedService<OutletCommandService>();
-        }
     }
 
     /// <summary>Wrap a plaintext secret as a read-only SecureString (for APIs that require one).</summary>


### PR DESCRIPTION
First concrete step toward the 3-component split in #127 (UI / middle-tier API / automation-data). The components already live as separate projects in one solution — this makes one executable able to run a chosen subset of them.

## What
A `HostRole` flags enum + `HostRoles.Resolve()` reads **`--role`** (CLI) or **`RPDU2MQTT_ROLE`** (env), accepting a comma list:

| role | runs |
|---|---|
| `worker` (aka `engine`/`data`) | automation/data-processing: PDU pollers, MQTT publish, exporters, HA discovery, outlet control |
| `api` | the read-only REST API |
| `ui` (aka `gui`/`web`) | the configuration GUI |
| `all` *(default)* | everything — a single node |

Unset or unrecognised → **`all`**, so **existing single-node deployments are unchanged**. `dotnet run -- --role worker` (or `RPDU2MQTT_ROLE=api,ui`) runs just those.

## How
In `ServiceConfiguration`, the **singletons (object graph) are always registered**; only the **hosted services** (the parts that actually do work) are gated by role. So nothing about the default wiring changes — `all` registers the exact same set as before.

## Scope / what's deliberately *not* here
Cross-role state is still **in-process** (the snapshot cache / config singleton are shared), so today only a single-node `all` deployment is fully functional — an `api`/`ui`-only process would have no data until the data tier is reachable over a wire. That boundary is the **next** step: a **message-bus transport over the existing MQTT broker** (chosen direction), put behind interfaces so the same code runs in-proc locally and remote when split. This PR is intentionally just the role switch + gating.

## Tests
`HostRoleTests` covers parsing (single role, aliases, comma list, env vs CLI precedence, unknown → all). **110 tests pass**, builds clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
