### PR TITLE
feat(transport): explicit RawSnapshot wire contract for cross-process snapshots (#127)

### DIFF
--- a/rPDU2MQTT.Core/Core/RawSnapshot.cs
+++ b/rPDU2MQTT.Core/Core/RawSnapshot.cs
@@ -1,0 +1,58 @@
+using rPDU2MQTT.Models.PDU;
+
+namespace rPDU2MQTT.Core.Transport;
+
+// Explicit, round-trippable wire contract for moving a single poll between role processes (#127).
+//
+// Why a dedicated DTO instead of serializing PduData directly: the PDU models are an *input* contract for
+// the Vertiv API. Their consumer-facing fields (Entity_Name/Entity_DisplayName) are [JsonIgnore] values
+// *derived* later by the naming/override transform, and even the dictionary keys ([JsonIgnore] Key) don't
+// serialize. So this carries only the *raw source* a consumer needs to reconstruct a PduData and re-run
+// the transform itself. (The transform isn't idempotent, so it must run once, consumer-side.)
+//
+// Scope: devices -> outlets -> measurements (the data the flow/Sankey and live views use). Device
+// entities and OneView groups are deliberately not carried yet — a mechanical follow-up.
+
+public sealed record RawSnapshot(string InstanceId, DateTime TimestampUtc, List<RawDevice> Devices);
+
+public sealed record RawDevice(string? Key, string? Name, string? Label, string? State, string? Type, List<RawOutlet> Outlets);
+
+public sealed record RawOutlet(int Key, string? Name, string? Label, string? State, List<RawMeasurement> Measurements);
+
+public sealed record RawMeasurement(string? Key, string? Type, string? Value, string? Units, string? State);
+
+/// <summary>Maps between the live <see cref="PduData"/> model and the <see cref="RawSnapshot"/> wire form.</summary>
+public static class RawSnapshotMapper
+{
+    /// <summary>Producer side: project a freshly-polled (pre-transform) snapshot onto the wire contract.</summary>
+    public static RawSnapshot ToWire(string instanceId, DateTime timestampUtc, PduData data) =>
+        new(instanceId, timestampUtc, data.Devices.Select(ToWire).ToList());
+
+    private static RawDevice ToWire(Device d) =>
+        new(d.Key, d.Name, d.Label, d.State, d.Type, d.Outlets.Select(ToWire).ToList());
+
+    private static RawOutlet ToWire(Outlet o) =>
+        new(o.Key, o.Name, o.Label, o.State, o.Measurements.Select(ToWire).ToList());
+
+    private static RawMeasurement ToWire(Measurement m) =>
+        new(m.Key, m.Type, m.Value, m.Units, m.State);
+
+    /// <summary>Consumer side: rebuild a raw <see cref="PduData"/> (keys restored) ready for the transform.</summary>
+    public static PduData ToData(RawSnapshot snapshot)
+    {
+        var data = new PduData();
+        foreach (var d in snapshot.Devices)
+        {
+            var device = new Device { Key = d.Key!, Name = d.Name!, Label = d.Label!, State = d.State!, Type = d.Type! };
+            foreach (var o in d.Outlets)
+            {
+                var outlet = new Outlet { Key = o.Key, Name = o.Name!, Label = o.Label!, State = o.State! };
+                foreach (var m in o.Measurements)
+                    outlet.Measurements.Add(new Measurement { Key = m.Key!, Type = m.Type!, Value = m.Value!, Units = m.Units!, State = m.State! });
+                device.Outlets.Add(outlet);
+            }
+            data.Devices.Add(device);
+        }
+        return data;
+    }
+}

--- a/rPDU2MQTT.Tests/RawSnapshotTests.cs
+++ b/rPDU2MQTT.Tests/RawSnapshotTests.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using rPDU2MQTT.Core.Transport;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// The cross-process transport (#127) serializes a <see cref="RawSnapshot"/> on a worker and reads it back
+/// on a consumer. This locks that contract: the raw source data (device/outlet/measurement identity +
+/// readings) survives PduData -> wire -> JSON -> wire -> PduData. (Derived display names are intentionally
+/// not carried — the consumer regenerates them via the naming/override transform.)
+/// </summary>
+public class RawSnapshotTests
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private static PduData SampleData()
+    {
+        var outlet = new Outlet { Key = 3, Name = "outlet3", Label = "Server", State = "on" };
+        outlet.Measurements.Add(new Measurement { Key = "realpower", Type = "realpower", Value = "123", Units = "W", State = "normal" });
+        var device = new Device { Key = "pdu1", Name = "pdu1", Label = "Rack PDU 1", State = "normal", Type = "device" };
+        device.Outlets.Add(outlet);
+        var data = new PduData();
+        data.Devices.Add(device);
+        return data;
+    }
+
+    [Fact]
+    public void RawSnapshot_RoundTrips_ThroughJsonAndBackToPduData()
+    {
+        var wire = RawSnapshotMapper.ToWire("pdu1", new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), SampleData());
+
+        var json = JsonSerializer.Serialize(wire, Json);
+        var backWire = JsonSerializer.Deserialize<RawSnapshot>(json, Json)!;
+        var data = RawSnapshotMapper.ToData(backWire);
+
+        Assert.Equal("pdu1", backWire.InstanceId);
+        Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), backWire.TimestampUtc);
+
+        var d = Assert.Single(data.Devices);
+        Assert.Equal("pdu1", d.Key);            // the keys the API models drop on (de)serialization
+        Assert.Equal("pdu1", d.Name);
+        Assert.Equal("Rack PDU 1", d.Label);
+        Assert.Equal("normal", d.State);
+        Assert.Equal("device", d.Type);
+
+        var o = Assert.Single(d.Outlets);
+        Assert.Equal(3, o.Key);
+        Assert.Equal("Server", o.Label);
+        Assert.Equal("on", o.State);
+
+        var m = Assert.Single(o.Measurements);
+        Assert.Equal("realpower", m.Key);
+        Assert.Equal("realpower", m.Type);
+        Assert.Equal("123", m.Value);
+        Assert.Equal("W", m.Units);
+        Assert.Equal("normal", m.State);
+    }
+
+    [Fact]
+    public void ToWire_PreservesStructureAndCounts()
+    {
+        var wire = RawSnapshotMapper.ToWire("inst", DateTime.UtcNow, SampleData());
+
+        var device = Assert.Single(wire.Devices);
+        var outlet = Assert.Single(device.Outlets);
+        Assert.Single(outlet.Measurements);
+        Assert.Equal(3, outlet.Key);
+        Assert.Equal("realpower", outlet.Measurements[0].Type);
+    }
+}


### PR DESCRIPTION
First building block of the cross-process role split (#127), and the answer to a concrete blocker found while prototyping the MQTT transport.

## The problem
A worker process must hand a poll to an API/UI process. But `PduData` **cannot be re-serialized faithfully**:
- `Entity_Name` / `Entity_DisplayName` (what consumers display) are `[JsonIgnore]` values **derived** later by the naming/override transform — serializing + reading back yields `null`.
- The dictionary keys (`Key`) are `[JsonIgnore]` too, and the top-level `Devices` list isn't keyed, so identities are lost.

So the API models are an **input contract** for the Vertiv API, not a round-trippable wire format.

## This PR
A dedicated, explicit wire DTO that carries only the **raw source** data, fully round-trippable by construction:

```
RawSnapshot(InstanceId, TimestampUtc, Devices)
  └ RawDevice(Key, Name, Label, State, Type, Outlets)
      └ RawOutlet(Key, Name, Label, State, Measurements)
          └ RawMeasurement(Key, Type, Value, Units, State)
```

`RawSnapshotMapper.ToWire(PduData)` / `ToData(RawSnapshot)` map both ways. The consumer rebuilds a raw `PduData` and **re-runs the transform itself** — which is required anyway because the transform isn't idempotent (e.g. name-prefixing), so it must run exactly once, consumer-side.

## Scope / safety
- **Additive only**: new Core types + tests; nothing is rewired, so zero behavior change.
- Covers devices → outlets → measurements (the flow/Sankey + live data). Device entities and OneView groups are a mechanical follow-up.

## Tests
`RawSnapshotTests`: full `PduData -> wire -> JSON -> wire -> PduData` round-trip (keys + raw readings preserved) and a structure/counts check. **99 tests pass**, build clean.

## What's next (tracked under #127)
1. Relocate the naming/override transform to run consumer-side.
2. MQTT bridge: worker publishes `RawSnapshot`; consumer ingests into its `SnapshotCache`.
3. Migrate the API/GUI live-data read path to the cache.
4. End-to-end verification (broker + two processes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
