### PR TITLE
feat(transport): serve a worker's data to UI/API roles over MQTT (#127)

### DIFF
--- a/docs/v2-architecture.md
+++ b/docs/v2-architecture.md
@@ -126,6 +126,29 @@ InstanceManager ──manages──> PduPoller (×N)
 Later (separate issues, built on this): energy-flow mapping (#128/#129), Tigo producer (#130),
 Sankey (#97).
 
+## Distributed mode — running roles as separate processes (#127)
+
+The single executable can run a subset of the workloads, so the three components can scale out across
+processes (or stay one node by default). The project boundaries already enforce the producer/consumer/UI
+split; this is the *runtime* split, behind the same `IMessageBus` seam.
+
+- **Role selection** — `--role` / `RPDU2MQTT_ROLE` picks `worker` (data processing), `api`, `ui`, or a
+  comma list. Unset → `all` (one node, everything; the default — unchanged). Singletons are always
+  registered; only the *hosted services* (the work) are gated by role.
+- **Cross-process bus** — `MqttBusBridge` (loaded only when roles are split) carries snapshots over the
+  existing broker: a `worker` mirrors each snapshot to a retained `‹parent›/_bus/snapshot/‹id›` topic; a
+  consumer-only node ingests them back onto its own bus → its `SnapshotCache`.
+- **Wire contract** — `RawSnapshot` (a plain, round-trippable DTO) carries the *finished* poll: raw
+  source name/label plus the computed display identity (`Entity_Name`/`DisplayName`/`Make`/`Model`) and
+  measurements. The worker transforms once (as it already does for its own sinks); the consumer renders
+  without re-running the non-idempotent transform.
+- **Read path** — the GUI/API read PDU data through the `SnapshotCache` (filled by the local poller, or by
+  the bridge on a consumer), falling back to a direct poll while the cache is cold. So a `ui`/`api` node
+  serves a worker's data without reaching a PDU itself.
+
+Still worker-side (need the live connection): polling, control/actions, discovery. Cross-process operation
+needs end-to-end verification against a real broker + two processes.
+
 ## Risks / open questions
 
 - **Back-pressure / slow sinks** — per-consumer bounded channels isolate a slow/broken sink; decide the
@@ -139,4 +162,3 @@ Sankey (#97).
 ## Not in scope here
 
 - The actual energy-flow mapping / Sankey / Tigo features (separate v2.0 issues).
-- A distributed/multi-process runtime (the `IMessageBus` seam leaves the door open if it's ever needed).

--- a/rPDU2MQTT.Core/Core/HostRole.cs
+++ b/rPDU2MQTT.Core/Core/HostRole.cs
@@ -1,0 +1,21 @@
+namespace rPDU2MQTT.Core;
+
+/// <summary>
+/// Which workload(s) a process runs (#127). The components live in one solution and one executable; the
+/// active role(s) decide which hosted services start. Default is <see cref="All"/> — a single node that
+/// does everything — but the same binary can run a single role per process to scale out (e.g. several
+/// <see cref="Worker"/>s behind one <see cref="Ui"/>). Lives in Core so every layer (host, engine, web)
+/// can read the active roles; the resolver that parses it from configuration stays in the host.
+/// </summary>
+[Flags]
+public enum HostRole
+{
+    None = 0,
+    /// <summary>Automation / data processing: PDU pollers, MQTT publish, exporters, discovery, control.</summary>
+    Worker = 1,
+    /// <summary>Middle tier: the read-only REST API.</summary>
+    Api = 2,
+    /// <summary>The configuration GUI.</summary>
+    Ui = 4,
+    All = Worker | Api | Ui,
+}

--- a/rPDU2MQTT.Core/Core/RawSnapshot.cs
+++ b/rPDU2MQTT.Core/Core/RawSnapshot.cs
@@ -2,57 +2,103 @@ using rPDU2MQTT.Models.PDU;
 
 namespace rPDU2MQTT.Core.Transport;
 
-// Explicit, round-trippable wire contract for moving a single poll between role processes (#127).
+// Round-trippable wire contract for moving a single poll between role processes (#127).
 //
-// Why a dedicated DTO instead of serializing PduData directly: the PDU models are an *input* contract for
-// the Vertiv API. Their consumer-facing fields (Entity_Name/Entity_DisplayName) are [JsonIgnore] values
-// *derived* later by the naming/override transform, and even the dictionary keys ([JsonIgnore] Key) don't
-// serialize. So this carries only the *raw source* a consumer needs to reconstruct a PduData and re-run
-// the transform itself. (The transform isn't idempotent, so it must run once, consumer-side.)
+// The PDU models can't be re-serialized faithfully (their Key and the computed Entity_* names are
+// [JsonIgnore], and the top-level device list isn't keyed), so this carries the fields a consumer needs
+// as plain, explicit properties. The worker transforms once (as it already does for its own sinks) and
+// this carries the *finished* result — raw source (name/label) for editors plus the computed identity
+// (Entity_Name/DisplayName/Make/Model) for display — so a consumer renders without re-running the
+// (non-idempotent) transform.
 //
-// Scope: devices -> outlets -> measurements (the data the flow/Sankey and live views use). Device
-// entities and OneView groups are deliberately not carried yet — a mechanical follow-up.
+// Scope: devices -> outlets/entities -> measurements. OneView groups are a follow-up.
 
 public sealed record RawSnapshot(string InstanceId, DateTime TimestampUtc, List<RawDevice> Devices);
 
-public sealed record RawDevice(string? Key, string? Name, string? Label, string? State, string? Type, List<RawOutlet> Outlets);
+public sealed record RawDevice(
+    string? Key, string? Name, string? Label, string? EntityName, string? DisplayName,
+    string? Make, string? Model, string? State, string? Type,
+    List<RawOutlet> Outlets, List<RawEntity> Entities);
 
-public sealed record RawOutlet(int Key, string? Name, string? Label, string? State, List<RawMeasurement> Measurements);
+public sealed record RawOutlet(
+    int Key, string? Name, string? Label, string? EntityName, string? DisplayName,
+    string? Make, string? Model, string? State, List<RawMeasurement> Measurements);
 
-public sealed record RawMeasurement(string? Key, string? Type, string? Value, string? Units, string? State);
+public sealed record RawEntity(
+    string? Key, string? Name, string? Label, string? EntityName, string? DisplayName,
+    List<RawMeasurement> Measurements);
+
+public sealed record RawMeasurement(
+    string? Key, string? Type, string? EntityName, string? DisplayName, string? Value, string? Units, string? State);
 
 /// <summary>Maps between the live <see cref="PduData"/> model and the <see cref="RawSnapshot"/> wire form.</summary>
 public static class RawSnapshotMapper
 {
-    /// <summary>Producer side: project a freshly-polled (pre-transform) snapshot onto the wire contract.</summary>
+    /// <summary>Producer side: project a transformed snapshot onto the wire contract.</summary>
     public static RawSnapshot ToWire(string instanceId, DateTime timestampUtc, PduData data) =>
         new(instanceId, timestampUtc, data.Devices.Select(ToWire).ToList());
 
-    private static RawDevice ToWire(Device d) =>
-        new(d.Key, d.Name, d.Label, d.State, d.Type, d.Outlets.Select(ToWire).ToList());
+    private static RawDevice ToWire(Device d) => new(
+        d.Key, d.Name, d.Label, d.Entity_Name, d.Entity_DisplayName, d.Entity_Make, d.Entity_Model, d.State, d.Type,
+        d.Outlets.Select(ToWire).ToList(), d.Entity.Select(ToWire).ToList());
 
-    private static RawOutlet ToWire(Outlet o) =>
-        new(o.Key, o.Name, o.Label, o.State, o.Measurements.Select(ToWire).ToList());
+    private static RawOutlet ToWire(Outlet o) => new(
+        o.Key, o.Name, o.Label, o.Entity_Name, o.Entity_DisplayName, o.Entity_Make, o.Entity_Model, o.State,
+        o.Measurements.Select(ToWire).ToList());
 
-    private static RawMeasurement ToWire(Measurement m) =>
-        new(m.Key, m.Type, m.Value, m.Units, m.State);
+    private static RawEntity ToWire(Entity e) => new(
+        e.Key, e.Name, e.Label, e.Entity_Name, e.Entity_DisplayName, e.Measurements.Select(ToWire).ToList());
 
-    /// <summary>Consumer side: rebuild a raw <see cref="PduData"/> (keys restored) ready for the transform.</summary>
+    private static RawMeasurement ToWire(Measurement m) => new(
+        m.Key, m.Type, m.Entity_Name, m.Entity_DisplayName, m.Value, m.Units, m.State);
+
+    /// <summary>Consumer side: rebuild a ready-to-render <see cref="PduData"/> (keys + computed names restored).</summary>
     public static PduData ToData(RawSnapshot snapshot)
     {
         var data = new PduData();
         foreach (var d in snapshot.Devices)
         {
-            var device = new Device { Key = d.Key!, Name = d.Name!, Label = d.Label!, State = d.State!, Type = d.Type! };
-            foreach (var o in d.Outlets)
+            var device = new Device
             {
-                var outlet = new Outlet { Key = o.Key, Name = o.Name!, Label = o.Label!, State = o.State! };
-                foreach (var m in o.Measurements)
-                    outlet.Measurements.Add(new Measurement { Key = m.Key!, Type = m.Type!, Value = m.Value!, Units = m.Units!, State = m.State! });
-                device.Outlets.Add(outlet);
-            }
+                Key = d.Key!, Name = d.Name!, Label = d.Label!, State = d.State!, Type = d.Type!,
+                Entity_Name = d.EntityName!, Entity_DisplayName = d.DisplayName!, Entity_Make = d.Make, Entity_Model = d.Model,
+            };
+            foreach (var o in d.Outlets)
+                device.Outlets.Add(ToOutlet(o));
+            foreach (var e in d.Entities)
+                device.Entity.Add(ToEntity(e));
             data.Devices.Add(device);
         }
         return data;
     }
+
+    private static Outlet ToOutlet(RawOutlet o)
+    {
+        var outlet = new Outlet
+        {
+            Key = o.Key, Name = o.Name!, Label = o.Label!, State = o.State!,
+            Entity_Name = o.EntityName!, Entity_DisplayName = o.DisplayName!, Entity_Make = o.Make, Entity_Model = o.Model,
+        };
+        foreach (var m in o.Measurements)
+            outlet.Measurements.Add(ToMeasurement(m));
+        return outlet;
+    }
+
+    private static Entity ToEntity(RawEntity e)
+    {
+        var entity = new Entity
+        {
+            Key = e.Key!, Name = e.Name!, Label = e.Label!,
+            Entity_Name = e.EntityName!, Entity_DisplayName = e.DisplayName!,
+        };
+        foreach (var m in e.Measurements)
+            entity.Measurements.Add(ToMeasurement(m));
+        return entity;
+    }
+
+    private static Measurement ToMeasurement(RawMeasurement m) => new()
+    {
+        Key = m.Key!, Type = m.Type!, Value = m.Value!, Units = m.Units!, State = m.State!,
+        Entity_Name = m.EntityName!, Entity_DisplayName = m.DisplayName!,
+    };
 }

--- a/rPDU2MQTT.Engine/Services/MqttBusBridge.cs
+++ b/rPDU2MQTT.Engine/Services/MqttBusBridge.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Events;
+using HiveMQtt.MQTT5.Types;
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Core.Transport;
+using rPDU2MQTT.Helpers;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Bridges the in-process snapshot bus (<see cref="IMessageBus"/>) across processes over MQTT, so the app
+/// can run as separate role processes (#127). A producer (Worker) node maps each local snapshot to the
+/// round-trippable <see cref="RawSnapshot"/> wire form and publishes it to a retained broker topic; a
+/// consumer-only (API/UI) node ingests those back onto its own bus — and therefore its
+/// <see cref="SnapshotCache"/> — without polling any PDU itself.
+/// <para>
+/// Only registered when roles are split; a single-node "all" deployment keeps the bus entirely in-process
+/// and never loads this, so there's no extra broker traffic by default.
+/// </para>
+/// Topic: <c>&lt;parentTopic&gt;/_bus/snapshot/&lt;instanceId&gt;</c> (retained, so a late consumer gets the latest at once).
+/// <para>
+/// Note: <see cref="RawSnapshot"/> carries the raw poll data only; a consumer still needs to run the
+/// naming/override transform to populate display names. That consumer-side transform is the next step.
+/// </para>
+/// </summary>
+public sealed class MqttBusBridge : IHostedService
+{
+    public const string BusSegment = "_bus";
+    public const string SnapshotSegment = "snapshot";
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private readonly HiveMQClient mqtt;
+    private readonly IMessageBus bus;
+    private readonly Config cfg;
+    private readonly bool producer;
+    private readonly CancellationTokenSource cts = new();
+    private Task? pump;
+
+    public MqttBusBridge(IHiveMQClient mqtt, IMessageBus bus, Config cfg, bool producer)
+    {
+        this.mqtt = (HiveMQClient)mqtt;
+        this.bus = bus;
+        this.cfg = cfg;
+        this.producer = producer;
+    }
+
+    /// <summary>The retained per-instance snapshot topic a producer publishes to / a consumer subscribes under.</summary>
+    public static string TopicFor(string parentTopic, string instanceId) =>
+        MQTTHelper.JoinPaths(parentTopic, BusSegment, SnapshotSegment, instanceId);
+
+    private string SubscriptionFilter => MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, BusSegment, SnapshotSegment, "+");
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (producer)
+        {
+            pump = Task.Run(() => PumpOutboundAsync(cts.Token), CancellationToken.None);
+            Log.Information($"MQTT bus bridge: mirroring local snapshots to '{MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, BusSegment, SnapshotSegment)}/<instance>'.");
+            return;
+        }
+
+        mqtt.OnMessageReceived += OnMessageReceived;
+        var result = await mqtt.SubscribeAsync(SubscriptionFilter, QualityOfService.AtLeastOnceDelivery);
+        foreach (var sub in result.Subscriptions)
+        {
+            if ((int)sub.SubscribeReasonCode <= 2)
+                Log.Information($"MQTT bus bridge: ingesting remote snapshots from '{sub.TopicFilter.Topic}'.");
+            else
+                Log.Error($"MQTT bus bridge: subscription to '{sub.TopicFilter.Topic}' was not granted ({sub.SubscribeReasonCode}); this node will have no PDU data.");
+        }
+    }
+
+    private async Task PumpOutboundAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var snapshot in bus.Subscribe(cancellationToken: ct))
+            {
+                // One bad snapshot must not stop the pump for the rest.
+                try
+                {
+                    var wire = RawSnapshotMapper.ToWire(snapshot.InstanceId, snapshot.TimestampUtc, snapshot.Data);
+                    await mqtt.PublishAsync(new MQTT5PublishMessage(TopicFor(cfg.MQTT.ParentTopic, snapshot.InstanceId), QualityOfService.AtLeastOnceDelivery)
+                    {
+                        PayloadAsString = JsonSerializer.Serialize(wire, Json),
+                        Retain = true,
+                    });
+                }
+                catch (Exception ex) { Log.Warning($"MQTT bus bridge: could not mirror a '{snapshot.InstanceId}' snapshot: {ex.Message}"); }
+            }
+        }
+        catch (OperationCanceledException) { /* shutting down */ }
+        catch (Exception ex) { Log.Error(ex, "MQTT bus bridge: outbound pump stopped."); }
+    }
+
+    private void OnMessageReceived(object? sender, OnMessageReceivedEventArgs e)
+    {
+        try
+        {
+            var json = e.PublishMessage.PayloadAsString;
+            if (string.IsNullOrEmpty(json)) return;
+            var wire = JsonSerializer.Deserialize<RawSnapshot>(json, Json);
+            if (wire is null || string.IsNullOrEmpty(wire.InstanceId)) return;
+            _ = bus.PublishAsync(new PduSnapshot(wire.InstanceId, wire.TimestampUtc, RawSnapshotMapper.ToData(wire)));
+        }
+        catch (Exception ex)
+        {
+            Log.Warning($"MQTT bus bridge: could not ingest a snapshot from '{e.PublishMessage.Topic}': {ex.Message}");
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (producer)
+        {
+            cts.Cancel();
+            if (pump is not null)
+                try { await pump; } catch { /* ignore shutdown races */ }
+        }
+        else
+        {
+            mqtt.OnMessageReceived -= OnMessageReceived;
+        }
+    }
+}

--- a/rPDU2MQTT.Tests/HostRoleTests.cs
+++ b/rPDU2MQTT.Tests/HostRoleTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Configuration;
+using rPDU2MQTT.Core;
 using rPDU2MQTT.Startup;
 using Xunit;
 

--- a/rPDU2MQTT.Tests/MqttBusBridgeTests.cs
+++ b/rPDU2MQTT.Tests/MqttBusBridgeTests.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Core.Transport;
+using rPDU2MQTT.Models.PDU;
+using rPDU2MQTT.Services;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// The MQTT bus bridge maps an in-process <see cref="PduSnapshot"/> to the <see cref="RawSnapshot"/> wire
+/// form on a worker and back on a consumer. These lock the topic convention and that the worker's raw poll
+/// survives the publish/ingest hop intact.
+/// </summary>
+public class MqttBusBridgeTests
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void TopicFor_NestsInstanceUnderTheBusNamespace()
+    {
+        Assert.Equal("rpdu/_bus/snapshot/pdu1", MqttBusBridge.TopicFor("rpdu", "pdu1"));
+    }
+
+    [Fact]
+    public void WorkerToConsumer_HopPreservesTheRawPoll()
+    {
+        var outlet = new Outlet { Key = 1, Name = "o1", Label = "NAS", State = "on" };
+        outlet.Measurements.Add(new Measurement { Key = "realpower", Type = "realpower", Value = "42", Units = "W", State = "normal" });
+        var device = new Device { Key = "pdu1", Name = "pdu1", Label = "PDU 1", State = "normal", Type = "device" };
+        device.Outlets.Add(outlet);
+        var data = new PduData();
+        data.Devices.Add(device);
+
+        // Worker side: snapshot -> wire -> JSON (what gets published).
+        var snapshot = new PduSnapshot("pdu1", new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), data);
+        var wireJson = JsonSerializer.Serialize(
+            RawSnapshotMapper.ToWire(snapshot.InstanceId, snapshot.TimestampUtc, snapshot.Data), Json);
+
+        // Consumer side: JSON -> wire -> PduSnapshot (what lands on the consumer's bus).
+        var wire = JsonSerializer.Deserialize<RawSnapshot>(wireJson, Json)!;
+        var ingested = new PduSnapshot(wire.InstanceId, wire.TimestampUtc, RawSnapshotMapper.ToData(wire));
+
+        Assert.Equal("pdu1", ingested.InstanceId);
+        Assert.Equal(snapshot.TimestampUtc, ingested.TimestampUtc);
+        var d = Assert.Single(ingested.Data.Devices);
+        Assert.Equal("pdu1", d.Key);
+        var o = Assert.Single(d.Outlets);
+        Assert.Equal(1, o.Key);
+        Assert.Equal("NAS", o.Label);
+        Assert.Equal("42", Assert.Single(o.Measurements).Value);
+    }
+}

--- a/rPDU2MQTT.Tests/RawSnapshotTests.cs
+++ b/rPDU2MQTT.Tests/RawSnapshotTests.cs
@@ -7,9 +7,9 @@ namespace rPDU2MQTT.Tests;
 
 /// <summary>
 /// The cross-process transport (#127) serializes a <see cref="RawSnapshot"/> on a worker and reads it back
-/// on a consumer. This locks that contract: the raw source data (device/outlet/measurement identity +
-/// readings) survives PduData -> wire -> JSON -> wire -> PduData. (Derived display names are intentionally
-/// not carried — the consumer regenerates them via the naming/override transform.)
+/// on a consumer. This locks that contract: the data a consumer renders — keys, raw source name/label, the
+/// computed display identity (Entity_Name/DisplayName/Make/Model), measurements, and device entities —
+/// survives PduData -> wire -> JSON -> wire -> PduData.
 /// </summary>
 public class RawSnapshotTests
 {
@@ -17,56 +17,59 @@ public class RawSnapshotTests
 
     private static PduData SampleData()
     {
-        var outlet = new Outlet { Key = 3, Name = "outlet3", Label = "Server", State = "on" };
-        outlet.Measurements.Add(new Measurement { Key = "realpower", Type = "realpower", Value = "123", Units = "W", State = "normal" });
-        var device = new Device { Key = "pdu1", Name = "pdu1", Label = "Rack PDU 1", State = "normal", Type = "device" };
+        var outlet = new Outlet
+        {
+            Key = 3, Name = "outlet3", Label = "Server", State = "on",
+            Entity_Name = "rack_pdu_1_outlet_3", Entity_DisplayName = "Server", Entity_Make = "Vertiv", Entity_Model = "Geist",
+        };
+        outlet.Measurements.Add(new Measurement
+        {
+            Key = "realpower", Type = "realpower", Value = "123", Units = "W", State = "normal",
+            Entity_Name = "rack_pdu_1_outlet_3_realpower", Entity_DisplayName = "Real Power",
+        });
+
+        var deviceEntity = new Entity { Key = "total", Name = "total", Label = "Total", Entity_Name = "rack_pdu_1_total", Entity_DisplayName = "Total" };
+        deviceEntity.Measurements.Add(new Measurement { Key = "realpower", Type = "realpower", Value = "500", Units = "W", State = "normal", Entity_Name = "rack_pdu_1_total_realpower", Entity_DisplayName = "Real Power" });
+
+        var device = new Device
+        {
+            Key = "pdu1", Name = "pdu1", Label = "Rack PDU 1", State = "normal", Type = "device",
+            Entity_Name = "rack_pdu_1", Entity_DisplayName = "Rack PDU 1", Entity_Make = "Vertiv", Entity_Model = "Geist",
+        };
         device.Outlets.Add(outlet);
+        device.Entity.Add(deviceEntity);
+
         var data = new PduData();
         data.Devices.Add(device);
         return data;
     }
 
     [Fact]
-    public void RawSnapshot_RoundTrips_ThroughJsonAndBackToPduData()
+    public void RawSnapshot_RoundTrips_PreservingFinishedConsumerData()
     {
         var wire = RawSnapshotMapper.ToWire("pdu1", new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), SampleData());
 
         var json = JsonSerializer.Serialize(wire, Json);
-        var backWire = JsonSerializer.Deserialize<RawSnapshot>(json, Json)!;
-        var data = RawSnapshotMapper.ToData(backWire);
-
-        Assert.Equal("pdu1", backWire.InstanceId);
-        Assert.Equal(new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc), backWire.TimestampUtc);
+        var data = RawSnapshotMapper.ToData(JsonSerializer.Deserialize<RawSnapshot>(json, Json)!);
 
         var d = Assert.Single(data.Devices);
-        Assert.Equal("pdu1", d.Key);            // the keys the API models drop on (de)serialization
-        Assert.Equal("pdu1", d.Name);
-        Assert.Equal("Rack PDU 1", d.Label);
-        Assert.Equal("normal", d.State);
-        Assert.Equal("device", d.Type);
+        Assert.Equal("pdu1", d.Key);
+        Assert.Equal("Rack PDU 1", d.Label);          // raw source (for the Overrides editor)
+        Assert.Equal("rack_pdu_1", d.Entity_Name);     // computed identity (object_id)
+        Assert.Equal("Rack PDU 1", d.Entity_DisplayName);
+        Assert.Equal("Vertiv", d.Entity_Make);
+        Assert.Equal("Geist", d.Entity_Model);
 
         var o = Assert.Single(d.Outlets);
         Assert.Equal(3, o.Key);
-        Assert.Equal("Server", o.Label);
-        Assert.Equal("on", o.State);
+        Assert.Equal("Server", o.Entity_DisplayName);
+        var om = Assert.Single(o.Measurements);
+        Assert.Equal("realpower", om.Type);
+        Assert.Equal("123", om.Value);
+        Assert.Equal("Real Power", om.Entity_DisplayName);
 
-        var m = Assert.Single(o.Measurements);
-        Assert.Equal("realpower", m.Key);
-        Assert.Equal("realpower", m.Type);
-        Assert.Equal("123", m.Value);
-        Assert.Equal("W", m.Units);
-        Assert.Equal("normal", m.State);
-    }
-
-    [Fact]
-    public void ToWire_PreservesStructureAndCounts()
-    {
-        var wire = RawSnapshotMapper.ToWire("inst", DateTime.UtcNow, SampleData());
-
-        var device = Assert.Single(wire.Devices);
-        var outlet = Assert.Single(device.Outlets);
-        Assert.Single(outlet.Measurements);
-        Assert.Equal(3, outlet.Key);
-        Assert.Equal("realpower", outlet.Measurements[0].Type);
+        var e = Assert.Single(d.Entity);
+        Assert.Equal("rack_pdu_1_total", e.Entity_Name);
+        Assert.Equal("500", Assert.Single(e.Measurements).Value);
     }
 }

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -42,10 +42,11 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly InstanceManager instances;
     private readonly EmonCmsStatus emonCmsStatus;
     private readonly Core.ISnapshotCache snapshots;
+    private readonly Core.HostRole hostRoles;
     private static readonly HttpClient testHttp = new() { Timeout = TimeSpan.FromSeconds(15) };
     private WebApplication? app;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots, Core.HostRole hostRoles)
     {
         this.config = config;
         this.mqtt = mqtt;
@@ -59,6 +60,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         this.instances = instances;
         this.emonCmsStatus = emonCmsStatus;
         this.snapshots = snapshots;
+        this.hostRoles = hostRoles;
     }
 
     /// <summary>
@@ -406,6 +408,25 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 mqttHost = $"{mqtt.Options.Host}:{mqtt.Options.Port}",
                 configSource = configSource.Describe,
                 lastPollUtc = health.LastPollUtc,
+                // Component health: which workloads this process runs, and whether PDU data is flowing
+                // (from the local poller, or a remote worker via the MQTT bus bridge).
+                roles = Enum.GetValues<Core.HostRole>()
+                    .Where(r => r is Core.HostRole.Worker or Core.HostRole.Api or Core.HostRole.Ui && hostRoles.HasFlag(r))
+                    .Select(r => r.ToString().ToLowerInvariant())
+                    .ToArray(),
+                dataSources = snapshots.All
+                    .OrderBy(s => s.InstanceId)
+                    .Select(s =>
+                    {
+                        var interval = config.Pdus.TryGetValue(s.InstanceId, out var pc) ? pc.PollInterval : 30;
+                        return new
+                        {
+                            instance = s.InstanceId,
+                            ageSeconds = (long)Math.Max(0, (DateTime.UtcNow - s.TimestampUtc).TotalSeconds),
+                            stale = Core.SnapshotFreshness.IsStale(s.TimestampUtc, interval, DateTime.UtcNow),
+                        };
+                    })
+                    .ToArray(),
                 kubernetes = k8s is not null,
                 pod = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME"),
                 ns = k8s?.Namespace,

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -41,10 +41,11 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly PduInstanceRegistry registry;
     private readonly InstanceManager instances;
     private readonly EmonCmsStatus emonCmsStatus;
+    private readonly Core.ISnapshotCache snapshots;
     private static readonly HttpClient testHttp = new() { Timeout = TimeSpan.FromSeconds(15) };
     private WebApplication? app;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots)
     {
         this.config = config;
         this.mqtt = mqtt;
@@ -57,7 +58,16 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         this.registry = registry;
         this.instances = instances;
         this.emonCmsStatus = emonCmsStatus;
+        this.snapshots = snapshots;
     }
+
+    /// <summary>
+    /// Current data for an instance, preferring the shared snapshot cache (filled by the local poller, or
+    /// by the MQTT bus bridge on a consumer-only node) and falling back to a direct poll when the cache is
+    /// still cold. This is the read seam that lets a UI/API role serve a worker's data without polling.
+    /// </summary>
+    private async Task<Models.PDU.PduData> ResolveData(string id, PDU pdu, CancellationToken ct) =>
+        snapshots.Get(id)?.Data ?? await pdu.GetRootData_Public(ct);
 
     /// <summary>The instance id a request targets — a usable (registry) instance, else the primary's.</summary>
     private string ResolveInstanceId(string? requested) =>
@@ -545,8 +555,8 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
-                var pdu = ResolveInstance(ctx.Request.Query["instance"]).Pdu;
-                var data = await pdu.GetRootData_Public(cts.Token);
+                var (id, pdu, _) = ResolveInstance(ctx.Request.Query["instance"]);
+                var data = await ResolveData(id, pdu, cts.Token);
 
                 // Expose the raw PDU label/name plus the currently-discovered display name and
                 // object_id, so the Overrides editor can show what each entity actually is.
@@ -600,8 +610,8 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
-                var pdu = ResolveInstance(ctx.Request.Query["instance"]).Pdu;
-                var data = await pdu.GetRootData_Public(cts.Token);
+                var (id, pdu, _) = ResolveInstance(ctx.Request.Query["instance"]);
+                var data = await ResolveData(id, pdu, cts.Token);
                 var readingList = MetricsHelper.EnumerateReadings(data)
                     .OrderBy(r => r.Device).ThenBy(r => r.Source).ThenBy(r => r.Type)
                     .ToList();
@@ -660,8 +670,8 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
-                var pdu = ResolveInstance(ctx.Request.Query["instance"]).Pdu;
-                var data = await pdu.GetRootData_Public(cts.Token);
+                var (id, pdu, _) = ResolveInstance(ctx.Request.Query["instance"]);
+                var data = await ResolveData(id, pdu, cts.Token);
                 return Results.Json(BuildPaths(data, config), ConfigSchema.Json);
             }
             catch (Exception ex)
@@ -677,8 +687,8 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
-                var pdu = ResolveInstance(ctx.Request.Query["instance"]).Pdu;
-                var data = await pdu.GetRootData_Public(cts.Token);
+                var (id, pdu, _) = ResolveInstance(ctx.Request.Query["instance"]);
+                var data = await ResolveData(id, pdu, cts.Token);
                 var metric = ctx.Request.Query["metric"].ToString();
                 var graph = FlowGraphBuilder.Build(data, config.EnergyFlow, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric);
                 return Results.Json(new { ok = true, graph.Nodes, graph.Links, graph.Metric, graph.Units }, ConfigSchema.Json);
@@ -721,8 +731,8 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             cts.CancelAfter(TimeSpan.FromSeconds(20));
             try
             {
-                var (_, pdu, instanceCfg) = ResolveInstance(ctx.Request.Query["instance"]);
-                var data = await pdu.GetRootData_Public(cts.Token);
+                var (id, pdu, instanceCfg) = ResolveInstance(ctx.Request.Query["instance"]);
+                var data = await ResolveData(id, pdu, cts.Token);
                 var outlets = data.Devices.SelectMany(d => d.Outlets.OrderBy(o => o.Key).Select(o => new
                 {
                     deviceId = d.Key,

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -365,14 +365,34 @@ function addDiagnosticsSection(nav, sections) {
   const restart = btn('Restart bridge', 'danger');
   bar.appendChild(refresh); bar.appendChild(restart); sec.appendChild(bar);
 
+  const comp = document.createElement('div'); comp.style.margin = '6px 0 14px'; sec.appendChild(comp);
   const info = document.createElement('table'); info.className = 'ld'; sec.appendChild(info);
   const k8sWrap = document.createElement('div'); sec.appendChild(k8sWrap);
+
+  // A "Components" panel: which roles this node runs, MQTT transport, and whether PDU data is flowing.
+  const compLine = (dotClass, label) => {
+    const ln = document.createElement('div'); ln.style.cssText = 'display:flex;align-items:center;gap:8px;margin:4px 0;font-size:13px;';
+    const dot = document.createElement('span'); dot.className = 'dot' + (dotClass ? ' ' + dotClass : '');
+    const t = document.createElement('span'); t.textContent = label;
+    ln.appendChild(dot); ln.appendChild(t); return ln;
+  };
+  const renderComponents = (b) => {
+    comp.innerHTML = '';
+    const head = document.createElement('div'); head.textContent = 'Components'; head.style.cssText = 'font-weight:600;color:var(--accent);margin-bottom:6px;'; comp.appendChild(head);
+    const roles = b.roles || [];
+    comp.appendChild(compLine('good', 'Roles on this node: ' + (roles.length ? roles.join(', ') : 'all')));
+    comp.appendChild(compLine(b.mqttConnected ? 'good' : 'bad', 'MQTT — ' + (b.mqttConnected ? 'connected' : 'disconnected') + ' (' + (b.mqttHost || '?') + ')'));
+    const ds = b.dataSources || [];
+    if (!ds.length) comp.appendChild(compLine('', 'PDU data — none yet' + (roles.length && !roles.includes('worker') ? ' (waiting on a worker)' : '')));
+    else ds.forEach(s => comp.appendChild(compLine(s.stale ? 'bad' : 'good', 'PDU data · ' + s.instance + ' — ' + (s.stale ? 'stale, ' : '') + 'updated ' + s.ageSeconds + 's ago')));
+  };
 
   const fmtUptime = s => { s = Math.floor(s); const d = Math.floor(s / 86400), h = Math.floor(s % 86400 / 3600), m = Math.floor(s % 3600 / 60); return (d ? d + 'd ' : '') + (h ? h + 'h ' : '') + m + 'm'; };
   const row = (k, v) => { const tr = document.createElement('tr'); const a = document.createElement('td'); a.textContent = k; a.style.color = 'var(--muted)'; a.style.width = '220px'; const b = document.createElement('td'); b.textContent = (v == null || v === '') ? '—' : v; tr.appendChild(a); tr.appendChild(b); return tr; };
 
   const load = async () => {
     const r = await api('/api/diagnostics'); const b = r.body;
+    renderComponents(b);
     info.innerHTML = '';
     info.appendChild(row('App version', b.version));
     if (b.image) info.appendChild(row('Container image', b.image));

--- a/rPDU2MQTT/Properties/launchSettings.json
+++ b/rPDU2MQTT/Properties/launchSettings.json
@@ -1,7 +1,19 @@
 {
   "profiles": {
-    "rPDU2MQTT": {
+    "rPDU2MQTT (all)": {
       "commandName": "Project"
+    },
+    "Worker (role)": {
+      "commandName": "Project",
+      "commandLineArgs": "--role worker"
+    },
+    "Api (role)": {
+      "commandName": "Project",
+      "commandLineArgs": "--role api"
+    },
+    "Ui (role)": {
+      "commandName": "Project",
+      "commandLineArgs": "--role ui"
     },
     "Container (Dockerfile)": {
       "commandName": "Docker"

--- a/rPDU2MQTT/Startup/HostRole.cs
+++ b/rPDU2MQTT/Startup/HostRole.cs
@@ -1,26 +1,7 @@
 using Microsoft.Extensions.Configuration;
+using rPDU2MQTT.Core;
 
 namespace rPDU2MQTT.Startup;
-
-/// <summary>
-/// Which workload(s) this process runs. The components live in one solution and one executable; the
-/// active role(s) decide which hosted services start. Default is <see cref="All"/> — a single node that
-/// does everything — but the same binary can run a single role per process to scale out (e.g. several
-/// <see cref="Worker"/>s behind one <see cref="Ui"/>). Cross-role communication is in-process today;
-/// a message-bus transport (the existing MQTT broker) is the planned seam for a distributed deployment.
-/// </summary>
-[Flags]
-public enum HostRole
-{
-    None = 0,
-    /// <summary>Automation / data processing: PDU pollers, MQTT publish, exporters, discovery, control.</summary>
-    Worker = 1,
-    /// <summary>Middle tier: the read-only REST API.</summary>
-    Api = 2,
-    /// <summary>The configuration GUI.</summary>
-    Ui = 4,
-    All = Worker | Api | Ui,
-}
 
 public static class HostRoles
 {

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core;
 using rPDU2MQTT.Helpers;
 using rPDU2MQTT.Services;
 using rPDU2MQTT.Services.Kubernetes;

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -113,6 +113,16 @@ public static class ServiceConfiguration
         // Coordinates on-demand rediscovery (the "Rediscover" diagnostic button).
         services.AddSingleton<DiscoveryCoordinator>();
 
+        // When roles are split across processes, bridge the in-process snapshot bus over MQTT: a Worker
+        // mirrors its snapshots to the broker; a consumer-only node ingests them onto its own bus/cache.
+        // Single-node "all" keeps the bus fully in-process and skips this (no extra broker traffic).
+        if (roles != HostRole.All)
+            services.AddHostedService(sp => new Services.MqttBusBridge(
+                sp.GetRequiredService<IHiveMQClient>(),
+                sp.GetRequiredService<Core.IMessageBus>(),
+                sp.GetRequiredService<Config>(),
+                producer: worker));
+
         // ---- Worker role: the data-processing workload (publish, export, discovery, control). ----
         if (worker)
         {


### PR DESCRIPTION
Makes the role split (#158) actually functional: a **UI/API process can serve a worker's PDU data** over MQTT, with no PDU access of its own. Builds on the `RawSnapshot` wire contract (#159).

## What's in here
**1. MQTT bus bridge** (`MqttBusBridge`, gated to `roles != All`)
- Worker mirrors each in-process snapshot to a retained `‹parent›/_bus/snapshot/‹id›` topic.
- Consumer-only node ingests them back onto its own bus → its `SnapshotCache`.
- Single-node `all` keeps the bus fully in-process — no extra broker traffic, zero behavior change.

**2. Consumer-ready snapshot DTO** (`RawSnapshot` enriched)
- The worker already transforms before publishing, so the wire carries the **finished** result: raw source (`name`/`label`) **plus** the computed identity (`Entity_Name`/`DisplayName`/`Make`/`Model`), device entities, and measurements.
- The consumer renders directly — **no consumer-side re-run of the non-idempotent transform** (which is entangled with the live connection + HA identity). This sidesteps the riskiest refactor entirely.

**3. Cache-backed read path** (GUI)
- `live`, `livedata`, `paths`, `flow`, `control/outlets` now read through the `SnapshotCache` (filled by the local poller, or by the bridge on a consumer), falling back to a direct poll while cold.
- Connection-test and posted-config preview correctly stay direct polls. `ApiService` already used the cache.

**4. Docs** — `docs/v2-architecture.md` now documents the distributed/role mode.

## Safety
- **Single-node `all` is unchanged**: the poller fills the cache; cold-start falls back to a direct poll, so the first request behaves exactly as before.
- Still worker-side (need the live connection): polling, control/actions, discovery.

## Tests
- `RawSnapshot` round-trip preserving finished consumer data (names, make/model, entities, measurements).
- Bridge topic convention + a worker → wire → JSON → consumer hop.
- **113 tests pass**, build clean.

## Needs your hands
Cross-process operation (run `--role worker` and `--role api,ui` as two processes against one broker) needs an **end-to-end smoke test in your environment** — that's the one thing I can't verify here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
