### PR TITLE
feat(gui): cross-process heartbeats on the diagnostics page (#127)

### DIFF
--- a/rPDU2MQTT.Core/Core/Heartbeat.cs
+++ b/rPDU2MQTT.Core/Core/Heartbeat.cs
@@ -1,0 +1,15 @@
+namespace rPDU2MQTT.Core;
+
+/// <summary>
+/// A liveness beacon one role process publishes about itself (#127), so the GUI can show every process in
+/// a split deployment — including ones that carry no PDU data (e.g. an <c>api</c> node). Liveness is by
+/// freshness: a process whose last heartbeat is older than <see cref="StaleAfterSeconds"/> is presumed gone.
+/// </summary>
+public sealed record Heartbeat(string Id, string[] Roles, string? Host, DateTime StartedUtc, DateTime TimestampUtc, string? Version)
+{
+    /// <summary>Heartbeats are published this often.</summary>
+    public const int IntervalSeconds = 15;
+
+    /// <summary>A process with no heartbeat in this long is considered gone.</summary>
+    public const int StaleAfterSeconds = IntervalSeconds * 3;
+}

--- a/rPDU2MQTT.Engine/Services/HeartbeatService.cs
+++ b/rPDU2MQTT.Engine/Services/HeartbeatService.cs
@@ -1,0 +1,108 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Events;
+using HiveMQtt.MQTT5.Types;
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Helpers;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Publishes this process's <see cref="Heartbeat"/> and listens for the others', so a split deployment can
+/// show every role process on the diagnostics page — including ones with no PDU data (#127). Only loaded
+/// when roles are split; a single-node "all" deployment has nothing to discover.
+/// <para>Topic: <c>&lt;parentTopic&gt;/_bus/heartbeat/&lt;id&gt;</c> (retained; a clean shutdown clears it).</para>
+/// </summary>
+public sealed class HeartbeatService : IHostedService
+{
+    private const string BusSegment = "_bus";
+    private const string HeartbeatSegment = "heartbeat";
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private readonly HiveMQClient mqtt;
+    private readonly Config cfg;
+    private readonly Heartbeat self;
+    private readonly ConcurrentDictionary<string, Heartbeat> seen = new(StringComparer.OrdinalIgnoreCase);
+    private readonly CancellationTokenSource cts = new();
+    private Task? pump;
+
+    public HeartbeatService(IHiveMQClient mqtt, Config cfg, HostRole roles)
+    {
+        this.mqtt = (HiveMQClient)mqtt;
+        this.cfg = cfg;
+
+        var roleNames = new[] { HostRole.Worker, HostRole.Api, HostRole.Ui }.Where(r => roles.HasFlag(r)).Select(r => r.ToString().ToLowerInvariant()).ToArray();
+        var host = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME") ?? Environment.MachineName;
+        var rawId = $"{string.Join('-', roleNames)}-{host}-{Guid.NewGuid():N}".ToLowerInvariant();
+        var id = Sanitize(rawId.Length > 80 ? rawId[..80] : rawId);
+        var version = System.Reflection.Assembly.GetEntryAssembly()?.GetName().Version?.ToString();
+        self = new Heartbeat(id, roleNames, host, DateTime.UtcNow, DateTime.UtcNow, version);
+    }
+
+    private static string Sanitize(string s) => new(s.Select(c => char.IsLetterOrDigit(c) || c is '-' or '_' or '.' ? c : '-').ToArray());
+
+    private string TopicFor(string id) => MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, BusSegment, HeartbeatSegment, id);
+
+    /// <summary>Every process seen recently (this one included), freshest reported via <see cref="Heartbeat.TimestampUtc"/>.</summary>
+    public IReadOnlyCollection<Heartbeat> Processes => seen.Values.ToArray();
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        seen[self.Id] = self with { TimestampUtc = DateTime.UtcNow };
+        mqtt.OnMessageReceived += OnMessageReceived;
+        var result = await mqtt.SubscribeAsync(MQTTHelper.JoinPaths(cfg.MQTT.ParentTopic, BusSegment, HeartbeatSegment, "+"), QualityOfService.AtLeastOnceDelivery);
+        foreach (var sub in result.Subscriptions)
+            if ((int)sub.SubscribeReasonCode > 2)
+                Log.Warning($"Heartbeat: subscription to '{sub.TopicFilter.Topic}' not granted ({sub.SubscribeReasonCode}); other processes won't be listed.");
+        pump = Task.Run(() => PumpAsync(cts.Token), CancellationToken.None);
+        Log.Information($"Heartbeat: announcing '{self.Id}' (roles: {string.Join(", ", self.Roles)}).");
+    }
+
+    private async Task PumpAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(Heartbeat.IntervalSeconds));
+            do
+            {
+                var beat = self with { TimestampUtc = DateTime.UtcNow };
+                seen[beat.Id] = beat;
+                await mqtt.PublishAsync(new MQTT5PublishMessage(TopicFor(beat.Id), QualityOfService.AtLeastOnceDelivery)
+                {
+                    PayloadAsString = JsonSerializer.Serialize(beat, Json),
+                    Retain = true,
+                });
+            }
+            while (await timer.WaitForNextTickAsync(ct));
+        }
+        catch (OperationCanceledException) { /* shutting down */ }
+        catch (Exception ex) { Log.Error(ex, "Heartbeat: publish loop stopped."); }
+    }
+
+    private void OnMessageReceived(object? sender, OnMessageReceivedEventArgs e)
+    {
+        try
+        {
+            var json = e.PublishMessage.PayloadAsString;
+            var topicId = e.PublishMessage.Topic?.Split('/').LastOrDefault();
+            if (string.IsNullOrEmpty(json)) { if (!string.IsNullOrEmpty(topicId)) seen.TryRemove(topicId, out _); return; } // empty retained = tombstone
+            var beat = JsonSerializer.Deserialize<Heartbeat>(json, Json);
+            if (beat is not null && !string.IsNullOrEmpty(beat.Id)) seen[beat.Id] = beat;
+        }
+        catch (Exception ex) { Log.Warning($"Heartbeat: could not read one from '{e.PublishMessage.Topic}': {ex.Message}"); }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        cts.Cancel();
+        if (pump is not null)
+            try { await pump; } catch { /* ignore shutdown races */ }
+        mqtt.OnMessageReceived -= OnMessageReceived;
+        // Clear our retained heartbeat so we disappear from other processes promptly on a clean stop.
+        try { await mqtt.PublishAsync(new MQTT5PublishMessage(TopicFor(self.Id), QualityOfService.AtLeastOnceDelivery) { PayloadAsString = "", Retain = true }); }
+        catch { /* best effort */ }
+    }
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -43,10 +43,11 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly EmonCmsStatus emonCmsStatus;
     private readonly Core.ISnapshotCache snapshots;
     private readonly Core.HostRole hostRoles;
+    private readonly HeartbeatService heartbeats;
     private static readonly HttpClient testHttp = new() { Timeout = TimeSpan.FromSeconds(15) };
     private WebApplication? app;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots, Core.HostRole hostRoles)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots, Core.HostRole hostRoles, HeartbeatService heartbeats)
     {
         this.config = config;
         this.mqtt = mqtt;
@@ -61,6 +62,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         this.emonCmsStatus = emonCmsStatus;
         this.snapshots = snapshots;
         this.hostRoles = hostRoles;
+        this.heartbeats = heartbeats;
     }
 
     /// <summary>
@@ -424,6 +426,22 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                             instance = s.InstanceId,
                             ageSeconds = (long)Math.Max(0, (DateTime.UtcNow - s.TimestampUtc).TotalSeconds),
                             stale = Core.SnapshotFreshness.IsStale(s.TimestampUtc, interval, DateTime.UtcNow),
+                        };
+                    })
+                    .ToArray(),
+                // Other role processes seen on the bus (split deployments). Empty for a single-node "all".
+                processes = heartbeats.Processes
+                    .OrderBy(p => string.Join(',', p.Roles)).ThenBy(p => p.Host)
+                    .Select(p =>
+                    {
+                        var age = (long)Math.Max(0, (DateTime.UtcNow - p.TimestampUtc).TotalSeconds);
+                        return new
+                        {
+                            id = p.Id,
+                            roles = p.Roles,
+                            host = p.Host,
+                            ageSeconds = age,
+                            stale = age > Core.Heartbeat.StaleAfterSeconds,
                         };
                     })
                     .ToArray(),

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -385,6 +385,8 @@ function addDiagnosticsSection(nav, sections) {
     const ds = b.dataSources || [];
     if (!ds.length) comp.appendChild(compLine('', 'PDU data — none yet' + (roles.length && !roles.includes('worker') ? ' (waiting on a worker)' : '')));
     else ds.forEach(s => comp.appendChild(compLine(s.stale ? 'bad' : 'good', 'PDU data · ' + s.instance + ' — ' + (s.stale ? 'stale, ' : '') + 'updated ' + s.ageSeconds + 's ago')));
+    // Other role processes seen on the bus (split deployments only).
+    (b.processes || []).forEach(p => comp.appendChild(compLine(p.stale ? 'bad' : 'good', 'Process · ' + ((p.roles || []).join('+') || '?') + ' @ ' + (p.host || '?') + ' — ' + (p.stale ? 'last seen ' : 'alive, ') + p.ageSeconds + 's ago')));
   };
 
   const fmtUptime = s => { s = Math.floor(s); const d = Math.floor(s / 86400), h = Math.floor(s % 86400 / 3600), m = Math.floor(s % 3600 / 60); return (d ? d + 'd ' : '') + (h ? h + 'h ' : '') + m + 'm'; };

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -124,6 +124,12 @@ public static class ServiceConfiguration
                 sp.GetRequiredService<Config>(),
                 producer: worker));
 
+        // Per-process liveness beacons so the GUI can list every role process in a split deployment.
+        // Always resolvable (the GUI reads it); only runs the publish/subscribe loop when roles are split.
+        services.AddSingleton<Services.HeartbeatService>();
+        if (roles != HostRole.All)
+            services.AddHostedService(sp => sp.GetRequiredService<Services.HeartbeatService>());
+
         // ---- Worker role: the data-processing workload (publish, export, discovery, control). ----
         if (worker)
         {


### PR DESCRIPTION
Polish on the distributed mode (#127): make the diagnostics page show **every role process**, not just whether data is flowing.

## Why
The merged work shows per-instance PDU-data freshness — which tells you a *worker* is alive. But a split deployment also runs processes with **no** PDU data (an `api`-only node, a second `ui`). Those were invisible.

## What
- Each process publishes a retained `Heartbeat` to `‹parent›/_bus/heartbeat/‹id›` every 15s (`roles`, `host`, `startedUtc`, `version`), and every process listens for the others.
- Diagnostics `/api/diagnostics` returns `processes`; the GUI **Components** panel lists each with an alive/stale dot (`Process · ui @ host — alive, 3s ago`).
- Liveness by freshness (stale after 45s); a clean shutdown publishes an empty retained beacon so the process disappears promptly.
- **Gated to split roles** — single-node `all` doesn't publish or subscribe (no extra broker traffic), and the panel just shows the local roles as before.

## Tests / build
113 tests pass, clean build. The publish/subscribe loop itself needs a live broker to verify end-to-end (same as the bridge).

## Deferred (tracked on #127)
OneView **groups** in the transport DTO — the group structure (`Entity.Outlets/PduTotal → GroupMeasurement` Sum/Avg/Min/Max + computed `MemberOutlets`) is heavy and OneView-only; it deserves its own focused PR rather than a rushed mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
