### PR TITLE
feat(gui): persistent tab navigation via the URL hash (#166)

### DIFF
--- a/rPDU2MQTT.Web/web/smoke.mjs
+++ b/rPDU2MQTT.Web/web/smoke.mjs
@@ -33,6 +33,7 @@ const sandbox = {
     elementFromPoint: () => null,
   },
   window: { addEventListener() {}, removeEventListener() {} },
+  location: { hash: '' },
   navigator: { clipboard: { writeText() {} } },
   DOMPoint: class { matrixTransform() { return { x: 0, y: 0 }; } },
   setTimeout: () => 0, setInterval: () => 0, clearInterval() {},

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -1,6 +1,6 @@
 // Schema-driven config form: render scalar/object/dictionary/list nodes, the per-section panels, the
 // nav, and the overall build() that wires every tab.
-import { ensure, el, btn, activate } from './helpers.js';
+import { ensure, el, btn, activate, slug } from './helpers.js';
 import { state } from './state.js';
 import { renderOverrides, previewOverridePaths } from './overrides.js';
 import { testMqtt, testPdu, testEmonCms, rediscoverHa, clearHa } from './actions.js';
@@ -230,7 +230,10 @@ export function build() {
   addExportSection(nav, sections);
   addDiagnosticsSection(nav, sections);
 
-  if (first) first.click();
+  // Open the tab named in the URL hash (so a refresh / shared link lands where you were), else the first.
+  const wanted = decodeURIComponent((location.hash || '').slice(1));
+  const target = wanted ? ([...nav.querySelectorAll('a')] as any[]).find(a => slug(a.textContent) === wanted) : null;
+  (target || first)?.click();
 }
 
 // In the Gui section, grey out the auth fields that don't apply to the selected AuthType.

--- a/rPDU2MQTT.Web/web/src/helpers.ts
+++ b/rPDU2MQTT.Web/web/src/helpers.ts
@@ -32,10 +32,19 @@ export function svgEl(tag: string, attrs?: any): any {
 
 export function toast(msg: string, good?: boolean) { const t: any = document.getElementById('toast'); t.textContent = msg; t.className = 'toast ' + (good ? 'good' : 'bad'); }
 
+// A URL-friendly slug for a nav label (used to put the active tab in the address bar).
+export function slug(text: string): string {
+  return (text || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
 export function activate(link: any, sec: any) {
   document.querySelectorAll('nav a').forEach(a => a.classList.remove('active'));
   document.querySelectorAll('.section').forEach(s => s.classList.remove('active'));
   link.classList.add('active'); sec.classList.add('active');
+  // Reflect the active tab in the URL hash so a refresh (or a shared link) reopens it. Only write when it
+  // actually changes, to avoid spurious history entries / hashchange loops (see the listener in main.ts).
+  const s = slug(link.textContent);
+  if (s && decodeURIComponent((location.hash || '').slice(1)) !== s) location.hash = s;
 }
 
 // Mouse-wheel zoom for an SVG inside a scroll container. The SVG must carry a viewBox of its base size;

--- a/rPDU2MQTT.Web/web/src/main.ts
+++ b/rPDU2MQTT.Web/web/src/main.ts
@@ -1,8 +1,18 @@
 // Bootstrap & shared status: load the schema + config, build the UI, and wire the global Save/Reload.
-import { api, toast } from './helpers.js';
+import { api, toast, slug } from './helpers.js';
 import { state } from './state.js';
 import { build } from './config-form.js';
 import { exportData } from './overrides.js';
+
+// Back/forward navigation + direct hash edits: open the matching tab if it isn't already active. (Normal
+// tab clicks already set the hash via activate(), so by the time this fires the tab is active -> no-op,
+// which also avoids re-loading a tab's data on every click.)
+window.addEventListener('hashchange', () => {
+  const wanted = decodeURIComponent((location.hash || '').slice(1));
+  if (!wanted) return;
+  const link = ([...document.querySelectorAll('nav a')] as any[]).find(a => slug(a.textContent) === wanted);
+  if (link && !link.classList.contains('active')) link.click();
+});
 
 export async function load() {
   state.schema = (await api('/api/schema')).body;

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -38,10 +38,19 @@ function svgEl(tag        , attrs      )      {
 
 function toast(msg        , good          ) { const t      = document.getElementById('toast'); t.textContent = msg; t.className = 'toast ' + (good ? 'good' : 'bad'); }
 
+// A URL-friendly slug for a nav label (used to put the active tab in the address bar).
+function slug(text        )         {
+  return (text || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
 function activate(link     , sec     ) {
   document.querySelectorAll('nav a').forEach(a => a.classList.remove('active'));
   document.querySelectorAll('.section').forEach(s => s.classList.remove('active'));
   link.classList.add('active'); sec.classList.add('active');
+  // Reflect the active tab in the URL hash so a refresh (or a shared link) reopens it. Only write when it
+  // actually changes, to avoid spurious history entries / hashchange loops (see the listener in main.ts).
+  const s = slug(link.textContent);
+  if (s && decodeURIComponent((location.hash || '').slice(1)) !== s) location.hash = s;
 }
 
 // Mouse-wheel zoom for an SVG inside a scroll container. The SVG must carry a viewBox of its base size;
@@ -1280,7 +1289,10 @@ function build() {
   addExportSection(nav, sections);
   addDiagnosticsSection(nav, sections);
 
-  if (first) first.click();
+  // Open the tab named in the URL hash (so a refresh / shared link lands where you were), else the first.
+  const wanted = decodeURIComponent((location.hash || '').slice(1));
+  const target = wanted ? ([...nav.querySelectorAll('a')]         ).find(a => slug(a.textContent) === wanted) : null;
+  (target || first)?.click();
 }
 
 // In the Gui section, grey out the auth fields that don't apply to the selected AuthType.
@@ -1334,6 +1346,16 @@ async function clearHa() {
 
 // ── main.ts ─────────────────────────────────────────────────────
 // Bootstrap & shared status: load the schema + config, build the UI, and wire the global Save/Reload.
+
+// Back/forward navigation + direct hash edits: open the matching tab if it isn't already active. (Normal
+// tab clicks already set the hash via activate(), so by the time this fires the tab is active -> no-op,
+// which also avoids re-loading a tab's data on every click.)
+window.addEventListener('hashchange', () => {
+  const wanted = decodeURIComponent((location.hash || '').slice(1));
+  if (!wanted) return;
+  const link = ([...document.querySelectorAll('nav a')]         ).find(a => slug(a.textContent) === wanted);
+  if (link && !link.classList.contains('active')) link.click();
+});
 
 async function load() {
   state.schema = (await api('/api/schema')).body;


### PR DESCRIPTION
Closes #166. The GUI is a single page with no routing, so a refresh always dumped you back on the default tab. Now the active tab lives in the URL.

## What
- `activate()` writes a slug of the active tab to the URL hash (e.g. `#flow`, `#pdu-control`), only when it changes.
- `build()` opens the tab named in the hash on load — so **refresh / a shared link lands where you were** — falling back to the first tab.
- A `hashchange` listener handles **back/forward** and manual hash edits (clicks no-op since the tab is already active, so no double data-load).

Hash-based (not path-based) so there are **no server/routing changes** — the SPA is still served at `/`.

## Tests
Rebuilt the TS bundle; `node --check` + the DOM-stub smoke test (run through `build()`); `dotnet build` regenerates the bundle; 113 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
