### PR TITLE
feat(ha): sync energy-flow hierarchy into HA's Energy Dashboard (#128)

### DIFF
--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -1,0 +1,47 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>One Home Assistant Energy-Dashboard "individual device" entry (the <c>device_consumption</c> shape).</summary>
+public sealed record HaDeviceConsumption(string stat_consumption, string? included_in_stat, string? name);
+
+/// <summary>
+/// Maps an energy-flow hierarchy onto Home Assistant's Energy-Dashboard device list (#128): one entry per
+/// tier that has an energy stat, with <c>included_in_stat</c> set to its nearest ancestor that also has a
+/// stat. HA's upstream relationship is single-parent, so a multi-feeder tier follows its primary feeder.
+/// Pure (no HA/IO) so it's unit-testable; the service feeds it a resolver from tier id → HA energy entity_id.
+/// </summary>
+public static class EnergyDashboardSync
+{
+    public static List<HaDeviceConsumption> BuildDeviceConsumption(FlowGraph graph, Func<string, string?> statFor)
+    {
+        var entries = new List<HaDeviceConsumption>();
+        foreach (var node in graph.Nodes)
+        {
+            var stat = statFor(node.Id);
+            if (string.IsNullOrEmpty(stat))
+                continue;   // no energy sensor for this tier -> can't be an Energy-Dashboard device
+            entries.Add(new HaDeviceConsumption(stat, NearestAncestorStat(graph, node.Id, statFor), node.Label));
+        }
+        return entries;
+    }
+
+    // Walk up the primary-feeder chain to the first ancestor that has an energy stat (skipping tiers that
+    // don't), so the upstream link stays valid even when an intermediate tier has no energy sensor.
+    private static string? NearestAncestorStat(FlowGraph graph, string id, Func<string, string?> statFor)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { id };
+        var current = id;
+        while (true)
+        {
+            var parents = FlowExport.Parents(graph, current);
+            if (parents.Length == 0)
+                return null;
+            var parent = parents[0];        // HA upstream is single-parent: follow the primary feeder
+            if (!seen.Add(parent))
+                return null;                // cycle guard
+            var stat = statFor(parent);
+            if (!string.IsNullOrEmpty(stat))
+                return stat;
+            current = parent;
+        }
+    }
+}

--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -1,7 +1,16 @@
+using System.Text.Json.Serialization;
+
 namespace rPDU2MQTT.Core.Flow;
 
-/// <summary>One Home Assistant Energy-Dashboard "individual device" entry (the <c>device_consumption</c> shape).</summary>
-public sealed record HaDeviceConsumption(string stat_consumption, string? included_in_stat, string? name);
+/// <summary>
+/// One Home Assistant Energy-Dashboard "individual device" entry (the <c>device_consumption</c> shape).
+/// HA's schema rejects a null <c>included_in_stat</c>/<c>name</c> — the keys must be omitted, not null —
+/// so both are dropped from the JSON when unset.
+/// </summary>
+public sealed record HaDeviceConsumption(
+    string stat_consumption,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? included_in_stat,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? name);
 
 /// <summary>
 /// Maps an energy-flow hierarchy onto Home Assistant's Energy-Dashboard device list (#128): one entry per

--- a/rPDU2MQTT.Core/Flow/FlowExport.cs
+++ b/rPDU2MQTT.Core/Flow/FlowExport.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using rPDU2MQTT.Models.Config;
 
 namespace rPDU2MQTT.Core.Flow;
@@ -37,8 +38,8 @@ public static class FlowExport
         var template = string.IsNullOrWhiteSpace(cfg.MqttTopicTemplate) ? "{parent}/energyflow/{id}" : cfg.MqttTopicTemplate;
         var topic = template
             .Replace("{parent}", (parentTopic ?? string.Empty).Trim('/'))
-            .Replace("{id}", Slug(node.Id))
-            .Replace("{label}", Slug(node.Label))
+            .Replace("{id}", NodeKey(node.Id))
+            .Replace("{label}", NodeKey(node.Label))
             .Replace("{kind}", node.Kind)
             .Replace("{metric}", graph.Metric)
             .Replace("{units}", graph.Units);
@@ -46,7 +47,62 @@ public static class FlowExport
         return string.Join('/', topic.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
     }
 
-    // Topic-safe form of an id/label: ':' (outlet:pdu:n) and other separators -> '_'.
-    private static string Slug(string value)
+    /// <summary>A stable, topic/id-safe key for a node id: ':' (outlet:pdu:n) and other separators -> '_'.</summary>
+    public static string NodeKey(string value)
         => new((value ?? string.Empty).Select(c => char.IsLetterOrDigit(c) || c is '-' or '_' ? c : '_').ToArray());
+
+    /// <summary>The Home Assistant device identifier for a tier ("energyflow_&lt;key&gt;").</summary>
+    public static string DeviceId(string nodeId) => "energyflow_" + NodeKey(nodeId);
+
+    /// <summary>The HA unique_id / entity object_id of a tier's energy sensor ("energyflow_&lt;key&gt;_energy").</summary>
+    public static string EnergyUniqueId(string nodeId) => DeviceId(nodeId) + "_energy";
+
+    /// <summary>
+    /// A Home Assistant device-discovery document for a tier (#128): one device with an Energy sensor
+    /// (kWh, total_increasing — so it can feed the Energy Dashboard) and a Power sensor (W), both reading
+    /// <c>value_json.energy</c> / <c>value_json.power</c> from the tier's exported MQTT topic. Publishing
+    /// these makes the whole hierarchy — not just leaf outlets — visible to HA and linkable in the dashboard.
+    /// </summary>
+    public static JsonObject DiscoveryDocument(FlowNode node, string? primaryParentId, string stateTopic,
+        string energyUnits, string powerUnits, string? availabilityTopic)
+    {
+        var id = DeviceId(node.Id);
+        var device = new JsonObject
+        {
+            ["identifiers"] = new JsonArray(id),
+            ["name"] = node.Label,
+            ["manufacturer"] = "rPDU2MQTT",
+            ["model"] = $"Energy Flow ({node.Kind})",
+        };
+        if (!string.IsNullOrEmpty(primaryParentId))
+            device["via_device"] = DeviceId(primaryParentId);
+
+        static JsonObject Sensor(string uniqueId, string name, string deviceClass, string stateClass, string units, string template) => new()
+        {
+            ["platform"] = "sensor",
+            ["name"] = name,
+            ["unique_id"] = uniqueId,
+            ["object_id"] = uniqueId,
+            ["device_class"] = deviceClass,
+            ["state_class"] = stateClass,
+            ["unit_of_measurement"] = units,
+            ["value_template"] = template,
+        };
+
+        var doc = new JsonObject
+        {
+            ["device"] = device,
+            ["origin"] = new JsonObject { ["name"] = "rPDU2MQTT" },
+            ["state_topic"] = stateTopic,
+            ["qos"] = 0,
+            ["components"] = new JsonObject
+            {
+                [$"{id}_energy"] = Sensor($"{id}_energy", "Energy", "energy", "total_increasing", string.IsNullOrWhiteSpace(energyUnits) ? "kWh" : energyUnits, "{{ value_json.energy }}"),
+                [$"{id}_power"] = Sensor($"{id}_power", "Power", "power", "measurement", string.IsNullOrWhiteSpace(powerUnits) ? "W" : powerUnits, "{{ value_json.power }}"),
+            },
+        };
+        if (!string.IsNullOrEmpty(availabilityTopic))
+            doc["availability_topic"] = availabilityTopic;
+        return doc;
+    }
 }

--- a/rPDU2MQTT.Core/Models/Config/HomeAssistantConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/HomeAssistantConfig.cs
@@ -58,4 +58,30 @@ public class HomeAssistantConfig
     [Description("Stable entity/object_id template for a group's mirrored member switches. Placeholders: {serial}, {number}, {device}, {group}.")]
     [TemplateVariables("serial", "number", "device", "group")]
     public string GroupMemberObjectIdTemplate { get; set; } = "{serial}_outlet_{number}";
+
+    /// <summary>Auto-configure HA's Energy Dashboard device hierarchy from the energy flow (#128).</summary>
+    [Description("Auto-configure Home Assistant's Energy Dashboard 'devices' (with upstream relationships) from the energy-flow hierarchy, via HA's WebSocket API.")]
+    public HomeAssistantEnergyDashboardConfig EnergyDashboard { get; set; } = new();
+}
+
+/// <summary>
+/// Pushes the energy-flow hierarchy into Home Assistant's Energy Dashboard "individual devices" — each
+/// tier's energy stat plus its upstream device (<c>included_in_stat</c>, which prevents double-counting) —
+/// via HA's WebSocket API (this can't be done over MQTT discovery). See #128.
+/// </summary>
+public class HomeAssistantEnergyDashboardConfig
+{
+    [DefaultValue(false)]
+    [Description("Sync the energy-flow hierarchy into HA's Energy Dashboard via its API. Requires Url + a long-lived access token.")]
+    public bool Enabled { get; set; }
+
+    [Description("Home Assistant base URL, e.g. http://homeassistant.local:8123 .")]
+    public string? Url { get; set; }
+
+    [Description("Home Assistant long-lived access token (or set RPDU2MQTT_HASS_TOKEN).")]
+    public string? Token { get; set; }
+
+    [DefaultValue("energy")]
+    [Description("Measurement type holding each entity's cumulative energy (kWh) — used to find the Energy Dashboard stat for each tier.")]
+    public string EnergyMeasurementType { get; set; } = "energy";
 }

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -1,5 +1,6 @@
 using rPDU2MQTT.Classes;
 using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Helpers;
 using rPDU2MQTT.Models.PDU;
 using rPDU2MQTT.Services.baseTypes;
 using System.Text.Json;
@@ -7,9 +8,11 @@ using System.Text.Json;
 namespace rPDU2MQTT.Services;
 
 /// <summary>
-/// Publishes each energy-hierarchy tier's rolled-up value to MQTT every poll (#164), when
+/// Publishes each energy-hierarchy tier's rolled-up power + energy to MQTT every poll (#164), when
 /// <c>EnergyFlow.MqttExport</c> is on. The topic per tier comes from <c>EnergyFlow.MqttTopicTemplate</c>.
-/// Registered in the Worker role; a no-op when the export is disabled.
+/// When HA discovery is enabled, each tier is also published as an HA device (Energy + Power sensors)
+/// so the whole hierarchy — not just leaf outlets — appears in Home Assistant and can feed the Energy
+/// Dashboard (#128). Registered in the Worker role; a no-op when the export is disabled.
 /// </summary>
 public class EnergyFlowMqttExportService : baseMQTTService
 {
@@ -28,19 +31,42 @@ public class EnergyFlowMqttExportService : baseMQTTService
         if (merged.Devices.Count == 0)
             return;
 
+        // Power defines the hierarchy/topics; energy is the same roll-up over the energy measurement, so
+        // each tier gets a total (kWh) it can contribute to the Energy Dashboard.
         var graph = FlowGraphBuilder.Build(merged, flow, FlowGraphBuilder.DefaultMetric);
+        var energyMetric = string.IsNullOrWhiteSpace(cfg.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : cfg.HASS.EnergyDashboard.EnergyMeasurementType;
+        var energyGraph = FlowGraphBuilder.Build(merged, flow, energyMetric);
+
+        var publishDiscovery = cfg.HASS.DiscoveryEnabled && !string.IsNullOrWhiteSpace(cfg.HASS.DiscoveryTopic);
+        var availability = cfg.MQTT.LastWill ? MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic) : null;
+
         foreach (var node in graph.Nodes)
         {
+            var topic = FlowExport.Topic(node, graph, cfg.MQTT.ParentTopic, flow);
+            var power = FlowExport.NodeValue(graph, node.Id);
+            var energy = FlowExport.NodeValue(energyGraph, node.Id);   // 0 when this tier has no energy sensor
+            var parents = FlowExport.Parents(graph, node.Id);          // the tiers that feed this one
+
             var payload = JsonSerializer.Serialize(new
             {
                 id = node.Id,
-                value = FlowExport.NodeValue(graph, node.Id),
+                value = power,       // retained for #164 back-compat (== power)
+                power,
+                energy,
                 units = graph.Units,
+                energyUnits = energyGraph.Units,
                 label = node.Label,
                 kind = node.Kind,
-                parents = FlowExport.Parents(graph, node.Id),   // the tiers that feed this one
+                parents,
             });
-            await PublishString(FlowExport.Topic(node, graph, cfg.MQTT.ParentTopic, flow), payload, retain: true, cancellationToken);
+            await PublishString(topic, payload, retain: true, cancellationToken);
+
+            if (publishDiscovery)
+            {
+                var doc = FlowExport.DiscoveryDocument(node, parents.FirstOrDefault(), topic, energyGraph.Units, graph.Units, availability);
+                var configTopic = $"{cfg.HASS.DiscoveryTopic}/device/{FlowExport.DeviceId(node.Id)}/config";
+                await PublishString(configTopic, doc.ToJsonString(), retain: cfg.HASS.DiscoveryRetain, cancellationToken);
+            }
         }
     }
 }

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardService.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardService.cs
@@ -1,0 +1,139 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.PDU;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Keeps Home Assistant's Energy-Dashboard "individual devices" in sync with the energy-flow hierarchy
+/// (#128): each tier's energy stat with its upstream device (<c>included_in_stat</c>). This can only be set
+/// through HA's WebSocket API (not MQTT discovery), so it needs a HA URL + long-lived access token. A no-op
+/// unless <c>HomeAssistant.EnergyDashboard.Enabled</c> is set.
+/// </summary>
+public sealed class HaEnergyDashboardService : BackgroundService
+{
+    private readonly Config config;
+    private readonly Core.ISnapshotCache snapshots;
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public HaEnergyDashboardService(Config config, Core.ISnapshotCache snapshots)
+    {
+        this.config = config;
+        this.snapshots = snapshots;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Reconcile periodically; HA only needs this when the hierarchy or available sensors change.
+        var period = TimeSpan.FromSeconds(Math.Max(30, config.Primary.PollInterval * 4));
+        using var timer = new PeriodicTimer(period);
+        do
+        {
+            try { await ReconcileAsync(stoppingToken); }
+            catch (OperationCanceledException) { return; }
+            catch (Exception ex) { Log.Warning($"HA Energy Dashboard sync failed: {ex.Message}"); }
+        }
+        while (await timer.WaitForNextTickAsync(stoppingToken));
+    }
+
+    private async Task ReconcileAsync(CancellationToken ct)
+    {
+        var ed = config.HASS.EnergyDashboard;
+        if (!ed.Enabled || string.IsNullOrWhiteSpace(ed.Url) || string.IsNullOrWhiteSpace(ed.Token))
+            return;
+
+        // Build one graph across all fresh sources and a tier-id -> HA energy entity_id resolver.
+        var merged = new PduData();
+        foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
+        if (merged.Devices.Count == 0) return;
+
+        var statFor = BuildStatResolver(merged, ed.EnergyMeasurementType);
+        var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric);
+        var desired = EnergyDashboardSync.BuildDeviceConsumption(graph, statFor);
+        if (desired.Count == 0) return;
+
+        await PushAsync(ed.Url!, ed.Token!, desired, ct);
+    }
+
+    // Map a flow tier id to its Home Assistant energy sensor entity_id (sensor.<object_id>), when the tier
+    // has a measurement of the configured energy type. Covers PDU tiers (device-level entities) and outlets.
+    private static Func<string, string?> BuildStatResolver(PduData data, string energyType)
+    {
+        var byNode = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        string? EnergyEntity(IEnumerable<Measurement> measurements) =>
+            measurements.FirstOrDefault(m => string.Equals(m.Type, energyType, StringComparison.OrdinalIgnoreCase))?.Entity_Name is { Length: > 0 } name
+                ? "sensor." + name
+                : null;
+
+        foreach (var device in data.Devices)
+        {
+            if (EnergyEntity(device.Entity.SelectMany(e => e.Measurements)) is { } pduStat)
+                byNode[$"pdu:{device.Entity_Name}"] = pduStat;
+            foreach (var outlet in device.Outlets)
+                if (EnergyEntity(outlet.Measurements) is { } outletStat)
+                    byNode[$"outlet:{device.Entity_Name}:{outlet.Key}"] = outletStat;
+        }
+        return id => byNode.TryGetValue(id, out var s) ? s : null;
+    }
+
+    private async Task PushAsync(string url, string token, List<HaDeviceConsumption> desired, CancellationToken ct)
+    {
+        var wsUrl = url.TrimEnd('/').Replace("https://", "wss://").Replace("http://", "ws://") + "/api/websocket";
+        using var ws = new ClientWebSocket();
+        await ws.ConnectAsync(new Uri(wsUrl), ct);
+
+        await Receive(ws, ct);                                                    // auth_required
+        await Send(ws, new { type = "auth", access_token = token }, ct);
+        var auth = await Receive(ws, ct);
+        if ((string?)auth?["type"] != "auth_ok")
+            throw new Exception("Home Assistant rejected the access token.");
+
+        await Send(ws, new { id = 1, type = "energy/get_prefs" }, ct);
+        var prefs = (await Receive(ws, ct))?["result"]?.AsObject()
+            ?? throw new Exception("Could not read HA energy preferences.");
+
+        // Keep the user's own devices; replace only the ones whose stat we manage.
+        var ours = desired.Select(d => d.stat_consumption).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var devices = new JsonArray();
+        foreach (var existing in prefs["device_consumption"]?.AsArray() ?? new JsonArray())
+            if (existing is JsonObject o && !ours.Contains((string?)o["stat_consumption"] ?? ""))
+                devices.Add(JsonNode.Parse(o.ToJsonString())!);
+        foreach (var d in desired)
+            devices.Add(JsonSerializer.SerializeToNode(d, Json)!);
+        prefs["device_consumption"] = devices;
+
+        var save = JsonSerializer.SerializeToNode(new { id = 2, type = "energy/save_prefs" }, Json)!.AsObject();
+        foreach (var kv in prefs) save[kv.Key] = kv.Value is null ? null : JsonNode.Parse(kv.Value.ToJsonString());
+        await Send(ws, save, ct);
+        var result = await Receive(ws, ct);
+        if ((bool?)result?["success"] != true)
+            throw new Exception($"HA save_prefs failed: {result?.ToJsonString()}");
+
+        Log.Information($"HA Energy Dashboard: synced {desired.Count} hierarchy device(s).");
+        await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, ct);
+    }
+
+    private static Task Send(ClientWebSocket ws, object message, CancellationToken ct)
+        => ws.SendAsync(Encoding.UTF8.GetBytes(message is JsonNode n ? n.ToJsonString() : JsonSerializer.Serialize(message, Json)),
+            WebSocketMessageType.Text, true, ct);
+
+    private static async Task<JsonNode?> Receive(ClientWebSocket ws, CancellationToken ct)
+    {
+        var buffer = new ArraySegment<byte>(new byte[64 * 1024]);
+        using var ms = new MemoryStream();
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await ws.ReceiveAsync(buffer, ct);
+            ms.Write(buffer.Array!, 0, result.Count);
+        }
+        while (!result.EndOfMessage);
+        return JsonNode.Parse(Encoding.UTF8.GetString(ms.ToArray()));
+    }
+}

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardService.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardService.cs
@@ -28,7 +28,7 @@ public sealed class HaEnergyDashboardService : BackgroundService
             var ed = config.HASS.EnergyDashboard;
             if (ed.Enabled && !string.IsNullOrWhiteSpace(ed.Url) && !string.IsNullOrWhiteSpace(ed.Token))
             {
-                try { await sync.SyncAsync(ed.Url!, ed.Token!, ed.EnergyMeasurementType, stoppingToken); }
+                try { await sync.SyncAsync(ed.Url!, ed.Token!, stoppingToken); }
                 catch (OperationCanceledException) { return; }
                 catch (Exception ex) { Log.Warning($"HA Energy Dashboard sync failed: {ex.Message}"); }
             }

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardService.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardService.cs
@@ -1,139 +1,38 @@
-using System.Net.WebSockets;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Nodes;
 using Microsoft.Extensions.Hosting;
 using rPDU2MQTT.Classes;
-using rPDU2MQTT.Core;
-using rPDU2MQTT.Core.Flow;
-using rPDU2MQTT.Models.PDU;
 
 namespace rPDU2MQTT.Services;
 
 /// <summary>
-/// Keeps Home Assistant's Energy-Dashboard "individual devices" in sync with the energy-flow hierarchy
-/// (#128): each tier's energy stat with its upstream device (<c>included_in_stat</c>). This can only be set
-/// through HA's WebSocket API (not MQTT discovery), so it needs a HA URL + long-lived access token. A no-op
-/// unless <c>HomeAssistant.EnergyDashboard.Enabled</c> is set.
+/// Periodically re-pushes the energy-flow hierarchy into HA's Energy Dashboard (#128) while
+/// <c>HomeAssistant.EnergyDashboard.Enabled</c> is on — the live toggle from the HA Energy Mapping page.
+/// The manual "Sync now"/"Clear" buttons use the same <see cref="HaEnergyDashboardSync"/>.
 /// </summary>
 public sealed class HaEnergyDashboardService : BackgroundService
 {
     private readonly Config config;
-    private readonly Core.ISnapshotCache snapshots;
-    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+    private readonly HaEnergyDashboardSync sync;
 
-    public HaEnergyDashboardService(Config config, Core.ISnapshotCache snapshots)
+    public HaEnergyDashboardService(Config config, HaEnergyDashboardSync sync)
     {
         this.config = config;
-        this.snapshots = snapshots;
+        this.sync = sync;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Reconcile periodically; HA only needs this when the hierarchy or available sensors change.
         var period = TimeSpan.FromSeconds(Math.Max(30, config.Primary.PollInterval * 4));
         using var timer = new PeriodicTimer(period);
         do
         {
-            try { await ReconcileAsync(stoppingToken); }
-            catch (OperationCanceledException) { return; }
-            catch (Exception ex) { Log.Warning($"HA Energy Dashboard sync failed: {ex.Message}"); }
+            var ed = config.HASS.EnergyDashboard;
+            if (ed.Enabled && !string.IsNullOrWhiteSpace(ed.Url) && !string.IsNullOrWhiteSpace(ed.Token))
+            {
+                try { await sync.SyncAsync(ed.Url!, ed.Token!, ed.EnergyMeasurementType, stoppingToken); }
+                catch (OperationCanceledException) { return; }
+                catch (Exception ex) { Log.Warning($"HA Energy Dashboard sync failed: {ex.Message}"); }
+            }
         }
         while (await timer.WaitForNextTickAsync(stoppingToken));
-    }
-
-    private async Task ReconcileAsync(CancellationToken ct)
-    {
-        var ed = config.HASS.EnergyDashboard;
-        if (!ed.Enabled || string.IsNullOrWhiteSpace(ed.Url) || string.IsNullOrWhiteSpace(ed.Token))
-            return;
-
-        // Build one graph across all fresh sources and a tier-id -> HA energy entity_id resolver.
-        var merged = new PduData();
-        foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
-        if (merged.Devices.Count == 0) return;
-
-        var statFor = BuildStatResolver(merged, ed.EnergyMeasurementType);
-        var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric);
-        var desired = EnergyDashboardSync.BuildDeviceConsumption(graph, statFor);
-        if (desired.Count == 0) return;
-
-        await PushAsync(ed.Url!, ed.Token!, desired, ct);
-    }
-
-    // Map a flow tier id to its Home Assistant energy sensor entity_id (sensor.<object_id>), when the tier
-    // has a measurement of the configured energy type. Covers PDU tiers (device-level entities) and outlets.
-    private static Func<string, string?> BuildStatResolver(PduData data, string energyType)
-    {
-        var byNode = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        string? EnergyEntity(IEnumerable<Measurement> measurements) =>
-            measurements.FirstOrDefault(m => string.Equals(m.Type, energyType, StringComparison.OrdinalIgnoreCase))?.Entity_Name is { Length: > 0 } name
-                ? "sensor." + name
-                : null;
-
-        foreach (var device in data.Devices)
-        {
-            if (EnergyEntity(device.Entity.SelectMany(e => e.Measurements)) is { } pduStat)
-                byNode[$"pdu:{device.Entity_Name}"] = pduStat;
-            foreach (var outlet in device.Outlets)
-                if (EnergyEntity(outlet.Measurements) is { } outletStat)
-                    byNode[$"outlet:{device.Entity_Name}:{outlet.Key}"] = outletStat;
-        }
-        return id => byNode.TryGetValue(id, out var s) ? s : null;
-    }
-
-    private async Task PushAsync(string url, string token, List<HaDeviceConsumption> desired, CancellationToken ct)
-    {
-        var wsUrl = url.TrimEnd('/').Replace("https://", "wss://").Replace("http://", "ws://") + "/api/websocket";
-        using var ws = new ClientWebSocket();
-        await ws.ConnectAsync(new Uri(wsUrl), ct);
-
-        await Receive(ws, ct);                                                    // auth_required
-        await Send(ws, new { type = "auth", access_token = token }, ct);
-        var auth = await Receive(ws, ct);
-        if ((string?)auth?["type"] != "auth_ok")
-            throw new Exception("Home Assistant rejected the access token.");
-
-        await Send(ws, new { id = 1, type = "energy/get_prefs" }, ct);
-        var prefs = (await Receive(ws, ct))?["result"]?.AsObject()
-            ?? throw new Exception("Could not read HA energy preferences.");
-
-        // Keep the user's own devices; replace only the ones whose stat we manage.
-        var ours = desired.Select(d => d.stat_consumption).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var devices = new JsonArray();
-        foreach (var existing in prefs["device_consumption"]?.AsArray() ?? new JsonArray())
-            if (existing is JsonObject o && !ours.Contains((string?)o["stat_consumption"] ?? ""))
-                devices.Add(JsonNode.Parse(o.ToJsonString())!);
-        foreach (var d in desired)
-            devices.Add(JsonSerializer.SerializeToNode(d, Json)!);
-        prefs["device_consumption"] = devices;
-
-        var save = JsonSerializer.SerializeToNode(new { id = 2, type = "energy/save_prefs" }, Json)!.AsObject();
-        foreach (var kv in prefs) save[kv.Key] = kv.Value is null ? null : JsonNode.Parse(kv.Value.ToJsonString());
-        await Send(ws, save, ct);
-        var result = await Receive(ws, ct);
-        if ((bool?)result?["success"] != true)
-            throw new Exception($"HA save_prefs failed: {result?.ToJsonString()}");
-
-        Log.Information($"HA Energy Dashboard: synced {desired.Count} hierarchy device(s).");
-        await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, ct);
-    }
-
-    private static Task Send(ClientWebSocket ws, object message, CancellationToken ct)
-        => ws.SendAsync(Encoding.UTF8.GetBytes(message is JsonNode n ? n.ToJsonString() : JsonSerializer.Serialize(message, Json)),
-            WebSocketMessageType.Text, true, ct);
-
-    private static async Task<JsonNode?> Receive(ClientWebSocket ws, CancellationToken ct)
-    {
-        var buffer = new ArraySegment<byte>(new byte[64 * 1024]);
-        using var ms = new MemoryStream();
-        WebSocketReceiveResult result;
-        do
-        {
-            result = await ws.ReceiveAsync(buffer, ct);
-            ms.Write(buffer.Array!, 0, result.Count);
-        }
-        while (!result.EndOfMessage);
-        return JsonNode.Parse(Encoding.UTF8.GetString(ms.ToArray()));
     }
 }

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -26,22 +26,18 @@ public sealed class HaEnergyDashboardSync
     }
 
     /// <summary>
-    /// The energy-dashboard devices the current hierarchy + sensors map to. When <paramref name="existing"/>
-    /// is supplied, a tier only counts as having a stat if that entity actually exists in HA — so tiers
-    /// whose energy sensor hasn't been created (e.g. a PDU-level total) are skipped and their children link
-    /// to the nearest ancestor that does exist, instead of producing an "entity not defined" in HA.
+    /// The energy-dashboard devices the current hierarchy + sensors map to. A tier's stat is resolved via
+    /// HA's authoritative <c>unique_id → entity_id</c> map (the discovery's unique_id is the measurement's
+    /// Entity_Identifier), so we never guess an entity_id that doesn't exist. Tiers whose energy sensor
+    /// isn't in HA are skipped and their children link to the nearest ancestor that is.
     /// </summary>
-    public List<HaDeviceConsumption> BuildDevices(string energyType, ISet<string>? existing = null)
+    public List<HaDeviceConsumption> BuildDevices(string energyType, IReadOnlyDictionary<string, string> entityByUniqueId)
     {
         var merged = new PduData();
         foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
         if (merged.Devices.Count == 0) return new();
 
-        var baseResolver = BuildStatResolver(merged, energyType);
-        Func<string, string?> resolver = existing is null
-            ? baseResolver
-            : id => baseResolver(id) is { } s && existing.Contains(s) ? s : null;
-
+        var resolver = BuildStatResolver(merged, energyType, entityByUniqueId);
         var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric);
         return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver);
     }
@@ -52,12 +48,14 @@ public sealed class HaEnergyDashboardSync
         using var ws = await ConnectAuth(url, token, ct);
         var call = Caller(ws, ct);
 
-        var states = (await call("get_states", null))?["result"]?.AsArray() ?? new JsonArray();
-        var existing = new HashSet<string>(
-            states.Select(s => (string?)s?["entity_id"]).Where(e => !string.IsNullOrEmpty(e))!,
-            StringComparer.OrdinalIgnoreCase);
+        // HA's authoritative unique_id -> entity_id map, so we use real entity_ids (not guesses).
+        var registry = (await call("config/entity_registry/list", null))?["result"]?.AsArray() ?? new JsonArray();
+        var entityByUniqueId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in registry)
+            if ((string?)e?["unique_id"] is { Length: > 0 } uid && (string?)e?["entity_id"] is { Length: > 0 } eid)
+                entityByUniqueId[uid] = eid;
 
-        var devices = BuildDevices(energyType, existing);
+        var devices = BuildDevices(energyType, entityByUniqueId);
         var prefs = (await call("energy/get_prefs", null))?["result"]?.AsObject()
             ?? throw new Exception("Could not read HA energy preferences.");
 
@@ -98,14 +96,16 @@ public sealed class HaEnergyDashboardSync
             throw new Exception($"HA save_prefs failed: {result?["error"]?["message"] ?? result?.ToJsonString()}");
     }
 
-    // Map a flow tier id to its HA energy sensor entity_id (sensor.<object_id>) when the tier has a
-    // measurement of the configured energy type. Covers PDU tiers (device-level entities) and outlets.
-    private static Func<string, string?> BuildStatResolver(PduData data, string energyType)
+    // Map a flow tier id to its HA energy sensor entity_id, resolving each tier's energy measurement
+    // (the configured type) through HA's unique_id -> entity_id registry (the discovery's unique_id is the
+    // measurement's Entity_Identifier). Covers PDU tiers (device-level entities) and outlets.
+    private static Func<string, string?> BuildStatResolver(PduData data, string energyType, IReadOnlyDictionary<string, string> entityByUniqueId)
     {
         var byNode = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         string? EnergyEntity(IEnumerable<Measurement> measurements) =>
-            measurements.FirstOrDefault(m => string.Equals(m.Type, energyType, StringComparison.OrdinalIgnoreCase))?.Entity_Name is { Length: > 0 } name
-                ? "sensor." + name
+            measurements.FirstOrDefault(m => string.Equals(m.Type, energyType, StringComparison.OrdinalIgnoreCase))?.Entity_Identifier is { Length: > 0 } uid
+             && entityByUniqueId.TryGetValue(uid, out var entityId)
+                ? entityId
                 : null;
 
         foreach (var device in data.Devices)

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -25,46 +25,77 @@ public sealed class HaEnergyDashboardSync
         this.snapshots = snapshots;
     }
 
-    /// <summary>The energy-dashboard devices the current hierarchy + sensors would map to.</summary>
-    public List<HaDeviceConsumption> BuildDevices(string energyType)
+    /// <summary>
+    /// The energy-dashboard devices the current hierarchy + sensors map to. When <paramref name="existing"/>
+    /// is supplied, a tier only counts as having a stat if that entity actually exists in HA — so tiers
+    /// whose energy sensor hasn't been created (e.g. a PDU-level total) are skipped and their children link
+    /// to the nearest ancestor that does exist, instead of producing an "entity not defined" in HA.
+    /// </summary>
+    public List<HaDeviceConsumption> BuildDevices(string energyType, ISet<string>? existing = null)
     {
         var merged = new PduData();
         foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
         if (merged.Devices.Count == 0) return new();
 
-        var statFor = BuildStatResolver(merged, energyType);
+        var baseResolver = BuildStatResolver(merged, energyType);
+        Func<string, string?> resolver = existing is null
+            ? baseResolver
+            : id => baseResolver(id) is { } s && existing.Contains(s) ? s : null;
+
         var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric);
-        return EnergyDashboardSync.BuildDeviceConsumption(graph, statFor);
+        return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver);
     }
 
     /// <summary>Merge our hierarchy devices into HA's energy prefs (preserving the user's own). Returns the count synced.</summary>
     public async Task<int> SyncAsync(string url, string token, string energyType, CancellationToken ct)
     {
-        var devices = BuildDevices(energyType);
-        await WithPrefs(url, token, ct, prefs =>
-        {
-            var ours = devices.Select(d => d.stat_consumption).ToHashSet(StringComparer.OrdinalIgnoreCase);
-            var keep = new JsonArray();
-            foreach (var existing in prefs["device_consumption"]?.AsArray() ?? new JsonArray())
-                if (existing is JsonObject o && !ours.Contains((string?)o["stat_consumption"] ?? ""))
-                    keep.Add(JsonNode.Parse(o.ToJsonString())!);
-            foreach (var d in devices)
-                keep.Add(JsonSerializer.SerializeToNode(d, Json)!);
-            prefs["device_consumption"] = keep;
-        });
+        using var ws = await ConnectAuth(url, token, ct);
+        var call = Caller(ws, ct);
+
+        var states = (await call("get_states", null))?["result"]?.AsArray() ?? new JsonArray();
+        var existing = new HashSet<string>(
+            states.Select(s => (string?)s?["entity_id"]).Where(e => !string.IsNullOrEmpty(e))!,
+            StringComparer.OrdinalIgnoreCase);
+
+        var devices = BuildDevices(energyType, existing);
+        var prefs = (await call("energy/get_prefs", null))?["result"]?.AsObject()
+            ?? throw new Exception("Could not read HA energy preferences.");
+
+        var ours = devices.Select(d => d.stat_consumption).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var keep = new JsonArray();
+        foreach (var existingDevice in prefs["device_consumption"]?.AsArray() ?? new JsonArray())
+            if (existingDevice is JsonObject o && !ours.Contains((string?)o["stat_consumption"] ?? ""))
+                keep.Add(o.DeepClone());
+        foreach (var d in devices)
+            keep.Add(JsonSerializer.SerializeToNode(d, Json)!);
+        prefs["device_consumption"] = keep;
+
+        await SavePrefs(call, prefs);
         return devices.Count;
     }
 
     /// <summary>Remove every device from HA's Energy-Dashboard device list. Returns how many were cleared.</summary>
     public async Task<int> ClearAsync(string url, string token, CancellationToken ct)
     {
-        var cleared = 0;
-        await WithPrefs(url, token, ct, prefs =>
-        {
-            cleared = prefs["device_consumption"]?.AsArray()?.Count ?? 0;
-            prefs["device_consumption"] = new JsonArray();
-        });
+        using var ws = await ConnectAuth(url, token, ct);
+        var call = Caller(ws, ct);
+
+        var prefs = (await call("energy/get_prefs", null))?["result"]?.AsObject()
+            ?? throw new Exception("Could not read HA energy preferences.");
+        var cleared = prefs["device_consumption"]?.AsArray()?.Count ?? 0;
+        prefs["device_consumption"] = new JsonArray();
+
+        await SavePrefs(call, prefs);
         return cleared;
+    }
+
+    private static async Task SavePrefs(Func<string, JsonObject?, Task<JsonNode?>> call, JsonObject prefs)
+    {
+        var body = new JsonObject();
+        foreach (var kv in prefs) body[kv.Key] = kv.Value?.DeepClone();
+        var result = await call("energy/save_prefs", body);
+        if ((bool?)result?["success"] != true)
+            throw new Exception($"HA save_prefs failed: {result?["error"]?["message"] ?? result?.ToJsonString()}");
     }
 
     // Map a flow tier id to its HA energy sensor entity_id (sensor.<object_id>) when the tier has a
@@ -88,35 +119,37 @@ public sealed class HaEnergyDashboardSync
         return id => byNode.TryGetValue(id, out var s) ? s : null;
     }
 
-    // Connect + auth, read energy/get_prefs, let the caller mutate it, then energy/save_prefs.
-    private async Task WithPrefs(string url, string token, CancellationToken ct, Action<JsonObject> mutate)
+    private static async Task<ClientWebSocket> ConnectAuth(string url, string token, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(token))
             throw new Exception("Home Assistant URL and access token are required.");
 
         var wsUrl = url.TrimEnd('/').Replace("https://", "wss://").Replace("http://", "ws://") + "/api/websocket";
-        using var ws = new ClientWebSocket();
-        await ws.ConnectAsync(new Uri(wsUrl), ct);
+        var ws = new ClientWebSocket();
+        try
+        {
+            await ws.ConnectAsync(new Uri(wsUrl), ct);
+            await Receive(ws, ct);                                                  // auth_required
+            await Send(ws, new { type = "auth", access_token = token }, ct);
+            if ((string?)(await Receive(ws, ct))?["type"] != "auth_ok")
+                throw new Exception("Home Assistant rejected the access token.");
+            return ws;
+        }
+        catch { ws.Dispose(); throw; }
+    }
 
-        await Receive(ws, ct);                                                     // auth_required
-        await Send(ws, new { type = "auth", access_token = token }, ct);
-        if ((string?)(await Receive(ws, ct))?["type"] != "auth_ok")
-            throw new Exception("Home Assistant rejected the access token.");
-
-        await Send(ws, new { id = 1, type = "energy/get_prefs" }, ct);
-        var prefs = (await Receive(ws, ct))?["result"]?.AsObject()
-            ?? throw new Exception("Could not read HA energy preferences.");
-
-        mutate(prefs);
-
-        var save = JsonSerializer.SerializeToNode(new { id = 2, type = "energy/save_prefs" }, Json)!.AsObject();
-        foreach (var kv in prefs) save[kv.Key] = kv.Value is null ? null : JsonNode.Parse(kv.Value.ToJsonString());
-        await Send(ws, save, ct);
-        var result = await Receive(ws, ct);
-        if ((bool?)result?["success"] != true)
-            throw new Exception($"HA save_prefs failed: {result?["error"]?["message"] ?? result?.ToJsonString()}");
-
-        await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, ct);
+    // A sequential command caller: {id, type, ...extra} -> the next message (its result). HA isn't
+    // subscribed to events here, so the reply to each command is the next frame.
+    private static Func<string, JsonObject?, Task<JsonNode?>> Caller(ClientWebSocket ws, CancellationToken ct)
+    {
+        var nextId = 1;
+        return async (type, extra) =>
+        {
+            var msg = new JsonObject { ["id"] = nextId++, ["type"] = type };
+            if (extra is not null) foreach (var kv in extra) msg[kv.Key] = kv.Value?.DeepClone();
+            await Send(ws, msg, ct);
+            return await Receive(ws, ct);
+        };
     }
 
     private static Task Send(ClientWebSocket ws, object message, CancellationToken ct)

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -1,0 +1,139 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.PDU;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Talks to Home Assistant's Energy-Dashboard preferences over its WebSocket API (#128): builds the
+/// device hierarchy from the energy flow + current PDU data, and pushes/clears it. Shared by the periodic
+/// <see cref="HaEnergyDashboardService"/> and the GUI's manual sync/clear buttons.
+/// </summary>
+public sealed class HaEnergyDashboardSync
+{
+    private readonly Config config;
+    private readonly Core.ISnapshotCache snapshots;
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    public HaEnergyDashboardSync(Config config, Core.ISnapshotCache snapshots)
+    {
+        this.config = config;
+        this.snapshots = snapshots;
+    }
+
+    /// <summary>The energy-dashboard devices the current hierarchy + sensors would map to.</summary>
+    public List<HaDeviceConsumption> BuildDevices(string energyType)
+    {
+        var merged = new PduData();
+        foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
+        if (merged.Devices.Count == 0) return new();
+
+        var statFor = BuildStatResolver(merged, energyType);
+        var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric);
+        return EnergyDashboardSync.BuildDeviceConsumption(graph, statFor);
+    }
+
+    /// <summary>Merge our hierarchy devices into HA's energy prefs (preserving the user's own). Returns the count synced.</summary>
+    public async Task<int> SyncAsync(string url, string token, string energyType, CancellationToken ct)
+    {
+        var devices = BuildDevices(energyType);
+        await WithPrefs(url, token, ct, prefs =>
+        {
+            var ours = devices.Select(d => d.stat_consumption).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var keep = new JsonArray();
+            foreach (var existing in prefs["device_consumption"]?.AsArray() ?? new JsonArray())
+                if (existing is JsonObject o && !ours.Contains((string?)o["stat_consumption"] ?? ""))
+                    keep.Add(JsonNode.Parse(o.ToJsonString())!);
+            foreach (var d in devices)
+                keep.Add(JsonSerializer.SerializeToNode(d, Json)!);
+            prefs["device_consumption"] = keep;
+        });
+        return devices.Count;
+    }
+
+    /// <summary>Remove every device from HA's Energy-Dashboard device list. Returns how many were cleared.</summary>
+    public async Task<int> ClearAsync(string url, string token, CancellationToken ct)
+    {
+        var cleared = 0;
+        await WithPrefs(url, token, ct, prefs =>
+        {
+            cleared = prefs["device_consumption"]?.AsArray()?.Count ?? 0;
+            prefs["device_consumption"] = new JsonArray();
+        });
+        return cleared;
+    }
+
+    // Map a flow tier id to its HA energy sensor entity_id (sensor.<object_id>) when the tier has a
+    // measurement of the configured energy type. Covers PDU tiers (device-level entities) and outlets.
+    private static Func<string, string?> BuildStatResolver(PduData data, string energyType)
+    {
+        var byNode = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        string? EnergyEntity(IEnumerable<Measurement> measurements) =>
+            measurements.FirstOrDefault(m => string.Equals(m.Type, energyType, StringComparison.OrdinalIgnoreCase))?.Entity_Name is { Length: > 0 } name
+                ? "sensor." + name
+                : null;
+
+        foreach (var device in data.Devices)
+        {
+            if (EnergyEntity(device.Entity.SelectMany(e => e.Measurements)) is { } pduStat)
+                byNode[$"pdu:{device.Entity_Name}"] = pduStat;
+            foreach (var outlet in device.Outlets)
+                if (EnergyEntity(outlet.Measurements) is { } outletStat)
+                    byNode[$"outlet:{device.Entity_Name}:{outlet.Key}"] = outletStat;
+        }
+        return id => byNode.TryGetValue(id, out var s) ? s : null;
+    }
+
+    // Connect + auth, read energy/get_prefs, let the caller mutate it, then energy/save_prefs.
+    private async Task WithPrefs(string url, string token, CancellationToken ct, Action<JsonObject> mutate)
+    {
+        if (string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(token))
+            throw new Exception("Home Assistant URL and access token are required.");
+
+        var wsUrl = url.TrimEnd('/').Replace("https://", "wss://").Replace("http://", "ws://") + "/api/websocket";
+        using var ws = new ClientWebSocket();
+        await ws.ConnectAsync(new Uri(wsUrl), ct);
+
+        await Receive(ws, ct);                                                     // auth_required
+        await Send(ws, new { type = "auth", access_token = token }, ct);
+        if ((string?)(await Receive(ws, ct))?["type"] != "auth_ok")
+            throw new Exception("Home Assistant rejected the access token.");
+
+        await Send(ws, new { id = 1, type = "energy/get_prefs" }, ct);
+        var prefs = (await Receive(ws, ct))?["result"]?.AsObject()
+            ?? throw new Exception("Could not read HA energy preferences.");
+
+        mutate(prefs);
+
+        var save = JsonSerializer.SerializeToNode(new { id = 2, type = "energy/save_prefs" }, Json)!.AsObject();
+        foreach (var kv in prefs) save[kv.Key] = kv.Value is null ? null : JsonNode.Parse(kv.Value.ToJsonString());
+        await Send(ws, save, ct);
+        var result = await Receive(ws, ct);
+        if ((bool?)result?["success"] != true)
+            throw new Exception($"HA save_prefs failed: {result?["error"]?["message"] ?? result?.ToJsonString()}");
+
+        await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, ct);
+    }
+
+    private static Task Send(ClientWebSocket ws, object message, CancellationToken ct)
+        => ws.SendAsync(Encoding.UTF8.GetBytes(message is JsonNode n ? n.ToJsonString() : JsonSerializer.Serialize(message, Json)),
+            WebSocketMessageType.Text, true, ct);
+
+    private static async Task<JsonNode?> Receive(ClientWebSocket ws, CancellationToken ct)
+    {
+        var buffer = new ArraySegment<byte>(new byte[64 * 1024]);
+        using var ms = new MemoryStream();
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await ws.ReceiveAsync(buffer, ct);
+            ms.Write(buffer.Array!, 0, result.Count);
+        }
+        while (!result.EndOfMessage);
+        return JsonNode.Parse(Encoding.UTF8.GetString(ms.ToArray()));
+    }
+}

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -26,24 +26,25 @@ public sealed class HaEnergyDashboardSync
     }
 
     /// <summary>
-    /// The energy-dashboard devices the current hierarchy + sensors map to. A tier's stat is resolved via
-    /// HA's authoritative <c>unique_id → entity_id</c> map (the discovery's unique_id is the measurement's
-    /// Entity_Identifier), so we never guess an entity_id that doesn't exist. Tiers whose energy sensor
-    /// isn't in HA are skipped and their children link to the nearest ancestor that is.
+    /// The energy-dashboard devices the current hierarchy maps to. Each tier is resolved to its exported
+    /// energy sensor (published by the flow MQTT export as <c>energyflow_&lt;key&gt;_energy</c>) via HA's
+    /// authoritative <c>unique_id → entity_id</c> map, so we never guess an entity_id that doesn't exist.
+    /// Tiers whose energy sensor isn't in HA are skipped and their children link to the nearest ancestor
+    /// that is — giving HA the full Grid → Panel → Circuit → PDU → outlet chain, not just leaf outlets.
     /// </summary>
-    public List<HaDeviceConsumption> BuildDevices(string energyType, IReadOnlyDictionary<string, string> entityByUniqueId)
+    public List<HaDeviceConsumption> BuildDevices(IReadOnlyDictionary<string, string> entityByUniqueId)
     {
         var merged = new PduData();
         foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
         if (merged.Devices.Count == 0) return new();
 
-        var resolver = BuildStatResolver(merged, energyType, entityByUniqueId);
         var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric);
+        Func<string, string?> resolver = id => entityByUniqueId.TryGetValue(FlowExport.EnergyUniqueId(id), out var e) ? e : null;
         return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver);
     }
 
     /// <summary>Merge our hierarchy devices into HA's energy prefs (preserving the user's own). Returns the count synced.</summary>
-    public async Task<int> SyncAsync(string url, string token, string energyType, CancellationToken ct)
+    public async Task<int> SyncAsync(string url, string token, CancellationToken ct)
     {
         using var ws = await ConnectAuth(url, token, ct);
         var call = Caller(ws, ct);
@@ -55,7 +56,7 @@ public sealed class HaEnergyDashboardSync
             if ((string?)e?["unique_id"] is { Length: > 0 } uid && (string?)e?["entity_id"] is { Length: > 0 } eid)
                 entityByUniqueId[uid] = eid;
 
-        var devices = BuildDevices(energyType, entityByUniqueId);
+        var devices = BuildDevices(entityByUniqueId);
         var prefs = (await call("energy/get_prefs", null))?["result"]?.AsObject()
             ?? throw new Exception("Could not read HA energy preferences.");
 
@@ -94,29 +95,6 @@ public sealed class HaEnergyDashboardSync
         var result = await call("energy/save_prefs", body);
         if ((bool?)result?["success"] != true)
             throw new Exception($"HA save_prefs failed: {result?["error"]?["message"] ?? result?.ToJsonString()}");
-    }
-
-    // Map a flow tier id to its HA energy sensor entity_id, resolving each tier's energy measurement
-    // (the configured type) through HA's unique_id -> entity_id registry (the discovery's unique_id is the
-    // measurement's Entity_Identifier). Covers PDU tiers (device-level entities) and outlets.
-    private static Func<string, string?> BuildStatResolver(PduData data, string energyType, IReadOnlyDictionary<string, string> entityByUniqueId)
-    {
-        var byNode = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        string? EnergyEntity(IEnumerable<Measurement> measurements) =>
-            measurements.FirstOrDefault(m => string.Equals(m.Type, energyType, StringComparison.OrdinalIgnoreCase))?.Entity_Identifier is { Length: > 0 } uid
-             && entityByUniqueId.TryGetValue(uid, out var entityId)
-                ? entityId
-                : null;
-
-        foreach (var device in data.Devices)
-        {
-            if (EnergyEntity(device.Entity.SelectMany(e => e.Measurements)) is { } pduStat)
-                byNode[$"pdu:{device.Entity_Name}"] = pduStat;
-            foreach (var outlet in device.Outlets)
-                if (EnergyEntity(outlet.Measurements) is { } outletStat)
-                    byNode[$"outlet:{device.Entity_Name}:{outlet.Key}"] = outletStat;
-        }
-        return id => byNode.TryGetValue(id, out var s) ? s : null;
     }
 
     private static async Task<ClientWebSocket> ConnectAuth(string url, string token, CancellationToken ct)

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -334,6 +334,26 @@ public class FlowGraphTests
     }
 
     [Fact]
+    public void EnergyDashboardSync_BuildsDevices_SkippingStatlessTiers_AndLinkingToNearestAncestorStat()
+    {
+        // total -> main_panel -> pdu -> outlet. Only total + outlet have energy stats; the middle tiers
+        // don't, so the outlet's upstream must skip them and point at total.
+        var graph = new FlowGraph(
+            new[] { new FlowNode("total", "Total", "node"), new FlowNode("main_panel", "Main Panel", "node"), new FlowNode("pdu", "PDU", "pdu"), new FlowNode("outlet", "Server", "outlet") },
+            new[] { new FlowLink("total", "main_panel", 100), new FlowLink("main_panel", "pdu", 100), new FlowLink("pdu", "outlet", 100) },
+            "realpower", "W");
+
+        string? statFor(string id) => id switch { "total" => "sensor.total_energy", "outlet" => "sensor.outlet_energy", _ => null };
+        var devices = EnergyDashboardSync.BuildDeviceConsumption(graph, statFor);
+
+        Assert.Equal(2, devices.Count);   // the stat-less middle tiers are skipped
+        var total = devices.Single(d => d.stat_consumption == "sensor.total_energy");
+        Assert.Null(total.included_in_stat);                              // root: no upstream
+        var outlet = devices.Single(d => d.stat_consumption == "sensor.outlet_energy");
+        Assert.Equal("sensor.total_energy", outlet.included_in_stat);      // upstream walked past pdu/main_panel
+    }
+
+    [Fact]
     public void FlowExport_Topic_FillsTemplate_SlugsIds_AndCollapsesEmptySegments()
     {
         var graph = new FlowGraph(new[] { new FlowNode("outlet:rack_pdu:10", "Dell MD1200", "outlet") }, Array.Empty<FlowLink>(), "realpower", "W");

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -374,4 +374,34 @@ public class FlowGraphTests
         cfg.MqttTopicTemplate = "{parent}/energyflow/{id}";
         Assert.Equal("energyflow/outlet_rack_pdu_10", FlowExport.Topic(node, graph, "", cfg));
     }
+
+    [Fact]
+    public void FlowExport_DiscoveryDocument_HasEnergyAndPowerSensors_LinkedToParentDevice()
+    {
+        var node = new FlowNode("outlet:rack_pdu:10", "Dell MD1200", "outlet");
+        var doc = FlowExport.DiscoveryDocument(node, "circuit_Servers", "rpdu2mqtt/energyflow/outlet_rack_pdu_10", "kWh", "W", "rpdu2mqtt/status");
+
+        // Device identity + registry-tree link back to its feeder.
+        Assert.Equal("energyflow_outlet_rack_pdu_10", (string?)doc["device"]!["identifiers"]!.AsArray()[0]);
+        Assert.Equal("Dell MD1200", (string?)doc["device"]!["name"]);
+        Assert.Equal("energyflow_circuit_Servers", (string?)doc["device"]!["via_device"]);
+        Assert.Equal("rpdu2mqtt/status", (string?)doc["availability_topic"]);
+
+        // An Energy sensor the dashboard can consume (total_increasing) + a Power sensor, both off the tier topic.
+        var energy = doc["components"]!["energyflow_outlet_rack_pdu_10_energy"]!;
+        Assert.Equal(FlowExport.EnergyUniqueId("outlet:rack_pdu:10"), (string?)energy["unique_id"]);
+        Assert.Equal("energy", (string?)energy["device_class"]);
+        Assert.Equal("total_increasing", (string?)energy["state_class"]);
+        Assert.Equal("kWh", (string?)energy["unit_of_measurement"]);
+        Assert.Equal("{{ value_json.energy }}", (string?)energy["value_template"]);
+
+        var power = doc["components"]!["energyflow_outlet_rack_pdu_10_power"]!;
+        Assert.Equal("power", (string?)power["device_class"]);
+        Assert.Equal("{{ value_json.power }}", (string?)power["value_template"]);
+
+        // A root tier (no feeder) omits via_device.
+        var root = FlowExport.DiscoveryDocument(new FlowNode("grid_power", "Grid", "node"), null, "t", "kWh", "W", null);
+        Assert.Null(root["device"]!["via_device"]);
+        Assert.Null(root["availability_topic"]);
+    }
 }

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -351,6 +351,11 @@ public class FlowGraphTests
         Assert.Null(total.included_in_stat);                              // root: no upstream
         var outlet = devices.Single(d => d.stat_consumption == "sensor.outlet_energy");
         Assert.Equal("sensor.total_energy", outlet.included_in_stat);      // upstream walked past pdu/main_panel
+
+        // HA rejects included_in_stat:null — a root with no upstream must omit the key entirely.
+        var rootJson = System.Text.Json.JsonSerializer.Serialize(total);
+        Assert.DoesNotContain("included_in_stat", rootJson);
+        Assert.Contains("included_in_stat", System.Text.Json.JsonSerializer.Serialize(outlet));
     }
 
     [Fact]

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -602,9 +602,8 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 var b = await System.Text.Json.JsonDocument.ParseAsync(ctx.Request.Body, cancellationToken: cts.Token);
                 var url = b.RootElement.TryGetProperty("url", out var u) ? u.GetString() : config.HASS.EnergyDashboard.Url;
                 var token = b.RootElement.TryGetProperty("token", out var t) ? t.GetString() : config.HASS.EnergyDashboard.Token;
-                var type = b.RootElement.TryGetProperty("energyMeasurementType", out var et) && !string.IsNullOrWhiteSpace(et.GetString()) ? et.GetString()! : config.HASS.EnergyDashboard.EnergyMeasurementType;
-                var count = await haEnergy.SyncAsync(url ?? "", token ?? "", type, cts.Token);
-                return Results.Json(new { ok = true, message = count == 0 ? "No tiers had an energy sensor to map (yet)." : $"Synced {count} device(s) into the Energy Dashboard." }, ConfigSchema.Json);
+                var count = await haEnergy.SyncAsync(url ?? "", token ?? "", cts.Token);
+                return Results.Json(new { ok = true, message = count == 0 ? "No tiers had an energy sensor in HA yet — enable “Export tiers to MQTT” + HA discovery and wait a poll." : $"Synced {count} device(s) into the Energy Dashboard." }, ConfigSchema.Json);
             }
             catch (Exception ex)
             {

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -44,10 +44,11 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly Core.ISnapshotCache snapshots;
     private readonly Core.HostRole hostRoles;
     private readonly HeartbeatService heartbeats;
+    private readonly HaEnergyDashboardSync haEnergy;
     private static readonly HttpClient testHttp = new() { Timeout = TimeSpan.FromSeconds(15) };
     private WebApplication? app;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots, Core.HostRole hostRoles, HeartbeatService heartbeats)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots, Core.HostRole hostRoles, HeartbeatService heartbeats, HaEnergyDashboardSync haEnergy)
     {
         this.config = config;
         this.mqtt = mqtt;
@@ -63,6 +64,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         this.snapshots = snapshots;
         this.hostRoles = hostRoles;
         this.heartbeats = heartbeats;
+        this.haEnergy = haEnergy;
     }
 
     /// <summary>
@@ -324,6 +326,9 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 // The energy-flow hierarchy is read fresh on every /api/flow request, so applying it here
                 // makes Flow/Sankey edits show up on the next refresh (previously they needed a restart).
                 config.EnergyFlow = reloaded.EnergyFlow;
+                // Likewise the HA Energy-Dashboard settings (URL/token/enable), so the periodic sync toggle
+                // and the manual sync/clear buttons pick up edits without a restart.
+                config.HASS.EnergyDashboard = reloaded.HASS.EnergyDashboard;
 
                 // Apply PDU instance add/remove live: refresh the instance set from the saved config and
                 // reconcile the running pollers (a new PDU starts polling, a removed one stops) without a
@@ -583,6 +588,45 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             catch (Exception ex)
             {
                 return Results.Json(new { ok = false, message = $"Could not reach EmonCMS: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
+        // HA Energy Mapping (#128): push the current hierarchy into HA's Energy Dashboard now, or clear it.
+        // Both take the connection settings in the body so they work with the page's (possibly unsaved) edits.
+        app.MapPost("/api/ha-energy/sync", async (HttpContext ctx) =>
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(20));
+            try
+            {
+                var b = await System.Text.Json.JsonDocument.ParseAsync(ctx.Request.Body, cancellationToken: cts.Token);
+                var url = b.RootElement.TryGetProperty("url", out var u) ? u.GetString() : config.HASS.EnergyDashboard.Url;
+                var token = b.RootElement.TryGetProperty("token", out var t) ? t.GetString() : config.HASS.EnergyDashboard.Token;
+                var type = b.RootElement.TryGetProperty("energyMeasurementType", out var et) && !string.IsNullOrWhiteSpace(et.GetString()) ? et.GetString()! : config.HASS.EnergyDashboard.EnergyMeasurementType;
+                var count = await haEnergy.SyncAsync(url ?? "", token ?? "", type, cts.Token);
+                return Results.Json(new { ok = true, message = count == 0 ? "No tiers had an energy sensor to map (yet)." : $"Synced {count} device(s) into the Energy Dashboard." }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Sync failed: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
+        app.MapPost("/api/ha-energy/clear", async (HttpContext ctx) =>
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(20));
+            try
+            {
+                var b = await System.Text.Json.JsonDocument.ParseAsync(ctx.Request.Body, cancellationToken: cts.Token);
+                var url = b.RootElement.TryGetProperty("url", out var u) ? u.GetString() : config.HASS.EnergyDashboard.Url;
+                var token = b.RootElement.TryGetProperty("token", out var t) ? t.GetString() : config.HASS.EnergyDashboard.Token;
+                var count = await haEnergy.ClearAsync(url ?? "", token ?? "", cts.Token);
+                return Results.Json(new { ok = true, message = $"Cleared {count} device(s) from the Energy Dashboard." }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Clear failed: {ex.Message}" }, ConfigSchema.Json);
             }
         });
 

--- a/rPDU2MQTT.Web/web/build.mjs
+++ b/rPDU2MQTT.Web/web/build.mjs
@@ -27,6 +27,7 @@ const MODULES = [
   'sections/livedata.ts',
   'sections/flow.ts',
   'sections/export.ts',
+  'sections/ha-energy.ts',
   'config-form.ts',
   'actions.ts',
   'main.ts',

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -10,6 +10,7 @@ import { addControlSection } from './sections/control.js';
 import { addLiveDataSection } from './sections/livedata.js';
 import { addFlowSection } from './sections/flow.js';
 import { addExportSection } from './sections/export.js';
+import { addHaEnergySection } from './sections/ha-energy.js';
 
 function scalarInput(node: any, obj: any): any {
   let el: any;
@@ -189,7 +190,9 @@ function renderConfigSection(node: any, nav: any, sections: any) {
   } else {
     if (node.type === 'object') {
       ensure(state.data, node.key, {});
-      renderObjectBody(node.properties, state.data[node.key], sec);
+      // EnergyDashboard has its own "HA Energy Mapping" tab, so don't also render it in the HA form.
+      const props = node.key === 'HomeAssistant' ? (node.properties || []).filter((p: any) => p.key !== 'EnergyDashboard') : node.properties;
+      renderObjectBody(props, state.data[node.key], sec);
     }
     else renderNode(node, state.data, sec);
     if (node.key === 'Gui') wireGuiAuth(sec);
@@ -228,6 +231,7 @@ export function build() {
   addLiveDataSection(nav, sections);
   addFlowSection(nav, sections);
   addPathsSection(nav, sections);
+  addHaEnergySection(nav, sections);
   addExportSection(nav, sections);
   addDiagnosticsSection(nav, sections);
 

--- a/rPDU2MQTT.Web/web/src/sections/ha-energy.ts
+++ b/rPDU2MQTT.Web/web/src/sections/ha-energy.ts
@@ -7,7 +7,7 @@ export function addHaEnergySection(nav: any, sections: any) {
   const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
   const h = document.createElement('h2'); h.textContent = 'Home Assistant Energy Mapping'; sec.appendChild(h);
   const d = document.createElement('div'); d.className = 'desc';
-  d.textContent = 'Map the energy-flow hierarchy into Home Assistant’s Energy Dashboard (individual devices + their upstream device). Settings persist with the main Save button; the buttons act immediately using the values below.';
+  d.textContent = 'Map the energy-flow hierarchy into Home Assistant’s Energy Dashboard (individual devices + their upstream device). Each tier is published to HA as an Energy sensor by the flow export, so enable “Export tiers to MQTT” (Flow tab) and HA discovery for the full Grid → Panel → Circuit → PDU → outlet chain to appear. Settings persist with the main Save button; the buttons act immediately using the values below.';
   sec.appendChild(d);
 
   const ha = ensure(ensure(state.data, 'HomeAssistant', {}), 'EnergyDashboard', {});

--- a/rPDU2MQTT.Web/web/src/sections/ha-energy.ts
+++ b/rPDU2MQTT.Web/web/src/sections/ha-energy.ts
@@ -1,0 +1,56 @@
+// Home Assistant Energy Mapping (#128): the EnergyDashboard settings + manual sync/clear actions.
+import { api, btn, el, ensure, activate, toast } from '../helpers.js';
+import { state } from '../state.js';
+
+export function addHaEnergySection(nav: any, sections: any) {
+  const link = document.createElement('a'); link.textContent = 'HA Energy Mapping'; nav.appendChild(link);
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  const h = document.createElement('h2'); h.textContent = 'Home Assistant Energy Mapping'; sec.appendChild(h);
+  const d = document.createElement('div'); d.className = 'desc';
+  d.textContent = 'Map the energy-flow hierarchy into Home Assistant’s Energy Dashboard (individual devices + their upstream device). Settings persist with the main Save button; the buttons act immediately using the values below.';
+  sec.appendChild(d);
+
+  const ha = ensure(ensure(state.data, 'HomeAssistant', {}), 'EnergyDashboard', {});
+
+  const field = (label: string, key: string, type = 'text', placeholder = '') => {
+    const f = el('div', { class: 'field' });
+    f.appendChild(el('label', { text: label }));
+    const inp: any = el('input', { type, placeholder });
+    if (ha[key] != null) inp.value = ha[key];
+    inp.onchange = () => { ha[key] = inp.value === '' ? null : inp.value; };
+    f.appendChild(inp);
+    return { f, inp };
+  };
+  const url = field('Home Assistant URL', 'Url', 'text', 'http://homeassistant.local:8123');
+  const token = field('Long-lived access token', 'Token', 'password', '');
+  const etype = field('Energy measurement type', 'EnergyMeasurementType', 'text', 'energy');
+
+  const chkF = el('div', { class: 'field' });
+  const chk: any = el('input', { type: 'checkbox' }); chk.checked = !!ha.Enabled;
+  chk.onchange = () => { ha.Enabled = chk.checked; };
+  chkF.appendChild(el('label', { style: { fontWeight: '600' } }, chk, ' Enable periodic sync'));
+  chkF.appendChild(el('div', { class: 'desc', text: 'Re-push the hierarchy automatically every few polls while enabled.' }));
+
+  const grid = el('div', { class: 'grid' });
+  grid.append(url.f, token.f, etype.f, chkF);
+  sec.appendChild(grid);
+
+  const bar = el('div', { class: 'sec-actions' });
+  const syncBtn = btn('Sync now', 'primary');
+  const clearBtn = btn('Clear energy dashboard', 'danger');
+  bar.append(syncBtn, clearBtn); sec.appendChild(bar);
+  sec.appendChild(el('div', { class: 'desc', text: 'Also Save (main button) so the periodic sync uses these settings.' }));
+
+  syncBtn.onclick = async () => {
+    toast('Syncing to Home Assistant…', true);
+    const r = await api('/api/ha-energy/sync', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url.inp.value.trim(), token: token.inp.value, energyMeasurementType: etype.inp.value.trim() }) });
+    toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
+  };
+  clearBtn.onclick = async () => {
+    if (!confirm('Clear ALL devices from Home Assistant’s Energy Dashboard?\n\nThis removes every entry in the dashboard’s device list — including any you added manually. You can re-add the hierarchy with “Sync now”.')) return;
+    toast('Clearing the Energy Dashboard…', true);
+    const r = await api('/api/ha-energy/clear', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url.inp.value.trim(), token: token.inp.value }) });
+    toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
+  };
+  link.onclick = () => activate(link, sec);
+}

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1086,7 +1086,7 @@ function addHaEnergySection(nav     , sections     ) {
   const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
   const h = document.createElement('h2'); h.textContent = 'Home Assistant Energy Mapping'; sec.appendChild(h);
   const d = document.createElement('div'); d.className = 'desc';
-  d.textContent = 'Map the energy-flow hierarchy into Home Assistant’s Energy Dashboard (individual devices + their upstream device). Settings persist with the main Save button; the buttons act immediately using the values below.';
+  d.textContent = 'Map the energy-flow hierarchy into Home Assistant’s Energy Dashboard (individual devices + their upstream device). Each tier is published to HA as an Energy sensor by the flow export, so enable “Export tiers to MQTT” (Flow tab) and HA discovery for the full Grid → Panel → Circuit → PDU → outlet chain to appear. Settings persist with the main Save button; the buttons act immediately using the values below.';
   sec.appendChild(d);
 
   const ha = ensure(ensure(state.data, 'HomeAssistant', {}), 'EnergyDashboard', {});

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1078,6 +1078,62 @@ function addExportSection(nav     , sections     ) {
   link.onclick = () => { activate(link, sec); fill(); };
 }
 
+// ── sections/ha-energy.ts ───────────────────────────────────────
+// Home Assistant Energy Mapping (#128): the EnergyDashboard settings + manual sync/clear actions.
+
+function addHaEnergySection(nav     , sections     ) {
+  const link = document.createElement('a'); link.textContent = 'HA Energy Mapping'; nav.appendChild(link);
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  const h = document.createElement('h2'); h.textContent = 'Home Assistant Energy Mapping'; sec.appendChild(h);
+  const d = document.createElement('div'); d.className = 'desc';
+  d.textContent = 'Map the energy-flow hierarchy into Home Assistant’s Energy Dashboard (individual devices + their upstream device). Settings persist with the main Save button; the buttons act immediately using the values below.';
+  sec.appendChild(d);
+
+  const ha = ensure(ensure(state.data, 'HomeAssistant', {}), 'EnergyDashboard', {});
+
+  const field = (label        , key        , type = 'text', placeholder = '') => {
+    const f = el('div', { class: 'field' });
+    f.appendChild(el('label', { text: label }));
+    const inp      = el('input', { type, placeholder });
+    if (ha[key] != null) inp.value = ha[key];
+    inp.onchange = () => { ha[key] = inp.value === '' ? null : inp.value; };
+    f.appendChild(inp);
+    return { f, inp };
+  };
+  const url = field('Home Assistant URL', 'Url', 'text', 'http://homeassistant.local:8123');
+  const token = field('Long-lived access token', 'Token', 'password', '');
+  const etype = field('Energy measurement type', 'EnergyMeasurementType', 'text', 'energy');
+
+  const chkF = el('div', { class: 'field' });
+  const chk      = el('input', { type: 'checkbox' }); chk.checked = !!ha.Enabled;
+  chk.onchange = () => { ha.Enabled = chk.checked; };
+  chkF.appendChild(el('label', { style: { fontWeight: '600' } }, chk, ' Enable periodic sync'));
+  chkF.appendChild(el('div', { class: 'desc', text: 'Re-push the hierarchy automatically every few polls while enabled.' }));
+
+  const grid = el('div', { class: 'grid' });
+  grid.append(url.f, token.f, etype.f, chkF);
+  sec.appendChild(grid);
+
+  const bar = el('div', { class: 'sec-actions' });
+  const syncBtn = btn('Sync now', 'primary');
+  const clearBtn = btn('Clear energy dashboard', 'danger');
+  bar.append(syncBtn, clearBtn); sec.appendChild(bar);
+  sec.appendChild(el('div', { class: 'desc', text: 'Also Save (main button) so the periodic sync uses these settings.' }));
+
+  syncBtn.onclick = async () => {
+    toast('Syncing to Home Assistant…', true);
+    const r = await api('/api/ha-energy/sync', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url.inp.value.trim(), token: token.inp.value, energyMeasurementType: etype.inp.value.trim() }) });
+    toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
+  };
+  clearBtn.onclick = async () => {
+    if (!confirm('Clear ALL devices from Home Assistant’s Energy Dashboard?\n\nThis removes every entry in the dashboard’s device list — including any you added manually. You can re-add the hierarchy with “Sync now”.')) return;
+    toast('Clearing the Energy Dashboard…', true);
+    const r = await api('/api/ha-energy/clear', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url.inp.value.trim(), token: token.inp.value }) });
+    toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
+  };
+  link.onclick = () => activate(link, sec);
+}
+
 // ── config-form.ts ──────────────────────────────────────────────
 // Schema-driven config form: render scalar/object/dictionary/list nodes, the per-section panels, the
 // nav, and the overall build() that wires every tab.
@@ -1260,7 +1316,9 @@ function renderConfigSection(node     , nav     , sections     ) {
   } else {
     if (node.type === 'object') {
       ensure(state.data, node.key, {});
-      renderObjectBody(node.properties, state.data[node.key], sec);
+      // EnergyDashboard has its own "HA Energy Mapping" tab, so don't also render it in the HA form.
+      const props = node.key === 'HomeAssistant' ? (node.properties || []).filter((p     ) => p.key !== 'EnergyDashboard') : node.properties;
+      renderObjectBody(props, state.data[node.key], sec);
     }
     else renderNode(node, state.data, sec);
     if (node.key === 'Gui') wireGuiAuth(sec);
@@ -1299,6 +1357,7 @@ function build() {
   addLiveDataSection(nav, sections);
   addFlowSection(nav, sections);
   addPathsSection(nav, sections);
+  addHaEnergySection(nav, sections);
   addExportSection(nav, sections);
   addDiagnosticsSection(nav, sections);
 

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -114,6 +114,10 @@ public static class ServiceConfiguration
         // Coordinates on-demand rediscovery (the "Rediscover" diagnostic button).
         services.AddSingleton<DiscoveryCoordinator>();
 
+        // HA Energy-Dashboard sync (#128) — shared by the periodic worker service and the GUI's manual
+        // sync/clear buttons, so register the engine singleton regardless of role.
+        services.AddSingleton<Services.HaEnergyDashboardSync>();
+
         // When roles are split across processes, bridge the in-process snapshot bus over MQTT: a Worker
         // mirrors its snapshots to the broker; a consumer-only node ingests them onto its own bus/cache.
         // Single-node "all" keeps the bus fully in-process and skips this (no extra broker traffic).
@@ -160,8 +164,8 @@ public static class ServiceConfiguration
                 Log.Warning($"Home Assistant Discovery Disabled.");
 
             // Sync the energy-flow hierarchy into HA's Energy Dashboard via its WebSocket API (#128).
-            if (cfg.HASS.EnergyDashboard.Enabled)
-                services.AddHostedService<HaEnergyDashboardService>();
+            // Registered unconditionally; it honors the live HomeAssistant.EnergyDashboard.Enabled toggle.
+            services.AddHostedService<HaEnergyDashboardService>();
 
             // Outlet control is opt-in; only subscribe to command topics when explicitly enabled.
             if (cfg.Primary.ActionsEnabled)

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -159,6 +159,10 @@ public static class ServiceConfiguration
             else
                 Log.Warning($"Home Assistant Discovery Disabled.");
 
+            // Sync the energy-flow hierarchy into HA's Energy Dashboard via its WebSocket API (#128).
+            if (cfg.HASS.EnergyDashboard.Enabled)
+                services.AddHostedService<HaEnergyDashboardService>();
+
             // Outlet control is opt-in; only subscribe to command topics when explicitly enabled.
             if (cfg.Primary.ActionsEnabled)
             {


### PR DESCRIPTION
Closes #128. Auto-populates Home Assistant's **Energy Dashboard → individual devices** from the energy-flow hierarchy — including the **"Upstream device"** relationship (`included_in_stat`) shown in your screenshot, which prevents HA double-counting.

## Why the WebSocket API
HA's Energy-Dashboard device list + upstream relationships live in HA's **energy preferences**, settable only via its **WebSocket API** (`energy/get_prefs` / `energy/save_prefs`) — not MQTT discovery. So this needs a **HA URL + long-lived access token**.

## What
- **Config** `HomeAssistant.EnergyDashboard` — `Enabled`, `Url`, `Token` (or `RPDU2MQTT_HASS_TOKEN`), `EnergyMeasurementType` (default `energy`). Renders automatically in the GUI's HomeAssistant section.
- **`EnergyDashboardSync`** (Core, pure + unit-tested) — maps the flow graph + a `tier → energy entity_id` resolver to HA `device_consumption` entries. Each tier's **upstream = nearest ancestor that has an energy stat** (skips stat-less intermediate tiers). HA upstream is single-parent, so a multi-feeder tier follows its **primary feeder**.
- **`HaEnergyDashboardService`** (Worker, gated on `Enabled`) — builds the graph + resolver from fresh PDU data, connects to HA's WS API, and **merges** our devices into the energy prefs, **preserving the user's own entries** (only replaces the stats we manage).

## Tests
`EnergyDashboardSync` builds the device list, skips stat-less tiers, and links upstream to the nearest ancestor with a stat. **118 tests pass**, clean build.

## Needs your env (the one part I can't verify here)
The WS push to a live HA: set `EnergyDashboard.Enabled` + `Url` + a long-lived token, then check the Energy Dashboard's devices get the upstream hierarchy. Two things to sanity-check against your setup:
- **Entity-id mapping** — I resolve a tier's stat as `sensor.<energy-measurement object_id>`; confirm that matches your actual energy sensor entity_ids (e.g. the `Rack_PDU kube06_energy` in your screenshot).
- **Intermediate tiers** (circuits/custom nodes like "Server Room") need their own energy sensor to appear as an upstream; tiers without one are skipped and their children link to the next ancestor that has one.

Happy to adjust the resolver once you see how it lines up live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
