### PR TITLE
fix(chart): gate metrics on Prometheus.Exporter, not the renamed Enabled

### DIFF
--- a/charts/rpdu2mqtt/templates/NOTES.txt
+++ b/charts/rpdu2mqtt/templates/NOTES.txt
@@ -15,9 +15,9 @@ Namespace: {{ .Release.Namespace }}
    Edit values and `helm upgrade` to change configuration.
 {{- end }}
 
-{{- if and (dig "Prometheus" "Enabled" false .Values.config) .Values.service.metrics.enabled }}
+{{- if and ((include "rpdu2mqtt.metricsEnabled" .)) .Values.service.metrics.enabled }}
 
-3. Metrics are exposed at :{{ dig "Prometheus" "Port" 9184 .Values.config }}/metrics on service
+3. Metrics are exposed at :{{ include "rpdu2mqtt.metricsPort" . }}/metrics on service
    {{ include "rpdu2mqtt.fullname" . }}-metrics.
    {{- if .Values.serviceMonitor.enabled }}
    A ServiceMonitor was created for the Prometheus Operator.

--- a/charts/rpdu2mqtt/templates/_helpers.tpl
+++ b/charts/rpdu2mqtt/templates/_helpers.tpl
@@ -49,6 +49,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- default (include "rpdu2mqtt.fullname" .) .Values.kubernetesConfigSource.crName -}}
 {{- end -}}
 
+{{/* True when the app exposes /metrics. Enabled is the old name for Exporter; the app still honors it. */}}
+{{- define "rpdu2mqtt.metricsEnabled" -}}
+{{- if or (dig "Prometheus" "Exporter" false .Values.config) (dig "Prometheus" "Enabled" false .Values.config) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "rpdu2mqtt.metricsPort" -}}
+{{- dig "Prometheus" "Port" 9184 .Values.config -}}
+{{- end -}}
+
 {{/* True when a credentials Secret should be referenced (either managed here or external). */}}
 {{- define "rpdu2mqtt.hasSecret" -}}
 {{- if or .Values.existingSecret .Values.credentials.mqtt.username .Values.credentials.mqtt.password .Values.credentials.pdu.username .Values.credentials.pdu.password .Values.credentials.emoncmsApiKey .Values.credentials.oidcClientSecret -}}

--- a/charts/rpdu2mqtt/templates/deployment.yaml
+++ b/charts/rpdu2mqtt/templates/deployment.yaml
@@ -71,9 +71,9 @@ spec:
             - name: gui
               containerPort: {{ dig "Gui" "Port" 8080 .Values.config }}
             {{- end }}
-            {{- if dig "Prometheus" "Enabled" false .Values.config }}
+            {{- if (include "rpdu2mqtt.metricsEnabled" .) }}
             - name: metrics
-              containerPort: {{ dig "Prometheus" "Port" 9184 .Values.config }}
+              containerPort: {{ include "rpdu2mqtt.metricsPort" . }}
             {{- end }}
             {{- if dig "Health" "Enabled" true .Values.config }}
             - name: health

--- a/charts/rpdu2mqtt/templates/networkpolicy.yaml
+++ b/charts/rpdu2mqtt/templates/networkpolicy.yaml
@@ -29,12 +29,12 @@ spec:
         - port: {{ dig "Gui" "Port" 8080 .Values.config }}
           protocol: TCP
     {{- end }}
-    {{- if and (dig "Prometheus" "Enabled" false .Values.config) .Values.networkPolicy.metricsIngressFrom }}
+    {{- if and ((include "rpdu2mqtt.metricsEnabled" .)) .Values.networkPolicy.metricsIngressFrom }}
     # Allow the metrics port only from the configured peers (e.g. Prometheus).
     - from:
         {{- toYaml .Values.networkPolicy.metricsIngressFrom | nindent 8 }}
       ports:
-        - port: {{ dig "Prometheus" "Port" 9184 .Values.config }}
+        - port: {{ include "rpdu2mqtt.metricsPort" . }}
           protocol: TCP
     {{- end }}
   {{- if .Values.networkPolicy.restrictEgress }}

--- a/charts/rpdu2mqtt/templates/service-metrics.yaml
+++ b/charts/rpdu2mqtt/templates/service-metrics.yaml
@@ -1,4 +1,4 @@
-{{- if and (dig "Prometheus" "Enabled" false .Values.config) .Values.service.metrics.enabled }}
+{{- if and ((include "rpdu2mqtt.metricsEnabled" .)) .Values.service.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,6 +16,6 @@ spec:
     {{- include "rpdu2mqtt.selectorLabels" . | nindent 4 }}
   ports:
     - name: metrics
-      port: {{ dig "Prometheus" "Port" 9184 .Values.config }}
+      port: {{ include "rpdu2mqtt.metricsPort" . }}
       targetPort: metrics
 {{- end }}

--- a/charts/rpdu2mqtt/templates/servicemonitor.yaml
+++ b/charts/rpdu2mqtt/templates/servicemonitor.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.serviceMonitor.enabled }}
+{{- if not (include "rpdu2mqtt.metricsEnabled" .) }}
+{{- fail "serviceMonitor.enabled=true requires config.Prometheus.Exporter=true — without it there is no metrics Service to scrape." }}
+{{- end }}
+{{- if not .Values.service.metrics.enabled }}
+{{- fail "serviceMonitor.enabled=true requires service.metrics.enabled=true — the ServiceMonitor selects the metrics Service." }}
+{{- end }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -17,7 +17,7 @@ replicaCount: 1
 # Application configuration.
 # This whole block is rendered verbatim into config.yaml (mounted at /config).
 # It is the single source of truth for app behaviour, including Gui.Enabled and
-# Prometheus.Enabled (the Kubernetes Service/Ingress/ServiceMonitor toggles below
+# Prometheus.Exporter (the Kubernetes Service/Ingress/ServiceMonitor toggles below
 # only control whether those *resources* are created).
 # See docs/Configuration.md for every option.
 # ---------------------------------------------------------------------------
@@ -37,7 +37,8 @@ config:
     DiscoveryEnabled: true
     DiscoveryTopic: homeassistant
   Prometheus:
-    Enabled: false
+    # Expose /metrics. (Old name: `Enabled`, still accepted.)
+    Exporter: false
     Port: 9184
   Gui:
     Enabled: false
@@ -98,8 +99,8 @@ service:
     type: ClusterIP
     annotations: {}
 
-# Prometheus Operator ServiceMonitor for the /metrics Service. Requires the
-# Prometheus Operator CRDs to be installed.
+# Prometheus Operator ServiceMonitor for the /metrics Service. Requires the Prometheus
+# Operator CRDs, plus config.Prometheus.Exporter and service.metrics.enabled.
 serviceMonitor:
   enabled: false
   interval: 30s


### PR DESCRIPTION
## The bug

The app's exporter flag was renamed **`Prometheus.Enabled` → `Prometheus.Exporter`**. `Enabled` survives only as a load-time back-compat alias (`PrometheusConfig.EnabledAlias`); the app reads `Exporter` (`ServiceConfiguration.cs:143`).

**The chart was never updated.** Every metrics gate still checked the dead field:

| Template | Gated on |
|---|---|
| `deployment.yaml` (metrics containerPort) | `dig "Prometheus" "Enabled"` |
| `service-metrics.yaml` | `dig "Prometheus" "Enabled"` |
| `networkpolicy.yaml` (metrics ingress) | `dig "Prometheus" "Enabled"` |
| `NOTES.txt` | `dig "Prometheus" "Enabled"` |
| **`servicemonitor.yaml`** | **`serviceMonitor.enabled` only** |

So a config setting `Exporter: true` — the current name, and what the GUI writes — rendered **no metrics containerPort and no metrics Service**, while the app happily served `/metrics` on 9184. The ServiceMonitor was created regardless, selected a Service that didn't exist, matched **zero targets**, and Prometheus **silently scraped nothing**.

Reproduced against a live cluster: the pod had only `gui`/`health` ports, a single `-gui` Service, and a dangling ServiceMonitor hunting for `component: metrics` + port `metrics`.

## The fix

- `rpdu2mqtt.metricsEnabled` / `rpdu2mqtt.metricsPort` helpers — accept **`Exporter`** or the **legacy `Enabled`**, mirroring the app's own alias.
- All the metrics templates gate through them.
- `values.yaml` ships `Prometheus.Exporter` (was the dead `Prometheus.Enabled`).
- The **ServiceMonitor now fails the render** when there's no metrics Service to select, instead of shipping a monitor that scrapes nothing. Intentionally loud — the silent no-op *is* the bug.

## Verification (`helm template`)

| Path | Before | After |
|---|---|---|
| `Exporter=true` + ServiceMonitor | 0 metrics resources, dangling monitor | port + Service + monitor ✅ |
| legacy `Enabled=true` | ✅ | ✅ still works |
| defaults | no metrics | no metrics ✅ |
| ServiceMonitor w/o exporter | silent no-op | hard fail, actionable message ✅ |

`helm lint` clean.

> **Note:** I have CI steps covering all four of these paths, but the push was rejected (`refusing to allow an OAuth App to ... workflow` — token lacks `workflow` scope). Patch is ready to apply separately if you want it.

## Upgrade note

`config.Prometheus.Enabled` in your values still works. Prefer `config.Prometheus.Exporter`. If you had `serviceMonitor.enabled: true` with no exporter, the render now **fails** — that config never produced metrics anyway; the error names the flag to set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)