### PR TITLE
feat(chart): manageResource toggle so GitOps doesn't overwrite GUI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,10 @@ jobs:
         run: helm template rpdu2mqtt charts/rpdu2mqtt > /dev/null
       - name: helm template (CRD config source)
         run: helm template rpdu2mqtt charts/rpdu2mqtt --set kubernetesConfigSource.enabled=true > /dev/null
+
+      - name: helm template (CRD config source, unmanaged resource)
+        run: |
+          out=$(helm template rpdu2mqtt charts/rpdu2mqtt \
+            --set kubernetesConfigSource.enabled=true --set kubernetesConfigSource.manageResource=false)
+          echo "$out" | grep -q 'kind: RpduConfig' && { echo "RpduConfig should not be rendered"; exit 1; }
+          echo "$out" | grep -q 'RPDU2MQTT_CONFIG_SOURCE' || { echo "app should still read from the CR"; exit 1; }

--- a/charts/rpdu2mqtt/Chart.yaml
+++ b/charts/rpdu2mqtt/Chart.yaml
@@ -3,7 +3,7 @@ name: rpdu2mqtt
 description: Bridge a Vertiv/Geist rPDU to MQTT, with Home Assistant discovery and optional metrics exporters.
 type: application
 # Chart version (bump on chart changes); appVersion tracks the container image.
-version: 1.0.0
+version: 1.1.0
 appVersion: "1.0.0"
 home: https://github.com/XtremeOwnage/rPDU2MQTT
 sources:

--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -55,7 +55,8 @@ credentials:
 | `service.metrics.enabled` | `true` | Create a Service for `/metrics` (when `config.Prometheus.Enabled`). |
 | `serviceMonitor.enabled` | `false` | Create a Prometheus Operator `ServiceMonitor` for `/metrics`. |
 | `kubernetesConfigSource.enabled` | `false` | Store config in an `RpduConfig` CR (writable by the GUI) instead of a ConfigMap; creates the CR + RBAC and wires the app to read it. Requires the CRD (in this chart's `crds/`). |
-| `kubernetesConfigSource.preserveExisting` | `true` | Create-once: keep the live CR `spec` on upgrade so GUI edits aren't reverted (`values.config` only seeds it on install). Set `false` for declarative config. Under Argo CD, use an `ignoreDifferences` on the CR `spec` instead — see [KubernetesCRD.md](../../docs/KubernetesCRD.md#keeping-gui-edits-across-chart-upgrades--argo-syncs). |
+| `kubernetesConfigSource.preserveExisting` | `true` | Create-once: keep the live CR `spec` on upgrade so GUI edits aren't reverted (`values.config` only seeds it on install). Set `false` for declarative config. Relies on Helm `lookup`, which is empty under Argo CD (`helm template`) — see `manageResource` below. |
+| `kubernetesConfigSource.manageResource` | `true` | Whether the chart renders the `RpduConfig` CR and the GUI-written credentials `Secret`. Set `false` to manage them out of band so GitOps (Argo/Flux) never syncs over GUI edits; RBAC + the config source stay on, but you must create the CR (and Secret, if used) once yourself. |
 | `ingress.enabled` | `false` | Expose the GUI via an Ingress. |
 | `httpRoute.enabled` | `false` | Expose the GUI via a Gateway API `HTTPRoute` (set `httpRoute.parentRefs`/`hostnames`). Requires the Gateway API CRDs. |
 | `healthProbes.enabled` | `true` | Liveness/readiness probes against the app's health endpoints. |

--- a/charts/rpdu2mqtt/templates/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/templates/rpduconfig.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kubernetesConfigSource.enabled }}
+{{- if and .Values.kubernetesConfigSource.enabled .Values.kubernetesConfigSource.manageResource }}
 {{- $name := include "rpdu2mqtt.crName" . }}
 {{- /*
   Create-once: when preserveExisting (default), keep the live CR's spec on upgrade so config edited

--- a/charts/rpdu2mqtt/templates/secret.yaml
+++ b/charts/rpdu2mqtt/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.existingSecret) (or (include "rpdu2mqtt.hasSecret" .) .Values.kubernetesConfigSource.enabled) }}
+{{- if and (not .Values.existingSecret) (or (include "rpdu2mqtt.hasSecret" .) (and .Values.kubernetesConfigSource.enabled .Values.kubernetesConfigSource.manageResource)) }}
 {{- $name := include "rpdu2mqtt.secretName" . }}
 {{- /*
   With the CRD config source, the GUI writes credentials (MQTT/PDU/EmonCMS/GUI/OIDC) into this Secret.

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -86,6 +86,11 @@ kubernetesConfigSource:
   # NOTE: relies on Helm `lookup` — under Argo CD (helm template) it can't read the live CR, so use
   # an Argo ignoreDifferences on the RpduConfig spec instead (see the chart README).
   preserveExisting: true
+  # Whether the chart renders the mutable config resources (the RpduConfig CR and the GUI-written
+  # credentials Secret). Set false to let the app read/write ones you manage out of band, so GitOps
+  # (Argo/Flux) never syncs over GUI edits. RBAC + the k8s config source stay on; you create the CR
+  # (and Secret, if used) yourself once.
+  manageResource: true
 
 # Kubernetes Services for the GUI and /metrics endpoints. Created only when the
 # corresponding feature is enabled in `config` AND the toggle here is true.


### PR DESCRIPTION
## Problem

With `kubernetesConfigSource.enabled`, config lives in an `RpduConfig` CR that the **GUI writes at runtime** (same for the credentials `Secret`). But the chart re-renders both from `values.config` on every sync. `preserveExisting` tries to keep live values via Helm `lookup` — which returns **nothing under `helm template`**, i.e. exactly how Argo CD / Flux render. So GitOps sees drift and **syncs over every GUI edit**. The chart's own comments admit this and punt to an Argo `ignoreDifferences`.

## Fix

New value **`kubernetesConfigSource.manageResource`** (default `true`). Set it `false` and the chart **stops rendering the `RpduConfig` CR and the GUI-written credentials `Secret`** — you manage them out of band, so GitOps never touches them. Everything else stays: RBAC, `RPDU2MQTT_CONFIG_SOURCE=k8s`, `RPDU2MQTT_CR_NAME`, and the deployment's `secretRef` (already `optional: true`). The app still reads/writes the CR you create once yourself.

## Render matrix (verified with `helm template`)

| `enabled` | `manageResource` | RpduConfig | chart Secret | RBAC + `CONFIG_SOURCE=k8s` |
|---|---|---|---|---|
| true | true (default) | ✅ | ✅ | ✅ |
| true | **false** | — | — | ✅ |
| true | false + creds in `values` | — | ✅ (explicit intent) | ✅ |
| false | — | — | — (ConfigMap path) | — |

CI renders the `manageResource=false` path and asserts no CR but the app still wired to k8s. `helm lint` clean. Chart `1.0.0 → 1.1.0`.

## Usage

```yaml
kubernetesConfigSource:
  enabled: true
  manageResource: false   # you own the RpduConfig CR (and Secret); Argo/Flux won't revert GUI edits
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)