### PR TITLE
fix(ha): stop energy-flow from duplicating outlet/PDU sensors in HA (#177)

### DIFF
--- a/rPDU2MQTT.Core/Flow/FlowExport.cs
+++ b/rPDU2MQTT.Core/Flow/FlowExport.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.PDU;
 
 namespace rPDU2MQTT.Core.Flow;
 
@@ -56,6 +57,31 @@ public static class FlowExport
 
     /// <summary>The HA unique_id / entity object_id of a tier's energy sensor ("energyflow_&lt;key&gt;_energy").</summary>
     public static string EnergyUniqueId(string nodeId) => DeviceId(nodeId) + "_energy";
+
+    /// <summary>
+    /// Flow node id -> the unique_id of the native PDU-discovery energy sensor it already has (#177): PDU
+    /// tiers (<c>pdu:{name}</c>) and outlets (<c>outlet:{name}:{key}</c>) that carry an energy measurement.
+    /// These already exist in HA, so the flow export must not publish a duplicate energyflow sensor for
+    /// them — only the synthetic hierarchy tiers (panels/circuits/etc.) need one.
+    /// </summary>
+    public static Dictionary<string, string> NativeEnergyUniqueIds(PduData data, string energyType)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        string? UniqueId(IEnumerable<Measurement> measurements) =>
+            measurements.FirstOrDefault(m => string.Equals(m.Type, energyType, StringComparison.OrdinalIgnoreCase))?.Entity_Identifier is { Length: > 0 } uid
+                ? uid
+                : null;
+
+        foreach (var device in data.Devices)
+        {
+            if (UniqueId(device.Entity.SelectMany(e => e.Measurements)) is { } pduUid)
+                map[$"pdu:{device.Entity_Name}"] = pduUid;
+            foreach (var outlet in device.Outlets)
+                if (UniqueId(outlet.Measurements) is { } outletUid)
+                    map[$"outlet:{device.Entity_Name}:{outlet.Key}"] = outletUid;
+        }
+        return map;
+    }
 
     /// <summary>
     /// A Home Assistant device-discovery document for a tier (#128): one device with an Energy sensor

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -16,6 +16,10 @@ namespace rPDU2MQTT.Services;
 /// </summary>
 public class EnergyFlowMqttExportService : baseMQTTService
 {
+    // Discovery config topics we've already retired (once per process) — the duplicate energyflow sensors
+    // an earlier build published for outlets/PDU tiers (#177). Cleared by an empty retained message.
+    private readonly HashSet<string> clearedDuplicates = new();
+
     public EnergyFlowMqttExportService(MQTTServiceDependencies deps) : base(deps, deps.Cfg.Primary.PollInterval) { }
 
     protected override async Task Execute(CancellationToken cancellationToken)
@@ -39,6 +43,10 @@ public class EnergyFlowMqttExportService : baseMQTTService
 
         var publishDiscovery = cfg.HASS.DiscoveryEnabled && !string.IsNullOrWhiteSpace(cfg.HASS.DiscoveryTopic);
         var availability = cfg.MQTT.LastWill ? MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic) : null;
+        // Outlets and PDU tiers already have native HA energy sensors from PDU discovery; publishing an
+        // energyflow sensor for them too would duplicate the record in HA (#177). Only the synthetic
+        // hierarchy tiers (panels/circuits/grid/etc.) get an energyflow discovery device.
+        var native = FlowExport.NativeEnergyUniqueIds(merged, energyMetric);
 
         foreach (var node in graph.Nodes)
         {
@@ -61,10 +69,19 @@ public class EnergyFlowMqttExportService : baseMQTTService
             });
             await PublishString(topic, payload, retain: true, cancellationToken);
 
-            if (publishDiscovery)
+            if (!publishDiscovery)
+                continue;
+
+            var configTopic = $"{cfg.HASS.DiscoveryTopic}/device/{FlowExport.DeviceId(node.Id)}/config";
+            if (native.ContainsKey(node.Id))
+            {
+                // Native sensor exists — retire any duplicate an earlier build left retained (once).
+                if (clearedDuplicates.Add(configTopic))
+                    await PublishString(configTopic, string.Empty, retain: true, cancellationToken);
+            }
+            else
             {
                 var doc = FlowExport.DiscoveryDocument(node, parents.FirstOrDefault(), topic, energyGraph.Units, graph.Units, availability);
-                var configTopic = $"{cfg.HASS.DiscoveryTopic}/device/{FlowExport.DeviceId(node.Id)}/config";
                 await PublishString(configTopic, doc.ToJsonString(), retain: cfg.HASS.DiscoveryRetain, cancellationToken);
             }
         }

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -26,11 +26,13 @@ public sealed class HaEnergyDashboardSync
     }
 
     /// <summary>
-    /// The energy-dashboard devices the current hierarchy maps to. Each tier is resolved to its exported
-    /// energy sensor (published by the flow MQTT export as <c>energyflow_&lt;key&gt;_energy</c>) via HA's
-    /// authoritative <c>unique_id → entity_id</c> map, so we never guess an entity_id that doesn't exist.
-    /// Tiers whose energy sensor isn't in HA are skipped and their children link to the nearest ancestor
-    /// that is — giving HA the full Grid → Panel → Circuit → PDU → outlet chain, not just leaf outlets.
+    /// The energy-dashboard devices the current hierarchy maps to. Outlets and PDU tiers resolve to their
+    /// native PDU-discovery energy sensor; the synthetic hierarchy tiers resolve to the energyflow sensor
+    /// the flow export publishes (<c>energyflow_&lt;key&gt;_energy</c>) — this matches which records actually
+    /// exist in HA (#177) and avoids the duplicates a uniform energyflow mapping caused. Everything is
+    /// resolved through HA's authoritative <c>unique_id → entity_id</c> map, so we never guess an entity_id;
+    /// tiers whose sensor isn't in HA are skipped and their children link to the nearest ancestor that is —
+    /// giving HA the full Grid → Panel → Circuit → PDU → outlet chain.
     /// </summary>
     public List<HaDeviceConsumption> BuildDevices(IReadOnlyDictionary<string, string> entityByUniqueId)
     {
@@ -38,8 +40,15 @@ public sealed class HaEnergyDashboardSync
         foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
         if (merged.Devices.Count == 0) return new();
 
+        var energyType = string.IsNullOrWhiteSpace(config.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : config.HASS.EnergyDashboard.EnergyMeasurementType;
+        var native = FlowExport.NativeEnergyUniqueIds(merged, energyType);
+
         var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric);
-        Func<string, string?> resolver = id => entityByUniqueId.TryGetValue(FlowExport.EnergyUniqueId(id), out var e) ? e : null;
+        Func<string, string?> resolver = id =>
+        {
+            var uid = native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id);
+            return entityByUniqueId.TryGetValue(uid, out var e) ? e : null;
+        };
         return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver);
     }
 

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -404,4 +404,32 @@ public class FlowGraphTests
         Assert.Null(root["device"]!["via_device"]);
         Assert.Null(root["availability_topic"]);
     }
+
+    [Fact]
+    public void FlowExport_NativeEnergyUniqueIds_MapsOnlyTiersWithANativeEnergySensor()
+    {
+        // An outlet with an energy measurement, and one without; a device-level energy entity too.
+        var withEnergy = new Outlet { Key = 0, Entity_Name = "o0", Entity_DisplayName = "Server" };
+        withEnergy.Measurements.Add(new Measurement { Type = "realpower", Value = "60", Units = "W" });
+        withEnergy.Measurements.Add(new Measurement { Type = "energy", Value = "12.5", Units = "kWh", Entity_Identifier = "rpdu_o0_energy" });
+        var noEnergy = new Outlet { Key = 1, Entity_Name = "o1", Entity_DisplayName = "Idle" };
+        noEnergy.Measurements.Add(new Measurement { Type = "realpower", Value = "0", Units = "W" });
+
+        var device = new Device { Key = "pdu1", Entity_Name = "pdu1", Entity_DisplayName = "PDU 1" };
+        device.Outlets.AddRange(new[] { withEnergy, noEnergy });
+        var pduEntity = new Entity { Entity_Name = "pdu1" };
+        pduEntity.Measurements.Add(new Measurement { Type = "energy", Value = "40", Units = "kWh", Entity_Identifier = "rpdu_pdu1_energy" });
+        device.Entity.Add(pduEntity);
+        var data = new PduData();
+        data.Devices.Add(device);
+
+        var map = FlowExport.NativeEnergyUniqueIds(data, "energy");
+
+        // Outlet + PDU tiers that carry an energy measurement map to that sensor's unique_id; the sensorless
+        // outlet does not — so the flow export won't publish a duplicate energyflow sensor for the first two.
+        Assert.Equal("rpdu_o0_energy", map["outlet:pdu1:0"]);
+        Assert.Equal("rpdu_pdu1_energy", map["pdu:pdu1"]);
+        Assert.False(map.ContainsKey("outlet:pdu1:1"));
+        Assert.Equal(2, map.Count);
+    }
 }


### PR DESCRIPTION
Fixes #177.

## Problem

The energy-flow HA discovery added in #171 published an `energyflow_<key>` device for **every** tier — including outlets and PDU tiers that **already have native energy sensors** from normal PDU discovery. So every outlet/PDU showed up **twice** in Home Assistant: `sensor.rack_pdu_1_outlet_11_energy` (native) *and* `sensor.energyflow_outlet_rack_pdu_1_10_energy` (duplicate).

## Fix

Only the **synthetic** hierarchy tiers (panels, circuits, grid — the ones with no native sensor) get an energyflow discovery device now.

- **`FlowExport.NativeEnergyUniqueIds(data, energyType)`** — maps each outlet / PDU tier that carries a native energy measurement to that sensor's `unique_id`.
- **Export** skips discovery for those nodes, and **retires the duplicates an earlier build already published** (empty retained message to the config topic, once per process) so existing installs self-heal.
- **Dashboard sync** resolver is now hybrid: outlets/PDU tiers → their **native** sensor, synthetic tiers → the **energyflow** sensor. This matches which records actually exist in HA and still builds the full Grid → Panel → Circuit → PDU → outlet chain.

State topics (the #164 MQTT export) are unchanged — every tier still publishes its rolled-up power/energy; only the *duplicate HA discovery* is removed.

## Tests

- `FlowExport_NativeEnergyUniqueIds_MapsOnlyTiersWithANativeEnergySensor` — outlet/PDU tiers with an energy measurement map to their `unique_id`; a sensorless outlet doesn't.
- Full suite: 120 pass.

## Upgrade note

On first poll after upgrading, the bridge clears the retained duplicate discovery configs, so the extra `energyflow_outlet_*` / `energyflow_pdu_*` devices disappear from HA automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)