### PR TITLE
feat(gui): render PDU connection scheme as a dropdown (#176)

### DIFF
--- a/rPDU2MQTT.Core/ConfigSchema.cs
+++ b/rPDU2MQTT.Core/ConfigSchema.cs
@@ -103,6 +103,16 @@ public static class ConfigSchema
         if (prop.GetCustomAttribute<TemplateVariablesAttribute>() is { } tv)
             node.TemplateVars = tv.Names;
 
+        // A string with a fixed set of choices ([AllowedValues]) renders as a dropdown, not free text (#176).
+        // An optional one keeps a leading blank choice so it can be cleared back to "unset" (auto).
+        if (type == typeof(string) && prop.GetCustomAttribute<AllowedValuesAttribute>() is { } allowed)
+        {
+            var values = allowed.Values.Select(v => v?.ToString() ?? string.Empty);
+            node.EnumValues = (node.Required ? values : values.Prepend(string.Empty)).ToArray();
+            node.Type = "enum";
+            return node;
+        }
+
         node.Type = ClassifyAndPopulate(type, prop.Name, node);
         return node;
     }

--- a/rPDU2MQTT.Core/Models/Config/Schemas/Connection.cs
+++ b/rPDU2MQTT.Core/Models/Config/Schemas/Connection.cs
@@ -31,6 +31,7 @@ public class Connection
     [YamlMember(Alias = "Scheme", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     [Display(Name = "Connection Scheme", Description = "Connection scheme used")]
     [Description("Default connection scheme.")]
+    [AllowedValues("http", "https")]
     public string? Scheme { get; set; }
 
     [DefaultValue(true)]

--- a/rPDU2MQTT.Tests/ConfigSchemaTests.cs
+++ b/rPDU2MQTT.Tests/ConfigSchemaTests.cs
@@ -22,6 +22,19 @@ public class ConfigSchemaTests
     }
 
     [Fact]
+    public void Build_ConnectionScheme_IsADropdownWithABlankChoice()
+    {
+        // Pdus (dictionary) -> PduConfig -> Connection -> Scheme should render as an enum (#176).
+        var pdus = ConfigSchema.Build().Single(n => n.Key == "Pdus");
+        var connection = pdus.ValueSchema!.Properties!.Single(n => n.Key == "Connection");
+        var scheme = connection.Properties!.Single(n => n.Key == "Scheme");
+
+        Assert.Equal("enum", scheme.Type);
+        // Optional field: a leading blank keeps "unset" (auto scheme from the port) selectable.
+        Assert.Equal(new[] { "", "http", "https" }, scheme.EnumValues);
+    }
+
+    [Fact]
     public void Build_OverrideDevicesAndOutletsExposeMakeAndModel()
     {
         var overrides = ConfigSchema.Build().Single(n => n.Key == "Overrides");

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -19,9 +19,10 @@ function scalarInput(node: any, obj: any): any {
     el.onchange = () => obj[node.key] = el.checked;
   } else if (node.type === 'enum') {
     el = document.createElement('select');
-    (node.enumValues || []).forEach((v: string) => { const o = document.createElement('option'); o.value = o.textContent = v; el.appendChild(o); });
+    // A blank choice (value "") means "unset" — leave the field out so its default/auto behaviour applies.
+    (node.enumValues || []).forEach((v: string) => { const o = document.createElement('option'); o.value = v; o.textContent = v === '' ? '(default)' : v; el.appendChild(o); });
     if (obj[node.key] != null) el.value = obj[node.key];
-    el.onchange = () => obj[node.key] = el.value;
+    el.onchange = () => obj[node.key] = el.value === '' ? undefined : el.value;
   } else if (node.type === 'int' || node.type === 'double') {
     el = document.createElement('input'); el.type = 'number'; if (node.type === 'double') el.step = 'any';
     if (node.min != null) el.min = node.min; if (node.max != null) el.max = node.max;

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1145,9 +1145,10 @@ function scalarInput(node     , obj     )      {
     el.onchange = () => obj[node.key] = el.checked;
   } else if (node.type === 'enum') {
     el = document.createElement('select');
-    (node.enumValues || []).forEach((v        ) => { const o = document.createElement('option'); o.value = o.textContent = v; el.appendChild(o); });
+    // A blank choice (value "") means "unset" — leave the field out so its default/auto behaviour applies.
+    (node.enumValues || []).forEach((v        ) => { const o = document.createElement('option'); o.value = v; o.textContent = v === '' ? '(default)' : v; el.appendChild(o); });
     if (obj[node.key] != null) el.value = obj[node.key];
-    el.onchange = () => obj[node.key] = el.value;
+    el.onchange = () => obj[node.key] = el.value === '' ? undefined : el.value;
   } else if (node.type === 'int' || node.type === 'double') {
     el = document.createElement('input'); el.type = 'number'; if (node.type === 'double') el.step = 'any';
     if (node.min != null) el.min = node.min; if (node.max != null) el.max = node.max;


### PR DESCRIPTION
Fixes #176.

The PDU **Connection Scheme** was a free-text input. Now it's a dropdown.

- `Connection.Scheme` is annotated `[AllowedValues("http", "https")]`.
- The config schema emits `type: enum` for a string with `[AllowedValues]`, so the existing enum `<select>` renderer picks it up — no per-field UI code.
- Because `Scheme` is optional (an unset scheme auto-derives from the port — 443→https, 80→http, see `PduInstanceFactory`), the dropdown keeps a leading **blank "(default)"** option that maps back to unset. So existing configs that relied on the auto behaviour are unchanged.

This is general: any optional string field marked `[AllowedValues(...)]` now renders as a dropdown with a clear-to-default choice.

**Tests:** `Build_ConnectionScheme_IsADropdownWithABlankChoice` asserts the node is an enum with `["", "http", "https"]`. GUI bundle rebuilt + smoke-passed. 120 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)