### PR TITLE
docs(chart): document the ServiceMonitor label gotcha

### DIFF
--- a/charts/rpdu2mqtt/Chart.yaml
+++ b/charts/rpdu2mqtt/Chart.yaml
@@ -3,7 +3,7 @@ name: rpdu2mqtt
 description: Bridge a Vertiv/Geist rPDU to MQTT, with Home Assistant discovery and optional metrics exporters.
 type: application
 # Chart version (bump on chart changes); appVersion tracks the container image.
-version: 1.2.0
+version: 1.2.1
 appVersion: "1.0.0"
 home: https://github.com/XtremeOwnage/rPDU2MQTT
 sources:

--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -55,8 +55,9 @@ credentials:
 | `split.{worker,api,ui}.replicaCount` | `1` | Replicas per role Deployment (only with `split.enabled`). Keep `worker` at `1` — it owns the single PDU session. |
 | `split.{worker,api,ui}.resources` | `{}` | Per-role resource requests/limits (falls back to `resources`). |
 | `service.gui.enabled` | `true` | Create a Service for the GUI (when `config.Gui.Enabled`). |
-| `service.metrics.enabled` | `true` | Create a Service for `/metrics` (when `config.Prometheus.Enabled`). |
+| `service.metrics.enabled` | `true` | Create a Service for `/metrics` (when `config.Prometheus.Exporter`). |
 | `serviceMonitor.enabled` | `false` | Create a Prometheus Operator `ServiceMonitor` for `/metrics`. |
+| `serviceMonitor.labels` | `{}` | Extra labels so your Prometheus adopts the ServiceMonitor (e.g. `release: <kube-prometheus-stack release>`); without a match it is silently ignored. |
 | `kubernetesConfigSource.enabled` | `false` | Store config in an `RpduConfig` CR (writable by the GUI) instead of a ConfigMap; creates the CR + RBAC and wires the app to read it. Requires the CRD (in this chart's `crds/`). |
 | `kubernetesConfigSource.preserveExisting` | `true` | Create-once: keep the live CR `spec` on upgrade so GUI edits aren't reverted (`values.config` only seeds it on install). Set `false` for declarative config. Relies on Helm `lookup`, which is empty under Argo CD (`helm template`) — see `manageResource` below. |
 | `kubernetesConfigSource.manageResource` | `true` | Whether the chart renders the `RpduConfig` CR and the GUI-written credentials `Secret`. Set `false` to manage them out of band so GitOps (Argo/Flux) never syncs over GUI edits; RBAC + the config source stay on, but you must create the CR (and Secret, if used) once yourself. |
@@ -73,7 +74,10 @@ credentials:
   *Save* is disabled — change config by editing values and running `helm upgrade`. To make the GUI
   *Save* work, set `kubernetesConfigSource.enabled=true` to store config in a writable `RpduConfig`
   custom resource (see [docs/KubernetesCRD.md](../../docs/KubernetesCRD.md)).
-- **Metrics scraping:** enable `config.Prometheus.Enabled` and `serviceMonitor.enabled` (requires the
-  Prometheus Operator) to have Prometheus auto-discover the `/metrics` endpoint.
+- **Metrics scraping:** enable `config.Prometheus.Exporter` and `serviceMonitor.enabled` (requires the
+  Prometheus Operator) to have Prometheus auto-discover the `/metrics` endpoint. A Prometheus only
+  adopts ServiceMonitors matching its `serviceMonitorSelector` — for kube-prometheus-stack that's
+  usually `release: <your-stack>`, so set `serviceMonitor.labels` to match or the ServiceMonitor is
+  silently ignored.
 - **Single replica:** the bridge owns a PDU session and has no leader election; keep `replicaCount: 1`
   (the Deployment uses the `Recreate` strategy).

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -125,7 +125,14 @@ serviceMonitor:
   enabled: false
   interval: 30s
   scrapeTimeout: ""
-  # Extra labels so your Prometheus's serviceMonitorSelector picks it up.
+  # Labels stamped on the ServiceMonitor so your Prometheus adopts it. A Prometheus only scrapes
+  # ServiceMonitors matching its spec.serviceMonitorSelector — most commonly the kube-prometheus-stack
+  # default of `release: <your-stack-release>`, so without this the ServiceMonitor is silently ignored.
+  # Find the value with:
+  #   kubectl get prometheus -A -o jsonpath='{.items[*].spec.serviceMonitorSelector}'
+  # e.g. for a release named "prometheus-stack":
+  #   labels:
+  #     release: prometheus-stack
   labels: {}
 
 # Ingress for the GUI Service.


### PR DESCRIPTION
While testing metrics in a kube-prometheus-stack cluster, the `/metrics` endpoint and ServiceMonitor were both healthy but nothing scraped it. Cause: that Prometheus only adopts ServiceMonitors matching its `serviceMonitorSelector` (`release: <stack>`), and ours had no such label — so it was silently ignored.

The mechanism (`serviceMonitor.labels`) already exists; the docs just didn't warn about the single most common reason a ServiceMonitor is dropped.

- `values.yaml`: expand the `serviceMonitor.labels` comment with the kube-prometheus-stack `release` requirement and a one-liner to find the selector value.
- `README.md`: add a `serviceMonitor.labels` row + note it in the metrics-scraping tip.
- Fix two stale `config.Prometheus.Enabled` references (renamed to `Exporter`).

The label **value** is environment-specific (your stack's release name), so it stays a per-deploy value rather than a chart default. Docs-only; `helm lint` clean. Chart `1.2.0 → 1.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)