### PR TITLE
feat(emoncms): customizable virtual-feed tag + "Delete all feeds" button

### DIFF
--- a/rPDU2MQTT.Core/EmonCms/EmonCmsFeedPlanner.cs
+++ b/rPDU2MQTT.Core/EmonCms/EmonCmsFeedPlanner.cs
@@ -74,9 +74,10 @@ public static class EmonCmsFeedPlanner
             if (f.Virtual.Enabled)
             {
                 var friendly = MetricsHelper.EmonCmsVirtualFeedName(r, config);
-                // Skip if the friendly name would collide with the storage feed (idempotent naming off).
-                if (!string.Equals(friendly, storageName, StringComparison.Ordinal))
-                    virtuals[friendly] = new DesiredVirtualFeed(friendly, tag, storageName);
+                var virtualTag = string.IsNullOrWhiteSpace(f.Virtual.Tag) ? tag : f.Virtual.Tag!;
+                // Skip if the friendly feed would collide with the storage feed (same name AND tag).
+                if (!(string.Equals(friendly, storageName, StringComparison.Ordinal) && string.Equals(virtualTag, tag, StringComparison.Ordinal)))
+                    virtuals[friendly] = new DesiredVirtualFeed(friendly, virtualTag, storageName);
             }
         }
 

--- a/rPDU2MQTT.Core/Models/Config/EmonCMSConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EmonCMSConfig.cs
@@ -147,6 +147,10 @@ public class EmonCmsVirtualFeedsConfig
     [Description("Template for the friendly virtual-feed name. {name} is the source's display name, so these can change freely without touching the stable storage feeds. Placeholders: {device}, {source}, {name}, {number}, {type}, {units}.")]
     [TemplateVariables("device", "source", "name", "number", "type", "units")]
     public string NameTemplate { get; set; } = "{name} {type}";
+
+    /// <summary>The EmonCMS tag (group) virtual feeds are filed under. Blank uses the main Feeds tag.</summary>
+    [Description("The EmonCMS tag (group/node) virtual feeds are filed under — set this to keep the friendly virtual feeds separate from the storage feeds. Blank uses the main Feeds tag.")]
+    public string? Tag { get; set; }
 }
 
 /// <summary>

--- a/rPDU2MQTT.Engine/Services/EmonCmsFeedSync.cs
+++ b/rPDU2MQTT.Engine/Services/EmonCmsFeedSync.cs
@@ -118,6 +118,30 @@ public sealed class EmonCmsFeedSync
         return new(errors.Count == 0, msg, created, processesSet, virtuals);
     }
 
+    /// <summary>Delete every feed filed under rPDU2MQTT's tag(s) — the storage tag and, if different, the
+    /// virtual-feed tag. Returns how many were deleted.</summary>
+    public async Task<EmonFeedSyncResult> DeleteAllAsync(CancellationToken ct)
+    {
+        var e = config.EmonCMS;
+        if (string.IsNullOrWhiteSpace(e.Url) || string.IsNullOrWhiteSpace(e.ApiKey))
+            return new(false, "EmonCMS Url and a read/write ApiKey are required.");
+
+        var tags = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            string.IsNullOrWhiteSpace(e.Feeds.Tag) ? e.Node : e.Feeds.Tag!,
+        };
+        if (!string.IsNullOrWhiteSpace(e.Feeds.Virtual.Tag)) tags.Add(e.Feeds.Virtual.Tag!);
+
+        int deleted = 0; var errors = new List<string>();
+        foreach (var f in (await GetFeeds(ct)).Where(f => tags.Contains(f.Tag ?? "")))
+            try { await PostForm("feed/delete.json", new() { ["id"] = f.Id.ToString() }, new(), ct); deleted++; }
+            catch (Exception ex) { errors.Add($"feed '{f.Name}': {ex.Message}"); }
+
+        var msg = $"Deleted {deleted} feed(s) under tag(s) {string.Join(", ", tags)}.";
+        if (errors.Count > 0) msg += $" {errors.Count} failed: {string.Join(" | ", errors.Take(3))}";
+        return new(errors.Count == 0, msg, deleted);
+    }
+
     private async Task<bool> EnsureFeed(Dictionary<string, EmonFeed> byName, string name, string tag, int engine, int interval, int dataType, CancellationToken ct)
     {
         if (byName.ContainsKey(name)) return false;

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -656,6 +656,22 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             }
         });
 
+        // Delete every EmonCMS feed rPDU2MQTT created (under its tag/node) — the "clean up" button.
+        app.MapPost("/api/emoncms/delete-feeds", async (HttpContext ctx) =>
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(60));
+            try
+            {
+                var r = await emonCmsFeeds.DeleteAllAsync(cts.Token);
+                return Results.Json(new { ok = r.Ok, message = r.Message }, ConfigSchema.Json);
+            }
+            catch (Exception ex)
+            {
+                return Results.Json(new { ok = false, message = $"Delete feeds failed: {ex.Message}" }, ConfigSchema.Json);
+            }
+        });
+
         // Live discovered structure (keys + current names) so the Overrides editor can be driven by
         // the actual devices/outlets/measurements instead of blindly-typed dictionary keys.
         app.MapGet("/api/live", async (HttpContext ctx) =>

--- a/rPDU2MQTT.Web/web/src/actions.ts
+++ b/rPDU2MQTT.Web/web/src/actions.ts
@@ -6,6 +6,12 @@ export async function testMqtt() { const r = await api('/api/test/mqtt', { metho
 export async function testPdu() { toast('Testing PDU…', true); const r = await api('/api/test/pdu', { method: 'POST' }); toast(r.body.message, r.body.ok); }
 export async function testEmonCms() { toast('Testing EmonCMS…', true); const r = await api('/api/test/emoncms', { method: 'POST' }); toast(r.body.message, r.body.ok); refreshStatus(); }
 export async function provisionEmonCmsFeeds() { toast('Provisioning EmonCMS feeds…', true); const r = await api('/api/emoncms/provision-feeds', { method: 'POST' }); toast(r.body.message, r.body.ok); }
+export async function deleteEmonCmsFeeds() {
+  if (!confirm('Delete ALL EmonCMS feeds created by rPDU2MQTT (under its tag/node)?\n\nThis removes the feeds and their stored data in EmonCMS. It cannot be undone.')) return;
+  toast('Deleting EmonCMS feeds…', true);
+  const r = await api('/api/emoncms/delete-feeds', { method: 'POST' });
+  toast(r.body.message, r.body.ok);
+}
 export async function rediscoverHa() { toast('Requesting discovery…', true); const r = await api('/api/discovery/rediscover', { method: 'POST' }); toast(r.body.message, r.body.ok); }
 export async function clearHa() {
   if (!confirm('Clear all Home Assistant discovery messages? The entities will disappear from Home Assistant until discovery runs again.')) return;

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -3,7 +3,7 @@
 import { ensure, el, btn, activate, slug } from './helpers.js';
 import { state } from './state.js';
 import { renderOverrides, previewOverridePaths } from './overrides.js';
-import { testMqtt, testPdu, testEmonCms, provisionEmonCmsFeeds, rediscoverHa, clearHa } from './actions.js';
+import { testMqtt, testPdu, testEmonCms, provisionEmonCmsFeeds, deleteEmonCmsFeeds, rediscoverHa, clearHa } from './actions.js';
 import { addPathsSection } from './sections/paths.js';
 import { addDiagnosticsSection } from './sections/diagnostics.js';
 import { addControlSection } from './sections/control.js';
@@ -291,7 +291,7 @@ function sectionActions(node: any) {
 
   if (node.key === 'MQTT') add('Test MQTT connection', testMqtt);
   else if (node.key === 'PDU') add('Test PDU connection', testPdu);
-  else if (node.key === 'EmonCMS') { add('Test EmonCMS connection', testEmonCms); add('Provision feeds now', provisionEmonCmsFeeds); }
+  else if (node.key === 'EmonCMS') { add('Test EmonCMS connection', testEmonCms); add('Provision feeds now', provisionEmonCmsFeeds); add('Delete all feeds', deleteEmonCmsFeeds, 'danger'); }
   else if (node.key === 'HomeAssistant') {
     if ((state.data.HomeAssistant || {}).DiscoveryEnabled === false) return null;
     add('Republish discovery', rediscoverHa);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1417,7 +1417,7 @@ function sectionActions(node     ) {
 
   if (node.key === 'MQTT') add('Test MQTT connection', testMqtt);
   else if (node.key === 'PDU') add('Test PDU connection', testPdu);
-  else if (node.key === 'EmonCMS') { add('Test EmonCMS connection', testEmonCms); add('Provision feeds now', provisionEmonCmsFeeds); }
+  else if (node.key === 'EmonCMS') { add('Test EmonCMS connection', testEmonCms); add('Provision feeds now', provisionEmonCmsFeeds); add('Delete all feeds', deleteEmonCmsFeeds, 'danger'); }
   else if (node.key === 'HomeAssistant') {
     if ((state.data.HomeAssistant || {}).DiscoveryEnabled === false) return null;
     add('Republish discovery', rediscoverHa);
@@ -1434,6 +1434,12 @@ async function testMqtt() { const r = await api('/api/test/mqtt', { method: 'POS
 async function testPdu() { toast('Testing PDU…', true); const r = await api('/api/test/pdu', { method: 'POST' }); toast(r.body.message, r.body.ok); }
 async function testEmonCms() { toast('Testing EmonCMS…', true); const r = await api('/api/test/emoncms', { method: 'POST' }); toast(r.body.message, r.body.ok); refreshStatus(); }
 async function provisionEmonCmsFeeds() { toast('Provisioning EmonCMS feeds…', true); const r = await api('/api/emoncms/provision-feeds', { method: 'POST' }); toast(r.body.message, r.body.ok); }
+async function deleteEmonCmsFeeds() {
+  if (!confirm('Delete ALL EmonCMS feeds created by rPDU2MQTT (under its tag/node)?\n\nThis removes the feeds and their stored data in EmonCMS. It cannot be undone.')) return;
+  toast('Deleting EmonCMS feeds…', true);
+  const r = await api('/api/emoncms/delete-feeds', { method: 'POST' });
+  toast(r.body.message, r.body.ok);
+}
 async function rediscoverHa() { toast('Requesting discovery…', true); const r = await api('/api/discovery/rediscover', { method: 'POST' }); toast(r.body.message, r.body.ok); }
 async function clearHa() {
   if (!confirm('Clear all Home Assistant discovery messages? The entities will disappear from Home Assistant until discovery runs again.')) return;


### PR DESCRIPTION
Two follow-ups to #163.

- **Customizable virtual-feed tag** — `EmonCMS.Feeds.Virtual.Tag` files the friendly virtual feeds under a different EmonCMS tag/node than the idempotent storage feeds. Blank keeps the main `Feeds.Tag`.
- **"Delete all feeds" button** (+ `POST /api/emoncms/delete-feeds`) — removes every feed rPDU2MQTT created, across its storage tag and (if set) the virtual tag, behind a confirm. Backed by `EmonCmsFeedSync.DeleteAllAsync`.

133 tests pass; GUI rebuilt + smoke-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)