### PR TITLE
feat(gui): stronger confirmation for Delete all feeds

### DIFF
--- a/rPDU2MQTT.Web/web/src/actions.ts
+++ b/rPDU2MQTT.Web/web/src/actions.ts
@@ -7,7 +7,13 @@ export async function testPdu() { toast('Testing PDU…', true); const r = await
 export async function testEmonCms() { toast('Testing EmonCMS…', true); const r = await api('/api/test/emoncms', { method: 'POST' }); toast(r.body.message, r.body.ok); refreshStatus(); }
 export async function provisionEmonCmsFeeds() { toast('Provisioning EmonCMS feeds…', true); const r = await api('/api/emoncms/provision-feeds', { method: 'POST' }); toast(r.body.message, r.body.ok); }
 export async function deleteEmonCmsFeeds() {
-  if (!confirm('Delete ALL EmonCMS feeds created by rPDU2MQTT (under its tag/node)?\n\nThis removes the feeds and their stored data in EmonCMS. It cannot be undone.')) return;
+  if (!confirm('⚠️ DELETE ALL EmonCMS feeds created by rPDU2MQTT?\n\n'
+    + 'This PERMANENTLY deletes every feed under rPDU2MQTT’s tag/node — and ALL of their stored history in EmonCMS.\n\n'
+    + 'It CANNOT be undone. Any EmonCMS dashboards, graphs, apps or virtual feeds that use these feeds will break.\n\n'
+    + 'Only continue if you intend to wipe and rebuild them.')) return;
+  if (!confirm('Are you absolutely sure?\n\nThis is your last chance to cancel before every rPDU2MQTT feed and its data are destroyed.')) return;
+  const typed = prompt('Final confirmation — type  DELETE  (all caps) to permanently delete all rPDU2MQTT feeds:');
+  if (typed !== 'DELETE') { toast('Cancelled — nothing was deleted.', false); return; }
   toast('Deleting EmonCMS feeds…', true);
   const r = await api('/api/emoncms/delete-feeds', { method: 'POST' });
   toast(r.body.message, r.body.ok);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1435,7 +1435,13 @@ async function testPdu() { toast('Testing PDU…', true); const r = await api('/
 async function testEmonCms() { toast('Testing EmonCMS…', true); const r = await api('/api/test/emoncms', { method: 'POST' }); toast(r.body.message, r.body.ok); refreshStatus(); }
 async function provisionEmonCmsFeeds() { toast('Provisioning EmonCMS feeds…', true); const r = await api('/api/emoncms/provision-feeds', { method: 'POST' }); toast(r.body.message, r.body.ok); }
 async function deleteEmonCmsFeeds() {
-  if (!confirm('Delete ALL EmonCMS feeds created by rPDU2MQTT (under its tag/node)?\n\nThis removes the feeds and their stored data in EmonCMS. It cannot be undone.')) return;
+  if (!confirm('⚠️ DELETE ALL EmonCMS feeds created by rPDU2MQTT?\n\n'
+    + 'This PERMANENTLY deletes every feed under rPDU2MQTT’s tag/node — and ALL of their stored history in EmonCMS.\n\n'
+    + 'It CANNOT be undone. Any EmonCMS dashboards, graphs, apps or virtual feeds that use these feeds will break.\n\n'
+    + 'Only continue if you intend to wipe and rebuild them.')) return;
+  if (!confirm('Are you absolutely sure?\n\nThis is your last chance to cancel before every rPDU2MQTT feed and its data are destroyed.')) return;
+  const typed = prompt('Final confirmation — type  DELETE  (all caps) to permanently delete all rPDU2MQTT feeds:');
+  if (typed !== 'DELETE') { toast('Cancelled — nothing was deleted.', false); return; }
   toast('Deleting EmonCMS feeds…', true);
   const r = await api('/api/emoncms/delete-feeds', { method: 'POST' });
   toast(r.body.message, r.body.ok);


### PR DESCRIPTION
The "Delete all feeds" button wipes every rPDU2MQTT feed and its stored EmonCMS history. Guard it with two warning confirms (consequences spelled out) plus a type-`DELETE` prompt, so it can't be triggered accidentally.

GUI-only; smoke-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)