### PR TITLE
feat(prometheus): configurable exporter labels incl. instance + hierarchy (#188)

### DIFF
--- a/rPDU2MQTT.Core/Helpers/PrometheusLabels.cs
+++ b/rPDU2MQTT.Core/Helpers/PrometheusLabels.cs
@@ -1,0 +1,54 @@
+using rPDU2MQTT.Classes;
+
+namespace rPDU2MQTT.Helpers;
+
+/// <summary>
+/// Resolves the configurable Prometheus label set (#188). Prometheus requires a consistent label set per
+/// metric, so the names come from <c>Prometheus.Labels</c> and every reading supplies a value for each
+/// (empty when it doesn't apply, e.g. an outlet number on a device-level entity).
+/// </summary>
+public static class PrometheusLabels
+{
+    /// <summary>Label names supported by <c>Prometheus.Labels</c>.</summary>
+    public static readonly string[] Supported = ["device", "source", "name", "number", "type", "units", "instance", "hierarchy"];
+
+    /// <summary>The configured label names, filtered to the supported set (falls back to the defaults).</summary>
+    public static string[] Names(Config config)
+    {
+        var names = (config.Prometheus.Labels ?? new())
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n.Trim().ToLowerInvariant())
+            .Where(n => Supported.Contains(n))
+            .Distinct()
+            .ToArray();
+        return names.Length > 0 ? names : ["device", "source", "units"];
+    }
+
+    /// <summary>
+    /// The label values for a reading, in the same order as <see cref="Names"/>.
+    /// <paramref name="instance"/> is the PDU instance key; <paramref name="hierarchy"/> the energy-flow
+    /// tier feeding this reading (both may be empty when unknown/not configured).
+    /// </summary>
+    public static string[] Values(string[] names, MeasurementReading r, Config config, string instance, string hierarchy)
+    {
+        var effectiveType = config.Overrides.Measurements.TryGetValue(r.Type, out var ov) && !string.IsNullOrWhiteSpace(ov?.ID)
+            ? ov!.ID!
+            : r.Type;
+
+        var values = new string[names.Length];
+        for (var i = 0; i < names.Length; i++)
+            values[i] = names[i] switch
+            {
+                "device" => r.Device,
+                "source" => r.Source,
+                "name" => r.SourceName ?? r.Source,
+                "number" => r.Number?.ToString() ?? string.Empty,
+                "type" => effectiveType,
+                "units" => r.Units,
+                "instance" => instance,
+                "hierarchy" => hierarchy,
+                _ => string.Empty,
+            };
+        return values;
+    }
+}

--- a/rPDU2MQTT.Core/Models/Config/PrometheusConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/PrometheusConfig.cs
@@ -30,6 +30,15 @@ public class PrometheusConfig
     [TemplateVariables("type", "device", "source", "units")]
     public string MetricNameTemplate { get; set; } = "rpdu2mqtt_{type}";
 
+    /// <summary>
+    /// Which labels to attach to every exported metric (#188). Available: <c>device</c>, <c>source</c>
+    /// (object-id form), <c>name</c> (display name), <c>number</c> (outlet number), <c>type</c>,
+    /// <c>units</c>, <c>instance</c> (the PDU instance key), <c>hierarchy</c> (the energy-flow tier
+    /// feeding this reading). Prometheus requires a consistent label set, so this applies to all metrics.
+    /// </summary>
+    [Description("Labels attached to every exported metric. Available: device, source, name, number, type, units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set.")]
+    public List<string> Labels { get; set; } = new() { "device", "source", "units" };
+
     [Description("Push metrics to a Prometheus Pushgateway.")]
     public PrometheusPushgatewayConfig Pushgateway { get; set; } = new();
 

--- a/rPDU2MQTT.Engine/Services/PrometheusExportService.cs
+++ b/rPDU2MQTT.Engine/Services/PrometheusExportService.cs
@@ -62,19 +62,54 @@ public class PrometheusExportService : baseMQTTService
 
     protected override Task Execute(CancellationToken cancellationToken)
     {
-        foreach (var data in FreshSnapshots())
-            foreach (var r in MetricsHelper.EnumerateReadings(data))
-                GetGauge(MetricsHelper.PrometheusMetricName(r, cfg)).WithLabels(r.Device, r.Source, r.Units).Set(r.Value);
+        var labelNames = PrometheusLabels.Names(cfg);
+        // The energy-flow tier feeding each reading — only built when the hierarchy label is wanted.
+        var hierarchy = labelNames.Contains("hierarchy") ? BuildHierarchy() : null;
+
+        foreach (var snapshot in FreshSnapshotsWithId())
+            foreach (var r in MetricsHelper.EnumerateReadings(snapshot.Data))
+            {
+                var tier = hierarchy is null ? string.Empty : HierarchyFor(hierarchy, r);
+                var values = PrometheusLabels.Values(labelNames, r, cfg, snapshot.InstanceId, tier);
+                GetGauge(MetricsHelper.PrometheusMetricName(r, cfg), labelNames).WithLabels(values).Set(r.Value);
+            }
 
         return Task.CompletedTask;
     }
 
+    /// <summary>Flow-node id -> the label of the tier feeding it, from the configured energy hierarchy.</summary>
+    private Dictionary<string, string> BuildHierarchy()
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        try
+        {
+            var merged = new Models.PDU.PduData();
+            foreach (var data in FreshSnapshots()) merged.Devices.AddRange(data.Devices);
+            if (merged.Devices.Count == 0) return map;
+
+            var graph = Core.Flow.FlowGraphBuilder.Build(merged, cfg.EnergyFlow, Core.Flow.FlowGraphBuilder.DefaultMetric);
+            var labels = graph.Nodes.ToDictionary(n => n.Id, n => n.Label, StringComparer.OrdinalIgnoreCase);
+            foreach (var node in graph.Nodes)
+                if (Core.Flow.FlowExport.Parents(graph, node.Id).FirstOrDefault() is { } parent)
+                    map[node.Id] = labels.TryGetValue(parent, out var l) ? l : parent;
+        }
+        catch (Exception ex) { Log.Debug($"Prometheus hierarchy label unavailable: {ex.Message}"); }
+        return map;
+    }
+
+    private static string HierarchyFor(Dictionary<string, string> map, MeasurementReading r)
+    {
+        // Readings come from outlets (outlet:{device}:{key}) or device-level entities (pdu:{device}).
+        if (r.Number is { } n && map.TryGetValue($"outlet:{r.Device}:{n - 1}", out var outletTier)) return outletTier;
+        return map.TryGetValue($"pdu:{r.Device}", out var pduTier) ? pduTier : string.Empty;
+    }
+
     // Cached by the resolved metric name (the template may vary the name by device/source/units).
-    private Gauge GetGauge(string name)
+    private Gauge GetGauge(string name, string[] labelNames)
     {
         if (!gauges.TryGetValue(name, out var gauge))
         {
-            gauge = Metrics.CreateGauge(name, "rPDU2MQTT measurement", "device", "source", "units");
+            gauge = Metrics.CreateGauge(name, "rPDU2MQTT measurement", labelNames);
             gauges[name] = gauge;
         }
         return gauge;

--- a/rPDU2MQTT.Engine/Services/baseTypes/baseMQTTService.cs
+++ b/rPDU2MQTT.Engine/Services/baseTypes/baseMQTTService.cs
@@ -172,11 +172,15 @@ public abstract class baseMQTTService : IHostedService, IDisposable
     /// mark their entities unavailable instead of us republishing last-known values forever.
     /// </summary>
     protected IReadOnlyList<Models.PDU.PduData> FreshSnapshots()
+        => FreshSnapshotsWithId().Select(s => s.Data).ToList();
+
+    /// <summary>As <see cref="FreshSnapshots"/>, but keeps each snapshot's instance id (for per-instance
+    /// labelling/routing).</summary>
+    protected IReadOnlyList<Core.PduSnapshot> FreshSnapshotsWithId()
     {
         var now = DateTime.UtcNow;
         return snapshotCache.All
             .Where(s => !Core.SnapshotFreshness.IsStale(s.TimestampUtc, cfg.Primary.PollInterval, now))
-            .Select(s => s.Data)
             .ToList();
     }
 

--- a/rPDU2MQTT.Tests/PrometheusLabelsTests.cs
+++ b/rPDU2MQTT.Tests/PrometheusLabelsTests.cs
@@ -1,0 +1,47 @@
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Helpers;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>PrometheusLabels: the configurable exporter label set (#188).</summary>
+public class PrometheusLabelsTests
+{
+    private static MeasurementReading Reading() =>
+        new("rack_pdu_1", "o0", "realpower", 60, "W", "id", "topic", "Server A", 1);
+
+    [Fact]
+    public void Names_DefaultsToLegacySet_AndFiltersUnknown()
+    {
+        var c = new Config();
+        Assert.Equal(new[] { "device", "source", "units" }, PrometheusLabels.Names(c));   // default = back-compat
+
+        c.Prometheus.Labels = new() { "Device", "bogus", "instance", "device" };          // case/dupe/unknown
+        Assert.Equal(new[] { "device", "instance" }, PrometheusLabels.Names(c));
+
+        c.Prometheus.Labels = new() { "bogus" };                                          // nothing valid -> defaults
+        Assert.Equal(new[] { "device", "source", "units" }, PrometheusLabels.Names(c));
+    }
+
+    [Fact]
+    public void Values_ResolveEverySupportedLabel_InOrder()
+    {
+        var c = new Config();
+        var names = new[] { "device", "source", "name", "number", "type", "units", "instance", "hierarchy" };
+
+        var v = PrometheusLabels.Values(names, Reading(), c, instance: "pdu-a", hierarchy: "Servers Circuit");
+
+        Assert.Equal(new[] { "rack_pdu_1", "o0", "Server A", "1", "realpower", "W", "pdu-a", "Servers Circuit" }, v);
+    }
+
+    [Fact]
+    public void Values_TypeHonoursMeasurementOverrideId()
+    {
+        var c = new Config();
+        c.Overrides.Measurements["realpower"] = new() { ID = "power" };
+
+        var v = PrometheusLabels.Values(new[] { "type" }, Reading(), c, "", "");
+
+        Assert.Equal("power", v[0]);
+    }
+}


### PR DESCRIPTION
Fixes #188.

The exporter hardcoded `device`/`source`/`units` — no way to know which **PDU instance** a metric came from, or where it sits in the **energy hierarchy**.

## `Prometheus.Labels`
Pick the label set from:

| label | value |
|---|---|
| `device` | PDU device name |
| `source` | outlet/entity object-id |
| `name` | friendly display name |
| `number` | outlet number |
| `type` | measurement type (honours the `Overrides.Measurements` ID) |
| `units` | units |
| **`instance`** | the PDU instance key (which PDU it came from) |
| **`hierarchy`** | the energy-flow tier feeding the reading (e.g. `Servers Circuit`) |

Defaults to `device, source, units` — **existing scrapes are unchanged**. Prometheus needs a consistent label set, so it applies to all metrics. The flow graph is only built when `hierarchy` is requested.

Also exposes `FreshSnapshotsWithId()` so the instance key survives (it was being discarded).

Tests: name filtering (case/dupes/unknown/fallback), all-label resolution in order, and override-id handling. 138 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)