### PR TITLE
feat(mqtt): scheme dropdown with real TLS/WebSocket support (#189)

### DIFF
--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -60,6 +60,15 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                     properties:
+                      Scheme:
+                        type: string
+                        enum:
+                        - ''
+                        - mqtt
+                        - mqtts
+                        - ws
+                        - wss
+                        description: 'How to reach the broker: mqtt (plain TCP), mqtts (TLS), ws (WebSocket) or wss (WebSocket over TLS). Leave unset to infer from the port.'
                       Host:
                         type: string
                         description: Hostname or IP to connect to.
@@ -73,9 +82,6 @@ spec:
                         description: Default connection timeout.
                         minimum: 1
                         maximum: 3600
-                      Scheme:
-                        type: string
-                        description: Connection scheme used
                       ValidateCertificate:
                         type: boolean
                         description: Enables certificate validation
@@ -115,6 +121,10 @@ spec:
                           maximum: 3600
                         Scheme:
                           type: string
+                          enum:
+                          - ''
+                          - http
+                          - https
                           description: Connection scheme used
                         ValidateCertificate:
                           type: boolean
@@ -171,6 +181,23 @@ spec:
                   GroupMemberObjectIdTemplate:
                     type: string
                     description: "Stable entity/object_id template for a group's mirrored member switches. Placeholders: {serial}, {number}, {device}, {group}."
+                  EnergyDashboard:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      Enabled:
+                        type: boolean
+                        description: Sync the energy-flow hierarchy into HA's Energy Dashboard via its API. Requires Url + a long-lived access token.
+                      Url:
+                        type: string
+                        description: Home Assistant base URL, e.g. http://homeassistant.local:8123 .
+                      Token:
+                        type: string
+                        description: Home Assistant long-lived access token (or set RPDU2MQTT_HASS_TOKEN).
+                      EnergyMeasurementType:
+                        type: string
+                        description: Measurement type holding each entity's cumulative energy (kWh) — used to find the Energy Dashboard stat for each tier.
+                    description: Auto-configure Home Assistant's Energy Dashboard 'devices' (with upstream relationships) from the energy-flow hierarchy, via HA's WebSocket API.
                 description: Home Assistant Configuration
               Overrides:
                 type: object
@@ -341,6 +368,11 @@ spec:
                   MetricNameTemplate:
                     type: string
                     description: "Template for Prometheus metric names. Placeholders: {type}, {device}, {source} (a.k.a. {outlet}), {units}. e.g. 'rpdu2mqtt_{type}' -> rpdu2mqtt_realpower; 'pdu_{device}_{type}' -> pdu_rack_pdu_1_realpower. (device/source/units are also emitted as labels.)"
+                  Labels:
+                    type: array
+                    items:
+                      type: string
+                    description: "Labels attached to every exported metric. Available: device, source, name, number, type, units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set."
                   Pushgateway:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -389,7 +421,108 @@ spec:
                     description: "Template for EmonCMS input keys. Placeholders: {device}, {source} (object-id form), {name} (formatted display name), {number} (outlet number), {type}, {units}. e.g. '{device}_{source}_{type}' -> rack_pdu_1_dell_md1200_realpower. Leave blank to use the full raw identifier."
                   MqttBaseTopic:
                     type: string
-                    description: Base MQTT topic for EmonCMS's MQTT input; values are published to <base>/<node> as JSON. (Mqtt transport.)
+                    description: Base MQTT topic for EmonCMS's MQTT input (the {base} placeholder of MqttTopicTemplate). (Mqtt transport.)
+                  MqttTopicTemplate:
+                    type: string
+                    description: "Template for the EmonCMS MQTT topic each JSON payload is published to. Placeholders: {base} (MqttBaseTopic), {node}, {device} (the PDU's name). Including {device} splits the export so each PDU publishes to its own topic instead of one combined payload, e.g. '{base}/{node}/{device}'. (Mqtt transport.)"
+                  Feeds:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      AutoConfigure:
+                        type: boolean
+                        description: Create and maintain EmonCMS feeds from the exported inputs (takes effect without a restart).
+                      Types:
+                        type: array
+                        items:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          properties:
+                            Type:
+                              type: string
+                              enum:
+                              - ''
+                              - realpower
+                              - apparentpower
+                              - energy
+                              - current
+                              - voltage
+                              - frequency
+                              - powerfactor
+                              description: The measurement type this applies to (raw PDU type name).
+                            Engine:
+                              type: string
+                              enum:
+                              - MySQL
+                              - PHPTimeSeries
+                              - PHPFina
+                              - VirtualFeed
+                              description: Feed storage engine for this type. Blank inherits Feeds.Engine. PHPFina = fixed-interval, PHPTimeSeries = variable, MySQL = MySQL storage.
+                            IntervalSeconds:
+                              type: integer
+                              description: Sample interval in seconds for this type's feed. Blank inherits Feeds.IntervalSeconds.
+                              minimum: 1
+                              maximum: 86400
+                            Daily:
+                              type: boolean
+                              description: 'Also create a daily kWh/d feed (an extra processlist step: kWh→kWh/d). Typically only for the energy type.'
+                            DailyIntervalSeconds:
+                              type: integer
+                              description: Interval (seconds) for the daily kWh/d feed. Should be a day (86400), not the base interval.
+                              minimum: 1
+                              maximum: 86400
+                        description: The measurement types to build feeds for, each with its own engine, interval and processing.
+                      Engine:
+                        type: string
+                        enum:
+                        - MySQL
+                        - PHPTimeSeries
+                        - PHPFina
+                        - VirtualFeed
+                        description: Default feed storage engine, for types that don't set their own. PHPFina = fixed-interval time series, PHPTimeSeries = variable interval, MySQL = MySQL storage (no phpfina files).
+                      IntervalSeconds:
+                        type: integer
+                        description: Default sample interval in seconds for a fixed-interval feed, for types that don't set their own.
+                        minimum: 1
+                        maximum: 86400
+                      IdempotentNames:
+                        type: boolean
+                        description: Name storage feeds idempotently from stable ids (device/source/type) so they DON'T change when a source is renamed. Turn off to name them from the display name instead (renaming a source renames its feed).
+                      Tag:
+                        type: string
+                        description: The EmonCMS tag (group) new feeds are filed under. Blank uses the input node name.
+                      StorageNameTemplate:
+                        type: string
+                        description: 'Template for the idempotent storage-feed name. Use only stable placeholders ({device}, {source}, {type}, {number}) so it never changes on a rename. Placeholders: {device}, {source}, {name}, {number}, {type}, {units}.'
+                      Virtual:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          Enabled:
+                            type: boolean
+                            description: Create a friendly-named virtual feed for each storage feed, sourced from it (source_feed process).
+                          NameTemplate:
+                            type: string
+                            description: "Template for the friendly virtual-feed name. {name} is the source's display name, so these can change freely without touching the stable storage feeds. Placeholders: {device}, {source}, {name}, {number}, {type}, {units}."
+                          Tag:
+                            type: string
+                            description: The EmonCMS tag (group/node) virtual feeds are filed under — set this to keep the friendly virtual feeds separate from the storage feeds. Blank uses the main Feeds tag.
+                        description: Optionally create friendly-named virtual feeds that source from the stable storage feeds — so dashboards get nice names while the underlying feeds stay idempotent.
+                      Processes:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          LogToFeed:
+                            type: string
+                            description: Process id_num for 'Log to feed' (EmonCMS stores processlists as id_num:feedid; default 1).
+                          KwhToKwhd:
+                            type: string
+                            description: Process id_num for 'kWh to kWh/d', used for daily energy feeds (default 23).
+                          SourceFeed:
+                            type: string
+                            description: Process id_num for 'Source feed', used for virtual feeds (default 53).
+                        description: EmonCMS process ids used in the generated processlists. Match these to your EmonCMS (Inputs → process dropdown).
+                    description: Automatically create and maintain EmonCMS feeds from the exported inputs. (Http transport; needs a read/write API key.)
                 description: EmonCMS exporter
               Logging:
                 type: object
@@ -541,6 +674,52 @@ spec:
                     type: string
                     description: Optional API key enabling the write/control endpoints. When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).
                 description: Read-only REST API + OpenAPI/Scalar docs
+              EnergyFlow:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  Nodes:
+                    type: array
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        Id:
+                          type: string
+                          description: Stable unique id used to wire parents/children.
+                        Label:
+                          type: string
+                          description: Human-readable label shown in the flow diagram.
+                        Value:
+                          type: number
+                          description: Optional directly-known value for a leaf node (used until a live sensor is bound).
+                    description: Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.
+                  Links:
+                    type: array
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        From:
+                          type: string
+                          description: Source node id — energy flows out of here.
+                        To:
+                          type: string
+                          description: Target node id — energy flows into here.
+                    description: Directed energy-flow links (From feeds To). Allows multiple feeders per node and producer inputs.
+                  Parents:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
+                    description: Legacy single-feeder map (child id -> parent id). Prefer Links; still honored for back-compat.
+                  MqttExport:
+                    type: boolean
+                    description: Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.
+                  MqttTopicTemplate:
+                    type: string
+                    description: "Template for each tier's MQTT topic. Placeholders: {parent} (MQTT parent topic), {id}, {label}, {kind}, {metric}, {units}. e.g. '{parent}/energyflow/{id}'."
+                description: Virtual upstream nodes (breakers, transfer switches, a “Total”) and their feeder wiring for the energy-flow hierarchy. Edited visually on the Flow tab.
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -19,6 +19,27 @@ Mqtt:
     Password: "password" # Replace with your MQTT password
 ```
 
+### Connection (Optional)
+
+`Scheme` selects how the broker is reached. When it is omitted, the scheme is inferred from `Port`
+(8883 → `mqtts`, 8000 → `ws`, 8884 → `wss`, anything else → `mqtt`), and when `Port` is omitted it
+defaults to the well-known port for the scheme.
+
+| Scheme  | Transport             | Default port |
+|---------|-----------------------|--------------|
+| `mqtt`  | Plain TCP             | 1883         |
+| `mqtts` | TLS                   | 8883         |
+| `ws`    | WebSocket             | 8000         |
+| `wss`   | WebSocket over TLS    | 8884         |
+
+```yaml
+Mqtt:
+  Connection:
+    Host: "broker.example.com"
+    Scheme: "mqtts"          # omit to infer from Port
+    ValidateCertificate: true # set false to accept a self-signed broker certificate (TLS schemes only)
+```
+
 ### Parent Topic (Optional)
 
 This defines the parent topic under which all MQTT keys will be published.

--- a/rPDU2MQTT.Core/Models/Config/MQTTConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/MQTTConfig.cs
@@ -32,7 +32,7 @@ public class MQTTConfig
     /// </summary>
     [Required(ErrorMessage = "Connection is required")]
     [Display(Description = "Connection details for MQTT Broker")]
-    public Connection Connection { get; set; } = new Connection();
+    public MqttConnection Connection { get; set; } = new MqttConnection();
 
     /// <summary>
     /// Gets or sets the keepalive interval for the MQTT connection in seconds.

--- a/rPDU2MQTT.Core/Models/Config/Schemas/Connection.cs
+++ b/rPDU2MQTT.Core/Models/Config/Schemas/Connection.cs
@@ -28,11 +28,15 @@ public class Connection
     [Description("Default connection timeout.")]
     public int? TimeoutSecs { get; set; } = 15;
 
+    /// <summary>
+    /// The connection scheme. Virtual so a transport with a different scheme vocabulary
+    /// (e.g. <see cref="MqttConnection"/>: mqtt/mqtts/ws/wss) can narrow the allowed values.
+    /// </summary>
     [YamlMember(Alias = "Scheme", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     [Display(Name = "Connection Scheme", Description = "Connection scheme used")]
     [Description("Default connection scheme.")]
     [AllowedValues("http", "https")]
-    public string? Scheme { get; set; }
+    public virtual string? Scheme { get; set; }
 
     [DefaultValue(true)]
     [Display(Name = "Validate Certificate", Description = "Enables certificate validation")]

--- a/rPDU2MQTT.Core/Models/Config/Schemas/MqttConnection.cs
+++ b/rPDU2MQTT.Core/Models/Config/Schemas/MqttConnection.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using YamlDotNet.Serialization;
+
+namespace rPDU2MQTT.Models.Config.Schemas;
+
+/// <summary>
+/// Connection details for an MQTT broker. Identical to <see cref="Connection"/> except that the
+/// scheme is drawn from the MQTT vocabulary (mqtt/mqtts/ws/wss) rather than http/https (#189).
+/// </summary>
+public class MqttConnection : Connection
+{
+    [YamlMember(Alias = "Scheme", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [Display(Name = "Connection Scheme", Description = "How to reach the broker: mqtt (plain TCP), mqtts (TLS), ws (WebSocket) or wss (WebSocket over TLS). Leave unset to infer from the port.")]
+    [Description("Broker connection scheme.")]
+    [AllowedValues("mqtt", "mqtts", "ws", "wss")]
+    public override string? Scheme { get; set; }
+
+    /// <summary>
+    /// The scheme actually in effect. When unset, infer it from the port so configs written before this
+    /// field existed keep working — and a broker on 8883 still gets TLS rather than silently connecting
+    /// in plaintext. Anything unrecognized falls back to plain mqtt, matching the previous behaviour.
+    /// </summary>
+    [JsonIgnore]
+    [YamlIgnore]
+    public string EffectiveScheme => Scheme?.ToLowerInvariant() ?? Port switch
+    {
+        8883 => "mqtts",
+        8000 => "ws",
+        8884 => "wss",
+        _ => "mqtt",
+    };
+
+    /// <summary>True when the effective scheme carries the connection over TLS.</summary>
+    [JsonIgnore]
+    [YamlIgnore]
+    public bool UsesTls => EffectiveScheme is "mqtts" or "wss";
+
+    /// <summary>True when the effective scheme tunnels MQTT over WebSockets.</summary>
+    [JsonIgnore]
+    [YamlIgnore]
+    public bool UsesWebSockets => EffectiveScheme is "ws" or "wss";
+
+    /// <summary>
+    /// The port to connect on. When unset, fall back to the well-known default for the effective scheme
+    /// so a host-plus-scheme config connects without also having to spell out the port.
+    /// </summary>
+    [JsonIgnore]
+    [YamlIgnore]
+    public int ResolvedPort => Port ?? EffectiveScheme switch
+    {
+        "mqtts" => 8883,
+        "ws" => 8000,
+        "wss" => 8884,
+        _ => 1883,
+    };
+}

--- a/rPDU2MQTT.Tests/ConfigSchemaTests.cs
+++ b/rPDU2MQTT.Tests/ConfigSchemaTests.cs
@@ -65,6 +65,80 @@ public class ConfigSchemaTests
     }
 
     [Fact]
+    public void Build_MqttScheme_IsADropdownOfBrokerSchemes()
+    {
+        // MQTT -> Connection -> Scheme must offer the broker vocabulary, not http/https (#189).
+        var mqtt = ConfigSchema.Build().Single(n => n.Key == "MQTT");
+        var connection = mqtt.Properties!.Single(n => n.Key == "Connection");
+        var scheme = connection.Properties!.Single(n => n.Key == "Scheme");
+
+        Assert.Equal("enum", scheme.Type);
+        Assert.Equal(new[] { "", "mqtt", "mqtts", "ws", "wss" }, scheme.EnumValues);
+        // The override must not leave a second, http/https-flavoured Scheme node behind.
+        Assert.Single(connection.Properties!, n => n.Key == "Scheme");
+    }
+
+    [Theory]
+    [InlineData("mqtt", null, 1883, false, false)]
+    [InlineData("mqtts", null, 8883, true, false)]
+    [InlineData("ws", null, 8000, false, true)]
+    [InlineData("wss", null, 8884, true, true)]
+    [InlineData("mqtts", 9999, 9999, true, false)]   // an explicit port still wins over the scheme default
+    public void MqttConnection_ResolvesPortAndTransportFromScheme(string scheme, int? port, int expectedPort, bool tls, bool ws)
+    {
+        var conn = new MqttConnection { Host = "broker.example.com", Scheme = scheme, Port = port };
+
+        Assert.Equal(expectedPort, conn.ResolvedPort);
+        Assert.Equal(tls, conn.UsesTls);
+        Assert.Equal(ws, conn.UsesWebSockets);
+    }
+
+    [Theory]
+    [InlineData(1883, "mqtt", false)]
+    [InlineData(8883, "mqtts", true)]
+    [InlineData(8884, "wss", true)]
+    [InlineData(1234, "mqtt", false)]   // an unrecognized port stays plain, as it behaved before #189
+    public void MqttConnection_InfersSchemeFromPort_WhenUnset(int port, string expected, bool tls)
+    {
+        // Configs written before the Scheme field existed only set Host/Port; a broker on 8883 must
+        // still get TLS rather than silently connecting in plaintext.
+        var conn = new MqttConnection { Host = "broker.example.com", Port = port };
+
+        Assert.Equal(expected, conn.EffectiveScheme);
+        Assert.Equal(tls, conn.UsesTls);
+        Assert.Equal(port, conn.ResolvedPort);
+    }
+
+    [Fact]
+    public void MqttConnection_DerivedProperties_AreNotSerialized()
+    {
+        // EffectiveScheme/UsesTls/ResolvedPort are computed; they must not leak into the CR spec or YAML.
+        var cfg = new Config();
+        cfg.MQTT.Connection.Host = "broker.example.com";
+        cfg.MQTT.Connection.Scheme = "mqtts";
+
+        foreach (var derived in new[] { "EffectiveScheme", "UsesTls", "UsesWebSockets", "ResolvedPort" })
+        {
+            Assert.DoesNotContain(derived, ConfigSchema.ToJson(cfg));
+            Assert.DoesNotContain(derived, ConfigSchema.ToYaml(cfg));
+        }
+
+        // The scheme itself still round-trips.
+        Assert.Equal("mqtts", ConfigSchema.FromJson(ConfigSchema.ToJson(cfg)).MQTT.Connection.Scheme);
+    }
+
+    [Fact]
+    public void MqttScheme_RoundTripsThroughYaml()
+    {
+        var cfg = YamlConfigLoader.DeserializeString(
+            "MQTT:\n  Connection:\n    Host: broker.example.com\n    Scheme: wss\n");
+
+        Assert.Equal("wss", cfg.MQTT.Connection.Scheme);
+        Assert.Equal(8884, cfg.MQTT.Connection.ResolvedPort);
+        Assert.True(cfg.MQTT.Connection.UsesWebSockets);
+    }
+
+    [Fact]
     public void Build_OverrideDevicesAndOutletsExposeMakeAndModel()
     {
         var overrides = ConfigSchema.Build().Single(n => n.Key == "Overrides");

--- a/rPDU2MQTT.Tests/ConfigWatcherTests.cs
+++ b/rPDU2MQTT.Tests/ConfigWatcherTests.cs
@@ -46,5 +46,9 @@ public class ConfigWatcherTests
 
         var gui = Sample(); gui.Gui.Port = 9090;
         Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, gui));
+
+        // The MQTT client is built once at startup, so switching transport must force a restart (#189).
+        var scheme = Sample(); scheme.MQTT.Connection.Scheme = "mqtts";
+        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, scheme));
     }
 }

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -53,14 +53,23 @@ public static class ServiceConfiguration
             ThrowError.TestRequiredConfigurationSection(cfg.MQTT, "MQTT");
             ThrowError.TestRequiredConfigurationSection(cfg.MQTT.Connection, "MQTT.Connection");
             ThrowError.TestRequiredConfigurationSection(cfg.MQTT.Connection.Host, "MQTT.Connection.Host");
-            ThrowError.TestRequiredConfigurationSection(cfg.MQTT.Connection.Host, "MQTT.Connection.Port");
 
+            var conn = cfg.MQTT.Connection;
             var mqttBuilder = new HiveMQClientOptionsBuilder()
-                .WithBroker(cfg.MQTT.Connection.Host)
-                .WithPort(cfg.MQTT.Connection.Port!.Value)
+                .WithBroker(conn.Host)
+                .WithPort(conn.ResolvedPort)
                 .WithClientId((cfg.MQTT.ClientID ?? "rpdu2mqtt") + Guid.NewGuid().ToString())
                 .WithAutomaticReconnect(true)
                 .WithKeepAlive(cfg.MQTT.KeepAlive);
+
+            // Honour the configured scheme: mqtts/wss get TLS, ws/wss tunnel over WebSockets (#189).
+            mqttBuilder.WithUseTls(conn.UsesTls);
+            if (conn.UsesWebSockets)
+                mqttBuilder.WithWebSocketServer($"{conn.EffectiveScheme}://{conn.Host}:{conn.ResolvedPort}/mqtt");
+
+            // ValidateCertificate=false is the escape hatch for a broker with a self-signed cert.
+            if (conn.UsesTls && conn.ValidateCertificate == false)
+                mqttBuilder.WithAllowInvalidBrokerCertificates(true);
 
             // Optional Last-Will so HA marks entities unavailable immediately on disconnect.
             if (cfg.MQTT.LastWill)


### PR DESCRIPTION
Closes #189.

## The problem

The MQTT section reuses the shared `Connection` schema, whose `Scheme` is `[AllowedValues("http", "https")]` — the wrong vocabulary for a broker. Worse, **nothing ever read it**: `ServiceConfiguration` built the HiveMQ client as plain TCP on the configured port and ignored `Scheme` and `ValidateCertificate` entirely. So the field was not just cosmetically wrong, it was inert.

## The fix

`MqttConnection : Connection` narrows `Scheme` to `mqtt`/`mqtts`/`ws`/`wss`. The GUI needs no changes — the existing `[AllowedValues]` → `enum` → `<select>` path (from #176) picks it up automatically, which is why this PR has no `web/src` diff.

The scheme is now actually wired into the client:

| Scheme  | Transport          | Default port |
|---------|--------------------|--------------|
| `mqtt`  | Plain TCP          | 1883         |
| `mqtts` | TLS                | 8883         |
| `ws`    | WebSocket          | 8000         |
| `wss`   | WebSocket over TLS | 8884         |

`ValidateCertificate: false` now maps to `WithAllowInvalidBrokerCertificates` for self-signed brokers (TLS schemes only).

## Backwards compatibility

`Scheme` stays optional. When unset it is inferred from the port (8883 → `mqtts`, 8000 → `ws`, 8884 → `wss`, else `mqtt`), so existing `Host`/`Port` configs keep working unchanged. One deliberate behaviour change worth flagging: **a broker already configured on 8883 now gets TLS**, where before it would silently attempt a plaintext connection. Unrecognized ports stay plain, as before.

When `Port` is unset it now defaults to the scheme's well-known port, which also removes a latent NRE on the old `Port!.Value`.

## Also here

The committed CRD is regenerated via `--emit-crd`. It had drifted from the model and was missing fields from several already-merged PRs (`EnergyDashboard`, Prometheus `Labels`, `MqttTopicTemplate`, EmonCMS `Feeds`) on top of the new `Scheme` enum — hence the diff being larger than the change itself. Every top-level object carries `x-kubernetes-preserve-unknown-fields: true`, so the drift was not blocking users, but the committed artifact should match its generator.

## Verification

`dotnet build` — 0 errors, warnings unchanged from baseline (7, all pre-existing).
`dotnet test` — 150/150 pass, including 12 new cases covering the dropdown values, port/transport resolution, port→scheme inference, YAML round-trip, and that the derived properties (`EffectiveScheme`/`UsesTls`/`UsesWebSockets`/`ResolvedPort`) stay out of the serialized CR spec and YAML.

A scheme change is correctly classified as restart-requiring by `KubernetesConfigWatcher` (the client is built once at startup); added a case pinning that.

**Not verified here:** an actual TLS or WebSocket connection against a live broker — no broker in this environment. Worth a smoke test against a real `mqtts` broker before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)