### PR TITLE
feat(api): docs links in the GUI + Kubernetes exposure for the API (#190)

### DIFF
--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -50,21 +50,24 @@ credentials:
 | `config` | see `values.yaml` | The full app config (rendered to `config.yaml`). |
 | `credentials.{mqtt,pdu}.{username,password}` | `""` | Injected as `RPDU2MQTT_*`; chart creates a Secret. |
 | `credentials.emoncmsApiKey` | `""` | EmonCMS write key (`RPDU2MQTT_EMONCMS_APIKEY`). |
+| `credentials.apiKey` | `""` | REST API key enabling its write/control endpoints (`RPDU2MQTT_API_KEY`). Required to use control via the API when `kubernetesConfigSource.enabled`, since secrets are stripped from the CR. |
 | `existingSecret` | `""` | Use a Secret you manage instead of creating one. |
 | `split.enabled` | `false` | Deploy the app's roles as separate Deployments (`-worker`, `-api`, `-ui`) so they scale independently. Off = one Deployment runs every role. The gui Service targets the `ui` pods and the metrics Service the `worker` pods. |
 | `split.{worker,api,ui}.replicaCount` | `1` | Replicas per role Deployment (only with `split.enabled`). Keep `worker` at `1` — it owns the single PDU session. |
 | `split.{worker,api,ui}.resources` | `{}` | Per-role resource requests/limits (falls back to `resources`). |
 | `service.gui.enabled` | `true` | Create a Service for the GUI (when `config.Gui.Enabled`). |
+| `service.api.enabled` | `true` | Create a Service for the REST API + its OpenAPI/Scalar docs (when `config.Api.Enabled`). |
 | `service.metrics.enabled` | `true` | Create a Service for `/metrics` (when `config.Prometheus.Exporter`). |
 | `serviceMonitor.enabled` | `false` | Create a Prometheus Operator `ServiceMonitor` for `/metrics`. |
 | `serviceMonitor.labels` | `{}` | Extra labels so your Prometheus adopts the ServiceMonitor (e.g. `release: <kube-prometheus-stack release>`); without a match it is silently ignored. |
 | `kubernetesConfigSource.enabled` | `false` | Store config in an `RpduConfig` CR (writable by the GUI) instead of a ConfigMap; creates the CR + RBAC and wires the app to read it. Requires the CRD (in this chart's `crds/`). |
 | `kubernetesConfigSource.preserveExisting` | `true` | Create-once: keep the live CR `spec` on upgrade so GUI edits aren't reverted (`values.config` only seeds it on install). Set `false` for declarative config. Relies on Helm `lookup`, which is empty under Argo CD (`helm template`) — see `manageResource` below. |
 | `kubernetesConfigSource.manageResource` | `true` | Whether the chart renders the `RpduConfig` CR and the GUI-written credentials `Secret`. Set `false` to manage them out of band so GitOps (Argo/Flux) never syncs over GUI edits; RBAC + the config source stay on, but you must create the CR (and Secret, if used) once yourself. |
-| `ingress.enabled` | `false` | Expose the GUI via an Ingress. |
-| `httpRoute.enabled` | `false` | Expose the GUI via a Gateway API `HTTPRoute` (set `httpRoute.parentRefs`/`hostnames`). Requires the Gateway API CRDs. |
+| `ingress.enabled` | `false` | Expose the GUI and/or REST API via an Ingress. Each `ingress.hosts[].paths[]` entry takes an optional `service:` of `gui` (default) or `api`. |
+| `httpRoute.enabled` | `false` | Expose the GUI and/or REST API via a Gateway API `HTTPRoute` (set `httpRoute.parentRefs`/`hostnames`). Requires the Gateway API CRDs. |
+| `httpRoute.paths` | `[]` | Path-based rules mirroring `ingress`, each with an optional `service:` (`gui`/`api`). Empty routes everything to the GUI. `httpRoute.rules` overrides this with raw rules. |
 | `healthProbes.enabled` | `true` | Liveness/readiness probes against the app's health endpoints. |
-| `networkPolicy.enabled` | `false` | Restrict pod access: GUI/metrics ingress only from `networkPolicy.guiIngressFrom` / `metricsIngressFrom`; health probes always allowed. Optionally restrict egress with `restrictEgress` + `egress`. Requires a NetworkPolicy-enforcing CNI. |
+| `networkPolicy.enabled` | `false` | Restrict pod access: GUI/API/metrics ingress only from `networkPolicy.guiIngressFrom` / `apiIngressFrom` / `metricsIngressFrom`; health probes always allowed. Optionally restrict egress with `restrictEgress` + `egress`. Requires a NetworkPolicy-enforcing CNI. |
 | `serviceAccount.create` | `true` | Create a ServiceAccount. |
 | `resources`, `nodeSelector`, `tolerations`, `affinity` | `{}` / `[]` | Standard pod scheduling/limits. |
 
@@ -79,5 +82,31 @@ credentials:
   adopts ServiceMonitors matching its `serviceMonitorSelector` — for kube-prometheus-stack that's
   usually `release: <your-stack>`, so set `serviceMonitor.labels` to match or the ServiceMonitor is
   silently ignored.
+- **Exposing the REST API:** enable `config.Api.Enabled` (the chart then creates a `<release>-api`
+  Service on `config.Api.Port`), then route to it with `service: api` on an Ingress or HTTPRoute path:
+
+  ```yaml
+  config:
+    Api:
+      Enabled: true
+  ingress:
+    enabled: true
+    hosts:
+      - host: rpdu2mqtt.example.com
+        paths:
+          - path: /
+            pathType: Prefix          # -> GUI
+          - path: /api
+            pathType: Prefix
+            service: api              # -> REST API
+          - path: /scalar             # the docs UI; add /openapi too if you want the raw document
+            pathType: Prefix
+            service: api
+  ```
+
+  The API's docs live at `/scalar/v1` and `/openapi/v1.json` — routing only `/api` leaves them
+  unreachable, so give the API its own host or add those paths as above. Routing to `service: api`
+  while the API is disabled fails the render rather than emitting a dangling backend. The API is
+  unauthenticated for reads: put auth at your ingress, or restrict `networkPolicy.apiIngressFrom`.
 - **Single replica:** the bridge owns a PDU session and has no leader election; keep `replicaCount: 1`
   (the Deployment uses the `Recreate` strategy).

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -672,7 +672,7 @@ spec:
                     description: Port the REST API + docs listen on.
                   ApiKey:
                     type: string
-                    description: Optional API key enabling the write/control endpoints. When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).
+                    description: Optional API key enabling the write/control endpoints (or set RPDU2MQTT_API_KEY). When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).
                 description: Read-only REST API + OpenAPI/Scalar docs
               EnergyFlow:
                 type: object

--- a/charts/rpdu2mqtt/templates/_helpers.tpl
+++ b/charts/rpdu2mqtt/templates/_helpers.tpl
@@ -60,9 +60,58 @@ true
 {{- dig "Prometheus" "Port" 9184 .Values.config -}}
 {{- end -}}
 
+{{/* True when the app exposes the read-only REST API + its OpenAPI/Scalar docs (#190). */}}
+{{- define "rpdu2mqtt.apiEnabled" -}}
+{{- if dig "Api" "Enabled" false .Values.config -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "rpdu2mqtt.apiPort" -}}
+{{- dig "Api" "Port" 8082 .Values.config -}}
+{{- end -}}
+
+{{/*
+Resolve a route backend name to a Service. Routes name a logical target ("gui" / "api"); this maps it
+to the release's Service so ingress.yaml and httproute.yaml stay in agreement about the naming.
+Usage: include "rpdu2mqtt.backendService" (dict "root" $ "service" "api")
+*/}}
+{{- define "rpdu2mqtt.backendService" -}}
+{{- $svc := default "gui" .service -}}
+{{- if not (has $svc (list "gui" "api")) -}}
+{{- fail (printf "route backend service must be \"gui\" or \"api\", got %q" $svc) -}}
+{{- end -}}
+{{- /* Fail loudly rather than emit a route to a Service this chart never creates. */ -}}
+{{- if eq $svc "api" -}}
+{{- if not (include "rpdu2mqtt.apiEnabled" .root) -}}
+{{- fail "a route targets `service: api`, but config.Api.Enabled is false — the API Service is not created. Set config.Api.Enabled=true." -}}
+{{- end -}}
+{{- if not .root.Values.service.api.enabled -}}
+{{- fail "a route targets `service: api`, but service.api.enabled is false — the API Service is not created." -}}
+{{- end -}}
+{{- else -}}
+{{- if not (dig "Gui" "Enabled" false .root.Values.config) -}}
+{{- fail "a route targets `service: gui`, but config.Gui.Enabled is false — the GUI Service is not created. Set config.Gui.Enabled=true." -}}
+{{- end -}}
+{{- if not .root.Values.service.gui.enabled -}}
+{{- fail "a route targets `service: gui`, but service.gui.enabled is false — the GUI Service is not created." -}}
+{{- end -}}
+{{- end -}}
+{{- printf "%s-%s" (include "rpdu2mqtt.fullname" .root) $svc -}}
+{{- end -}}
+
+{{- define "rpdu2mqtt.backendPort" -}}
+{{- $svc := default "gui" .service -}}
+{{- if eq $svc "api" -}}
+{{- include "rpdu2mqtt.apiPort" .root -}}
+{{- else -}}
+{{- dig "Gui" "Port" 8080 .root.Values.config -}}
+{{- end -}}
+{{- end -}}
+
 {{/* True when a credentials Secret should be referenced (either managed here or external). */}}
 {{- define "rpdu2mqtt.hasSecret" -}}
-{{- if or .Values.existingSecret .Values.credentials.mqtt.username .Values.credentials.mqtt.password .Values.credentials.pdu.username .Values.credentials.pdu.password .Values.credentials.emoncmsApiKey .Values.credentials.oidcClientSecret -}}
+{{- if or .Values.existingSecret .Values.credentials.mqtt.username .Values.credentials.mqtt.password .Values.credentials.pdu.username .Values.credentials.pdu.password .Values.credentials.emoncmsApiKey .Values.credentials.oidcClientSecret .Values.credentials.apiKey -}}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/rpdu2mqtt/templates/deployment.yaml
+++ b/charts/rpdu2mqtt/templates/deployment.yaml
@@ -97,6 +97,10 @@ spec:
             - name: gui
               containerPort: {{ dig "Gui" "Port" 8080 $.Values.config }}
             {{- end }}
+            {{- if (include "rpdu2mqtt.apiEnabled" $) }}
+            - name: api
+              containerPort: {{ include "rpdu2mqtt.apiPort" $ }}
+            {{- end }}
             {{- if (include "rpdu2mqtt.metricsEnabled" $) }}
             - name: metrics
               containerPort: {{ include "rpdu2mqtt.metricsPort" $ }}

--- a/charts/rpdu2mqtt/templates/httproute.yaml
+++ b/charts/rpdu2mqtt/templates/httproute.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.httpRoute.enabled }}
 {{- $fullName := include "rpdu2mqtt.fullname" . -}}
-{{- $svcPort := dig "Gui" "Port" 8080 .Values.config -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -21,9 +20,20 @@ spec:
   rules:
     {{- if .Values.httpRoute.rules }}
     {{- toYaml .Values.httpRoute.rules | nindent 4 }}
+    {{- else if .Values.httpRoute.paths }}
+    {{- range .Values.httpRoute.paths }}
+    {{- $backend := dict "root" $ "service" (default "gui" .service) }}
+    - matches:
+        - path:
+            type: {{ default "PathPrefix" .type }}
+            value: {{ .path | quote }}
+      backendRefs:
+        - name: {{ include "rpdu2mqtt.backendService" $backend }}
+          port: {{ include "rpdu2mqtt.backendPort" $backend }}
+    {{- end }}
     {{- else }}
     - backendRefs:
         - name: {{ $fullName }}-gui
-          port: {{ $svcPort }}
+          port: {{ dig "Gui" "Port" 8080 .Values.config }}
     {{- end }}
 {{- end }}

--- a/charts/rpdu2mqtt/templates/ingress.yaml
+++ b/charts/rpdu2mqtt/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled }}
 {{- $fullName := include "rpdu2mqtt.fullname" . -}}
-{{- $svcPort := dig "Gui" "Port" 8080 .Values.config -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -25,13 +24,14 @@ spec:
       http:
         paths:
           {{- range .paths }}
+          {{- $backend := dict "root" $ "service" (default "gui" .service) }}
           - path: {{ .path }}
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ $fullName }}-gui
+                name: {{ include "rpdu2mqtt.backendService" $backend }}
                 port:
-                  number: {{ $svcPort }}
+                  number: {{ include "rpdu2mqtt.backendPort" $backend }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/rpdu2mqtt/templates/networkpolicy.yaml
+++ b/charts/rpdu2mqtt/templates/networkpolicy.yaml
@@ -29,6 +29,14 @@ spec:
         - port: {{ dig "Gui" "Port" 8080 .Values.config }}
           protocol: TCP
     {{- end }}
+    {{- if and ((include "rpdu2mqtt.apiEnabled" .)) .Values.networkPolicy.apiIngressFrom }}
+    # Allow the REST API port only from the configured peers (e.g. your gateway/ingress controller).
+    - from:
+        {{- toYaml .Values.networkPolicy.apiIngressFrom | nindent 8 }}
+      ports:
+        - port: {{ include "rpdu2mqtt.apiPort" . }}
+          protocol: TCP
+    {{- end }}
     {{- if and ((include "rpdu2mqtt.metricsEnabled" .)) .Values.networkPolicy.metricsIngressFrom }}
     # Allow the metrics port only from the configured peers (e.g. Prometheus).
     - from:

--- a/charts/rpdu2mqtt/templates/secret.yaml
+++ b/charts/rpdu2mqtt/templates/secret.yaml
@@ -40,5 +40,8 @@ stringData:
   {{- with .Values.credentials.oidcClientSecret }}
   RPDU2MQTT_OIDC_CLIENT_SECRET: {{ . | quote }}
   {{- end }}
+  {{- with .Values.credentials.apiKey }}
+  RPDU2MQTT_API_KEY: {{ . | quote }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rpdu2mqtt/templates/service-api.yaml
+++ b/charts/rpdu2mqtt/templates/service-api.yaml
@@ -1,0 +1,24 @@
+{{- if and ((include "rpdu2mqtt.apiEnabled" .)) .Values.service.api.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rpdu2mqtt.fullname" . }}-api
+  labels:
+    {{- include "rpdu2mqtt.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  {{- with .Values.service.api.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.api.type }}
+  selector:
+    {{- include "rpdu2mqtt.selectorLabels" . | nindent 4 }}
+    {{- if .Values.split.enabled }}
+    app.kubernetes.io/component: api   # the REST API is served by the api role
+    {{- end }}
+  ports:
+    - name: api
+      port: {{ include "rpdu2mqtt.apiPort" . }}
+      targetPort: api
+{{- end }}

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -64,6 +64,15 @@ config:
   Health:
     Enabled: true
     Port: 8081
+  Api:
+    # Read-only REST API (/api/v1/*) plus its OpenAPI document (/openapi/v1.json) and
+    # interactive Scalar docs (/scalar/v1). Unauthenticated for reads — keep it on a
+    # trusted network, or front it with auth at your ingress.
+    Enabled: false
+    Port: 8082
+    # Set ApiKey to enable the write/control endpoints (sent as the X-Api-Key header).
+    # Prefer credentials.apiKey below (injected as RPDU2MQTT_API_KEY) over setting it here.
+    # ApiKey: ""
 
 # ---------------------------------------------------------------------------
 # Credentials, injected as RPDU2MQTT_* environment variables via a Secret so
@@ -82,6 +91,8 @@ credentials:
   emoncmsApiKey: ""
   # GUI OIDC client secret (RPDU2MQTT_OIDC_CLIENT_SECRET) when using Gui.Oidc.
   oidcClientSecret: ""
+  # REST API key (RPDU2MQTT_API_KEY) enabling the API's write/control endpoints (config.Api.ApiKey).
+  apiKey: ""
 
 serviceAccount:
   create: true
@@ -107,10 +118,15 @@ kubernetesConfigSource:
   # (and Secret, if used) yourself once.
   manageResource: true
 
-# Kubernetes Services for the GUI and /metrics endpoints. Created only when the
+# Kubernetes Services for the GUI, REST API and /metrics endpoints. Created only when the
 # corresponding feature is enabled in `config` AND the toggle here is true.
 service:
   gui:
+    enabled: true
+    type: ClusterIP
+    annotations: {}
+  # Requires config.Api.Enabled. Backs the `service: api` route option below.
+  api:
     enabled: true
     type: ClusterIP
     annotations: {}
@@ -135,7 +151,17 @@ serviceMonitor:
   #     release: prometheus-stack
   labels: {}
 
-# Ingress for the GUI Service.
+# Ingress for the GUI and/or REST API Services.
+# Each path routes to `service: gui` (default) or `service: api` — the latter requires
+# config.Api.Enabled and service.api.enabled. To expose the API too, add a path for it, e.g.
+#   paths:
+#     - path: /
+#       pathType: Prefix
+#     - path: /api
+#       pathType: Prefix
+#       service: api
+# The API serves its docs at /scalar/v1 and /openapi/v1.json, so routing only /api hides them;
+# give the API its own host (or add those paths) if you want the docs reachable too.
 ingress:
   enabled: false
   className: ""
@@ -145,6 +171,7 @@ ingress:
       paths:
         - path: /
           pathType: Prefix
+          # service: gui
   tls: []
 
 # Gateway API HTTPRoute for the GUI Service (alternative to Ingress). Requires the
@@ -158,7 +185,16 @@ httpRoute:
   hostnames:
     - rpdu2mqtt.example.com
   annotations: {}
-  # Override the default rule (route everything to the GUI Service) with custom matches if needed.
+  # Path-based routing, mirroring `ingress.hosts[].paths`. Each entry routes to `service: gui`
+  # (default) or `service: api`. Empty = route everything to the GUI Service. e.g.
+  #   paths:
+  #     - path: /
+  #       type: PathPrefix
+  #     - path: /api
+  #       type: PathPrefix
+  #       service: api
+  paths: []
+  # Full escape hatch: raw HTTPRoute rules, used verbatim and taking precedence over `paths`.
   rules: []
 
 # NetworkPolicy to restrict pod access. When enabled, ingress to the GUI/metrics ports is allowed
@@ -172,6 +208,9 @@ networkPolicy:
     # - namespaceSelector:
     #     matchLabels:
     #       kubernetes.io/metadata.name: ingress-nginx
+  # Peers allowed to reach the REST API port (e.g. your ingress controller/Gateway, or the
+  # automation that consumes it). Empty = no direct API ingress is permitted.
+  apiIngressFrom: []
   # Peers allowed to scrape the metrics port (e.g. your Prometheus). Empty = none.
   metricsIngressFrom: []
   # Restrict egress to DNS + the rules below. When false, egress is unrestricted.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -653,6 +653,11 @@ Api:
   ApiKey: ""            # optional; set to enable the write/control endpoints (see below)
 ```
 
+`ApiKey` can also be supplied out of band as **`RPDU2MQTT_API_KEY`** (or `RPDU2MQTT_API_KEY_FILE`
+pointing at a file, e.g. a Docker/Kubernetes secret), like the other credentials. With the Kubernetes
+config source this is **required** rather than optional: the API key is stripped from the `RpduConfig`
+CR along with every other secret, so it has to come from the environment.
+
 | Endpoint | Description |
 | --- | --- |
 | `GET /api/v1/instances` | Configured PDU instances (id, primary, host, poll interval, actions). |
@@ -660,6 +665,11 @@ Api:
 | `GET /api/v1/snapshots` | Latest snapshot timestamp/age per instance. |
 | `GET /api/v1/readings` | Flattened measurements from the latest snapshot(s); filter with `?instance=`. |
 | `GET /openapi/v1.json`, `/scalar/v1` | OpenAPI document + interactive docs UI. |
+
+Browsing to the API port's root (`/`) redirects to `/scalar/v1`. The GUI's **Api** page also links
+straight to these URLs. Because the API listens on its own port, those links only resolve if that port
+is reachable from your browser — in Kubernetes, expose it via the chart's `service: api` route (see
+[the chart README](../charts/rpdu2mqtt/README.md)).
 
 ### Control endpoints (opt-in)
 

--- a/rPDU2MQTT.Core/Models/Config/ApiConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/ApiConfig.cs
@@ -17,6 +17,6 @@ public class ApiConfig
     public int Port { get; set; } = 8082;
 
     [DefaultValue(null)]
-    [Description("Optional API key enabling the write/control endpoints. When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).")]
+    [Description("Optional API key enabling the write/control endpoints (or set RPDU2MQTT_API_KEY). When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).")]
     public string? ApiKey { get; set; } = null;
 }

--- a/rPDU2MQTT.Engine/ConfigSources/KubernetesConfigSource.cs
+++ b/rPDU2MQTT.Engine/ConfigSources/KubernetesConfigSource.cs
@@ -37,6 +37,7 @@ public sealed class KubernetesConfigSource : IConfigSource
         ("RPDU2MQTT_PDU_PASSWORD",  c => c.Primary.Credentials?.Password,  (c, v) => (c.Primary.Credentials  ??= new()).Password = v),
         ("RPDU2MQTT_EMONCMS_APIKEY", c => c.EmonCMS.ApiKey, (c, v) => c.EmonCMS.ApiKey = v),
         ("RPDU2MQTT_GUI_PASSWORD",   c => c.Gui.Password,   (c, v) => c.Gui.Password = v),
+        ("RPDU2MQTT_API_KEY",        c => c.Api.ApiKey,     (c, v) => c.Api.ApiKey = v),
         ("RPDU2MQTT_OIDC_CLIENT_SECRET", c => c.Gui.Oidc?.ClientSecret, (c, v) => (c.Gui.Oidc ??= new()).ClientSecret = v),
     };
 

--- a/rPDU2MQTT.Engine/YamlConfigLoader.cs
+++ b/rPDU2MQTT.Engine/YamlConfigLoader.cs
@@ -182,6 +182,9 @@ internal class YamlConfigLoader
         var emonKey = ResolveSecret("RPDU2MQTT_EMONCMS_APIKEY");
         if (emonKey is not null) { config.EmonCMS.ApiKey = emonKey; Log.Information("Using EmonCMS API key from environment."); }
 
+        var apiKey = ResolveSecret("RPDU2MQTT_API_KEY");
+        if (apiKey is not null) { config.Api.ApiKey = apiKey; Log.Information("Using API key from environment."); }
+
         var guiPass = ResolveSecret("RPDU2MQTT_GUI_PASSWORD");
         if (guiPass is not null) { config.Gui.Password = guiPass; Log.Information("Using GUI password from environment."); }
 

--- a/rPDU2MQTT.Tests/ConfigSchemaTests.cs
+++ b/rPDU2MQTT.Tests/ConfigSchemaTests.cs
@@ -139,6 +139,41 @@ public class ConfigSchemaTests
     }
 
     [Fact]
+    public void ApiKey_IsReadFromTheEnvironment()
+    {
+        // Api.ApiKey is stripped by RedactSecrets, so without an env path it could not be supplied at
+        // all under the Kubernetes config source (#190).
+        try
+        {
+            Environment.SetEnvironmentVariable("RPDU2MQTT_API_KEY", "from-env");
+            Assert.Equal("from-env", YamlConfigLoader.Initialize(new Config()).Api.ApiKey);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("RPDU2MQTT_API_KEY", null);
+        }
+    }
+
+    [Fact]
+    public void ApiKey_FileVariantTakesPrecedence_LikeOtherSecrets()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(path, "from-file\n");   // trailing newline must be trimmed
+            Environment.SetEnvironmentVariable("RPDU2MQTT_API_KEY", "from-env");
+            Environment.SetEnvironmentVariable("RPDU2MQTT_API_KEY_FILE", path);
+            Assert.Equal("from-file", YamlConfigLoader.Initialize(new Config()).Api.ApiKey);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("RPDU2MQTT_API_KEY", null);
+            Environment.SetEnvironmentVariable("RPDU2MQTT_API_KEY_FILE", null);
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void Build_OverrideDevicesAndOutletsExposeMakeAndModel()
     {
         var overrides = ConfigSchema.Build().Single(n => n.Key == "Overrides");

--- a/rPDU2MQTT.Tests/KubernetesConfigTests.cs
+++ b/rPDU2MQTT.Tests/KubernetesConfigTests.cs
@@ -50,6 +50,7 @@ public class KubernetesConfigTests
         cfg.Pdus[Config.DefaultInstanceKey] = new PduConfig { Credentials = new() { Username = "hass", Password = "pw" } };
         cfg.EmonCMS.ApiKey = "key";
         cfg.Gui.Password = "guipass";
+        cfg.Api.ApiKey = "apikey";
 
         var redacted = ConfigSchema.RedactSecrets(cfg);
 
@@ -57,6 +58,8 @@ public class KubernetesConfigTests
         Assert.Null(redacted.Primary.Credentials);
         Assert.Null(redacted.EmonCMS.ApiKey);
         Assert.Null(redacted.Gui.Password);
+        // Stripped from the CR, so it must come back via RPDU2MQTT_API_KEY (#190).
+        Assert.Null(redacted.Api.ApiKey);
         // Original is untouched.
         Assert.NotNull(cfg.MQTT.Credentials);
     }

--- a/rPDU2MQTT.Web/web/smoke.mjs
+++ b/rPDU2MQTT.Web/web/smoke.mjs
@@ -33,7 +33,8 @@ const sandbox = {
     elementFromPoint: () => null,
   },
   window: { addEventListener() {}, removeEventListener() {} },
-  location: { hash: '' },
+  // protocol/hostname are read when building the API docs links (#190).
+  location: { hash: '', protocol: 'http:', hostname: 'localhost' },
   navigator: { clipboard: { writeText() {} } },
   DOMPoint: class { matrixTransform() { return { x: 0, y: 0 }; } },
   setTimeout: () => 0, setInterval: () => 0, clearInterval() {},

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -199,6 +199,7 @@ function renderConfigSection(node: any, nav: any, sections: any) {
     else renderNode(node, state.data, sec);
     if (node.key === 'Gui') wireGuiAuth(sec);
     else if (node.key === 'EmonCMS') wireEmonCmsTransport(sec);
+    else if (node.key === 'Api') wireApiDocs(sec);
     link.onclick = () => activate(link, sec);
   }
   return link;
@@ -283,6 +284,56 @@ function wireEmonCmsTransport(sec: any) {
   transportSel.addEventListener('change', apply);
   feedsAuto?.addEventListener('change', apply);
   apply();
+}
+
+// The API section advertises OpenAPI/Scalar docs but never said where they live (#190). Show the real
+// URLs, derived from the configured port. The API listens on its own port, so the links are built from
+// this page's hostname rather than its path — they are only reachable if that port is exposed to you.
+function wireApiDocs(sec: any) {
+  const fields = [...sec.querySelectorAll('.field')] as any[];
+  const field = (label: string) => fields.find(f => f.querySelector('label')?.textContent === label);
+  const enabled = field('Enabled')?.querySelector('input[type=checkbox]');
+  const portIn = field('Port')?.querySelector('input');
+  if (!portIn) return;
+
+  const box = document.createElement('fieldset');
+  const lg = document.createElement('legend'); lg.textContent = 'Documentation'; box.appendChild(lg);
+  const desc = document.createElement('div'); desc.className = 'desc'; box.appendChild(desc);
+  const list = document.createElement('div');
+  list.style.cssText = 'display:flex;flex-direction:column;gap:4px;';
+  box.appendChild(list);
+
+  const LINKS = [
+    ['Interactive docs (Scalar)', '/scalar/v1'],
+    ['OpenAPI document', '/openapi/v1.json'],
+    ['API root', '/api/v1'],
+  ];
+
+  const apply = () => {
+    const on = enabled ? enabled.checked : true;
+    const port = portIn.value || '8082';
+    const base = `${location.protocol}//${location.hostname}:${port}`;
+    desc.textContent = on
+      ? 'The API is served on its own port — these links work once that port is reachable from your browser.'
+      : 'The API is disabled. Enable it above, save, and restart; these links will work once it is listening.';
+    list.innerHTML = '';
+    for (const [label, path] of LINKS) {
+      const row = document.createElement('div');
+      const a = document.createElement('a');
+      a.href = base + path; a.textContent = base + path;
+      a.target = '_blank'; a.rel = 'noopener';
+      a.style.cssText = 'font:12px ui-monospace,Consolas,monospace;';
+      if (!on) { a.style.pointerEvents = 'none'; a.style.opacity = '0.5'; }
+      row.appendChild(document.createTextNode(label + ': '));
+      row.appendChild(a);
+      list.appendChild(row);
+    }
+  };
+
+  portIn.addEventListener('input', apply);
+  enabled?.addEventListener('change', apply);
+  apply();
+  sec.appendChild(box);
 }
 
 // Section-specific action buttons (connection tests; Home Assistant discovery actions).

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1406,6 +1406,7 @@ function renderConfigSection(node     , nav     , sections     ) {
     else renderNode(node, state.data, sec);
     if (node.key === 'Gui') wireGuiAuth(sec);
     else if (node.key === 'EmonCMS') wireEmonCmsTransport(sec);
+    else if (node.key === 'Api') wireApiDocs(sec);
     link.onclick = () => activate(link, sec);
   }
   return link;
@@ -1490,6 +1491,56 @@ function wireEmonCmsTransport(sec     ) {
   transportSel.addEventListener('change', apply);
   feedsAuto?.addEventListener('change', apply);
   apply();
+}
+
+// The API section advertises OpenAPI/Scalar docs but never said where they live (#190). Show the real
+// URLs, derived from the configured port. The API listens on its own port, so the links are built from
+// this page's hostname rather than its path — they are only reachable if that port is exposed to you.
+function wireApiDocs(sec     ) {
+  const fields = [...sec.querySelectorAll('.field')]         ;
+  const field = (label        ) => fields.find(f => f.querySelector('label')?.textContent === label);
+  const enabled = field('Enabled')?.querySelector('input[type=checkbox]');
+  const portIn = field('Port')?.querySelector('input');
+  if (!portIn) return;
+
+  const box = document.createElement('fieldset');
+  const lg = document.createElement('legend'); lg.textContent = 'Documentation'; box.appendChild(lg);
+  const desc = document.createElement('div'); desc.className = 'desc'; box.appendChild(desc);
+  const list = document.createElement('div');
+  list.style.cssText = 'display:flex;flex-direction:column;gap:4px;';
+  box.appendChild(list);
+
+  const LINKS = [
+    ['Interactive docs (Scalar)', '/scalar/v1'],
+    ['OpenAPI document', '/openapi/v1.json'],
+    ['API root', '/api/v1'],
+  ];
+
+  const apply = () => {
+    const on = enabled ? enabled.checked : true;
+    const port = portIn.value || '8082';
+    const base = `${location.protocol}//${location.hostname}:${port}`;
+    desc.textContent = on
+      ? 'The API is served on its own port — these links work once that port is reachable from your browser.'
+      : 'The API is disabled. Enable it above, save, and restart; these links will work once it is listening.';
+    list.innerHTML = '';
+    for (const [label, path] of LINKS) {
+      const row = document.createElement('div');
+      const a = document.createElement('a');
+      a.href = base + path; a.textContent = base + path;
+      a.target = '_blank'; a.rel = 'noopener';
+      a.style.cssText = 'font:12px ui-monospace,Consolas,monospace;';
+      if (!on) { a.style.pointerEvents = 'none'; a.style.opacity = '0.5'; }
+      row.appendChild(document.createTextNode(label + ': '));
+      row.appendChild(a);
+      list.appendChild(row);
+    }
+  };
+
+  portIn.addEventListener('input', apply);
+  enabled?.addEventListener('change', apply);
+  apply();
+  sec.appendChild(box);
 }
 
 // Section-specific action buttons (connection tests; Home Assistant discovery actions).


### PR DESCRIPTION
Closes #190.

Both halves of the issue, plus a related bug found on the way.

## 1. "Claims it has documentation, but offers no link"

The GUI's **Api** section now lists the real URLs, derived from the configured port and updated live as you edit it (greyed out while the API is disabled):

```
Interactive docs (Scalar): http://<host>:8082/scalar/v1
OpenAPI document:          http://<host>:8082/openapi/v1.json
API root:                  http://<host>:8082/api/v1
```

The API listens on its **own port**, so the links are built from the page's hostname rather than its path — they only resolve if that port is reachable from your browser. The panel says so, and the docs now point at the chart for the Kubernetes path.

## 2. "No HTTPRoute / Ingress objects for the API path"

Worse than reported — there was nothing to route *to*. The API had **no Service and no container port**, and both `ingress.yaml` and `httproute.yaml` hardcoded the GUI backend.

- `config.Api` added to values; a `<release>-api` Service and the `api` containerPort are created when `config.Api.Enabled`.
- Each ingress/httpRoute path takes an optional **`service: gui|api`**, defaulting to `gui` — existing values render byte-identically.
- `httpRoute.paths` mirrors the ingress shape; `httpRoute.rules` still works as a raw escape hatch and takes precedence.
- `networkPolicy.apiIngressFrom` added, or the API port stays blocked when policies are on.
- Under `split.enabled`, the API Service selects the `api` role pods (verified).

```yaml
config:
  Api:
    Enabled: true
ingress:
  enabled: true
  hosts:
    - host: rpdu2mqtt.example.com
      paths:
        - path: /
          pathType: Prefix          # -> GUI
        - path: /api
          pathType: Prefix
          service: api              # -> REST API
        - path: /scalar
          pathType: Prefix
          service: api
```

Note the docs live at `/scalar/v1` and `/openapi/v1.json`, so routing only `/api` leaves them unreachable — the README calls this out.

## 3. Bug found on the way: the API key was unsettable in Kubernetes

`RedactSecrets` strips `Api.ApiKey` from the `RpduConfig` CR like every other secret — but unlike every other secret, it had **no env/Secret path back in**. Under `kubernetesConfigSource.enabled` the key was therefore impossible to supply, making the control endpoints permanently unusable.

Adds `RPDU2MQTT_API_KEY` (and the `_FILE` variant) alongside the other credentials, plus `credentials.apiKey` in the chart's Secret.

## Behaviour change worth flagging

Routing to a Service the chart won't create now **fails the render** with an actionable message instead of silently emitting a dangling backend:

```
Error: a route targets `service: api`, but config.Api.Enabled is false — the API Service is not created. Set config.Api.Enabled=true.
```

This also catches the **pre-existing** case of `ingress.enabled=true` with `config.Gui.Enabled=false`, which previously rendered a broken Ingress. Anyone in that state gets a hard error on upgrade — which is the misconfiguration surfacing, not a regression, but it will be visible.

## Verification

- `dotnet build` 0 errors, no new warnings; `dotnet test` **152/152** (4 new: API key from env, `_FILE` precedence + trimming, redaction, and the existing suite).
- `helm lint` clean. Rendered and asserted with a real `helm` binary: the ingress/httpRoute backends resolve to the right Service+port, the default values produce **zero** API resources, split-role selectors match, the Secret key lands in `envFrom`, and the README example renders exactly as documented. Both fail-fast guards produce the expected errors.
- GUI: `node web/build.mjs` + `node --check` + `web/smoke.mjs`. The smoke stub's `location` had no `protocol`/`hostname`, so it couldn't exercise this — added them, and verified the panel with a DOM harness asserting all three links render against a configured port of 9999.

**Not verified here:** no live cluster, so the manifests are validated by rendering + schema, not by an actual apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)