### PR TITLE
fix(k8s): re-point MQTT live instead of restarting the pod (#192)

### DIFF
--- a/docs/KubernetesCRD.md
+++ b/docs/KubernetesCRD.md
@@ -126,8 +126,9 @@ Mechanics:
 - The chart **pre-creates** the Secret (create-once, like the CR) so GUI-written values survive `helm
   upgrade`, and grants the pod `get,patch,update` on **just that Secret**. Non-Helm/Argo deploys must
   create the Secret, mount it, and grant the same RBAC (and add an Argo `ignoreDifferences` on its data).
-- Credential **changes apply on restart** (use the Diagnostics **Restart bridge** button) — the same as
-  any other connection change, and required for OIDC which is wired up at startup.
+- MQTT **credential/broker changes apply live** — the watcher re-points the running client (#192). GUI
+  **OIDC** is the exception: it is wired up at startup, so it still needs a restart (use the Diagnostics
+  **Restart bridge** button).
 
 ### GitOps & exporting manifests (decided)
 
@@ -174,10 +175,12 @@ Because the GUI writes the CR `spec` and a redeploy also renders the CR `spec` f
 
 ### Reacting to changes & status (Phase 2)
 
-- **Watch** the CR; on change, the simplest correct behaviour is
-  `IHostApplicationLifetime.StopApplication()` so the container restarts and reloads (mirrors how the
-  existing "Restart" diagnostic works). True hot-reload without restart is a larger change and is out
-  of scope for Phase 1.
+- **Watch** the CR; on change, apply it live: the reloaded config is copied into the shared singleton,
+  the MQTT client is re-pointed at the new broker/credentials, and the PDU pollers are reconciled
+  (#187/#192). Restarting the process is a last resort, because a clean exit leaves the pod in
+  `Completed` and the kubelet re-starts it under backoff. It remains only for things bound once when the
+  host is built: the listening sockets (GUI/API/health/metrics ports), GUI auth, and the primary PDU
+  instance (the fixed DI singleton the reconciler cannot rebuild).
 - **Status:** a lightweight hosted service patches `status` (connected from the MQTT client, device
   count + last poll from `PDU.GetRootData_Public`) on the poll interval, using the values already
   surfaced by `/api/status` and `/api/livedata`.
@@ -256,7 +259,7 @@ No phasing — the full feature ships at once:
 - **GUI write-back enabled by default** (`PATCH` the CR `spec`), with a GitOps-drift warning and a
   redacted CR-manifest export for re-importing into source control.
 - **`status` subresource** updated with `connected` / `deviceCount` / `lastPoll`.
-- **Watch** the CR and restart on `spec` change.
+- **Watch** the CR and apply `spec` changes live (restarting only for listen ports / GUI auth / the primary PDU).
 - CRD OpenAPI `spec` schema **generated from the `Config` model** (reusing the GUI's `ConfigSchema`
   reflection).
 - CRD shipped both in the Helm chart's `crds/` directory **and** as a standalone manifest; the app does

--- a/rPDU2MQTT.Engine/Classes/MqttEventHandler.cs
+++ b/rPDU2MQTT.Engine/Classes/MqttEventHandler.cs
@@ -54,9 +54,16 @@ public class MqttEventHandler
 
     private async Task PublishStatusAsync()
     {
+        // The availability topic only exists when MQTT.LastWill is on; with it off there is nothing to
+        // publish to, so skip rather than throwing on every tick. Read once — the client can be re-pointed
+        // at a new broker (with different options) underneath us (#192).
+        var topic = client.Options?.LastWillAndTestament?.Topic;
+        if (string.IsNullOrEmpty(topic))
+            return;
+
         try
         {
-            await client.PublishAsync(client.Options!.LastWillAndTestament!.Topic, "online", HiveMQtt.MQTT5.Types.QualityOfService.AtLeastOnceDelivery);
+            await client.PublishAsync(topic, "online", HiveMQtt.MQTT5.Types.QualityOfService.AtLeastOnceDelivery);
         }
         catch (Exception ex)
         {

--- a/rPDU2MQTT.Engine/Classes/MqttOptionsFactory.cs
+++ b/rPDU2MQTT.Engine/Classes/MqttOptionsFactory.cs
@@ -1,0 +1,78 @@
+using System.Security;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Options;
+using rPDU2MQTT.Helpers;
+using rPDU2MQTT.Models.Config;
+
+namespace rPDU2MQTT.Classes;
+
+/// <summary>
+/// Builds the HiveMQ client options from <see cref="Config"/>. Shared by startup and by the live
+/// re-point in <see cref="Services.MqttReconfigurator"/>, so a broker setting can never be honoured on
+/// one path but not the other (#192).
+/// </summary>
+public static class MqttOptionsFactory
+{
+    /// <summary>
+    /// The MQTT settings that define the connection itself. Compared to decide whether a reloaded config
+    /// needs the client re-pointed; anything not here is either irrelevant to the client or applied
+    /// elsewhere.
+    /// </summary>
+    public static string Fingerprint(Config cfg)
+    {
+        var c = cfg.MQTT.Connection;
+        // ClientId is deliberately excluded: it gets a fresh GUID suffix per build, so including it would
+        // make every comparison differ. A configured ClientID change is caught by the ClientID field.
+        return string.Join('|',
+            c.Host, c.ResolvedPort, c.EffectiveScheme, c.UsesTls, c.UsesWebSockets, c.ValidateCertificate,
+            cfg.MQTT.ClientID, cfg.MQTT.KeepAlive, cfg.MQTT.LastWill, cfg.MQTT.ParentTopic,
+            cfg.MQTT.Credentials?.Username, cfg.MQTT.Credentials?.Password);
+    }
+
+    /// <summary>Build the client options for the given config.</summary>
+    public static HiveMQClientOptions Build(Config cfg)
+    {
+        ThrowError.TestRequiredConfigurationSection(cfg.MQTT, "MQTT");
+        ThrowError.TestRequiredConfigurationSection(cfg.MQTT.Connection, "MQTT.Connection");
+        ThrowError.TestRequiredConfigurationSection(cfg.MQTT.Connection.Host, "MQTT.Connection.Host");
+
+        var conn = cfg.MQTT.Connection;
+        var builder = new HiveMQClientOptionsBuilder()
+            .WithBroker(conn.Host)
+            .WithPort(conn.ResolvedPort)
+            .WithClientId((cfg.MQTT.ClientID ?? "rpdu2mqtt") + Guid.NewGuid().ToString())
+            .WithAutomaticReconnect(true)
+            .WithKeepAlive(cfg.MQTT.KeepAlive);
+
+        // Honour the configured scheme: mqtts/wss get TLS, ws/wss tunnel over WebSockets (#189).
+        builder.WithUseTls(conn.UsesTls);
+        if (conn.UsesWebSockets)
+            builder.WithWebSocketServer($"{conn.EffectiveScheme}://{conn.Host}:{conn.ResolvedPort}/mqtt");
+
+        // ValidateCertificate=false is the escape hatch for a broker with a self-signed cert.
+        if (conn.UsesTls && conn.ValidateCertificate == false)
+            builder.WithAllowInvalidBrokerCertificates(true);
+
+        // Optional Last-Will so HA marks entities unavailable immediately on disconnect.
+        if (cfg.MQTT.LastWill)
+            builder.WithLastWillAndTestament(new LastWillAndTestament(
+                MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic), payload: "offline", HiveMQtt.MQTT5.Types.QualityOfService.AtLeastOnceDelivery, true));
+
+        if (cfg.MQTT.Credentials?.Username is not null)
+            builder.WithUserName(cfg.MQTT.Credentials.Username);
+
+        if (cfg.MQTT.Credentials?.Password is not null)
+            builder.WithPassword(ToSecureString(cfg.MQTT.Credentials.Password));
+
+        return builder.Build();
+    }
+
+    private static SecureString ToSecureString(string value)
+    {
+        var secure = new SecureString();
+        foreach (var c in value)
+            secure.AppendChar(c);
+        secure.MakeReadOnly();
+        return secure;
+    }
+}

--- a/rPDU2MQTT.Engine/Services/Kubernetes/KubernetesConfigWatcher.cs
+++ b/rPDU2MQTT.Engine/Services/Kubernetes/KubernetesConfigWatcher.cs
@@ -7,10 +7,13 @@ using rPDU2MQTT.Startup.ConfigSources;
 namespace rPDU2MQTT.Services.Kubernetes;
 
 /// <summary>
-/// Watches the RpduConfig <c>spec</c> for changes. Most edits are applied live — the reloaded config is
-/// copied into the shared singleton and the PDU instances reconciled — so the API/UI don't restart on
-/// every save (#187) and pods stop bouncing through Completed (#192). The process is only restarted when a
-/// setting that can't be re-read at runtime changed (broker connection, listen ports, GUI auth).
+/// Watches the RpduConfig <c>spec</c> for changes and applies them live — the reloaded config is copied
+/// into the shared singleton, the MQTT client is re-pointed and the PDU instances reconciled — so the
+/// API/UI don't restart on every save (#187) and pods stop bouncing through Completed (#192).
+/// <para>
+/// The only remaining restart is a change to a listening socket (GUI/API/health/metrics ports) or GUI
+/// auth, which are bound once when the host is built.
+/// </para>
 /// </summary>
 public sealed class KubernetesConfigWatcher : IHostedService, IDisposable
 {
@@ -18,18 +21,20 @@ public sealed class KubernetesConfigWatcher : IHostedService, IDisposable
     private readonly IHostApplicationLifetime lifetime;
     private readonly Config config;
     private readonly InstanceManager instances;
+    private readonly MqttReconfigurator mqtt;
     private readonly HostRole roles;
     private readonly PeriodicTimer timer = new(TimeSpan.FromSeconds(30));
     private readonly CancellationTokenSource stoppingCts = new();
     private Task loop = Task.CompletedTask;
     private string? baselineSpec;
 
-    public KubernetesConfigWatcher(KubernetesConfigSource source, IHostApplicationLifetime lifetime, Config config, InstanceManager instances, HostRole roles)
+    public KubernetesConfigWatcher(KubernetesConfigSource source, IHostApplicationLifetime lifetime, Config config, InstanceManager instances, MqttReconfigurator mqtt, HostRole roles)
     {
         this.source = source;
         this.lifetime = lifetime;
         this.config = config;
         this.instances = instances;
+        this.mqtt = mqtt;
         this.roles = roles;
     }
 
@@ -77,30 +82,54 @@ public sealed class KubernetesConfigWatcher : IHostedService, IDisposable
         config.Prometheus = reloaded.Prometheus;
         config.Debug = reloaded.Debug;
         config.Pdus = reloaded.Pdus;
+        config.MQTT = reloaded.MQTT;
+
+        // Re-point the broker connection in place rather than exiting to be restarted (#192).
+        await mqtt.ApplyAsync(stoppingCts.Token);
 
         // The poller lives on the worker; reconcile there so added/removed/retuned PDUs take effect live.
+        // This also covers a changed Connection on an existing instance — the factory rebuilds it.
         if (roles.HasFlag(HostRole.Worker))
             await instances.ReconcileAsync();
     }
 
-    /// <summary>True when a setting that can only be applied at startup changed (broker/ports/auth).</summary>
+    /// <summary>
+    /// True when a setting that can only be applied at startup changed. MQTT settings are no longer here —
+    /// the client is re-pointed live (#192) — and neither are the non-primary PDU instances, which the
+    /// reconciler rebuilds. What remains needs the host rebuilt:
+    /// <list type="bullet">
+    /// <item>the listening sockets (GUI/API/health/metrics ports) and GUI auth, bound once at startup;</item>
+    /// <item>the primary PDU instance, which is the fixed DI singleton — <see cref="InstanceManager"/>
+    /// cannot rebuild it, so without a restart a change to it would be silently dropped. Note this covers
+    /// its full signature (credentials and poll interval too), not just the connection: those were
+    /// previously neither restarted for nor applied, so they were quietly ignored.</item>
+    /// </list>
+    /// </summary>
     public static bool RequiresRestart(Config live, Config reloaded)
         => Critical(live) != Critical(reloaded);
 
     private static string Critical(Config c) => JsonSerializer.Serialize(new
     {
-        c.MQTT.Connection,
-        c.MQTT.ClientID,
-        c.MQTT.KeepAlive,
-        c.MQTT.LastWill,
-        c.MQTT.ParentTopic,
-        Pdu = c.Pdus.ToDictionary(p => p.Key, p => new { p.Value.Connection }),
+        Primary = PrimarySignature(c),
         c.Gui,
         c.Api,
         HealthPort = c.Health.Port,
         HealthEnabled = c.Health.Enabled,
         PromPort = c.Prometheus.Port,
     });
+
+    /// <summary>
+    /// The primary instance's rebuild signature, or "" when there isn't one. Resolved the same way
+    /// <see cref="PduInstanceRegistry"/> picks the primary, so the two can't disagree about which
+    /// instance is pinned to the process lifetime.
+    /// </summary>
+    private static string PrimarySignature(Config c)
+    {
+        if (c.Pdus is null || c.Pdus.Count == 0)
+            return "";
+        var id = c.Pdus.ContainsKey(Config.DefaultInstanceKey) ? Config.DefaultInstanceKey : c.Pdus.Keys.First();
+        return c.Pdus.TryGetValue(id, out var pdu) ? id + "=" + InstanceReconcile.Signature(pdu) : "";
+    }
 
     private async Task<bool> SafeWaitAsync(CancellationToken ct)
     {

--- a/rPDU2MQTT.Engine/Services/MqttReconfigurator.cs
+++ b/rPDU2MQTT.Engine/Services/MqttReconfigurator.cs
@@ -1,0 +1,87 @@
+using HiveMQtt.Client;
+using HiveMQtt.MQTT5.Types;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Models.Config;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Re-points the live MQTT client at a new broker/credentials without restarting the process (#192).
+/// <para>
+/// The client singleton is kept and its <see cref="IHiveMQClient.Options"/> swapped in place, rather than
+/// replaced: every service holds a reference to this instance and has wired its own event handlers to it,
+/// so replacing the object would silently orphan all of them.
+/// </para>
+/// <para>
+/// A reconnect drops the broker-side session, so subscriptions are captured before disconnecting and
+/// replayed afterwards — otherwise control/diagnostic topics would go deaf after a broker change.
+/// </para>
+/// </summary>
+public sealed class MqttReconfigurator
+{
+    private readonly IHiveMQClient client;
+    private readonly Config config;
+    private readonly SemaphoreSlim gate = new(1, 1);
+    private string fingerprint;
+
+    public MqttReconfigurator(IHiveMQClient client, Config config)
+    {
+        this.client = client;
+        this.config = config;
+        fingerprint = MqttOptionsFactory.Fingerprint(config);
+    }
+
+    /// <summary>True when <paramref name="reloaded"/> changes the broker connection in any way.</summary>
+    public bool NeedsRepoint(Config reloaded) => MqttOptionsFactory.Fingerprint(reloaded) != fingerprint;
+
+    /// <summary>
+    /// Apply the reloaded MQTT settings to the live client. Assumes the caller has already copied them onto
+    /// the shared <see cref="Config"/>. No-op when nothing the client cares about changed.
+    /// </summary>
+    public async Task<bool> ApplyAsync(CancellationToken cancellationToken = default)
+    {
+        var target = MqttOptionsFactory.Fingerprint(config);
+        if (target == fingerprint)
+            return false;
+
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            // Re-check inside the gate: a concurrent caller may have already applied this change.
+            if (MqttOptionsFactory.Fingerprint(config) == fingerprint)
+                return false;
+
+            var options = MqttOptionsFactory.Build(config);
+            var previous = client.Subscriptions.Select(s => s.TopicFilter).ToList();
+
+            Log.Information($"MQTT settings changed; re-pointing the client at {options.Host}:{options.Port} without a restart.");
+
+            if (client.IsConnected())
+                await client.DisconnectAsync();
+
+            client.Options = options;
+            await client.ConnectAsync();
+
+            // Resubscribe to whatever the services had subscribed to before the reconnect.
+            foreach (var filter in previous)
+            {
+                try
+                {
+                    await client.SubscribeAsync(filter.Topic, filter.QoS);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning($"Could not resubscribe to '{filter.Topic}' after re-pointing MQTT: {ex.Message}");
+                }
+            }
+
+            fingerprint = target;
+            Log.Information($"MQTT client re-pointed at {options.Host}:{options.Port} ({previous.Count} subscription(s) restored).");
+            return true;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+}

--- a/rPDU2MQTT.Tests/ConfigWatcherTests.cs
+++ b/rPDU2MQTT.Tests/ConfigWatcherTests.cs
@@ -1,11 +1,15 @@
 using rPDU2MQTT.Classes;
 using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Services;
 using rPDU2MQTT.Services.Kubernetes;
 using Xunit;
 
 namespace rPDU2MQTT.Tests;
 
-/// <summary>KubernetesConfigWatcher.RequiresRestart: only connection/port/auth changes force a restart (#187/#192).</summary>
+/// <summary>
+/// KubernetesConfigWatcher.RequiresRestart: only the listen ports/GUI auth and the primary PDU instance
+/// force a restart now; MQTT is re-pointed live and other instances are reconciled (#187/#192).
+/// </summary>
 public class ConfigWatcherTests
 {
     private static Config Sample()
@@ -34,21 +38,246 @@ public class ConfigWatcherTests
     }
 
     [Fact]
-    public void ConnectionPortAndAuthChanges_RequireRestart()
+    public void ListenPortsAndAuthChanges_RequireRestart()
     {
         var baseline = Sample();
 
-        var mqtt = Sample(); mqtt.MQTT.Connection.Host = "other.example.com";
-        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, mqtt));
-
-        var pdu = Sample(); pdu.Pdus["default"].Connection.Port = 443;
-        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, pdu));
-
+        // Listening sockets are bound once when the host is built.
         var gui = Sample(); gui.Gui.Port = 9090;
         Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, gui));
 
-        // The MQTT client is built once at startup, so switching transport must force a restart (#189).
-        var scheme = Sample(); scheme.MQTT.Connection.Scheme = "mqtts";
-        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, scheme));
+        var api = Sample(); api.Api.Port = 9999;
+        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, api));
+
+        var health = Sample(); health.Health.Port = 9091;
+        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, health));
+    }
+
+    [Fact]
+    public void MqttChanges_NoLongerRequireRestart()
+    {
+        // The client is re-pointed in place by MqttReconfigurator instead of exiting the process (#192).
+        var baseline = Sample();
+
+        foreach (var mutate in new Action<Config>[]
+        {
+            c => c.MQTT.Connection.Host = "other.example.com",
+            c => c.MQTT.Connection.Port = 8883,
+            c => c.MQTT.Connection.Scheme = "mqtts",
+            c => c.MQTT.Credentials = new() { Username = "u", Password = "p" },
+            c => c.MQTT.ClientID = "different",
+            c => c.MQTT.KeepAlive = 120,
+            c => c.MQTT.LastWill = false,
+            c => c.MQTT.ParentTopic = "other",
+        })
+        {
+            var changed = Sample(); mutate(changed);
+            Assert.False(KubernetesConfigWatcher.RequiresRestart(baseline, changed));
+        }
+    }
+
+    [Fact]
+    public void PrimaryPduChanges_RequireRestart_ButOtherInstancesDoNot()
+    {
+        var baseline = Sample();
+
+        // The primary is the fixed DI singleton — InstanceManager cannot rebuild it, so a change to it
+        // must restart or it would be silently dropped. This covers its whole signature, not just the host.
+        var host = Sample(); host.Pdus["default"].Connection.Host = "moved.example.com";
+        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, host));
+
+        var poll = Sample(); poll.Pdus["default"].PollInterval = 60;
+        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, poll));
+
+        var creds = Sample(); creds.Pdus["default"].Credentials = new() { Username = "u", Password = "p" };
+        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, creds));
+
+        // A second (non-primary) instance is reconciled live — adding or retuning it must not restart.
+        var added = Sample();
+        added.Pdus["second"] = new PduConfig { PollInterval = 5 };
+        added.Pdus["second"].Connection.Host = "pdu-2.example.com";
+        Assert.False(KubernetesConfigWatcher.RequiresRestart(baseline, added));
+
+        var retuned = Sample();
+        retuned.Pdus["second"] = new PduConfig { PollInterval = 5 };
+        retuned.Pdus["second"].Connection.Host = "pdu-2.example.com";
+        var retuned2 = Sample();
+        retuned2.Pdus["second"] = new PduConfig { PollInterval = 30 };
+        retuned2.Pdus["second"].Connection.Host = "pdu-2-moved.example.com";
+        Assert.False(KubernetesConfigWatcher.RequiresRestart(retuned, retuned2));
+    }
+}
+
+/// <summary>MqttOptionsFactory: the fingerprint that decides whether the live client is re-pointed (#192).</summary>
+public class MqttOptionsFactoryTests
+{
+    private static Config Sample()
+    {
+        var c = new Config();
+        c.MQTT.Connection.Host = "mqtt.example.com";
+        c.MQTT.Connection.Port = 1883;
+        return c;
+    }
+
+    [Fact]
+    public void Fingerprint_IsStableForAnUnchangedConfig()
+    {
+        // ClientId gets a fresh GUID per Build(), so the fingerprint must not be derived from built options.
+        Assert.Equal(MqttOptionsFactory.Fingerprint(Sample()), MqttOptionsFactory.Fingerprint(Sample()));
+    }
+
+    [Theory]
+    [InlineData("host")]
+    [InlineData("port")]
+    [InlineData("scheme")]
+    [InlineData("username")]
+    [InlineData("password")]
+    [InlineData("clientid")]
+    [InlineData("keepalive")]
+    [InlineData("lastwill")]
+    [InlineData("parenttopic")]
+    [InlineData("validatecert")]
+    public void Fingerprint_ChangesForEverySettingTheClientDependsOn(string field)
+    {
+        var a = Sample();
+        var b = Sample();
+        switch (field)
+        {
+            case "host": b.MQTT.Connection.Host = "other.example.com"; break;
+            case "port": b.MQTT.Connection.Port = 1884; break;
+            case "scheme": b.MQTT.Connection.Scheme = "mqtts"; break;
+            case "username": b.MQTT.Credentials = new() { Username = "u" }; break;
+            case "password": b.MQTT.Credentials = new() { Password = "p" }; break;
+            case "clientid": b.MQTT.ClientID = "other"; break;
+            case "keepalive": b.MQTT.KeepAlive = 120; break;
+            case "lastwill": b.MQTT.LastWill = !a.MQTT.LastWill; break;
+            case "parenttopic": b.MQTT.ParentTopic = "other"; break;
+            case "validatecert": b.MQTT.Connection.ValidateCertificate = false; break;
+        }
+
+        Assert.NotEqual(MqttOptionsFactory.Fingerprint(a), MqttOptionsFactory.Fingerprint(b));
+    }
+
+    [Fact]
+    public void Build_AppliesSchemeCredentialsAndLastWill()
+    {
+        var c = Sample();
+        c.MQTT.Connection.Scheme = "mqtts";
+        c.MQTT.Connection.Port = null;              // inferred from the scheme
+        c.MQTT.Credentials = new() { Username = "u", Password = "p" };
+        c.MQTT.ParentTopic = "topic";
+
+        var o = MqttOptionsFactory.Build(c);
+
+        Assert.Equal("mqtt.example.com", o.Host);
+        Assert.Equal(8883, o.Port);
+        Assert.True(o.UseTLS);
+        Assert.Equal("u", o.UserName);
+        Assert.NotNull(o.LastWillAndTestament);
+        Assert.StartsWith("topic", o.LastWillAndTestament!.Topic);
+    }
+
+    [Fact]
+    public void Build_OmitsLastWill_WhenDisabled()
+    {
+        var c = Sample();
+        c.MQTT.LastWill = false;
+        Assert.Null(MqttOptionsFactory.Build(c).LastWillAndTestament);
+    }
+}
+
+/// <summary>
+/// MqttReconfigurator (#192): the decision to re-point, and the re-point sequence itself, driven through
+/// <see cref="FakeHiveMQClient"/> so no live broker is needed.
+/// </summary>
+public class MqttReconfiguratorTests
+{
+    private static Config Sample()
+    {
+        var c = new Config();
+        c.MQTT.Connection.Host = "mqtt.example.com";
+        c.MQTT.Connection.Port = 1883;
+        return c;
+    }
+
+    // A real client, never connected — enough to exercise the paths that don't touch the socket.
+    private static HiveMQtt.Client.HiveMQClient Client(Config c) => new(MqttOptionsFactory.Build(c));
+
+    [Fact]
+    public async Task ApplyAsync_IsANoOp_WhenNothingTheClientCaresAboutChanged()
+    {
+        var cfg = Sample();
+        var sut = new MqttReconfigurator(Client(cfg), cfg);
+
+        // A change the client doesn't depend on must not trigger a reconnect (which would throw here,
+        // since there is no broker to connect to).
+        cfg.HASS.DiscoveryEnabled = !cfg.HASS.DiscoveryEnabled;
+        cfg.Prometheus.Exporter = true;
+
+        Assert.False(sut.NeedsRepoint(cfg));
+        Assert.False(await sut.ApplyAsync());
+    }
+
+    [Fact]
+    public async Task ApplyAsync_Disconnects_SwapsOptions_Reconnects_AndRestoresSubscriptions()
+    {
+        var cfg = Sample();
+        var fake = new FakeHiveMQClient { Options = MqttOptionsFactory.Build(cfg) };
+        // Two topics the services had subscribed to before the change.
+        fake.Subscriptions.Add(new HiveMQtt.MQTT5.Types.Subscription(
+            new HiveMQtt.MQTT5.Types.TopicFilter("rPDU2MQTT/cmd", HiveMQtt.MQTT5.Types.QualityOfService.AtLeastOnceDelivery)));
+        fake.Subscriptions.Add(new HiveMQtt.MQTT5.Types.Subscription(
+            new HiveMQtt.MQTT5.Types.TopicFilter("rPDU2MQTT/restart", HiveMQtt.MQTT5.Types.QualityOfService.AtLeastOnceDelivery)));
+
+        var sut = new MqttReconfigurator(fake, cfg);
+
+        cfg.MQTT.Connection.Host = "new-broker.example.com";
+        cfg.MQTT.Connection.Port = 8883;
+        cfg.MQTT.Connection.Scheme = "mqtts";
+
+        Assert.True(await sut.ApplyAsync());
+
+        // Order matters: the socket must be closed and the options swapped BEFORE reconnecting, then the
+        // subscriptions replayed — otherwise the new broker never learns about the command topics.
+        Assert.Equal(
+            new[] { "disconnect", "connect", "subscribe:rPDU2MQTT/cmd", "subscribe:rPDU2MQTT/restart" },
+            fake.Calls);
+
+        // The client connected with the NEW options, and kept the same client object.
+        Assert.Equal("new-broker.example.com", fake.OptionsWhenConnected!.Host);
+        Assert.Equal(8883, fake.OptionsWhenConnected.Port);
+        Assert.True(fake.OptionsWhenConnected.UseTLS);
+        Assert.True(fake.Connected);
+
+        // Applying again with no further change is a no-op (no second reconnect).
+        fake.Calls.Clear();
+        Assert.False(await sut.ApplyAsync());
+        Assert.Empty(fake.Calls);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_SkipsTheDisconnect_WhenNotCurrentlyConnected()
+    {
+        var cfg = Sample();
+        var fake = new FakeHiveMQClient { Options = MqttOptionsFactory.Build(cfg), Connected = false };
+        var sut = new MqttReconfigurator(fake, cfg);
+
+        cfg.MQTT.Connection.Host = "new-broker.example.com";
+        Assert.True(await sut.ApplyAsync());
+
+        Assert.Equal(new[] { "connect" }, fake.Calls);
+    }
+
+    [Fact]
+    public void NeedsRepoint_TracksTheLiveConfig()
+    {
+        var cfg = Sample();
+        var sut = new MqttReconfigurator(Client(cfg), cfg);
+
+        Assert.False(sut.NeedsRepoint(cfg));
+
+        var moved = Sample();
+        moved.MQTT.Connection.Host = "other.example.com";
+        Assert.True(sut.NeedsRepoint(moved));
     }
 }

--- a/rPDU2MQTT.Tests/FakeHiveMQClient.cs
+++ b/rPDU2MQTT.Tests/FakeHiveMQClient.cs
@@ -1,0 +1,88 @@
+using HiveMQtt.Client;
+using HiveMQtt.Client.Options;
+using HiveMQtt.Client.Results;
+using HiveMQtt.MQTT5.Types;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// A stand-in IHiveMQClient that records the re-point sequence, so MqttReconfigurator can be tested
+/// without a live broker (#192). Only the members the reconfigurator touches do anything.
+/// </summary>
+internal sealed class FakeHiveMQClient : IHiveMQClient
+{
+    public List<string> Calls { get; } = new();
+    public List<string> Subscribed { get; } = new();
+    public bool Connected { get; set; } = true;
+    public HiveMQClientOptions? OptionsWhenConnected { get; private set; }
+
+    public HiveMQClientOptions Options { get; set; } = new();
+    public List<Subscription> Subscriptions { get; } = new();
+    public Dictionary<string, string> LocalStore { get; } = new();
+
+    public bool IsConnected() => Connected;
+
+    public Task<ConnectResult> ConnectAsync(ConnectOptions? connectOptions = default)
+    {
+        Calls.Add("connect");
+        Connected = true;
+        // Capture what the options were AT connect time, to prove the swap happened before connecting.
+        OptionsWhenConnected = Options;
+        return Task.FromResult<ConnectResult>(null!);
+    }
+
+    public Task<bool> DisconnectAsync(DisconnectOptions? options = default)
+    {
+        Calls.Add("disconnect");
+        Connected = false;
+        return Task.FromResult(true);
+    }
+
+    public Task<SubscribeResult> SubscribeAsync(string topic, QualityOfService qos = default, bool noLocal = default, bool retainAsPublished = default, RetainHandling retainHandling = default)
+    {
+        Calls.Add("subscribe:" + topic);
+        Subscribed.Add(topic);
+        return Task.FromResult<SubscribeResult>(null!);
+    }
+
+    public Task<SubscribeResult> SubscribeAsync(SubscribeOptions options) => throw new NotImplementedException();
+    public Task<PublishResult> PublishAsync(MQTT5PublishMessage message, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    public Task<PublishResult> PublishAsync(string topic, string payload, QualityOfService qos = default) => throw new NotImplementedException();
+    public Task<PublishResult> PublishAsync(string topic, byte[] payload, QualityOfService qos = default) => throw new NotImplementedException();
+    public Task<UnsubscribeResult> UnsubscribeAsync(string topic) => throw new NotImplementedException();
+    public Task<UnsubscribeResult> UnsubscribeAsync(Subscription subscription) => throw new NotImplementedException();
+    public Task<UnsubscribeResult> UnsubscribeAsync(List<Subscription> subscriptions) => throw new NotImplementedException();
+    public Task AckAsync(ushort packetIdentifier) => throw new NotImplementedException();
+    public Task AckAsync(HiveMQtt.Client.Events.OnMessageReceivedEventArgs eventArgs) => throw new NotImplementedException();
+    public void Dispose() { }
+
+    public event System.EventHandler<HiveMQtt.Client.Events.BeforeConnectEventArgs>? BeforeConnect { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.AfterConnectEventArgs>? AfterConnect { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.BeforeDisconnectEventArgs>? BeforeDisconnect { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.AfterDisconnectEventArgs>? AfterDisconnect { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.BeforeSubscribeEventArgs>? BeforeSubscribe { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.AfterSubscribeEventArgs>? AfterSubscribe { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.BeforeUnsubscribeEventArgs>? BeforeUnsubscribe { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.AfterUnsubscribeEventArgs>? AfterUnsubscribe { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnMessageReceivedEventArgs>? OnMessageReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnConnectSentEventArgs>? OnConnectSent { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnConnAckReceivedEventArgs>? OnConnAckReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnDisconnectSentEventArgs>? OnDisconnectSent { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnDisconnectReceivedEventArgs>? OnDisconnectReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPingReqSentEventArgs>? OnPingReqSent { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPingRespReceivedEventArgs>? OnPingRespReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnSubscribeSentEventArgs>? OnSubscribeSent { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnSubAckReceivedEventArgs>? OnSubAckReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnUnsubscribeSentEventArgs>? OnUnsubscribeSent { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnUnsubAckReceivedEventArgs>? OnUnsubAckReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPublishReceivedEventArgs>? OnPublishReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPublishSentEventArgs>? OnPublishSent { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPubAckReceivedEventArgs>? OnPubAckReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPubAckSentEventArgs>? OnPubAckSent { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPubRecReceivedEventArgs>? OnPubRecReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPubRecSentEventArgs>? OnPubRecSent { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPubRelReceivedEventArgs>? OnPubRelReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPubRelSentEventArgs>? OnPubRelSent { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPubCompReceivedEventArgs>? OnPubCompReceived { add { } remove { } }
+    public event System.EventHandler<HiveMQtt.Client.Events.OnPubCompSentEventArgs>? OnPubCompSent { add { } remove { } }
+}

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -48,43 +48,11 @@ public static class ServiceConfiguration
         services.ConfigureLogging(cfg);
 
         // Bind IHiveMQClient
-        services.AddSingleton<IHiveMQClient, HiveMQClient>((sp) =>
-        {
-            ThrowError.TestRequiredConfigurationSection(cfg.MQTT, "MQTT");
-            ThrowError.TestRequiredConfigurationSection(cfg.MQTT.Connection, "MQTT.Connection");
-            ThrowError.TestRequiredConfigurationSection(cfg.MQTT.Connection.Host, "MQTT.Connection.Host");
+        // Options are built by the shared factory so startup and the live re-point can't drift (#192).
+        services.AddSingleton<IHiveMQClient, HiveMQClient>((sp) => new HiveMQClient(MqttOptionsFactory.Build(cfg)));
 
-            var conn = cfg.MQTT.Connection;
-            var mqttBuilder = new HiveMQClientOptionsBuilder()
-                .WithBroker(conn.Host)
-                .WithPort(conn.ResolvedPort)
-                .WithClientId((cfg.MQTT.ClientID ?? "rpdu2mqtt") + Guid.NewGuid().ToString())
-                .WithAutomaticReconnect(true)
-                .WithKeepAlive(cfg.MQTT.KeepAlive);
-
-            // Honour the configured scheme: mqtts/wss get TLS, ws/wss tunnel over WebSockets (#189).
-            mqttBuilder.WithUseTls(conn.UsesTls);
-            if (conn.UsesWebSockets)
-                mqttBuilder.WithWebSocketServer($"{conn.EffectiveScheme}://{conn.Host}:{conn.ResolvedPort}/mqtt");
-
-            // ValidateCertificate=false is the escape hatch for a broker with a self-signed cert.
-            if (conn.UsesTls && conn.ValidateCertificate == false)
-                mqttBuilder.WithAllowInvalidBrokerCertificates(true);
-
-            // Optional Last-Will so HA marks entities unavailable immediately on disconnect.
-            if (cfg.MQTT.LastWill)
-                mqttBuilder.WithLastWillAndTestament(new LastWillAndTestament(
-                    MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic), payload: "offline", HiveMQtt.MQTT5.Types.QualityOfService.AtLeastOnceDelivery, true));
-
-            if (cfg.MQTT.Credentials?.Username is not null)
-                mqttBuilder.WithUserName(cfg.MQTT.Credentials.Username);
-
-            if (cfg.MQTT.Credentials?.Password is not null)
-                mqttBuilder.WithPassword(ToSecureString(cfg.MQTT.Credentials.Password));
-
-            // Return new client, with options applied.
-            return new HiveMQClient(mqttBuilder.Build());
-        });
+        // Re-points the live client when the broker/credentials change, instead of exiting to be restarted.
+        services.AddSingleton<Services.MqttReconfigurator>();
 
         // Wires the client's connect/disconnect events and the online-status heartbeat.
         // Instantiated explicitly in Program.cs before the initial connect.
@@ -207,15 +175,5 @@ public static class ServiceConfiguration
         // ---- Ui role: the embedded configuration GUI. ----
         if (ui && cfg.Gui.Enabled)
             services.AddHostedService<Services.Gui.GuiService>();
-    }
-
-    /// <summary>Wrap a plaintext secret as a read-only SecureString (for APIs that require one).</summary>
-    private static System.Security.SecureString ToSecureString(string value)
-    {
-        var secure = new System.Security.SecureString();
-        foreach (var c in value)
-            secure.AppendChar(c);
-        secure.MakeReadOnly();
-        return secure;
     }
 }


### PR DESCRIPTION
Addresses #192.

## Root cause

Nothing was crash-looping. A config change that touched MQTT deliberately called `IHostApplicationLifetime.StopApplication()`. That's a **clean exit (code 0)**, so the kubelet marks the container `Completed` and restarts it under **exponential backoff** — which is the "delayed start" in the report. The pod was doing exactly what it was told; the design was to bounce the process to reload config.

## The fix: don't exit

`MqttReconfigurator` re-points the running client instead: disconnect → swap `IHiveMQClient.Options` → reconnect.

Two things worth calling out, because they're the traps here:

- **The client singleton is kept, not replaced.** Every service holds a reference to it and has wired its own event handlers onto that instance; swapping the object would silently orphan all of them. `Options` is settable, so the instance can be re-pointed in place.
- **Subscriptions are captured and replayed.** A reconnect drops the broker-side session, so without this the control/diagnostic topics would silently go deaf after a broker change — the process would look healthy and just stop responding to commands.

Option building moved into a shared `MqttOptionsFactory`, so startup and the live re-point can't drift apart (the #189 scheme/TLS logic now has exactly one home).

## What still restarts — the honest limit

You asked to remove the restart entirely. I got most of the way and want to be precise about what's left, because two of these are load-bearing:

| Setting | Status |
| --- | --- |
| MQTT broker / port / scheme / credentials / keepalive / LWT / parent topic | **Live** |
| Non-primary PDU instances (add / remove / retune / re-point) | **Live** (already were — restarting for them was pure waste) |
| GUI / API / health / metrics **ports**, GUI auth | Restart — sockets are bound once when the host is built |
| **Primary** PDU instance | Restart — it's the fixed DI singleton; `InstanceManager` cannot rebuild it |

The primary PDU is the same class of problem the MQTT client had (consumers hold a direct reference), and it's solvable the same way — but it means making `PDU`/`PduApiHandler` swap their `HttpClient` in place, which is its own PR. Same for rebinding listeners. Happy to do both as follow-ups.

## Bug found on the way

`RequiresRestart`'s primary-PDU entry now covers the instance's **whole signature**, not just `Connection`. Its **credentials and poll interval were in neither list** — not restarted for, and skipped by the reconciler with only a `Log.Warning` ("needs a restart to take effect"). So changing the primary's poll interval was **silently ignored**. It now restarts, which at least applies it.

Also fixed: `MqttEventHandler` dereferenced `Options.LastWillAndTestament!.Topic` unconditionally, throwing every 10 seconds when `MQTT.LastWill` is off. Latent before; this change makes it reachable by letting `LastWill` toggle at runtime.

## Verification

`dotnet build` 0 errors, warnings back to the baseline 7. `dotnet test` **171/171** (+19).

The re-point sequence is genuinely exercised, not just asserted about: `FakeHiveMQClient` (generated against the real 45-member interface) proves the exact order — `disconnect → connect → subscribe → subscribe` — that the client connects with the *new* options, that both subscriptions are restored, that a no-change apply is a no-op, and that the disconnect is skipped when not connected.

Also ran the app against the new factory to confirm the DI graph resolves and startup builds options through it (it retries against an absent broker, as expected). The regenerated CRD is byte-identical, so no schema drift.

**Not verified here:** no broker and no cluster in this environment, so the re-point is proven against a fake rather than a live `mqtts` broker, and the `Completed`-status behaviour itself is reasoned from the exit code, not observed. Both are worth a smoke test before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)