### PR TITLE
fix(k8s): re-point the primary PDU live, removing the last config restart (#192)

### DIFF
--- a/docs/KubernetesCRD.md
+++ b/docs/KubernetesCRD.md
@@ -177,10 +177,10 @@ Because the GUI writes the CR `spec` and a redeploy also renders the CR `spec` f
 
 - **Watch** the CR; on change, apply it live: the reloaded config is copied into the shared singleton,
   the MQTT client is re-pointed at the new broker/credentials, and the PDU pollers are reconciled
-  (#187/#192). Restarting the process is a last resort, because a clean exit leaves the pod in
-  `Completed` and the kubelet re-starts it under backoff. It remains only for things bound once when the
-  host is built: the listening sockets (GUI/API/health/metrics ports), GUI auth, and the primary PDU
-  instance (the fixed DI singleton the reconciler cannot rebuild).
+  (#187/#192) — the primary instance included, which is re-pointed in place because DI pins its object
+  identity. Restarting the process is a last resort, because a clean exit leaves the pod in `Completed`
+  and the kubelet re-starts it under backoff. It remains only for the listening sockets (GUI/API/health/
+  metrics ports) and GUI auth, which are bound once when the host is built.
 - **Status:** a lightweight hosted service patches `status` (connected from the MQTT client, device
   count + last poll from `PDU.GetRootData_Public`) on the poll interval, using the values already
   surfaced by `/api/status` and `/api/livedata`.
@@ -259,7 +259,7 @@ No phasing — the full feature ships at once:
 - **GUI write-back enabled by default** (`PATCH` the CR `spec`), with a GitOps-drift warning and a
   redacted CR-manifest export for re-importing into source control.
 - **`status` subresource** updated with `connected` / `deviceCount` / `lastPoll`.
-- **Watch** the CR and apply `spec` changes live (restarting only for listen ports / GUI auth / the primary PDU).
+- **Watch** the CR and apply `spec` changes live (restarting only for listen ports / GUI auth).
 - CRD OpenAPI `spec` schema **generated from the `Config` model** (reusing the GUI's `ConfigSchema`
   reflection).
 - CRD shipped both in the Helm chart's `crds/` directory **and** as a standalone manifest; the app does

--- a/rPDU2MQTT.Engine/Classes/InstanceReconcile.cs
+++ b/rPDU2MQTT.Engine/Classes/InstanceReconcile.cs
@@ -27,8 +27,9 @@ public static class InstanceReconcile
     /// <summary>
     /// Plan the move from the currently-running instance signatures to the desired config. Returns the ids
     /// to stop (removed or changed) and to start (added or changed); a changed non-primary instance appears
-    /// in both (rebuild). The primary is never stopped — it's the fixed DI singleton — so a changed primary
-    /// is surfaced via <c>primaryChanged</c> instead (needs a restart). Hostless desired entries are ignored.
+    /// in both (rebuild). The primary's PDU is the fixed DI singleton, so it's never rebuilt that way — a
+    /// changed primary is surfaced via <c>primaryChanged</c>, and the manager re-points it in place (#192).
+    /// Hostless desired entries are ignored.
     /// </summary>
     public static (List<string> toStop, List<string> toStart, bool primaryChanged) Plan(
         IReadOnlyDictionary<string, string> running,

--- a/rPDU2MQTT.Engine/Classes/PDU.cs
+++ b/rPDU2MQTT.Engine/Classes/PDU.cs
@@ -10,7 +10,7 @@ namespace rPDU2MQTT.Classes;
 public partial class PDU
 {
     private readonly Config config;
-    private readonly Models.Config.PduConfig instanceConfig;
+    private Models.Config.PduConfig instanceConfig;
     private readonly PduApiHandler api;
 
     /// <summary>
@@ -26,6 +26,32 @@ public partial class PDU
         this.instanceConfig = instanceConfig;
         this.config = config;
         this.api = api;
+    }
+
+    /// <summary>The address this PDU is currently pointed at (changes when it is re-pointed).</summary>
+    public string BaseAddress => api.BaseAddress;
+
+    /// <summary>
+    /// Point this PDU at a different host/credentials/settings in place (#192).
+    /// <para>
+    /// The object itself is kept: the primary instance is the DI singleton the GUI, control and discovery
+    /// all hold a reference to, so it can never be swapped out — only re-pointed. Everything cached here
+    /// describes the OLD device, so it is all dropped: the OneView detection (a different host may not be
+    /// a OneView master), the poll cache, and the pending-state latches (they key off the old device's
+    /// outlets and would otherwise mask the new device's real state until they expire).
+    /// </para>
+    /// </summary>
+    public void Repoint(Models.Config.PduConfig newConfig, HttpClient newHttp)
+    {
+        instanceConfig = newConfig;
+        api.Repoint(newHttp, newConfig);
+        useOneView = null;
+        lock (pendingLock)
+        {
+            pendingOutletStates.Clear();
+            pendingConfig.Clear();
+        }
+        InvalidateCache();
     }
 
     // After a control command the PDU can sit in a "pending" state for up to ~a minute while it

--- a/rPDU2MQTT.Engine/Classes/PduApiHandler.cs
+++ b/rPDU2MQTT.Engine/Classes/PduApiHandler.cs
@@ -12,8 +12,8 @@ namespace rPDU2MQTT.Classes;
 /// </summary>
 public class PduApiHandler
 {
-    private readonly HttpClient http;
-    private readonly PduConfig instanceConfig;
+    private HttpClient http;
+    private PduConfig instanceConfig;
     // Session token per host web port (OneView cluster members are reached via the master's proxy port).
     private readonly Dictionary<long, string> tokensByPort = new();
     // deviceId -> owning host web port (0 = the directly-connected/base host).
@@ -23,6 +23,26 @@ public class PduApiHandler
     {
         this.http = http ?? throw new NullReferenceException("HttpClient in constructor was null");
         this.instanceConfig = instanceConfig;
+    }
+
+    /// <summary>
+    /// Point this handler at a different host/credentials, keeping the handler object so its owning
+    /// <see cref="PDU"/> (the DI singleton) stays valid (#192). Session tokens and the device→port map are
+    /// tied to the old host, so they're dropped: replaying them against a new PDU would fail auth or,
+    /// worse, address the wrong device.
+    /// </summary>
+    public void Repoint([DisallowNull, NotNull] HttpClient newHttp, PduConfig newConfig)
+    {
+        ArgumentNullException.ThrowIfNull(newHttp);
+
+        var old = http;
+        http = newHttp;
+        instanceConfig = newConfig;
+        tokensByPort.Clear();
+        deviceWebPorts = null;
+
+        // The old client owns a pooled connection to the previous host; don't leak it.
+        old?.Dispose();
     }
 
     public string BaseAddress => http.BaseAddress?.ToString() ?? string.Empty;

--- a/rPDU2MQTT.Engine/Classes/PduInstanceFactory.cs
+++ b/rPDU2MQTT.Engine/Classes/PduInstanceFactory.cs
@@ -28,6 +28,19 @@ public sealed class PduInstanceFactory
         return new PDU(instanceConfig, configForOverrides, api);
     }
 
+    /// <summary>
+    /// Re-point an existing PDU at a new configuration, instead of building a replacement (#192). Used for
+    /// the primary instance, whose object identity is pinned by DI. Built through the same path as
+    /// <see cref="Create(PduConfig)"/>, so a re-pointed instance is configured identically to a fresh one.
+    /// </summary>
+    public void Repoint(PDU pdu, PduConfig instanceConfig)
+    {
+        ThrowError.TestRequiredConfigurationSection(instanceConfig.Connection, "Pdus[].Connection");
+        ThrowError.TestRequiredConfigurationSection(instanceConfig.Connection.Host, "Pdus[].Connection.Host");
+
+        pdu.Repoint(instanceConfig, BuildHttpClient(instanceConfig.Connection));
+    }
+
     private static HttpClient BuildHttpClient(Connection conn)
     {
         var uri = new UriBuilder { Host = conn.Host, Port = conn.Port ?? 80 };

--- a/rPDU2MQTT.Engine/Classes/PduInstanceRegistry.cs
+++ b/rPDU2MQTT.Engine/Classes/PduInstanceRegistry.cs
@@ -9,9 +9,10 @@ namespace rPDU2MQTT.Classes;
 /// discovery use <see cref="Primary"/>.
 /// </summary>
 /// <remarks>
-/// <see cref="Primary"/> is fixed for the process lifetime — it's the DI-resolved <see cref="PDU"/> shared
-/// with the GUI / control / discovery, so runtime reconciliation never swaps it (a primary connection
-/// change still needs a restart). Reads/writes are guarded so reconciliation can run while the GUI reads.
+/// <see cref="Primary"/>'s PDU <i>object</i> is fixed for the process lifetime — it's the DI-resolved
+/// <see cref="PDU"/> shared with the GUI / control / discovery, so reconciliation never swaps it. A
+/// changed primary is applied by <see cref="RepointPrimary"/>, which mutates that object in place instead
+/// (#192). Reads/writes are guarded so reconciliation can run while the GUI reads.
 /// </remarks>
 public sealed class PduInstanceRegistry
 {
@@ -53,7 +54,7 @@ public sealed class PduInstanceRegistry
         get { lock (gate) return new Dictionary<string, PDU>(instances, StringComparer.OrdinalIgnoreCase); }
     }
 
-    /// <summary>The primary instance's PDU (fixed for the process lifetime).</summary>
+    /// <summary>The primary instance's PDU (the same object for the process lifetime; see RepointPrimary).</summary>
     public PDU Primary { get { lock (gate) return instances[PrimaryId]; } }
 
     public PDU Get(string instanceId)
@@ -65,6 +66,26 @@ public sealed class PduInstanceRegistry
     public PDU? TryCreate(string id, PduConfig pduCfg)
     {
         lock (gate) return TryCreateInternal(id, pduCfg);
+    }
+
+    /// <summary>
+    /// Re-point the primary at a new configuration (#192). The primary's PDU object can't be replaced —
+    /// it's the DI singleton — so it's mutated in place instead, which keeps every existing reference
+    /// valid. Returns false (leaving the instance untouched) when the new config has no Host to point at.
+    /// </summary>
+    public bool RepointPrimary(PduConfig pduCfg)
+    {
+        if (string.IsNullOrWhiteSpace(pduCfg.Connection?.Host))
+        {
+            Log.Warning($"Primary PDU instance '{PrimaryId}' has no Connection.Host; keeping the previous connection.");
+            return false;
+        }
+
+        lock (gate)
+        {
+            factory.Repoint(instances[PrimaryId], pduCfg);
+            return true;
+        }
     }
 
     /// <summary>Remove an instance at runtime. Never removes the primary. Returns true if it was removed.</summary>

--- a/rPDU2MQTT.Engine/Services/InstanceManager.cs
+++ b/rPDU2MQTT.Engine/Services/InstanceManager.cs
@@ -8,9 +8,9 @@ namespace rPDU2MQTT.Services;
 /// Owns the running PDU producers — one <see cref="PduPoller"/> per instance in the
 /// <see cref="PduInstanceRegistry"/>. Starts every instance at startup and, via <see cref="ReconcileAsync"/>,
 /// adds/removes/rebuilds pollers at runtime when <see cref="Config.Pdus"/> changes (phase 5) — so a PDU
-/// added or removed in the GUI takes effect without a restart. The primary instance is never torn down
-/// (its PDU is the DI singleton shared with the GUI/control/discovery); a primary connection change is
-/// logged as needing a restart.
+/// added or removed in the GUI takes effect without a restart. The primary's PDU object is never torn
+/// down (it's the DI singleton shared with the GUI/control/discovery) — a changed primary is re-pointed
+/// in place and its poller restarted, so it needs no restart either (#192).
 /// </summary>
 public sealed class InstanceManager : IHostedService
 {
@@ -64,7 +64,7 @@ public sealed class InstanceManager : IHostedService
             var (toStop, toStart, primaryChanged) = InstanceReconcile.Plan(runningSignatures, cfg.Pdus, registry.PrimaryId);
 
             if (primaryChanged)
-                Log.Warning($"Connection/credential changes to the primary PDU instance '{registry.PrimaryId}' need a restart to take effect.");
+                await RepointPrimaryAsync();
 
             foreach (var id in toStop)
             {
@@ -86,6 +86,44 @@ public sealed class InstanceManager : IHostedService
             }
         }
         finally { reconcileLock.Release(); }
+    }
+
+    /// <summary>
+    /// Apply a changed primary instance without restarting the process (#192). Its PDU is the DI singleton
+    /// so it can't be rebuilt — instead the poller is stopped, the PDU re-pointed in place, and a poller
+    /// restarted on the (possibly new) interval. Stopping first means no poll can observe the PDU
+    /// mid-swap, and the restart is what picks up a changed PollInterval.
+    /// </summary>
+    private async Task RepointPrimaryAsync()
+    {
+        var id = registry.PrimaryId;
+        if (!cfg.Pdus.TryGetValue(id, out var pduCfg))
+            return;
+
+        Log.Information($"Primary PDU instance '{id}' changed; re-pointing it without a restart.");
+
+        if (pollers.Remove(id, out var poller))
+            await poller.StopAsync();
+
+        try
+        {
+            if (!registry.RepointPrimary(pduCfg))
+            {
+                // Hostless: the PDU still points at the old device. Restart the poller against it so we
+                // don't silently stop polling entirely.
+                StartPoller(id, registry.Primary);
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            // A bad new config must not leave the primary unpolled; keep the old connection running.
+            Log.Error(ex, $"Could not re-point primary PDU instance '{id}' ({ex.Message}); keeping the previous connection.");
+            StartPoller(id, registry.Primary);
+            return;
+        }
+
+        StartPoller(id, registry.Primary);
     }
 
     private void StartPoller(string id, PDU pdu)

--- a/rPDU2MQTT.Engine/Services/Kubernetes/KubernetesConfigWatcher.cs
+++ b/rPDU2MQTT.Engine/Services/Kubernetes/KubernetesConfigWatcher.cs
@@ -94,23 +94,16 @@ public sealed class KubernetesConfigWatcher : IHostedService, IDisposable
     }
 
     /// <summary>
-    /// True when a setting that can only be applied at startup changed. MQTT settings are no longer here —
-    /// the client is re-pointed live (#192) — and neither are the non-primary PDU instances, which the
-    /// reconciler rebuilds. What remains needs the host rebuilt:
-    /// <list type="bullet">
-    /// <item>the listening sockets (GUI/API/health/metrics ports) and GUI auth, bound once at startup;</item>
-    /// <item>the primary PDU instance, which is the fixed DI singleton — <see cref="InstanceManager"/>
-    /// cannot rebuild it, so without a restart a change to it would be silently dropped. Note this covers
-    /// its full signature (credentials and poll interval too), not just the connection: those were
-    /// previously neither restarted for nor applied, so they were quietly ignored.</item>
-    /// </list>
+    /// True when a setting that can only be applied at startup changed. All that remains is the listening
+    /// sockets (GUI/API/health/metrics ports) and GUI auth, which are bound once when the host is built.
+    /// Everything else is applied live (#192): the MQTT client is re-pointed, and every PDU instance —
+    /// including the primary, which is re-pointed in place because DI pins its identity — is reconciled.
     /// </summary>
     public static bool RequiresRestart(Config live, Config reloaded)
         => Critical(live) != Critical(reloaded);
 
     private static string Critical(Config c) => JsonSerializer.Serialize(new
     {
-        Primary = PrimarySignature(c),
         c.Gui,
         c.Api,
         HealthPort = c.Health.Port,
@@ -118,18 +111,6 @@ public sealed class KubernetesConfigWatcher : IHostedService, IDisposable
         PromPort = c.Prometheus.Port,
     });
 
-    /// <summary>
-    /// The primary instance's rebuild signature, or "" when there isn't one. Resolved the same way
-    /// <see cref="PduInstanceRegistry"/> picks the primary, so the two can't disagree about which
-    /// instance is pinned to the process lifetime.
-    /// </summary>
-    private static string PrimarySignature(Config c)
-    {
-        if (c.Pdus is null || c.Pdus.Count == 0)
-            return "";
-        var id = c.Pdus.ContainsKey(Config.DefaultInstanceKey) ? Config.DefaultInstanceKey : c.Pdus.Keys.First();
-        return c.Pdus.TryGetValue(id, out var pdu) ? id + "=" + InstanceReconcile.Signature(pdu) : "";
-    }
 
     private async Task<bool> SafeWaitAsync(CancellationToken ct)
     {

--- a/rPDU2MQTT.Tests/ConfigWatcherTests.cs
+++ b/rPDU2MQTT.Tests/ConfigWatcherTests.cs
@@ -7,8 +7,8 @@ using Xunit;
 namespace rPDU2MQTT.Tests;
 
 /// <summary>
-/// KubernetesConfigWatcher.RequiresRestart: only the listen ports/GUI auth and the primary PDU instance
-/// force a restart now; MQTT is re-pointed live and other instances are reconciled (#187/#192).
+/// KubernetesConfigWatcher.RequiresRestart: only the listen ports / GUI auth still force a restart —
+/// MQTT and every PDU instance (primary included) are applied live (#187/#192).
 /// </summary>
 public class ConfigWatcherTests
 {
@@ -77,34 +77,30 @@ public class ConfigWatcherTests
     }
 
     [Fact]
-    public void PrimaryPduChanges_RequireRestart_ButOtherInstancesDoNot()
+    public void PduChanges_NoLongerRequireRestart_IncludingThePrimary()
     {
+        // The primary is re-pointed in place now (its PDU object identity is pinned by DI, but its
+        // internals are swapped), so nothing about any instance needs the process to exit (#192).
         var baseline = Sample();
 
-        // The primary is the fixed DI singleton — InstanceManager cannot rebuild it, so a change to it
-        // must restart or it would be silently dropped. This covers its whole signature, not just the host.
-        var host = Sample(); host.Pdus["default"].Connection.Host = "moved.example.com";
-        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, host));
+        foreach (var mutate in new Action<Config>[]
+        {
+            c => c.Pdus["default"].Connection.Host = "moved.example.com",
+            c => c.Pdus["default"].Connection.Port = 443,
+            c => c.Pdus["default"].Connection.Scheme = "https",
+            c => c.Pdus["default"].PollInterval = 60,
+            c => c.Pdus["default"].Credentials = new() { Username = "u", Password = "p" },
+        })
+        {
+            var changed = Sample(); mutate(changed);
+            Assert.False(KubernetesConfigWatcher.RequiresRestart(baseline, changed));
+        }
 
-        var poll = Sample(); poll.Pdus["default"].PollInterval = 60;
-        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, poll));
-
-        var creds = Sample(); creds.Pdus["default"].Credentials = new() { Username = "u", Password = "p" };
-        Assert.True(KubernetesConfigWatcher.RequiresRestart(baseline, creds));
-
-        // A second (non-primary) instance is reconciled live — adding or retuning it must not restart.
+        // Adding a second instance stays live too.
         var added = Sample();
         added.Pdus["second"] = new PduConfig { PollInterval = 5 };
         added.Pdus["second"].Connection.Host = "pdu-2.example.com";
         Assert.False(KubernetesConfigWatcher.RequiresRestart(baseline, added));
-
-        var retuned = Sample();
-        retuned.Pdus["second"] = new PduConfig { PollInterval = 5 };
-        retuned.Pdus["second"].Connection.Host = "pdu-2.example.com";
-        var retuned2 = Sample();
-        retuned2.Pdus["second"] = new PduConfig { PollInterval = 30 };
-        retuned2.Pdus["second"].Connection.Host = "pdu-2-moved.example.com";
-        Assert.False(KubernetesConfigWatcher.RequiresRestart(retuned, retuned2));
     }
 }
 

--- a/rPDU2MQTT.Tests/MultiPduConfigTests.cs
+++ b/rPDU2MQTT.Tests/MultiPduConfigTests.cs
@@ -232,3 +232,68 @@ public class PduInstanceRegistryRuntimeTests
         Assert.False(registry.All.ContainsKey("b"));
     }
 }
+
+/// <summary>
+/// Re-pointing the primary instance in place (#192). Its PDU object is the DI singleton the GUI, control
+/// and discovery hold, so it must keep its identity while its connection changes underneath.
+/// </summary>
+public class PrimaryRepointTests
+{
+    private static Config Cfg(string host, int? port = null, string? scheme = null)
+    {
+        var c = new Config();
+        c.Pdus["default"] = new PduConfig { PollInterval = 5 };
+        c.Pdus["default"].Connection.Host = host;
+        c.Pdus["default"].Connection.Port = port;
+        c.Pdus["default"].Connection.Scheme = scheme;
+        return c;
+    }
+
+    [Fact]
+    public void RepointPrimary_KeepsTheSameObject_ButChangesTheTarget()
+    {
+        var cfg = Cfg("pdu-a.example.com");
+        var registry = new PduInstanceRegistry(cfg, new PduInstanceFactory(cfg));
+        var before = registry.Primary;
+        Assert.Contains("pdu-a.example.com", before.BaseAddress);
+
+        var moved = Cfg("pdu-b.example.com", 443, "https");
+        Assert.True(registry.RepointPrimary(moved.Pdus["default"]));
+
+        // Same instance — every existing reference (GUI/control/discovery) must stay valid.
+        Assert.Same(before, registry.Primary);
+        Assert.Contains("pdu-b.example.com", registry.Primary.BaseAddress);
+        Assert.StartsWith("https://", registry.Primary.BaseAddress);
+    }
+
+    [Fact]
+    public void RepointPrimary_IsRefused_WhenTheNewConfigHasNoHost()
+    {
+        var cfg = Cfg("pdu-a.example.com");
+        var registry = new PduInstanceRegistry(cfg, new PduInstanceFactory(cfg));
+
+        var hostless = new PduConfig { PollInterval = 5 };
+
+        Assert.False(registry.RepointPrimary(hostless));
+        // Left pointed at the previous device rather than broken.
+        Assert.Contains("pdu-a.example.com", registry.Primary.BaseAddress);
+    }
+
+    [Fact]
+    public void Repoint_IsIdempotentAndRepeatable()
+    {
+        var cfg = Cfg("pdu-a.example.com");
+        var registry = new PduInstanceRegistry(cfg, new PduInstanceFactory(cfg));
+        var pdu = registry.Primary;
+
+        // Repeated re-points must not leave the PDU wedged (the old HttpClient is disposed each time;
+        // using a disposed client would throw here).
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.True(registry.RepointPrimary(Cfg($"pdu-{i}.example.com").Pdus["default"]));
+            Assert.Contains($"pdu-{i}.example.com", pdu.BaseAddress);
+        }
+
+        Assert.Same(pdu, registry.Primary);
+    }
+}


### PR DESCRIPTION
Follow-up to #200. Finishes #192: **no config change exits the process any more.**

## What was left

#200 made MQTT live but left the primary PDU instance restarting. The reason it was special: its `PDU` object identity is **pinned by DI** — the GUI, control and discovery all hold a reference to that exact instance — so the reconciler could never rebuild it and settled for `Log.Warning("...needs a restart to take effect")`.

That's the same shape of problem the MQTT client had, so it gets the same fix: **keep the object, swap its internals.**

## The fix

`PDU` and `PduApiHandler` gain `Repoint()`. `InstanceManager` stops the primary's poller, re-points the PDU, and starts a new poller — the restart is what picks up a changed `PollInterval`. Stopping first means no poll can observe the PDU mid-swap.

**Everything cached describes the old device, so it's all dropped** — this is the part that would bite subtly if missed:

- **session tokens + the device→web-port map** — replaying these against a new PDU would fail auth or, worse, address the *wrong device* on a OneView cluster;
- **OneView detection** (`useOneView`) — a different host may not be a OneView master;
- **the poll cache**;
- **pending-state latches** — they key off the old device's outlets and would mask the new device's real state until they expired (~2 min).

The old `HttpClient` is disposed rather than leaked with its pooled connection to the previous host.

Failure handling: a hostless or unbuildable new config leaves the primary pointed at the **old** device with its poller still running, rather than silently unpolled.

## Result

`RequiresRestart` is now **only** the listening sockets (GUI/API/health/metrics ports) and GUI auth — genuinely bound once when the host is built.

| Setting | Before #200 | Now |
| --- | --- | --- |
| MQTT broker / credentials / scheme / LWT | restart | **live** |
| Non-primary PDU instances | restart | **live** |
| **Primary PDU** (host, port, scheme, credentials, poll interval) | restart | **live** |
| GUI / API / health / metrics ports, GUI auth | restart | restart |

## Verification

`dotnet build` 0 errors, warnings at the baseline 7. `dotnet test` **174/174** (+3).

The new tests assert the thing that actually matters — that re-pointing **keeps the same object** (`Assert.Same`, so every existing GUI/control/discovery reference stays valid) while the target genuinely changes, that scheme/port are honoured, that a hostless config is refused and leaves the old connection intact, and that repeated re-points don't wedge the PDU (the disposed-client trap — using a disposed `HttpClient` would throw). To make any of this observable I exposed `PDU.BaseAddress`, which the internals already used.

Also confirmed the app still starts (registry/DI construction changed) and the regenerated CRD is byte-identical.

**Not verified here:** no PDU and no cluster in this environment, so the re-point is proven at the object level rather than against real hardware — worth pointing a running instance at a different PDU before release, especially to confirm the OneView re-detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)