### PR TITLE
docs(k8s): fix the Argo CD recipe that let syncs revert GUI edits (#178)

### DIFF
--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -61,7 +61,7 @@ credentials:
 | `serviceMonitor.enabled` | `false` | Create a Prometheus Operator `ServiceMonitor` for `/metrics`. |
 | `serviceMonitor.labels` | `{}` | Extra labels so your Prometheus adopts the ServiceMonitor (e.g. `release: <kube-prometheus-stack release>`); without a match it is silently ignored. |
 | `kubernetesConfigSource.enabled` | `false` | Store config in an `RpduConfig` CR (writable by the GUI) instead of a ConfigMap; creates the CR + RBAC and wires the app to read it. Requires the CRD (in this chart's `crds/`). |
-| `kubernetesConfigSource.preserveExisting` | `true` | Create-once: keep the live CR `spec` on upgrade so GUI edits aren't reverted (`values.config` only seeds it on install). Set `false` for declarative config. Relies on Helm `lookup`, which is empty under Argo CD (`helm template`) — see `manageResource` below. |
+| `kubernetesConfigSource.preserveExisting` | `true` | Create-once: keep the live CR `spec` on upgrade so GUI edits aren't reverted (`values.config` only seeds it on install). Set `false` for declarative config. Relies on Helm `lookup`, so it is a **no-op under Argo CD** (`helm template`) — see *Argo CD and GUI edits* under [Notes](#notes). |
 | `kubernetesConfigSource.manageResource` | `true` | Whether the chart renders the `RpduConfig` CR and the GUI-written credentials `Secret`. Set `false` to manage them out of band so GitOps (Argo/Flux) never syncs over GUI edits; RBAC + the config source stay on, but you must create the CR (and Secret, if used) once yourself. |
 | `ingress.enabled` | `false` | Expose the GUI and/or REST API via an Ingress. Each `ingress.hosts[].paths[]` entry takes an optional `service:` of `gui` (default) or `api`. |
 | `httpRoute.enabled` | `false` | Expose the GUI and/or REST API via a Gateway API `HTTPRoute` (set `httpRoute.parentRefs`/`hostnames`). Requires the Gateway API CRDs. |
@@ -82,6 +82,35 @@ credentials:
   adopts ServiceMonitors matching its `serviceMonitorSelector` — for kube-prometheus-stack that's
   usually `release: <your-stack>`, so set `serviceMonitor.labels` to match or the ServiceMonitor is
   silently ignored.
+- **Argo CD and GUI edits:** if you let the GUI write config (`kubernetesConfigSource.enabled`), Argo
+  will sync `values.config` back over those edits — `preserveExisting` cannot help, because the Helm
+  `lookup` it relies on is always empty under `helm template`. Add this to your **Application**:
+
+  ```yaml
+  spec:
+    ignoreDifferences:
+      - group: rpdu2mqtt.xtremeownage.com
+        kind: RpduConfig
+        jsonPointers:
+          - /spec
+      - group: ""
+        kind: Secret
+        name: <release-name>   # only if the GUI manages credentials
+        jsonPointers:
+          - /data
+    syncPolicy:
+      syncOptions:
+        - RespectIgnoreDifferences=true
+  ```
+
+  **`ignoreDifferences` alone is not enough:** without `RespectIgnoreDifferences=true` it only hides the
+  OutOfSync status while the sync still reverts your config — a green "Synced" app that clobbers you
+  anyway. The first sync still seeds the CR from `values.config` (the option has no effect on resources
+  that don't exist yet), so this behaves exactly like `preserveExisting` does under plain Helm.
+
+  Prefer not to touch the Application? Set `kubernetesConfigSource.manageResource: false` and create the
+  CR yourself once — the chart then renders neither the CR nor the Secret, so Argo never manages them.
+  See [docs/KubernetesCRD.md](../../docs/KubernetesCRD.md).
 - **Exposing the REST API:** enable `config.Api.Enabled` (the chart then creates a `<release>-api`
   Service on `config.Api.Port`), then route to it with `service: api` on an Ingress or HTTPRoute path:
 

--- a/charts/rpdu2mqtt/templates/NOTES.txt
+++ b/charts/rpdu2mqtt/templates/NOTES.txt
@@ -31,3 +31,27 @@ Namespace: {{ .Release.Namespace }}
 WARNING: no credentials were provided. If your MQTT broker or PDU require auth,
 set `credentials.*` (or `existingSecret`) so the RPDU2MQTT_* env vars are injected.
 {{- end }}
+
+{{- if and .Values.kubernetesConfigSource.enabled .Values.kubernetesConfigSource.manageResource .Values.kubernetesConfigSource.preserveExisting }}
+
+NOTE: config is stored in the RpduConfig CR and the GUI can write to it.
+`preserveExisting` keeps your GUI edits across `helm upgrade` — but it relies on
+Helm's `lookup`, which is ALWAYS EMPTY under Argo CD / `helm template`.
+
+If you deploy with Argo CD, add this to your Application or it will sync
+`values.config` back over anything you change in the GUI (#178):
+
+  spec:
+    ignoreDifferences:
+      - group: rpdu2mqtt.xtremeownage.com
+        kind: RpduConfig
+        jsonPointers: [/spec]
+    syncPolicy:
+      syncOptions:
+        - RespectIgnoreDifferences=true
+
+RespectIgnoreDifferences is required: ignoreDifferences on its own only hides the
+OutOfSync status, and the sync still reverts your config.
+Alternatively set `kubernetesConfigSource.manageResource: false` and create the CR
+yourself. See the chart README.
+{{- end }}

--- a/docs/KubernetesCRD.md
+++ b/docs/KubernetesCRD.md
@@ -17,11 +17,11 @@ config from the `RpduConfig` CR when `RPDU2MQTT_CONFIG_SOURCE=k8s` (+ `RPDU2MQTT
 ## Motivation
 
 Today configuration is a single `config.yaml` loaded at startup (see
-[`YamlConfigLoader`](../rPDU2MQTT/Startup/YamlConfigLoader.cs)), optionally mounted from a ConfigMap.
+[`YamlConfigLoader`](../rPDU2MQTT.Engine/YamlConfigLoader.cs)), optionally mounted from a ConfigMap.
 That works, but in Kubernetes it has two rough edges:
 
 1. **A ConfigMap mount is read-only.** The configuration GUI detects this and disables *Save* (see the
-   `configWritable` handling in [`GuiService`](../rPDU2MQTT/Services/Gui/GuiService.cs) and
+   `configWritable` handling in [`GuiService`](../rPDU2MQTT.Web/Gui/GuiService.cs) and
    [Configuration.md](Configuration.md#gui-with-kubernetes--read-only-config)). So in k8s the GUI is
    view/test only.
 2. The config is "just a blob" to Kubernetes — no schema validation, no health/status surfaced to the
@@ -70,7 +70,7 @@ status:
 ```
 
 - **Group/Version/Kind:** `rpdu2mqtt.xtremeownage.com` / `v1alpha1` / `RpduConfig` (namespaced).
-- **`spec`** is the existing [`Config`](../rPDU2MQTT/Models/Config/Config.cs) shape, 1:1. Secrets
+- **`spec`** is the existing [`Config`](../rPDU2MQTT.Core/Models/Config/Config.cs) shape, 1:1. Secrets
   (MQTT/PDU passwords, EmonCMS key) should still be sourceable from env/Secret via the existing
   `RPDU2MQTT_*` overrides so they don't have to live in the CR.
 - **`status`** is a [status subresource](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource)
@@ -79,7 +79,7 @@ status:
 ### Generating the CRD schema from the model (key reuse)
 
 We already reflect over the `Config` model to build the GUI's form schema
-([`ConfigSchema.Build()`](../rPDU2MQTT/Services/Gui/ConfigSchema.cs)). The same reflection can emit the
+([`ConfigSchema.Build()`](../rPDU2MQTT.Core/ConfigSchema.cs)). The same reflection can emit the
 CRD's **OpenAPI v3** `spec` schema, so the CRD validation stays in sync with the model automatically
 instead of being hand-maintained. (Phase 1 can ship with `x-kubernetes-preserve-unknown-fields: true`
 to avoid blocking on this, then tighten the schema once generation is wired up.)
@@ -106,7 +106,7 @@ IConfigSource
   consumes the resulting `Config` exactly as it does today — nothing downstream changes.
 - **Auth:** in-cluster ServiceAccount token; the official `KubernetesClient` NuGet handles in-cluster
   and kubeconfig contexts.
-- **GUI write-back:** the [`POST /api/config`](../rPDU2MQTT/Services/Gui/GuiService.cs) handler calls
+- **GUI write-back:** the [`POST /api/config`](../rPDU2MQTT.Web/Gui/GuiService.cs) handler calls
   `IConfigSource.Save`, which for k8s issues a `PATCH` to the CR `spec`. `configWritable` becomes true,
   re-enabling Save in-cluster.
 
@@ -136,7 +136,7 @@ The CR can be the GitOps source of truth, so:
 
 - After a GUI **Save** that writes to a CR, the UI shows a **notice to update the GitOps source** so the
   cluster's desired state doesn't silently drift from the repo.
-- The GUI's existing **Export** view ([`/api/config/yaml`](../rPDU2MQTT/Services/Gui/GuiService.cs))
+- The GUI's existing **Export** view ([`/api/config/yaml`](../rPDU2MQTT.Web/Gui/GuiService.cs))
   gains a **"RpduConfig manifest"** export that renders the current (edited) config as a ready-to-commit
   CR, **with secrets redacted to placeholders**. This lets users round-trip GUI edits back into source
   control.
@@ -157,21 +157,48 @@ Because the GUI writes the CR `spec` and a redeploy also renders the CR `spec` f
   (`kubernetesConfigSource.preserveExisting: true`) — it reads the live CR with Helm `lookup` and
   re-emits its current `spec`, so `values.config` only seeds the CR on first install. Set
   `preserveExisting: false` to manage the config declaratively (every upgrade applies `values.config`).
-- **Argo CD:** `lookup` returns nothing under `helm template`, so the rendered CR always carries
-  `values.config` and Argo would sync it. Tell Argo to ignore the CR `spec` so GUI edits stick:
+- **Argo CD:** `lookup` returns nothing under `helm template`, so `preserveExisting` is a **no-op under
+  Argo** — the rendered CR always carries `values.config`, and Argo syncs it over your GUI edits (#178).
+  The Argo-native equivalent is `ignoreDifferences` **plus `RespectIgnoreDifferences=true`**:
 
   ```yaml
   # Argo CD Application
   spec:
     ignoreDifferences:
+      # Config the GUI writes.
       - group: rpdu2mqtt.xtremeownage.com
         kind: RpduConfig
         jsonPointers:
           - /spec
+      # Credentials the GUI writes (only if you let it manage the Secret).
+      - group: ""
+        kind: Secret
+        name: <release-name>
+        jsonPointers:
+          - /data
+    syncPolicy:
+      syncOptions:
+        - RespectIgnoreDifferences=true
   ```
 
-  (Or keep config declarative in git and treat the GUI as view/test only — your choice of source of
-  truth. The GUI's Save already warns to update the GitOps source.)
+  > **`ignoreDifferences` on its own is not enough** — and this is the trap. Without
+  > `RespectIgnoreDifferences=true` it only suppresses the **OutOfSync status**; the sync stage still
+  > applies `values.config` and reverts the GUI. You get a green "Synced" app that quietly clobbers your
+  > config anyway. With the sync option set, Argo pre-patches the ignored paths out of the desired state
+  > before applying, so the live `spec` survives.
+
+  This gives exactly the create-once behaviour `preserveExisting` provides under plain Helm, because
+  `RespectIgnoreDifferences` [has no effect when the resource does not yet
+  exist](https://argo-cd.readthedocs.io/en/latest/user-guide/sync-options/): on the **first** sync the CR
+  is created from `values.config` (seeding it), and every sync after that leaves `/spec` alone.
+
+  Alternatives, if you'd rather not touch the Application:
+
+  - `kubernetesConfigSource.manageResource: false` — the chart stops rendering the CR and Secret
+    entirely, so Argo never manages (or prunes) them. You create the CR once yourself; RBAC and the
+    config source stay wired up.
+  - Keep config declarative in git and treat the GUI as view/test only — your choice of source of truth.
+    The GUI's Save already warns to update the GitOps source.
 
 ### Reacting to changes & status (Phase 2)
 
@@ -207,7 +234,7 @@ one-time step), documented alongside the manifests.
 ## Related: Prometheus Operator scraping (ServiceMonitor / PodMonitor)
 
 rPDU2MQTT already exposes a Prometheus `/metrics` endpoint (the
-[`PrometheusExportService`](../rPDU2MQTT/Services/PrometheusExportService.cs), gated by
+[`PrometheusExportService`](../rPDU2MQTT.Engine/Services/PrometheusExportService.cs), gated by
 `Prometheus.Enabled`). In a cluster running the **Prometheus Operator**, we can ship a
 `ServiceMonitor` (or `PodMonitor`) so Prometheus **auto-discovers and scrapes** the endpoint — no
 hand-written scrape config, and it tracks pod restarts/scaling automatically:


### PR DESCRIPTION
Closes #178.

## What's actually wrong

The chart already had the machinery for this (`preserveExisting`, `manageResource`) and the docs already told you to use Argo's `ignoreDifferences`. So why does the GUI still get clobbered?

**Because `ignoreDifferences` on its own doesn't do what it looks like it does.** Per the [Argo CD docs](https://argo-cd.readthedocs.io/en/latest/user-guide/sync-options/), it only affects the **diff / OutOfSync status**. The sync stage still applies `values.config` and reverts your GUI edits. Following the recipe this repo shipped gave you a green **"Synced"** application that quietly overwrote your config anyway — precisely the reported symptom, and worse than no guidance, because it looks like it's working.

The missing half is `RespectIgnoreDifferences=true`, which is what makes Argo pre-patch the ignored paths out of the desired state before applying:

```yaml
spec:
  ignoreDifferences:
    - group: rpdu2mqtt.xtremeownage.com
      kind: RpduConfig
      jsonPointers: [/spec]
    - group: ""
      kind: Secret
      name: <release-name>     # only if the GUI manages credentials
      jsonPointers: [/data]
  syncPolicy:
    syncOptions:
      - RespectIgnoreDifferences=true
```

## Why this is the right fix, not a workaround

It reproduces the **create-once** semantics `preserveExisting` promises but cannot deliver under Argo. `RespectIgnoreDifferences` [has no effect on a resource that doesn't exist yet](https://argo-cd.readthedocs.io/en/latest/user-guide/sync-options/), so:

- **first** sync → CR doesn't exist → desired state applies as-is → `values.config` **seeds** it;
- **every** sync after → `/spec` is patched out → **GUI edits survive**.

That's exactly `preserveExisting`'s behaviour, achieved the Argo-native way instead of via Helm `lookup` — which is **always empty** under `helm template`, making `preserveExisting` a silent no-op under Argo. The docs now say that outright instead of burying it.

## Changes

- **docs/KubernetesCRD.md** — corrected recipe, the Secret `/data` path, an explicit callout of the `ignoreDifferences`-alone trap, and the seeding explanation.
- **charts/rpdu2mqtt/README.md** — an *Argo CD and GUI edits* note with the same recipe; the `preserveExisting` row now says it's a no-op under Argo rather than implying it helps.
- **NOTES.txt** — an install-time warning, **gated to when the GUI can actually write config** (`kubernetesConfigSource.enabled && manageResource && preserveExisting`), so you see it *before* losing config rather than after.
- `manageResource: false` documented as the alternative for anyone who'd rather not touch the Application.
- Fixed **7 doc links** still pointing at pre-v2 paths (`rPDU2MQTT/Services/Gui/...` → `rPDU2MQTT.Web/Gui/...` etc.), found by link-checking the file I was editing.

## Verification

`helm lint` clean; templating with `kubernetesConfigSource.enabled=true` succeeds. Confirmed the NOTES warning renders **only** on the path where it applies — present with the CR config source on, absent by default and absent with `manageResource: false`. All relative doc links now resolve (checked programmatically). Build 0 errors / baseline 7 warnings, tests 174/174 (untouched by this change).

The Argo behaviour is sourced from the upstream docs above rather than my recollection — I checked it specifically because the existing recipe looked correct and wasn't. **Not verified here:** no Argo instance in this environment, so the recipe is grounded in upstream documentation rather than an observed sync. Worth confirming against your actual Application before we call #178 closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)