### PR TITLE
chore: clear the build warnings (OpenApi advisory pin + xUnit2031)

### DIFF
--- a/rPDU2MQTT.Api/rPDU2MQTT.Api.csproj
+++ b/rPDU2MQTT.Api/rPDU2MQTT.Api.csproj
@@ -14,6 +14,8 @@
 	<ItemGroup>
 		<PackageReference Include="HiveMQtt" Version="0.45.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+		<!-- Pinned over the 2.0.0 that AspNetCore.OpenApi 10.0.9 resolves: GHSA-v5pm-xwqc-g5wc is fixed in 2.7.5. -->
+		<PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
 		<PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
 	</ItemGroup>
 

--- a/rPDU2MQTT.Tests/EmonCmsFeedPlannerTests.cs
+++ b/rPDU2MQTT.Tests/EmonCmsFeedPlannerTests.cs
@@ -83,7 +83,7 @@ public class EmonCmsFeedPlannerTests
         var d = EmonCmsFeedPlanner.BuildDesired(data, config);
 
         Assert.Contains(d.Feeds, x => x.Name == "rack_pdu_1_o0_energy" && x.DataType == 1 && x.IntervalSeconds == 10);
-        var daily = Assert.Single(d.Feeds.Where(x => x.DataType == 2));
+        var daily = Assert.Single(d.Feeds, x => x.DataType == 2);
         Assert.Equal("rack_pdu_1_o0_energy_d", daily.Name);
         Assert.Equal(86400, daily.IntervalSeconds);
         Assert.Equal("rack_pdu_1_o0_energy_d", Assert.Single(d.Inputs).DailyFeed);


### PR DESCRIPTION
The build had 7 warnings; it now has **zero**.

## Microsoft.OpenApi advisory

`Microsoft.AspNetCore.OpenApi` 10.0.9 resolves `Microsoft.OpenApi` **2.0.0**, which carries [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) (CVE-2026-49451) — uncontrolled recursion on circular schema references, CVSS 7.5.

Bumping the parent doesn't help: 10.0.10 still pins 2.0.0. So this references the fixed **2.7.5** directly.

**Real-world risk here is low** — the advisory only bites when *parsing untrusted* OpenAPI documents, and we only ever serve one. This is warning hygiene rather than an urgent fix; reasonable to revert and wait for Microsoft to bump the transitive dep upstream if you'd rather not carry the pin.

Because 2.0.0 → 2.7.5 is a big jump that could build clean and break at runtime, I verified the OpenAPI surface against the pinned version using the same package set:

- `/openapi/v1.json` generates (OpenAPI 3.1.1)
- `/scalar/v1` returns 200
- endpoints serve normally

## xUnit2031

Switched to the `Assert.Single` filter overload in `EmonCmsFeedPlannerTests`.

## Verification

- `dotnet build` — succeeded, 0 warnings, 0 errors
- `dotnet test` — 174/174 passing
- GUI bundle builds; `smoke.mjs` passes

## Note on the `ToDo` file

The untracked `ToDo` scratch file is **fully shipped** — every item maps to already-merged work (#163, #176, #178). Left it and the `image*.png` files untouched since they're untracked and deleting them isn't recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)