### PR TITLE
feat(flow): source energy-flow nodes from MQTT (Solar Assistant et al.) (#205)

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -60,6 +60,15 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                     properties:
+                      Scheme:
+                        type: string
+                        enum:
+                        - ''
+                        - mqtt
+                        - mqtts
+                        - ws
+                        - wss
+                        description: 'How to reach the broker: mqtt (plain TCP), mqtts (TLS), ws (WebSocket) or wss (WebSocket over TLS). Leave unset to infer from the port.'
                       Host:
                         type: string
                         description: Hostname or IP to connect to.
@@ -73,9 +82,6 @@ spec:
                         description: Default connection timeout.
                         minimum: 1
                         maximum: 3600
-                      Scheme:
-                        type: string
-                        description: Connection scheme used
                       ValidateCertificate:
                         type: boolean
                         description: Enables certificate validation
@@ -115,6 +121,10 @@ spec:
                           maximum: 3600
                         Scheme:
                           type: string
+                          enum:
+                          - ''
+                          - http
+                          - https
                           description: Connection scheme used
                         ValidateCertificate:
                           type: boolean
@@ -171,6 +181,23 @@ spec:
                   GroupMemberObjectIdTemplate:
                     type: string
                     description: "Stable entity/object_id template for a group's mirrored member switches. Placeholders: {serial}, {number}, {device}, {group}."
+                  EnergyDashboard:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      Enabled:
+                        type: boolean
+                        description: Sync the energy-flow hierarchy into HA's Energy Dashboard via its API. Requires Url + a long-lived access token.
+                      Url:
+                        type: string
+                        description: Home Assistant base URL, e.g. http://homeassistant.local:8123 .
+                      Token:
+                        type: string
+                        description: Home Assistant long-lived access token (or set RPDU2MQTT_HASS_TOKEN).
+                      EnergyMeasurementType:
+                        type: string
+                        description: Measurement type holding each entity's cumulative energy (kWh) — used to find the Energy Dashboard stat for each tier.
+                    description: Auto-configure Home Assistant's Energy Dashboard 'devices' (with upstream relationships) from the energy-flow hierarchy, via HA's WebSocket API.
                 description: Home Assistant Configuration
               Overrides:
                 type: object
@@ -341,6 +368,11 @@ spec:
                   MetricNameTemplate:
                     type: string
                     description: "Template for Prometheus metric names. Placeholders: {type}, {device}, {source} (a.k.a. {outlet}), {units}. e.g. 'rpdu2mqtt_{type}' -> rpdu2mqtt_realpower; 'pdu_{device}_{type}' -> pdu_rack_pdu_1_realpower. (device/source/units are also emitted as labels.)"
+                  Labels:
+                    type: array
+                    items:
+                      type: string
+                    description: "Labels attached to every exported metric. Available: device, source, name, number, type, units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set."
                   Pushgateway:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -389,7 +421,108 @@ spec:
                     description: "Template for EmonCMS input keys. Placeholders: {device}, {source} (object-id form), {name} (formatted display name), {number} (outlet number), {type}, {units}. e.g. '{device}_{source}_{type}' -> rack_pdu_1_dell_md1200_realpower. Leave blank to use the full raw identifier."
                   MqttBaseTopic:
                     type: string
-                    description: Base MQTT topic for EmonCMS's MQTT input; values are published to <base>/<node> as JSON. (Mqtt transport.)
+                    description: Base MQTT topic for EmonCMS's MQTT input (the {base} placeholder of MqttTopicTemplate). (Mqtt transport.)
+                  MqttTopicTemplate:
+                    type: string
+                    description: "Template for the EmonCMS MQTT topic each JSON payload is published to. Placeholders: {base} (MqttBaseTopic), {node}, {device} (the PDU's name). Including {device} splits the export so each PDU publishes to its own topic instead of one combined payload, e.g. '{base}/{node}/{device}'. (Mqtt transport.)"
+                  Feeds:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      AutoConfigure:
+                        type: boolean
+                        description: Create and maintain EmonCMS feeds from the exported inputs (takes effect without a restart).
+                      Types:
+                        type: array
+                        items:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          properties:
+                            Type:
+                              type: string
+                              enum:
+                              - ''
+                              - realpower
+                              - apparentpower
+                              - energy
+                              - current
+                              - voltage
+                              - frequency
+                              - powerfactor
+                              description: The measurement type this applies to (raw PDU type name).
+                            Engine:
+                              type: string
+                              enum:
+                              - MySQL
+                              - PHPTimeSeries
+                              - PHPFina
+                              - VirtualFeed
+                              description: Feed storage engine for this type. Blank inherits Feeds.Engine. PHPFina = fixed-interval, PHPTimeSeries = variable, MySQL = MySQL storage.
+                            IntervalSeconds:
+                              type: integer
+                              description: Sample interval in seconds for this type's feed. Blank inherits Feeds.IntervalSeconds.
+                              minimum: 1
+                              maximum: 86400
+                            Daily:
+                              type: boolean
+                              description: 'Also create a daily kWh/d feed (an extra processlist step: kWh→kWh/d). Typically only for the energy type.'
+                            DailyIntervalSeconds:
+                              type: integer
+                              description: Interval (seconds) for the daily kWh/d feed. Should be a day (86400), not the base interval.
+                              minimum: 1
+                              maximum: 86400
+                        description: The measurement types to build feeds for, each with its own engine, interval and processing.
+                      Engine:
+                        type: string
+                        enum:
+                        - MySQL
+                        - PHPTimeSeries
+                        - PHPFina
+                        - VirtualFeed
+                        description: Default feed storage engine, for types that don't set their own. PHPFina = fixed-interval time series, PHPTimeSeries = variable interval, MySQL = MySQL storage (no phpfina files).
+                      IntervalSeconds:
+                        type: integer
+                        description: Default sample interval in seconds for a fixed-interval feed, for types that don't set their own.
+                        minimum: 1
+                        maximum: 86400
+                      IdempotentNames:
+                        type: boolean
+                        description: Name storage feeds idempotently from stable ids (device/source/type) so they DON'T change when a source is renamed. Turn off to name them from the display name instead (renaming a source renames its feed).
+                      Tag:
+                        type: string
+                        description: The EmonCMS tag (group) new feeds are filed under. Blank uses the input node name.
+                      StorageNameTemplate:
+                        type: string
+                        description: 'Template for the idempotent storage-feed name. Use only stable placeholders ({device}, {source}, {type}, {number}) so it never changes on a rename. Placeholders: {device}, {source}, {name}, {number}, {type}, {units}.'
+                      Virtual:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          Enabled:
+                            type: boolean
+                            description: Create a friendly-named virtual feed for each storage feed, sourced from it (source_feed process).
+                          NameTemplate:
+                            type: string
+                            description: "Template for the friendly virtual-feed name. {name} is the source's display name, so these can change freely without touching the stable storage feeds. Placeholders: {device}, {source}, {name}, {number}, {type}, {units}."
+                          Tag:
+                            type: string
+                            description: The EmonCMS tag (group/node) virtual feeds are filed under — set this to keep the friendly virtual feeds separate from the storage feeds. Blank uses the main Feeds tag.
+                        description: Optionally create friendly-named virtual feeds that source from the stable storage feeds — so dashboards get nice names while the underlying feeds stay idempotent.
+                      Processes:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          LogToFeed:
+                            type: string
+                            description: Process id_num for 'Log to feed' (EmonCMS stores processlists as id_num:feedid; default 1).
+                          KwhToKwhd:
+                            type: string
+                            description: Process id_num for 'kWh to kWh/d', used for daily energy feeds (default 23).
+                          SourceFeed:
+                            type: string
+                            description: Process id_num for 'Source feed', used for virtual feeds (default 53).
+                        description: EmonCMS process ids used in the generated processlists. Match these to your EmonCMS (Inputs → process dropdown).
+                    description: Automatically create and maintain EmonCMS feeds from the exported inputs. (Http transport; needs a read/write API key.)
                 description: EmonCMS exporter
               Logging:
                 type: object
@@ -539,8 +672,87 @@ spec:
                     description: Port the REST API + docs listen on.
                   ApiKey:
                     type: string
-                    description: Optional API key enabling the write/control endpoints. When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).
+                    description: Optional API key enabling the write/control endpoints (or set RPDU2MQTT_API_KEY). When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).
                 description: Read-only REST API + OpenAPI/Scalar docs
+              EnergyFlow:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  Nodes:
+                    type: array
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        Id:
+                          type: string
+                          description: Stable unique id used to wire parents/children.
+                        Label:
+                          type: string
+                          description: Human-readable label shown in the flow diagram.
+                        Value:
+                          type: number
+                          description: Optional fixed value for a leaf node. Used only when no live MQTT source has reported for it.
+                        Mqtt:
+                          type: array
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              Topic:
+                                type: string
+                                description: MQTT topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.
+                              Metric:
+                                type: string
+                                enum:
+                                - ''
+                                - realpower
+                                - apparentpower
+                                - energy
+                                - current
+                                - voltage
+                                - frequency
+                                - powerfactor
+                                description: Which measurement this topic supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                              JsonField:
+                                type: string
+                                description: For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.
+                              Scale:
+                                type: number
+                                description: Multiplier applied to the received value — for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.
+                              StaleAfterSeconds:
+                                type: integer
+                                description: Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).
+                                minimum: 0
+                                maximum: 86400
+                          description: Live values for this node read from MQTT topics (e.g. Solar Assistant). One entry per metric; supersedes Value.
+                    description: Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.
+                  Links:
+                    type: array
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        From:
+                          type: string
+                          description: Source node id — energy flows out of here.
+                        To:
+                          type: string
+                          description: Target node id — energy flows into here.
+                    description: Directed energy-flow links (From feeds To). Allows multiple feeders per node and producer inputs.
+                  Parents:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties:
+                      type: string
+                    description: Legacy single-feeder map (child id -> parent id). Prefer Links; still honored for back-compat.
+                  MqttExport:
+                    type: boolean
+                    description: Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.
+                  MqttTopicTemplate:
+                    type: string
+                    description: "Template for each tier's MQTT topic. Placeholders: {parent} (MQTT parent topic), {id}, {label}, {kind}, {metric}, {units}. e.g. '{parent}/energyflow/{id}'."
+                description: Virtual upstream nodes (breakers, transfer switches, a “Total”) and their feeder wiring for the energy-flow hierarchy. Edited visually on the Flow tab.
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -692,7 +692,40 @@ spec:
                           description: Human-readable label shown in the flow diagram.
                         Value:
                           type: number
-                          description: Optional directly-known value for a leaf node (used until a live sensor is bound).
+                          description: Optional fixed value for a leaf node. Used only when no live MQTT source has reported for it.
+                        Mqtt:
+                          type: array
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              Topic:
+                                type: string
+                                description: MQTT topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.
+                              Metric:
+                                type: string
+                                enum:
+                                - ''
+                                - realpower
+                                - apparentpower
+                                - energy
+                                - current
+                                - voltage
+                                - frequency
+                                - powerfactor
+                                description: Which measurement this topic supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                              JsonField:
+                                type: string
+                                description: For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.
+                              Scale:
+                                type: number
+                                description: Multiplier applied to the received value — for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.
+                              StaleAfterSeconds:
+                                type: integer
+                                description: Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).
+                                minimum: 0
+                                maximum: 86400
+                          description: Live values for this node read from MQTT topics (e.g. Solar Assistant). One entry per metric; supersedes Value.
                     description: Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.
                   Links:
                     type: array

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -688,6 +688,56 @@ curl -X POST -H "X-Api-Key: $KEY" -H "Content-Type: application/json" \
   http://rpdu2mqtt:8082/api/v1/instances/default/outlets/DEVICE/0/control
 ```
 
+## Energy Flow (Optional)
+
+The **Flow** tab models where your energy actually goes: PDU → outlet links are derived automatically, and
+you add the upstream nodes yourself (panels, breakers, a transfer switch, a "Total"). Every tier's value
+rolls up from its children, and with `MqttExport` on, each tier is published to MQTT and — when HA
+discovery is enabled — appears in Home Assistant as its own device.
+
+### Live sources from MQTT
+
+A node doesn't have to be a fixed number. Bind it to a topic that's already on your broker and it becomes a
+live measurement, rolling up and exporting exactly like a PDU outlet does. This is how you pull in a
+producer that rPDU2MQTT doesn't poll itself — **Solar Assistant**, a CT clamp, an inverter bridge.
+
+```yaml
+EnergyFlow:
+  Nodes:
+    - Id: solar
+      Label: Solar Array
+      Mqtt:
+        # Solar Assistant's /state topics publish a bare number, so no JsonField is needed.
+        - Topic: solar_assistant/inverter_1/pv_power/state
+          Metric: realpower           # drives the power roll-up (W)
+        - Topic: solar_assistant/inverter_1/pv_energy/state
+          Metric: energy              # drives the energy roll-up (kWh) -> HA Energy Dashboard
+    - Id: main_panel
+      Label: Main Panel
+  Links:
+    - { From: solar, To: main_panel }
+  MqttExport: true
+```
+
+Per-source settings:
+
+| Setting | Purpose |
+| --- | --- |
+| `Topic` | The topic to subscribe to. Bound live — adding one in the GUI needs no restart. |
+| `Metric` | Which roll-up this feeds (`realpower`, `energy`, …). Bind one topic per metric to drive both power and energy. |
+| `JsonField` | For JSON payloads, the field to read — dotted for nesting (`battery.power`). Blank means the whole payload is the number. |
+| `Scale` | Multiplier for unit conversion (`0.001` for W → kW) or to flip a sign convention (`-1`). |
+| `StaleAfterSeconds` | Ignore the value once it's this old (default 900). Stops a dead publisher from propping up the flow with a reading that stopped being true. `0` disables the check. |
+
+Notes:
+
+- A live reading **supersedes** the node's fixed `Value`, which stays as the fallback for anything you're
+  modelling by hand. A live `0` is a real reading (solar at night), not a fall-back to `Value`.
+- Negative readings are clamped to `0` — a directed flow graph can't carry a negative, and it would
+  subtract from the roll-up. Use `Scale: -1` if your publisher's sign convention is inverted.
+- Values feed the same exports as everything else, so an MQTT-sourced node reaches Prometheus, the MQTT
+  tier export, and the HA Energy Dashboard without any extra wiring.
+
 ## Example Configurations
 
 Here- are a few example configuration files.

--- a/rPDU2MQTT.Api/ApiService.cs
+++ b/rPDU2MQTT.Api/ApiService.cs
@@ -28,10 +28,12 @@ public sealed class ApiService : IHostedService, IAsyncDisposable
     private readonly ISnapshotCache snapshots;
     private readonly HealthState health;
     private readonly IHiveMQClient mqtt;
+    private readonly Core.Flow.IFlowValueSource? live;
     private WebApplication? app;
 
-    public ApiService(Config cfg, PduInstanceRegistry registry, ISnapshotCache snapshots, HealthState health, IHiveMQClient mqtt)
+    public ApiService(Config cfg, PduInstanceRegistry registry, ISnapshotCache snapshots, HealthState health, IHiveMQClient mqtt, Core.Flow.IFlowValueSource? live = null)
     {
+        this.live = live;
         this.cfg = cfg;
         this.registry = registry;
         this.snapshots = snapshots;
@@ -108,7 +110,7 @@ public sealed class ApiService : IHostedService, IAsyncDisposable
             if (snap is null)
                 return Results.NotFound(new { ok = false, message = "No snapshot available yet for that instance." });
 
-            return Results.Ok(FlowGraphBuilder.Build(snap.Data, cfg.EnergyFlow, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric));
+            return Results.Ok(FlowGraphBuilder.Build(snap.Data, cfg.EnergyFlow, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric, live));
         }).WithName("GetFlow").WithSummary("Energy/power flow graph (PDU -> outlets) for a Sankey view; ?instance= and ?metric= (default realpower).");
 
         // --- Write/control (opt-in: requires Api.ApiKey set + a matching X-Api-Key header) ---

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -17,7 +17,11 @@ public static class FlowGraphBuilder
     public static FlowGraph Build(PduData data, string metric = DefaultMetric)
         => Build(data, null, metric);
 
-    public static FlowGraph Build(PduData data, EnergyFlowConfig? flow, string metric = DefaultMetric)
+    /// <param name="live">
+    /// Optional supplier of live leaf values for custom nodes (MQTT/Solar Assistant today, #205). A live
+    /// reading for the metric being built wins over the node's static <c>Value</c>.
+    /// </param>
+    public static FlowGraph Build(PduData data, EnergyFlowConfig? flow, string metric = DefaultMetric, IFlowValueSource? live = null)
     {
         flow ??= new EnergyFlowConfig();
         var label = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -89,14 +93,26 @@ public static class FlowGraphBuilder
             }
         }
 
-        // Custom upstream nodes (#129). A node with a directly-known Value is a leaf source (the seam
-        // where external sensors — CT clamps, emoncms, Tigo, inverter ports — will bind their live value).
+        // Custom upstream nodes (#129). A node is a leaf source when it has a value of its own: a live
+        // reading bound to this metric (MQTT/Solar Assistant, #205) if one has arrived, else the static
+        // Value. Nodes that aggregate children have neither and are summed from below.
         foreach (var n in flow.Nodes)
             if (!string.IsNullOrEmpty(n.Id))
             {
                 label[n.Id] = string.IsNullOrEmpty(n.Label) ? n.Id : n.Label;
                 if (!kind.ContainsKey(n.Id)) kind[n.Id] = "node";
-                if (n.Value is > 0) leaf[n.Id] = n.Value.Value;
+                if (live is not null && live.TryGetValue(n.Id, metric, out var liveValue))
+                {
+                    // A live reading is authoritative even at 0: solar at night generates nothing, and the
+                    // static Value must not resurrect a phantom figure. (0 makes it a producer supplying 0,
+                    // so its links drop out — as opposed to having no value at all, which would make it an
+                    // aggregator that passes its children's demand upward.)
+                    // A negative reading — a battery under the opposite sign convention — can't be expressed
+                    // in a directed DAG and would subtract from the roll-up, so clamp it; use Scale: -1 on
+                    // the source to flip the convention instead.
+                    leaf[n.Id] = Math.Max(0, liveValue);
+                }
+                else if (n.Value is > 0) leaf[n.Id] = n.Value.Value;
             }
 
         // Custom directed links (From feeds To) plus legacy Parents (parent feeds child) — only when both

--- a/rPDU2MQTT.Core/Flow/FlowValueCache.cs
+++ b/rPDU2MQTT.Core/Flow/FlowValueCache.cs
@@ -1,0 +1,43 @@
+using System.Collections.Concurrent;
+
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// Holds the newest externally-reported value per (node, metric) and expires it once the publisher goes
+/// quiet (#205). Kept free of any transport so the staleness rules are testable on their own; the MQTT
+/// ingest (<c>EnergyFlowMqttSourceService</c>) is just one writer, and a future CT-clamp or inverter
+/// poller can share it.
+/// </summary>
+public sealed class FlowValueCache : IFlowValueSource
+{
+    private sealed record Reading(double Value, DateTime AtUtc, int StaleAfterSeconds);
+
+    // Written from broker callbacks, read by the exporters/GUI — hence concurrent.
+    private readonly ConcurrentDictionary<(string Node, string Metric), Reading> latest = new();
+
+    /// <summary>Record a reading. <paramref name="staleAfterSeconds"/> of 0 means it never expires.</summary>
+    public void Set(string nodeId, string metric, double value, int staleAfterSeconds, DateTime nowUtc)
+        => latest[(nodeId, metric)] = new Reading(value, nowUtc, staleAfterSeconds);
+
+    public void Remove(string nodeId, string metric) => latest.TryRemove((nodeId, metric), out _);
+
+    /// <summary>The (node, metric) pairs currently held, fresh or not.</summary>
+    public IReadOnlyCollection<(string Node, string Metric)> Keys => latest.Keys.ToList();
+
+    public bool TryGetValue(string nodeId, string metric, out double value)
+        => TryGetValue(nodeId, metric, DateTime.UtcNow, out value);
+
+    /// <summary>Testable overload: resolve against an explicit "now".</summary>
+    public bool TryGetValue(string nodeId, string metric, DateTime nowUtc, out double value)
+    {
+        value = 0;
+        if (!latest.TryGetValue((nodeId, metric), out var r))
+            return false;
+        // A dead publisher must not keep propping up the flow (and the energy dashboard) with a value that
+        // stopped being true hours ago — better to drop the node than to export a stale reading as current.
+        if (r.StaleAfterSeconds > 0 && (nowUtc - r.AtUtc).TotalSeconds > r.StaleAfterSeconds)
+            return false;
+        value = r.Value;
+        return true;
+    }
+}

--- a/rPDU2MQTT.Core/Flow/IFlowValueSource.cs
+++ b/rPDU2MQTT.Core/Flow/IFlowValueSource.cs
@@ -1,0 +1,18 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// Supplies live leaf values for flow nodes that aren't derived from a PDU — the seam
+/// <see cref="Models.Config.EnergyFlowNode.Value"/> always described: a node can bind to a real
+/// measurement instead of a hand-entered figure. Implemented today by the MQTT ingest
+/// (<c>EnergyFlowMqttSourceService</c>, e.g. Solar Assistant); CT clamps or an inverter API can plug in
+/// the same way without touching <see cref="FlowGraphBuilder"/>.
+/// </summary>
+public interface IFlowValueSource
+{
+    /// <summary>
+    /// The current value for <paramref name="nodeId"/> expressed in <paramref name="metric"/>
+    /// (e.g. <c>realpower</c>, <c>energy</c>), or false when this source has nothing fresh for it.
+    /// Values are per-metric, so a node can feed both the power and the energy roll-up from different topics.
+    /// </summary>
+    bool TryGetValue(string nodeId, string metric, out double value);
+}

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -65,12 +65,51 @@ public class EnergyFlowNode
     public string Label { get; set; } = "";
 
     /// <summary>
-    /// A directly-known value for this node, used when it has no children (a leaf). The seam where
-    /// external sensors will bind: today it's a manual/known figure (e.g. an untracked load, or a panel
-    /// you're modelling before its CT clamp is ingested); later a node can instead bind to a live
-    /// measurement from any producer (CT clamps over MQTT/emoncms, Tigo solar, inverter ports, …).
-    /// Ignored when the node aggregates children.
+    /// A directly-known value for this node, used when it has no children (a leaf) and no <see cref="Mqtt"/>
+    /// source has reported. A manual/known figure — e.g. an untracked load, or a panel you're modelling
+    /// before its CT clamp is ingested. Ignored when the node aggregates children.
     /// </summary>
-    [Description("Optional directly-known value for a leaf node (used until a live sensor is bound).")]
+    [Description("Optional fixed value for a leaf node. Used only when no live MQTT source has reported for it.")]
     public double? Value { get; set; }
+
+    /// <summary>
+    /// Live measurements for this leaf node, read straight off the broker (#205) — the seam
+    /// <see cref="Value"/> always described. One entry per metric, so the same node can feed both the
+    /// power and the energy roll-up (e.g. Solar Assistant's <c>pv_power</c> and <c>pv_energy</c> topics).
+    /// A live reading supersedes <see cref="Value"/>; ignored when the node aggregates children.
+    /// </summary>
+    [Description("Live values for this node read from MQTT topics (e.g. Solar Assistant). One entry per metric; supersedes Value.")]
+    public List<EnergyFlowMqttSource> Mqtt { get; set; } = new();
+}
+
+/// <summary>
+/// Binds one MQTT topic to one metric of a flow node (#205). Built for producers that already publish to
+/// the broker — Solar Assistant, CT clamps, an inverter bridge — so their data joins the same hierarchy,
+/// roll-ups and exports as the PDU outlets.
+/// </summary>
+public class EnergyFlowMqttSource
+{
+    [Description("MQTT topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.")]
+    public string Topic { get; set; } = "";
+
+    [DefaultValue("realpower")]
+    [Description("Which measurement this topic supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.")]
+    [AllowedValues("realpower", "apparentpower", "energy", "current", "voltage", "frequency", "powerfactor")]
+    public string Metric { get; set; } = "realpower";
+
+    /// <summary>
+    /// For JSON payloads: the field to read, dotted for nesting (<c>battery.power</c>). Blank treats the
+    /// whole payload as the number, which is what Solar Assistant's <c>/state</c> topics publish.
+    /// </summary>
+    [Description("For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.")]
+    public string? JsonField { get; set; }
+
+    [DefaultValue(1.0)]
+    [Description("Multiplier applied to the received value — for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.")]
+    public double Scale { get; set; } = 1.0;
+
+    [DefaultValue(900)]
+    [Range(0, 86400, ErrorMessage = "StaleAfterSeconds must be between 0 and 86400.")]
+    [Description("Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).")]
+    public int StaleAfterSeconds { get; set; } = 900;
 }

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -19,8 +19,10 @@ public class EnergyFlowMqttExportService : baseMQTTService
     // Discovery config topics we've already retired (once per process) — the duplicate energyflow sensors
     // an earlier build published for outlets/PDU tiers (#177). Cleared by an empty retained message.
     private readonly HashSet<string> clearedDuplicates = new();
+    private readonly IFlowValueSource? live;
 
-    public EnergyFlowMqttExportService(MQTTServiceDependencies deps) : base(deps, deps.Cfg.Primary.PollInterval) { }
+    public EnergyFlowMqttExportService(MQTTServiceDependencies deps, IFlowValueSource? live = null) : base(deps, deps.Cfg.Primary.PollInterval)
+        => this.live = live;
 
     protected override async Task Execute(CancellationToken cancellationToken)
     {
@@ -37,9 +39,9 @@ public class EnergyFlowMqttExportService : baseMQTTService
 
         // Power defines the hierarchy/topics; energy is the same roll-up over the energy measurement, so
         // each tier gets a total (kWh) it can contribute to the Energy Dashboard.
-        var graph = FlowGraphBuilder.Build(merged, flow, FlowGraphBuilder.DefaultMetric);
+        var graph = FlowGraphBuilder.Build(merged, flow, FlowGraphBuilder.DefaultMetric, live);
         var energyMetric = string.IsNullOrWhiteSpace(cfg.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : cfg.HASS.EnergyDashboard.EnergyMeasurementType;
-        var energyGraph = FlowGraphBuilder.Build(merged, flow, energyMetric);
+        var energyGraph = FlowGraphBuilder.Build(merged, flow, energyMetric, live);
 
         var publishDiscovery = cfg.HASS.DiscoveryEnabled && !string.IsNullOrWhiteSpace(cfg.HASS.DiscoveryTopic);
         var availability = cfg.MQTT.LastWill ? MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic) : null;

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -1,0 +1,191 @@
+using System.Globalization;
+using System.Text.Json;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Events;
+using HiveMQtt.MQTT5.Types;
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Feeds energy-flow nodes from data already on the broker (#205) — Solar Assistant, CT clamps, an
+/// inverter bridge — by subscribing to the topics bound in <c>EnergyFlow.Nodes[].Mqtt</c> and keeping the
+/// latest value per (node, metric). <see cref="FlowGraphBuilder"/> reads it through
+/// <see cref="IFlowValueSource"/>, so an MQTT-sourced node rolls up, exports and appears in Home
+/// Assistant exactly like a PDU outlet does.
+///
+/// Subscriptions are reconciled on a timer rather than only at startup, so binding a topic in the GUI
+/// takes effect without a restart (matching the rest of the app's live-reload behaviour).
+/// </summary>
+public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueSource
+{
+    private readonly HiveMQClient mqtt;
+    private readonly Config cfg;
+    // The staleness rules live in the cache (Core) so they're testable without a broker.
+    private readonly FlowValueCache latest = new();
+    // Topic -> the bindings fed by it. One topic may drive several nodes/metrics.
+    private volatile Dictionary<string, List<(string NodeId, EnergyFlowMqttSource Source)>> bindings = new(StringComparer.Ordinal);
+    private readonly HashSet<string> subscribed = new(StringComparer.Ordinal);
+
+    public EnergyFlowMqttSourceService(MQTTServiceDependencies deps)
+    {
+        // OnMessageReceived lives on the concrete client, not the interface.
+        mqtt = deps.Mqtt as HiveMQClient
+            ?? throw new InvalidOperationException("Expected a HiveMQClient instance for energy-flow MQTT sources.");
+        cfg = deps.Cfg;
+    }
+
+    public bool TryGetValue(string nodeId, string metric, out double value)
+        => latest.TryGetValue(nodeId, metric, out value);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        mqtt.OnMessageReceived += OnMessageReceived;
+        try
+        {
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(15));
+            do
+            {
+                try { await Reconcile(stoppingToken); }
+                catch (OperationCanceledException) { return; }
+                catch (Exception ex) { Log.Warning($"Energy-flow MQTT sources: {ex.Message}"); }
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+        catch (OperationCanceledException) { /* shutting down */ }
+        finally { mqtt.OnMessageReceived -= OnMessageReceived; }
+    }
+
+    /// <summary>Bring the broker subscriptions in line with the current config (added/removed topics).</summary>
+    private async Task Reconcile(CancellationToken ct)
+    {
+        var desired = BuildBindings(cfg.EnergyFlow.Nodes);
+        bindings = desired;
+
+        foreach (var topic in desired.Keys)
+        {
+            if (!subscribed.Add(topic)) continue;
+            try
+            {
+                // AtLeastOnce so a value isn't silently dropped; retained messages arrive immediately, which
+                // is what makes a restarted process pick up e.g. Solar Assistant's last reading at once.
+                await mqtt.SubscribeAsync(topic, QualityOfService.AtLeastOnceDelivery);
+                Log.Information($"Energy-flow: subscribed to {topic}.");
+            }
+            catch (Exception ex)
+            {
+                subscribed.Remove(topic);   // retry on the next pass
+                Log.Warning($"Energy-flow: could not subscribe to {topic}: {ex.Message}");
+            }
+            if (ct.IsCancellationRequested) return;
+        }
+
+        foreach (var topic in subscribed.Where(t => !desired.ContainsKey(t)).ToList())
+        {
+            try
+            {
+                await mqtt.UnsubscribeAsync(topic);
+                subscribed.Remove(topic);
+                // Drop its cached readings too, so an unbound topic stops feeding the graph immediately.
+                foreach (var key in latest.Keys.Where(k => BoundOnlyBy(k, topic))) latest.Remove(key.Node, key.Metric);
+                Log.Information($"Energy-flow: unsubscribed from {topic}.");
+            }
+            catch (Exception ex) { Log.Warning($"Energy-flow: could not unsubscribe from {topic}: {ex.Message}"); }
+        }
+    }
+
+    /// <summary>Is this cached (node, metric) no longer produced by any still-bound topic?</summary>
+    private bool BoundOnlyBy((string Node, string Metric) key, string removedTopic)
+    {
+        foreach (var (topic, list) in bindings)
+        {
+            if (topic == removedTopic) continue;
+            foreach (var (nodeId, src) in list)
+                if (nodeId == key.Node && string.Equals(src.Metric, key.Metric, StringComparison.OrdinalIgnoreCase))
+                    return false;
+        }
+        return true;
+    }
+
+    private void OnMessageReceived(object? sender, OnMessageReceivedEventArgs e)
+        => Apply(bindings, latest, e.PublishMessage.Topic, e.PublishMessage.PayloadAsString, DateTime.UtcNow);
+
+    /// <summary>Flatten the nodes' MQTT bindings into a topic → (node, source) lookup for the subscriber.</summary>
+    internal static Dictionary<string, List<(string NodeId, EnergyFlowMqttSource Source)>> BuildBindings(IEnumerable<EnergyFlowNode> nodes)
+    {
+        var desired = new Dictionary<string, List<(string, EnergyFlowMqttSource)>>(StringComparer.Ordinal);
+        foreach (var node in nodes)
+        {
+            if (string.IsNullOrWhiteSpace(node.Id) || node.Mqtt is null) continue;
+            foreach (var src in node.Mqtt)
+            {
+                if (string.IsNullOrWhiteSpace(src.Topic) || string.IsNullOrWhiteSpace(src.Metric)) continue;
+                var topic = src.Topic.Trim();
+                if (!desired.TryGetValue(topic, out var list)) desired[topic] = list = new();
+                list.Add((node.Id.Trim(), src));
+            }
+        }
+        return desired;
+    }
+
+    /// <summary>
+    /// Route one received message into the cache: for every (node, metric) bound to <paramref name="topic"/>,
+    /// parse the payload, scale it, and store it. The broker callback and the tests share this so the whole
+    /// subscribe → parse → cache glue is exercised without a live broker.
+    /// </summary>
+    internal static void Apply(
+        IReadOnlyDictionary<string, List<(string NodeId, EnergyFlowMqttSource Source)>> bindings,
+        FlowValueCache cache, string? topic, string? payload, DateTime nowUtc)
+    {
+        if (topic is null || !bindings.TryGetValue(topic, out var list) || string.IsNullOrWhiteSpace(payload))
+            return;
+
+        foreach (var (nodeId, src) in list)
+        {
+            if (!TryParse(payload, src.JsonField, out var raw))
+            {
+                Log.Debug($"Energy-flow: could not read a number from {topic} for node '{nodeId}' (payload: {Truncate(payload)}).");
+                continue;
+            }
+            cache.Set(nodeId, src.Metric, raw * src.Scale, src.StaleAfterSeconds, nowUtc);
+        }
+    }
+
+    private static string Truncate(string s) => s.Length <= 80 ? s : s[..80] + "…";
+
+    /// <summary>
+    /// Read a number out of a payload: the bare value (Solar Assistant's <c>/state</c> topics), or
+    /// <paramref name="jsonField"/> out of a JSON object (dotted for nesting).
+    /// </summary>
+    internal static bool TryParse(string payload, string? jsonField, out double value)
+    {
+        value = 0;
+        payload = payload.Trim();
+        if (string.IsNullOrEmpty(payload)) return false;
+
+        if (string.IsNullOrWhiteSpace(jsonField))
+            return double.TryParse(payload, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
+
+        try
+        {
+            using var doc = JsonDocument.Parse(payload);
+            var el = doc.RootElement;
+            foreach (var part in jsonField.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (el.ValueKind != JsonValueKind.Object || !el.TryGetProperty(part, out el))
+                    return false;
+            }
+            return el.ValueKind switch
+            {
+                JsonValueKind.Number => el.TryGetDouble(out value),
+                // Numbers-as-strings are common in hand-rolled bridges.
+                JsonValueKind.String => double.TryParse(el.GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out value),
+                _ => false,
+            };
+        }
+        catch (JsonException) { return false; }
+    }
+}

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -17,12 +17,14 @@ public sealed class HaEnergyDashboardSync
 {
     private readonly Config config;
     private readonly Core.ISnapshotCache snapshots;
+    private readonly Core.Flow.IFlowValueSource? live;
     private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
 
-    public HaEnergyDashboardSync(Config config, Core.ISnapshotCache snapshots)
+    public HaEnergyDashboardSync(Config config, Core.ISnapshotCache snapshots, Core.Flow.IFlowValueSource? live = null)
     {
         this.config = config;
         this.snapshots = snapshots;
+        this.live = live;
     }
 
     /// <summary>
@@ -43,7 +45,7 @@ public sealed class HaEnergyDashboardSync
         var energyType = string.IsNullOrWhiteSpace(config.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : config.HASS.EnergyDashboard.EnergyMeasurementType;
         var native = FlowExport.NativeEnergyUniqueIds(merged, energyType);
 
-        var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric);
+        var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric, live);
         Func<string, string?> resolver = id =>
         {
             var uid = native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id);

--- a/rPDU2MQTT.Engine/Services/PrometheusExportService.cs
+++ b/rPDU2MQTT.Engine/Services/PrometheusExportService.cs
@@ -15,9 +15,11 @@ public class PrometheusExportService : baseMQTTService
     private readonly Dictionary<string, Gauge> gauges = new();
     private readonly IMetricServer? exporter;
     private readonly IMetricServer? pusher;
+    private readonly Core.Flow.IFlowValueSource? live;
 
-    public PrometheusExportService(MQTTServiceDependencies deps) : base(deps, deps.Cfg.Primary.PollInterval)
+    public PrometheusExportService(MQTTServiceDependencies deps, Core.Flow.IFlowValueSource? live = null) : base(deps, deps.Cfg.Primary.PollInterval)
     {
+        this.live = live;
         var cfg = deps.Cfg.Prometheus;
 
         if (cfg.Exporter)
@@ -87,7 +89,7 @@ public class PrometheusExportService : baseMQTTService
             foreach (var data in FreshSnapshots()) merged.Devices.AddRange(data.Devices);
             if (merged.Devices.Count == 0) return map;
 
-            var graph = Core.Flow.FlowGraphBuilder.Build(merged, cfg.EnergyFlow, Core.Flow.FlowGraphBuilder.DefaultMetric);
+            var graph = Core.Flow.FlowGraphBuilder.Build(merged, cfg.EnergyFlow, Core.Flow.FlowGraphBuilder.DefaultMetric, live);
             var labels = graph.Nodes.ToDictionary(n => n.Id, n => n.Label, StringComparer.OrdinalIgnoreCase);
             foreach (var node in graph.Nodes)
                 if (Core.Flow.FlowExport.Parents(graph, node.Id).FirstOrDefault() is { } parent)

--- a/rPDU2MQTT.Tests/ConfigSchemaTests.cs
+++ b/rPDU2MQTT.Tests/ConfigSchemaTests.cs
@@ -238,6 +238,41 @@ public class ConfigSchemaTests
     }
 
     [Fact]
+    public void EnergyFlowMqttSources_SurviveTheSaveThenReloadRoundTrip()
+    {
+        // Same path as above, for the live MQTT bindings (#205). The GUI is the only way to set these, so
+        // if they don't survive JSON -> YAML -> load, a bound topic silently disappears on save.
+        var posted = new Config();
+        posted.EnergyFlow.Nodes.Add(new EnergyFlowNode
+        {
+            Id = "solar",
+            Label = "Solar",
+            Mqtt =
+            {
+                new EnergyFlowMqttSource { Topic = "solar_assistant/inverter_1/pv_power/state", Metric = "realpower" },
+                new EnergyFlowMqttSource { Topic = "solar_assistant/inverter_1/pv_energy/state", Metric = "energy", JsonField = "value", Scale = 0.001, StaleAfterSeconds = 0 },
+            },
+        });
+
+        var parsed = ConfigSchema.FromJson(ConfigSchema.ToJson(posted));
+        var yaml = ConfigSchema.ToYaml(parsed);
+        var reloaded = YamlConfigLoader.DeserializeString(yaml);
+
+        var node = Assert.Single(reloaded.EnergyFlow.Nodes);
+        Assert.Equal(2, node.Mqtt.Count);
+
+        var power = Assert.Single(node.Mqtt, s => s.Metric == "realpower");
+        Assert.Equal("solar_assistant/inverter_1/pv_power/state", power.Topic);
+        Assert.Equal(1.0, power.Scale);                 // default survives
+        Assert.Equal(900, power.StaleAfterSeconds);     // default survives
+
+        var energy = Assert.Single(node.Mqtt, s => s.Metric == "energy");
+        Assert.Equal("value", energy.JsonField);
+        Assert.Equal(0.001, energy.Scale);
+        Assert.Equal(0, energy.StaleAfterSeconds);      // an explicit 0 must not be lost to the default
+    }
+
+    [Fact]
     public void Build_UsesFriendlyDisplayNamesAndHelpText()
     {
         // PDU settings now live under the Pdus instance map; the per-instance schema is its ValueSchema.

--- a/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
+++ b/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
@@ -1,0 +1,389 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.PDU;
+using rPDU2MQTT.Services;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Energy-flow nodes fed from MQTT (#205) — payload parsing, and the builder preferring a live reading
+/// over the node's static Value.
+/// </summary>
+public class EnergyFlowMqttSourceTests
+{
+    /// <summary>A stand-in for the live MQTT cache: whatever the test says is currently reported.</summary>
+    private sealed class FakeLive : IFlowValueSource
+    {
+        private readonly Dictionary<(string, string), double> values = new();
+        public FakeLive Set(string node, string metric, double v) { values[(node, metric)] = v; return this; }
+        public bool TryGetValue(string nodeId, string metric, out double value)
+            => values.TryGetValue((nodeId, metric), out value);
+    }
+
+    private static Outlet Outlet(int key, string name, string type, string value, string units = "W")
+    {
+        var o = new Outlet { Key = key, Entity_Name = $"o{key}", Entity_DisplayName = name };
+        o.Measurements.Add(new Measurement { Type = type, Value = value, Units = units });
+        return o;
+    }
+
+    private static PduData OnePdu(params Outlet[] outlets)
+    {
+        var device = new Device { Key = "pdu1", Entity_Name = "pdu1", Entity_DisplayName = "PDU 1" };
+        device.Outlets.AddRange(outlets);
+        var data = new PduData();
+        data.Devices.Add(device);
+        return data;
+    }
+
+    // --- Payload parsing ---------------------------------------------------------------------------
+
+    [Theory]
+    // Solar Assistant's /state topics publish the bare number.
+    [InlineData("1234", 1234d)]
+    [InlineData("1234.5", 1234.5d)]
+    [InlineData("  42 ", 42d)]
+    [InlineData("-15.5", -15.5d)]
+    [InlineData("0", 0d)]
+    public void TryParse_ReadsABarePayload(string payload, double expected)
+    {
+        Assert.True(EnergyFlowMqttSourceService.TryParse(payload, null, out var v));
+        Assert.Equal(expected, v);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("ON")]
+    [InlineData("unavailable")]
+    public void TryParse_RejectsANonNumericPayload(string payload)
+        => Assert.False(EnergyFlowMqttSourceService.TryParse(payload, null, out _));
+
+    [Fact]
+    public void TryParse_ReadsAJsonField()
+    {
+        Assert.True(EnergyFlowMqttSourceService.TryParse("""{"power":812.5,"unit":"W"}""", "power", out var v));
+        Assert.Equal(812.5, v);
+    }
+
+    [Fact]
+    public void TryParse_ReadsANestedJsonField()
+    {
+        Assert.True(EnergyFlowMqttSourceService.TryParse("""{"battery":{"power":-240}}""", "battery.power", out var v));
+        Assert.Equal(-240, v);
+    }
+
+    [Fact]
+    public void TryParse_ReadsANumberPublishedAsAString()
+    {
+        Assert.True(EnergyFlowMqttSourceService.TryParse("""{"power":"812.5"}""", "power", out var v));
+        Assert.Equal(812.5, v);
+    }
+
+    [Theory]
+    [InlineData("""{"power":1}""", "missing")]          // field absent
+    [InlineData("""{"power":{"a":1}}""", "power")]      // field isn't a number
+    [InlineData("not json", "power")]                   // payload isn't JSON
+    [InlineData("""{"power":1}""", "power.deeper")]     // path runs past a leaf
+    public void TryParse_RejectsAJsonPayloadItCannotRead(string payload, string field)
+        => Assert.False(EnergyFlowMqttSourceService.TryParse(payload, field, out _));
+
+    [Fact]
+    public void TryParse_WithoutAFieldDoesNotAcceptAJsonObject()
+        => Assert.False(EnergyFlowMqttSourceService.TryParse("""{"power":1}""", null, out _));
+
+    // --- Staleness (FlowValueCache) ----------------------------------------------------------------
+
+    [Fact]
+    public void Cache_ReturnsAFreshReading()
+    {
+        var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+        var cache = new FlowValueCache();
+        cache.Set("solar", "realpower", 750, staleAfterSeconds: 900, now);
+
+        Assert.True(cache.TryGetValue("solar", "realpower", now.AddSeconds(60), out var v));
+        Assert.Equal(750, v);
+    }
+
+    [Fact]
+    public void Cache_ExpiresAReadingOnceThePublisherGoesQuiet()
+    {
+        // The point of the whole staleness rule: a dead Solar Assistant must stop propping up the flow.
+        var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+        var cache = new FlowValueCache();
+        cache.Set("solar", "realpower", 750, staleAfterSeconds: 900, now);
+
+        Assert.True(cache.TryGetValue("solar", "realpower", now.AddSeconds(900), out _));
+        Assert.False(cache.TryGetValue("solar", "realpower", now.AddSeconds(901), out _));
+    }
+
+    [Fact]
+    public void Cache_ZeroStaleAfterMeansNeverExpires()
+    {
+        var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+        var cache = new FlowValueCache();
+        cache.Set("meter", "energy", 42, staleAfterSeconds: 0, now);
+
+        Assert.True(cache.TryGetValue("meter", "energy", now.AddDays(30), out var v));
+        Assert.Equal(42, v);
+    }
+
+    [Fact]
+    public void Cache_AnExpiredNodeDropsOutOfTheGraphRatherThanExportingAStaleValue()
+    {
+        // The builder resolves freshness against the real clock (no seam for "now"), so seed timestamps
+        // relative to DateTime.UtcNow rather than a fixed instant, or the "fresh" reading is already stale.
+        var cache = new FlowValueCache();
+
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig();
+        flow.Nodes.Add(new EnergyFlowNode { Id = "solar", Label = "Solar" });
+        flow.Links.Add(new EnergyFlowLink { From = "solar", To = "outlet:pdu1:0" });
+
+        // Fresh: just published, so solar supplies its reading.
+        cache.Set("solar", "realpower", 750, staleAfterSeconds: 60, DateTime.UtcNow);
+        Assert.Equal(750, Assert.Single(FlowGraphBuilder.Build(data, flow, "realpower", cache).Links, l => l.Source == "solar").Value);
+
+        // Stale: last published a day ago, past the 60s window. The reading is gone, so the node has no
+        // value of its own and falls back to carrying the outlet's demand rather than reporting a
+        // generation figure that stopped being true.
+        cache.Set("solar", "realpower", 750, staleAfterSeconds: 60, DateTime.UtcNow.AddDays(-1));
+        Assert.Equal(100, Assert.Single(FlowGraphBuilder.Build(data, flow, "realpower", cache).Links, l => l.Source == "solar").Value);
+    }
+
+    [Fact]
+    public void Cache_LatestWriteWins()
+    {
+        var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+        var cache = new FlowValueCache();
+        cache.Set("solar", "realpower", 100, 900, now);
+        cache.Set("solar", "realpower", 250, 900, now.AddSeconds(5));
+
+        Assert.True(cache.TryGetValue("solar", "realpower", now.AddSeconds(6), out var v));
+        Assert.Equal(250, v);
+    }
+
+    [Fact]
+    public void Cache_RemoveDropsTheReading()
+    {
+        var now = new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc);
+        var cache = new FlowValueCache();
+        cache.Set("solar", "realpower", 100, 900, now);
+        cache.Remove("solar", "realpower");
+
+        Assert.False(cache.TryGetValue("solar", "realpower", now, out _));
+    }
+
+    // --- Subscribe → parse → cache glue (BuildBindings + Apply) ------------------------------------
+
+    private static EnergyFlowNode NodeWith(string id, params EnergyFlowMqttSource[] sources)
+    {
+        var n = new EnergyFlowNode { Id = id, Label = id };
+        n.Mqtt.AddRange(sources);
+        return n;
+    }
+
+    [Fact]
+    public void Apply_RoutesAPayloadToTheBoundNodeAndMetric()
+    {
+        var nodes = new[] { NodeWith("solar", new EnergyFlowMqttSource { Topic = "sa/pv_power", Metric = "realpower" }) };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+        var cache = new FlowValueCache();
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_power", "812.5", DateTime.UtcNow);
+
+        Assert.True(cache.TryGetValue("solar", "realpower", out var v));
+        Assert.Equal(812.5, v);
+    }
+
+    [Fact]
+    public void Apply_AppliesScaleAndReadsAJsonField()
+    {
+        var nodes = new[] { NodeWith("meter", new EnergyFlowMqttSource { Topic = "sa/energy", Metric = "energy", JsonField = "wh", Scale = 0.001 }) };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+        var cache = new FlowValueCache();
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/energy", """{"wh":1500}""", DateTime.UtcNow);
+
+        Assert.True(cache.TryGetValue("meter", "energy", out var v));
+        Assert.Equal(1.5, v);   // 1500 Wh * 0.001 = 1.5 kWh
+    }
+
+    [Fact]
+    public void Apply_IgnoresAnUnboundTopic()
+    {
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(
+            new[] { NodeWith("solar", new EnergyFlowMqttSource { Topic = "sa/pv_power", Metric = "realpower" }) });
+        var cache = new FlowValueCache();
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "some/other/topic", "999", DateTime.UtcNow);
+
+        Assert.Empty(cache.Keys);
+    }
+
+    [Fact]
+    public void Apply_LeavesTheCacheUntouchedForAnUnparseablePayload()
+    {
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(
+            new[] { NodeWith("solar", new EnergyFlowMqttSource { Topic = "sa/pv_power", Metric = "realpower" }) });
+        var cache = new FlowValueCache();
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_power", "unavailable", DateTime.UtcNow);
+
+        Assert.False(cache.TryGetValue("solar", "realpower", out _));
+    }
+
+    [Fact]
+    public void Apply_FansOneTopicOutToEveryNodeBoundToIt()
+    {
+        // A shared bus topic can legitimately feed more than one node.
+        var nodes = new[]
+        {
+            NodeWith("a", new EnergyFlowMqttSource { Topic = "shared/power", Metric = "realpower" }),
+            NodeWith("b", new EnergyFlowMqttSource { Topic = "shared/power", Metric = "realpower", Scale = 2 }),
+        };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+        var cache = new FlowValueCache();
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "shared/power", "50", DateTime.UtcNow);
+
+        Assert.True(cache.TryGetValue("a", "realpower", out var va)); Assert.Equal(50, va);
+        Assert.True(cache.TryGetValue("b", "realpower", out var vb)); Assert.Equal(100, vb);
+    }
+
+    [Fact]
+    public void BuildBindings_SkipsNodesWithNoTopicOrId()
+    {
+        var nodes = new[]
+        {
+            NodeWith("", new EnergyFlowMqttSource { Topic = "t1", Metric = "realpower" }),         // no id
+            NodeWith("ok", new EnergyFlowMqttSource { Topic = "", Metric = "realpower" }),          // no topic
+            NodeWith("solar", new EnergyFlowMqttSource { Topic = "  sa/pv  ", Metric = "realpower" }), // trimmed
+        };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+
+        Assert.True(bindings.ContainsKey("sa/pv"));
+        Assert.Single(bindings);
+    }
+
+    // --- Builder integration -----------------------------------------------------------------------
+
+    [Fact]
+    public void Build_UsesTheLiveValueForAnMqttBoundNode()
+    {
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig();
+        flow.Nodes.Add(new EnergyFlowNode { Id = "solar", Label = "Solar" });
+        flow.Nodes.Add(new EnergyFlowNode { Id = "panel", Label = "Panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "solar", To = "panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "panel", To = "outlet:pdu1:0" });
+
+        var graph = FlowGraphBuilder.Build(data, flow, "realpower", new FakeLive().Set("solar", "realpower", 750));
+
+        // Solar is a producer: it supplies its measured generation into the panel.
+        var link = Assert.Single(graph.Links, l => l.Source == "solar" && l.Target == "panel");
+        Assert.Equal(750, link.Value);
+    }
+
+    [Fact]
+    public void Build_PrefersTheLiveValueOverTheStaticValue()
+    {
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig();
+        flow.Nodes.Add(new EnergyFlowNode { Id = "solar", Label = "Solar", Value = 50 });
+        flow.Nodes.Add(new EnergyFlowNode { Id = "panel", Label = "Panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "solar", To = "panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "panel", To = "outlet:pdu1:0" });
+
+        var graph = FlowGraphBuilder.Build(data, flow, "realpower", new FakeLive().Set("solar", "realpower", 750));
+
+        Assert.Equal(750, Assert.Single(graph.Links, l => l.Source == "solar").Value);
+    }
+
+    [Fact]
+    public void Build_FallsBackToTheStaticValueWhenNothingIsReported()
+    {
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig();
+        flow.Nodes.Add(new EnergyFlowNode { Id = "solar", Label = "Solar", Value = 50 });
+        flow.Nodes.Add(new EnergyFlowNode { Id = "panel", Label = "Panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "solar", To = "panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "panel", To = "outlet:pdu1:0" });
+
+        // A live source exists but has only reported energy — the power graph must still use Value.
+        var graph = FlowGraphBuilder.Build(data, flow, "realpower", new FakeLive().Set("solar", "energy", 9));
+
+        Assert.Equal(50, Assert.Single(graph.Links, l => l.Source == "solar").Value);
+    }
+
+    [Fact]
+    public void Build_LiveValueIsPerMetric()
+    {
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"), Outlet(1, "Load", "energy", "5", "kWh"));
+        var flow = new EnergyFlowConfig();
+        flow.Nodes.Add(new EnergyFlowNode { Id = "solar", Label = "Solar" });
+        flow.Nodes.Add(new EnergyFlowNode { Id = "panel", Label = "Panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "solar", To = "panel" });
+
+        var live = new FakeLive().Set("solar", "realpower", 750).Set("solar", "energy", 12.5);
+
+        Assert.Equal(750, Assert.Single(FlowGraphBuilder.Build(data, flow, "realpower", live).Links, l => l.Source == "solar").Value);
+        Assert.Equal(12.5, Assert.Single(FlowGraphBuilder.Build(data, flow, "energy", live).Links, l => l.Source == "solar").Value);
+    }
+
+    [Fact]
+    public void Build_LiveZeroMeansZeroAndDoesNotFallBackToValue()
+    {
+        // Solar at night reports 0. That's a real reading, not "no reading" — the static Value must not
+        // resurrect a phantom 50W, so the producer link drops out entirely.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig();
+        flow.Nodes.Add(new EnergyFlowNode { Id = "solar", Label = "Solar", Value = 50 });
+        flow.Nodes.Add(new EnergyFlowNode { Id = "panel", Label = "Panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "solar", To = "panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "panel", To = "outlet:pdu1:0" });
+
+        var graph = FlowGraphBuilder.Build(data, flow, "realpower", new FakeLive().Set("solar", "realpower", 0));
+
+        Assert.DoesNotContain(graph.Links, l => l.Source == "solar");
+    }
+
+    [Fact]
+    public void Build_ClampsANegativeLiveReadingRatherThanSubtractingFromTheRollUp()
+    {
+        // Battery power is negative under some sign conventions (Solar Assistant included). A directed DAG
+        // can't carry a negative flow, and letting it through would subtract from the parent's roll-up, so
+        // it clamps to 0 — Scale: -1 is the way to flip the convention.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig();
+        flow.Nodes.Add(new EnergyFlowNode { Id = "battery", Label = "Battery" });
+        flow.Nodes.Add(new EnergyFlowNode { Id = "solar", Label = "Solar" });
+        flow.Nodes.Add(new EnergyFlowNode { Id = "panel", Label = "Panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "battery", To = "panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "solar", To = "panel" });
+        flow.Links.Add(new EnergyFlowLink { From = "panel", To = "outlet:pdu1:0" });
+
+        var live = new FakeLive().Set("battery", "realpower", -240).Set("solar", "realpower", 600);
+        var graph = FlowGraphBuilder.Build(data, flow, "realpower", live);
+
+        Assert.DoesNotContain(graph.Links, l => l.Source == "battery");
+        // Solar's contribution is untouched by the battery's negative reading.
+        Assert.Equal(600, Assert.Single(graph.Links, l => l.Source == "solar").Value);
+    }
+
+    [Fact]
+    public void Build_WithoutALiveSourceIsUnchanged()
+    {
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig();
+        flow.Nodes.Add(new EnergyFlowNode { Id = "solar", Label = "Solar", Value = 50 });
+        flow.Links.Add(new EnergyFlowLink { From = "solar", To = "outlet:pdu1:0" });
+
+        var withNull = FlowGraphBuilder.Build(data, flow, "realpower", null);
+        var withDefault = FlowGraphBuilder.Build(data, flow, "realpower");
+
+        Assert.Equal(withDefault.Links.Count, withNull.Links.Count);
+        Assert.Equal(50, Assert.Single(withNull.Links, l => l.Source == "solar").Value);
+    }
+}

--- a/rPDU2MQTT.Tests/KubernetesConfigTests.cs
+++ b/rPDU2MQTT.Tests/KubernetesConfigTests.cs
@@ -77,4 +77,35 @@ public class KubernetesConfigTests
         Assert.Contains("HomeAssistant", yaml);     // generated spec property
         Assert.Contains("status", yaml);            // status subresource
     }
+
+    /// <summary>
+    /// The committed CRD manifests are generated artifacts (<c>rPDU2MQTT --emit-crd</c>), and nothing was
+    /// checking they still matched the config model. Examples/Kubernetes/crd/crd.yaml had silently drifted
+    /// 199 lines behind across several releases — anyone applying it got a schema with no EnergyFlow and no
+    /// EmonCMS feed settings. Pin both so adding a config field can't quietly leave them stale again.
+    /// </summary>
+    [Theory]
+    [InlineData("charts/rpdu2mqtt/crds/rpduconfig.yaml")]
+    [InlineData("Examples/Kubernetes/crd/crd.yaml")]
+    public void CommittedCrdManifests_MatchTheGenerator(string relativePath)
+    {
+        var repoRoot = FindRepoRoot();
+        var path = Path.Combine(repoRoot, relativePath);
+        Assert.True(File.Exists(path), $"{relativePath} is missing.");
+
+        var committed = File.ReadAllText(path).ReplaceLineEndings("\n").TrimEnd();
+        var generated = CrdGenerator.ToYaml().ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.True(committed == generated,
+            $"{relativePath} is out of date with the config model. Regenerate it:\n" +
+            $"    dotnet run --project rPDU2MQTT --no-launch-profile -- --emit-crd > {relativePath}");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "rPDU2MQTT.sln")))
+            dir = dir.Parent;
+        return dir?.FullName ?? throw new InvalidOperationException("Could not locate the repository root (no rPDU2MQTT.sln above the test output).");
+    }
 }

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -46,11 +46,13 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly HeartbeatService heartbeats;
     private readonly HaEnergyDashboardSync haEnergy;
     private readonly EmonCmsFeedSync emonCmsFeeds;
+    private readonly Core.Flow.IFlowValueSource? live;
     private static readonly HttpClient testHttp = new() { Timeout = TimeSpan.FromSeconds(15) };
     private WebApplication? app;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots, Core.HostRole hostRoles, HeartbeatService heartbeats, HaEnergyDashboardSync haEnergy, EmonCmsFeedSync emonCmsFeeds)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots, Core.HostRole hostRoles, HeartbeatService heartbeats, HaEnergyDashboardSync haEnergy, EmonCmsFeedSync emonCmsFeeds, Core.Flow.IFlowValueSource? live = null)
     {
+        this.live = live;
         this.config = config;
         this.mqtt = mqtt;
         this.pdu = pdu;
@@ -815,7 +817,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 var (id, pdu, _) = ResolveInstance(ctx.Request.Query["instance"]);
                 var data = await ResolveData(id, pdu, cts.Token);
                 var metric = ctx.Request.Query["metric"].ToString();
-                var graph = FlowGraphBuilder.Build(data, config.EnergyFlow, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric);
+                var graph = FlowGraphBuilder.Build(data, config.EnergyFlow, string.IsNullOrEmpty(metric) ? FlowGraphBuilder.DefaultMetric : metric, live);
                 return Results.Json(new { ok = true, graph.Nodes, graph.Links, graph.Metric, graph.Units }, ConfigSchema.Json);
             }
             catch (Exception ex)

--- a/rPDU2MQTT.Web/web/smoke.mjs
+++ b/rPDU2MQTT.Web/web/smoke.mjs
@@ -89,10 +89,30 @@ const getEl = (id) => (byId[id] ||= Object.assign(makeEl(id === 'nav' ? 'nav' : 
 root.appendChild(getEl('nav'));
 root.appendChild(getEl('sections'));
 
+// A config with a custom flow node already bound to an MQTT source (#205), so opening the Flow tab
+// exercises the hierarchy editor and the live-sources table rather than just their empty states.
+const config = {
+  EnergyFlow: {
+    Nodes: [
+      { Id: 'solar', Label: 'Solar', Mqtt: [{ Topic: 'solar_assistant/inverter_1/pv_power/state', Metric: 'realpower' }] },
+      { Id: 'panel', Label: 'Panel', Value: 100 },
+    ],
+    Links: [{ From: 'solar', To: 'panel' }],
+    MqttExport: true,
+  },
+};
+const flowGraph = {
+  ok: true,
+  nodes: [{ id: 'solar', label: 'Solar', kind: 'node' }, { id: 'panel', label: 'Panel', kind: 'node' }],
+  links: [{ source: 'solar', target: 'panel', value: 750 }],
+  metric: 'realpower', units: 'W',
+};
+
 const bodies = (url) =>
   url.includes('/api/schema') ? schema :
   url.includes('/api/instances') ? { ok: true, instances: [] } :
-  url.includes('/api/config') ? {} :
+  url.includes('/api/config') ? config :
+  url.includes('/api/flow') ? flowGraph :
   { ok: true };
 
 const sandbox = {
@@ -144,4 +164,17 @@ if (linkText.includes('EnergyFlow')) fail('EnergyFlow should be hidden from the 
 
 if (!query(getEl('sections'), '.section', true).length) fail('no sections were rendered');
 
-console.log(`smoke: build() rendered ${linkText.length} nav links across ${groups.length} groups; sections OK`);
+// Tabs build their body lazily on first click, so build() alone never touches the bespoke editors. Open
+// the Flow tab to exercise the hierarchy editor + the MQTT live-sources binding table (#205).
+const flowLink = query(nav, 'a', true).find(a => a.textContent === 'Flow');
+if (!flowLink) fail('no Flow tab');
+flowLink.click();
+await new Promise(r => setTimeout(r, 50));
+
+const sectionsText = query(getEl('sections'), '.section', true).map(s => s.textContent).join(' ');
+if (!sectionsText.includes('Live sources (MQTT)')) fail('the Flow tab did not render the live-sources editor');
+// The configured binding must show in the table — proves it read Nodes[].Mqtt, not just the empty state.
+if (!sectionsText.includes('solar_assistant/inverter_1/pv_power/state'))
+  fail('the live-sources table did not list the configured MQTT binding');
+
+console.log(`smoke: build() rendered ${linkText.length} nav links across ${groups.length} groups; Flow editor + MQTT sources OK`);

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -3,6 +3,78 @@ import { api, btn, el, ensure, formatNum, svgEl, attachZoom, activate, toast, in
 import { state } from '../state.js';
 import { exportData } from '../overrides.js';
 
+// Metrics a live source can supply — mirrors [AllowedValues] on EnergyFlowMqttSource.Metric.
+const SOURCE_METRICS = ['realpower', 'apparentpower', 'energy', 'current', 'voltage', 'frequency', 'powerfactor'];
+
+// Binds custom nodes to live MQTT topics (#205): the values a producer (Solar Assistant, a CT clamp)
+// already publishes become this node's reading, so it rolls up and exports like a PDU outlet. Only custom
+// nodes appear — PDU/outlet nodes get their values from the poll.
+function renderMqttSources(customNodes: any[], rerender: () => void) {
+  const box = el('div', { style: { margin: '18px 0' } });
+  box.appendChild(el('h3', { text: 'Live sources (MQTT)', style: { margin: '4px 0', fontSize: '15px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'Feed a node from a topic already on your broker — e.g. Solar Assistant’s solar_assistant/inverter_1/pv_power/state. A live reading replaces the node’s fixed value; bind one topic per metric to drive both the power and the energy roll-up. Takes effect without a restart once saved.' }));
+
+  if (!customNodes.length) {
+    box.appendChild(el('div', { class: 'desc', text: 'Add a node above first — live sources attach to custom nodes.' }));
+    return box;
+  }
+
+  // Existing bindings, flattened across nodes.
+  const rows = customNodes.flatMap((n: any) => (n.Mqtt || []).map((s: any) => ({ node: n, src: s })));
+  if (rows.length) {
+    const tbl = el('table', { class: 'ld' });
+    const head = el('tr');
+    ['Node', 'Topic', 'Metric', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
+    tbl.appendChild(el('thead', {}, head));
+    const body = el('tbody');
+    rows.forEach(({ node, src }: any) => {
+      const tr = el('tr');
+      tr.appendChild(el('td', { text: node.Label || node.Id }));
+      tr.appendChild(el('td', {}, el('code', { text: src.Topic })));
+      tr.appendChild(el('td', { text: src.Metric || 'realpower' }));
+      tr.appendChild(el('td', { text: src.JsonField || '—' }));
+      tr.appendChild(el('td', { class: 'num', text: String(src.Scale ?? 1) }));
+      const rm = btn('Remove', 'danger');
+      rm.onclick = () => { node.Mqtt.splice(node.Mqtt.indexOf(src), 1); rerender(); };
+      tr.appendChild(el('td', {}, rm));
+      body.appendChild(tr);
+    });
+    tbl.appendChild(body);
+    box.appendChild(tbl);
+  }
+
+  const bar = el('div', { class: 'ld-toolbar' });
+  const nodeSel = el('select', { style: { width: 'auto' } });
+  customNodes.forEach((n: any) => nodeSel.appendChild(el('option', { value: n.Id, text: n.Label || n.Id })));
+  const topicIn = el('input', { type: 'text', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '320px' } });
+  const metricSel = el('select', { style: { width: 'auto' } });
+  SOURCE_METRICS.forEach(m => metricSel.appendChild(el('option', { value: m, text: m })));
+  const fieldIn = el('input', { type: 'text', placeholder: 'JSON field (optional)', style: { width: '150px' } });
+  const scaleIn = el('input', { type: 'number', step: 'any', placeholder: 'scale', value: '1', style: { width: '90px' } });
+  const add = btn('Bind topic', 'primary');
+  add.onclick = () => {
+    const topic = (topicIn.value || '').trim();
+    if (!topic) { toast('A topic is required.', false); return; }
+    const node = customNodes.find((n: any) => n.Id === nodeSel.value);
+    if (!node) { toast('Pick a node to bind.', false); return; }
+    const metric = metricSel.value;
+    const mqtt = ensure(node, 'Mqtt', []);
+    // One reading per metric per node — a second binding would just race the first.
+    if (mqtt.some((s: any) => (s.Metric || 'realpower') === metric)) {
+      toast(`${node.Label || node.Id} already has a ${metric} source.`, false); return;
+    }
+    const src: any = { Topic: topic, Metric: metric };
+    const field = (fieldIn.value || '').trim(); if (field) src.JsonField = field;
+    const scale = +scaleIn.value; if (scaleIn.value !== '' && !isNaN(scale) && scale !== 1) src.Scale = scale;
+    mqtt.push(src);
+    toast(`${topic} → ${node.Label || node.Id} (${metric}).`, true);
+    rerender();
+  };
+  bar.append(nodeSel, topicIn, metricSel, fieldIn, scaleIn, add);
+  box.appendChild(bar);
+  return box;
+}
+
 export function addFlowSection(nav: any, sections: any) {
   const link = document.createElement('a'); link.textContent = 'Flow'; nav.appendChild(link);
   const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
@@ -148,6 +220,8 @@ export function addFlowSection(nav: any, sections: any) {
     expChk.onchange = () => { flow.MqttExport = expChk.checked; topicIn.disabled = !expChk.checked; };
     exportRow.append(el('label', {}, expChk, ' Export tiers to MQTT'), el('span', { class: 'desc', style: { margin: '0' }, text: 'Topic:' }), topicIn);
     ed.appendChild(exportRow);
+
+    ed.appendChild(renderMqttSources(customNodes, renderEditor));
 
     // Candidate nodes (from the built graph + custom defs).
     const cand = new Map();

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -752,6 +752,78 @@ function addLiveDataSection(nav     , sections     ) {
 // ── sections/flow.ts ────────────────────────────────────────────
 // Energy Flow: a read-only Sankey + the layered arrow-graph hierarchy editor.
 
+// Metrics a live source can supply — mirrors [AllowedValues] on EnergyFlowMqttSource.Metric.
+const SOURCE_METRICS = ['realpower', 'apparentpower', 'energy', 'current', 'voltage', 'frequency', 'powerfactor'];
+
+// Binds custom nodes to live MQTT topics (#205): the values a producer (Solar Assistant, a CT clamp)
+// already publishes become this node's reading, so it rolls up and exports like a PDU outlet. Only custom
+// nodes appear — PDU/outlet nodes get their values from the poll.
+function renderMqttSources(customNodes       , rerender            ) {
+  const box = el('div', { style: { margin: '18px 0' } });
+  box.appendChild(el('h3', { text: 'Live sources (MQTT)', style: { margin: '4px 0', fontSize: '15px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'Feed a node from a topic already on your broker — e.g. Solar Assistant’s solar_assistant/inverter_1/pv_power/state. A live reading replaces the node’s fixed value; bind one topic per metric to drive both the power and the energy roll-up. Takes effect without a restart once saved.' }));
+
+  if (!customNodes.length) {
+    box.appendChild(el('div', { class: 'desc', text: 'Add a node above first — live sources attach to custom nodes.' }));
+    return box;
+  }
+
+  // Existing bindings, flattened across nodes.
+  const rows = customNodes.flatMap((n     ) => (n.Mqtt || []).map((s     ) => ({ node: n, src: s })));
+  if (rows.length) {
+    const tbl = el('table', { class: 'ld' });
+    const head = el('tr');
+    ['Node', 'Topic', 'Metric', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
+    tbl.appendChild(el('thead', {}, head));
+    const body = el('tbody');
+    rows.forEach(({ node, src }     ) => {
+      const tr = el('tr');
+      tr.appendChild(el('td', { text: node.Label || node.Id }));
+      tr.appendChild(el('td', {}, el('code', { text: src.Topic })));
+      tr.appendChild(el('td', { text: src.Metric || 'realpower' }));
+      tr.appendChild(el('td', { text: src.JsonField || '—' }));
+      tr.appendChild(el('td', { class: 'num', text: String(src.Scale ?? 1) }));
+      const rm = btn('Remove', 'danger');
+      rm.onclick = () => { node.Mqtt.splice(node.Mqtt.indexOf(src), 1); rerender(); };
+      tr.appendChild(el('td', {}, rm));
+      body.appendChild(tr);
+    });
+    tbl.appendChild(body);
+    box.appendChild(tbl);
+  }
+
+  const bar = el('div', { class: 'ld-toolbar' });
+  const nodeSel = el('select', { style: { width: 'auto' } });
+  customNodes.forEach((n     ) => nodeSel.appendChild(el('option', { value: n.Id, text: n.Label || n.Id })));
+  const topicIn = el('input', { type: 'text', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '320px' } });
+  const metricSel = el('select', { style: { width: 'auto' } });
+  SOURCE_METRICS.forEach(m => metricSel.appendChild(el('option', { value: m, text: m })));
+  const fieldIn = el('input', { type: 'text', placeholder: 'JSON field (optional)', style: { width: '150px' } });
+  const scaleIn = el('input', { type: 'number', step: 'any', placeholder: 'scale', value: '1', style: { width: '90px' } });
+  const add = btn('Bind topic', 'primary');
+  add.onclick = () => {
+    const topic = (topicIn.value || '').trim();
+    if (!topic) { toast('A topic is required.', false); return; }
+    const node = customNodes.find((n     ) => n.Id === nodeSel.value);
+    if (!node) { toast('Pick a node to bind.', false); return; }
+    const metric = metricSel.value;
+    const mqtt = ensure(node, 'Mqtt', []);
+    // One reading per metric per node — a second binding would just race the first.
+    if (mqtt.some((s     ) => (s.Metric || 'realpower') === metric)) {
+      toast(`${node.Label || node.Id} already has a ${metric} source.`, false); return;
+    }
+    const src      = { Topic: topic, Metric: metric };
+    const field = (fieldIn.value || '').trim(); if (field) src.JsonField = field;
+    const scale = +scaleIn.value; if (scaleIn.value !== '' && !isNaN(scale) && scale !== 1) src.Scale = scale;
+    mqtt.push(src);
+    toast(`${topic} → ${node.Label || node.Id} (${metric}).`, true);
+    rerender();
+  };
+  bar.append(nodeSel, topicIn, metricSel, fieldIn, scaleIn, add);
+  box.appendChild(bar);
+  return box;
+}
+
 function addFlowSection(nav     , sections     ) {
   const link = document.createElement('a'); link.textContent = 'Flow'; nav.appendChild(link);
   const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
@@ -897,6 +969,8 @@ function addFlowSection(nav     , sections     ) {
     expChk.onchange = () => { flow.MqttExport = expChk.checked; topicIn.disabled = !expChk.checked; };
     exportRow.append(el('label', {}, expChk, ' Export tiers to MQTT'), el('span', { class: 'desc', style: { margin: '0' }, text: 'Topic:' }), topicIn);
     ed.appendChild(exportRow);
+
+    ed.appendChild(renderMqttSources(customNodes, renderEditor));
 
     // Candidate nodes (from the built graph + custom defs).
     const cand = new Map();

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -99,6 +99,14 @@ public static class ServiceConfiguration
         // now" button, so register the singleton regardless of role.
         services.AddSingleton<Services.EmonCmsFeedSync>();
 
+        // Energy-flow values sourced from the broker (#205, e.g. Solar Assistant). Registered in every role
+        // and started unconditionally: any process that renders or exports the flow (GUI, API, worker) needs
+        // the live values, and it self-gates — with no Mqtt bindings configured it subscribes to nothing.
+        // It reconciles subscriptions on a timer, so binding a topic in the GUI needs no restart.
+        services.AddSingleton<Services.EnergyFlowMqttSourceService>();
+        services.AddSingleton<Core.Flow.IFlowValueSource>(sp => sp.GetRequiredService<Services.EnergyFlowMqttSourceService>());
+        services.AddHostedService(sp => sp.GetRequiredService<Services.EnergyFlowMqttSourceService>());
+
         // When roles are split across processes, bridge the in-process snapshot bus over MQTT: a Worker
         // mirrors its snapshots to the broker; a consumer-only node ingests them onto its own bus/cache.
         // Single-node "all" keeps the bus fully in-process and skips this (no extra broker traffic).


### PR DESCRIPTION
## What & why

A custom energy-flow node could only carry a hand-entered number. This lets a node **bind to a topic that's already on your broker** — Solar Assistant, a CT clamp, an inverter bridge — so an external producer's data joins the same hierarchy, roll-ups, and exports (MQTT tier export, Prometheus, HA Energy Dashboard) as the PDU outlets. Set up for the Solar Assistant case specifically.

This builds on the seam `EnergyFlowNode.Value` always documented: *"later a node can instead bind to a live measurement from any producer (CT clamps over MQTT/emoncms, Tigo solar, inverter ports…)"*.

## Design

- **`IFlowValueSource`** — `FlowGraphBuilder` pulls live leaf values through this seam, so a future CT-clamp/inverter poller plugs in without touching the builder.
- **`FlowValueCache`** (Core) — newest value per `(node, metric)` with per-source staleness, so a dead publisher stops propping up the flow. Transport-free, so the expiry rules are unit-tested without a broker.
- **`EnergyFlowMqttSourceService`** (Engine) — subscribes to the bound topics and fills the cache. Reconciles subscriptions **on a timer**, so binding a topic in the GUI takes effect with **no restart**. Handles bare payloads (SA's `/state` topics) and a dotted JSON field, with per-source `Scale` and `StaleAfterSeconds`.

## Semantics that needed deciding (each pinned by a test)

- A live reading **wins over** the static `Value`; `Value` stays the fallback.
- A live **0 means 0** (solar at night), not "fall back to `Value`".
- **Negative readings clamp to 0** — a directed DAG can't carry a negative and it would subtract from the roll-up; use `Scale: -1` to flip a sign convention.
- **One value per `(node, metric)`** — bind one topic for power, another for energy.

## Config

```yaml
EnergyFlow:
  Nodes:
    - Id: solar
      Label: Solar Array
      Mqtt:
        - { Topic: solar_assistant/inverter_1/pv_power/state,  Metric: realpower }
        - { Topic: solar_assistant/inverter_1/pv_energy/state, Metric: energy }
  Links:
    - { From: solar, To: main_panel }
  MqttExport: true
```

GUI: a **live-sources binding table** on the Flow tab (the only editor for `EnergyFlow`).

## Also in here

- **Regenerated both committed CRD manifests + added a drift test.** `Examples/Kubernetes/crd/crd.yaml` had silently fallen **199 lines behind** since June — anyone applying it got a schema with no `EnergyFlow` and no EmonCMS feed fields. The new test pins both manifests to the generator so this can't recur.
- `smoke.mjs` now opens the Flow tab (tabs build lazily, so `build()` alone never touched the new editor) and asserts the live-sources table renders. Verified it fails when the editor is unwired.
- Round-trip test for the MQTT bindings through JSON → YAML → load, since the GUI is the only way to set them.
- Documented with a Solar Assistant example in `docs/Configuration.md`.

## Testing

`dotnet build` clean (0 warnings), **213/213 tests pass** (39 new), GUI bundle builds, smoke passes.

## ⚠️ Not runtime-verified against a live broker

This box has no MQTT broker or container runtime, so I could not drive the real subscribe → receive → export path end-to-end. It's covered by unit tests at every seam instead: payload parsing, the cache's staleness rules, the topic→cache routing glue (`BuildBindings` + `Apply`), and the builder integration. The DI wiring is compile-checked and all-singleton with no cycle, but its runtime resolution (which only happens after broker connect) is unverified. **Worth a smoke test against a real Solar Assistant feed before relying on it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)