### PR TITLE
feat(flow): energy-flow overhaul — node modes, dedicated Nodes tab, typed MQTT/Modbus bindings

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -741,7 +741,10 @@ spec:
                                 - voltage
                                 - frequency
                                 - powerfactor
-                                description: Which measurement this source supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                                description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.'
+                              Unit:
+                                type: string
+                                description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.
                               Topic:
                                 type: string
                                 description: "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker."
@@ -780,7 +783,10 @@ spec:
                                 - voltage
                                 - frequency
                                 - powerfactor
-                                description: Which measurement this source supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                                description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.'
+                              Unit:
+                                type: string
+                                description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.
                               Topic:
                                 type: string
                                 description: "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker."

--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -729,7 +729,8 @@ spec:
                                 enum:
                                 - ''
                                 - mqtt
-                                description: Where this value comes from. Currently only 'mqtt' (subscribe to a broker topic); more ingest types can be added later.
+                                - modbus
+                                description: "Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection)."
                               Metric:
                                 type: string
                                 enum:
@@ -759,6 +760,36 @@ spec:
                                 description: Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).
                                 minimum: 0
                                 maximum: 86400
+                              Connection:
+                                type: string
+                                description: "For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from."
+                              Register:
+                                type: integer
+                                description: "For Type 'modbus': the register address to read (0-based)."
+                              RegisterType:
+                                type: string
+                                enum:
+                                - ''
+                                - holding
+                                - input
+                                description: "For Type 'modbus': which register bank — 'holding' (function 3) or 'input' (function 4)."
+                              DataType:
+                                type: string
+                                enum:
+                                - ''
+                                - uint16
+                                - int16
+                                - uint32
+                                - int32
+                                - float32
+                                description: "For Type 'modbus': how to decode the register(s) — uint16, int16, uint32, int32, or float32."
+                              WordOrder:
+                                type: string
+                                enum:
+                                - ''
+                                - big
+                                - little
+                                description: "For Type 'modbus' 32-bit values: word order — 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped)."
                           description: Live value bindings for this node, one per metric. Each binds a metric to an external source (Type 'mqtt' today). Supersedes Value.
                         Mqtt:
                           type: array
@@ -771,7 +802,8 @@ spec:
                                 enum:
                                 - ''
                                 - mqtt
-                                description: Where this value comes from. Currently only 'mqtt' (subscribe to a broker topic); more ingest types can be added later.
+                                - modbus
+                                description: "Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection)."
                               Metric:
                                 type: string
                                 enum:
@@ -801,6 +833,36 @@ spec:
                                 description: Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).
                                 minimum: 0
                                 maximum: 86400
+                              Connection:
+                                type: string
+                                description: "For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from."
+                              Register:
+                                type: integer
+                                description: "For Type 'modbus': the register address to read (0-based)."
+                              RegisterType:
+                                type: string
+                                enum:
+                                - ''
+                                - holding
+                                - input
+                                description: "For Type 'modbus': which register bank — 'holding' (function 3) or 'input' (function 4)."
+                              DataType:
+                                type: string
+                                enum:
+                                - ''
+                                - uint16
+                                - int16
+                                - uint32
+                                - int32
+                                - float32
+                                description: "For Type 'modbus': how to decode the register(s) — uint16, int16, uint32, int32, or float32."
+                              WordOrder:
+                                type: string
+                                enum:
+                                - ''
+                                - big
+                                - little
+                                description: "For Type 'modbus' 32-bit values: word order — 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped)."
                           description: "Deprecated: use Sources. Legacy MQTT bindings (implicitly Type 'mqtt'); still honored for back-compat."
                     description: Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.
                   Links:
@@ -829,6 +891,41 @@ spec:
                     type: string
                     description: "Template for each tier's MQTT topic. Placeholders: {parent} (MQTT parent topic), {id}, {label}, {kind}, {metric}, {units}. e.g. '{parent}/energyflow/{id}'."
                 description: Virtual upstream nodes (breakers, transfer switches, a “Total”) and their feeder wiring for the energy-flow hierarchy. Edited visually on the Flow tab.
+              Modbus:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  Connections:
+                    type: array
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        Id:
+                          type: string
+                          description: Stable id used to reference this connection from a source binding.
+                        Name:
+                          type: string
+                          description: Friendly name for the device (shown in the editor).
+                        Host:
+                          type: string
+                          description: Hostname or IP address of the Modbus TCP device.
+                        Port:
+                          type: integer
+                          description: TCP port the device listens on (Modbus default 502).
+                        UnitId:
+                          type: integer
+                          description: Modbus unit / slave id.
+                        PollIntervalSeconds:
+                          type: integer
+                          description: How often to poll this device, in seconds.
+                          minimum: 1
+                          maximum: 86400
+                        Enabled:
+                          type: boolean
+                          description: Poll this device. Turn off to disable it without deleting the connection.
+                    description: Modbus TCP devices to poll. Add one per device, then reference it from a source binding's Connection.
+                description: Modbus TCP connections that energy-flow nodes can be bound to (inverters, meters, PLCs).
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -713,10 +713,11 @@ spec:
                           enum:
                           - ''
                           - auto
+                          - static
                           - residual
                           - untracked
                           - none
-                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live/static Value always wins."
+                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'static' (a fixed leaf at Value), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins."
                         Sources:
                           type: array
                           items:

--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -693,6 +693,14 @@ spec:
                         Value:
                           type: number
                           description: Optional fixed value for a leaf node. Used only when no live MQTT source has reported for it.
+                        Mode:
+                          type: string
+                          enum:
+                          - ''
+                          - auto
+                          - residual
+                          - none
+                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand), or 'none' (never inferred). A live/static Value always wins."
                         Mqtt:
                           type: array
                           items:

--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -690,9 +690,24 @@ spec:
                         Label:
                           type: string
                           description: Human-readable label shown in the flow diagram.
+                        Kind:
+                          type: string
+                          enum:
+                          - ''
+                          - node
+                          - panel
+                          - inverter
+                          - battery
+                          - solar
+                          - grid
+                          - load
+                          description: "What this node represents: 'node' (generic), 'panel', 'inverter', 'battery', 'solar', 'grid', or 'load'. Drives styling and the fields the editor offers."
                         Value:
                           type: number
-                          description: Optional fixed value for a leaf node. Used only when no live MQTT source has reported for it.
+                          description: Optional fixed value for a leaf node. Used only when no live source has reported for it.
+                        StorageKwh:
+                          type: number
+                          description: 'For a battery node: usable storage capacity in kWh (display metadata; optional).'
                         Mode:
                           type: string
                           enum:
@@ -702,15 +717,18 @@ spec:
                           - untracked
                           - none
                           description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live/static Value always wins."
-                        Mqtt:
+                        Sources:
                           type: array
                           items:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                             properties:
-                              Topic:
+                              Type:
                                 type: string
-                                description: MQTT topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.
+                                enum:
+                                - ''
+                                - mqtt
+                                description: Where this value comes from. Currently only 'mqtt' (subscribe to a broker topic); more ingest types can be added later.
                               Metric:
                                 type: string
                                 enum:
@@ -722,7 +740,10 @@ spec:
                                 - voltage
                                 - frequency
                                 - powerfactor
-                                description: Which measurement this topic supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                                description: Which measurement this source supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                              Topic:
+                                type: string
+                                description: "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker."
                               JsonField:
                                 type: string
                                 description: For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.
@@ -734,7 +755,46 @@ spec:
                                 description: Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).
                                 minimum: 0
                                 maximum: 86400
-                          description: Live values for this node read from MQTT topics (e.g. Solar Assistant). One entry per metric; supersedes Value.
+                          description: Live value bindings for this node, one per metric. Each binds a metric to an external source (Type 'mqtt' today). Supersedes Value.
+                        Mqtt:
+                          type: array
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              Type:
+                                type: string
+                                enum:
+                                - ''
+                                - mqtt
+                                description: Where this value comes from. Currently only 'mqtt' (subscribe to a broker topic); more ingest types can be added later.
+                              Metric:
+                                type: string
+                                enum:
+                                - ''
+                                - realpower
+                                - apparentpower
+                                - energy
+                                - current
+                                - voltage
+                                - frequency
+                                - powerfactor
+                                description: Which measurement this source supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                              Topic:
+                                type: string
+                                description: "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker."
+                              JsonField:
+                                type: string
+                                description: For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.
+                              Scale:
+                                type: number
+                                description: Multiplier applied to the received value — for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.
+                              StaleAfterSeconds:
+                                type: integer
+                                description: Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).
+                                minimum: 0
+                                maximum: 86400
+                          description: "Deprecated: use Sources. Legacy MQTT bindings (implicitly Type 'mqtt'); still honored for back-compat."
                     description: Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.
                   Links:
                     type: array

--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -699,8 +699,9 @@ spec:
                           - ''
                           - auto
                           - residual
+                          - untracked
                           - none
-                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand), or 'none' (never inferred). A live/static Value always wins."
+                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live/static Value always wins."
                         Mqtt:
                           type: array
                           items:

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -741,7 +741,10 @@ spec:
                                 - voltage
                                 - frequency
                                 - powerfactor
-                                description: Which measurement this source supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                                description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.'
+                              Unit:
+                                type: string
+                                description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.
                               Topic:
                                 type: string
                                 description: "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker."
@@ -780,7 +783,10 @@ spec:
                                 - voltage
                                 - frequency
                                 - powerfactor
-                                description: Which measurement this source supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                                description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.'
+                              Unit:
+                                type: string
+                                description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.
                               Topic:
                                 type: string
                                 description: "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker."

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -729,7 +729,8 @@ spec:
                                 enum:
                                 - ''
                                 - mqtt
-                                description: Where this value comes from. Currently only 'mqtt' (subscribe to a broker topic); more ingest types can be added later.
+                                - modbus
+                                description: "Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection)."
                               Metric:
                                 type: string
                                 enum:
@@ -759,6 +760,36 @@ spec:
                                 description: Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).
                                 minimum: 0
                                 maximum: 86400
+                              Connection:
+                                type: string
+                                description: "For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from."
+                              Register:
+                                type: integer
+                                description: "For Type 'modbus': the register address to read (0-based)."
+                              RegisterType:
+                                type: string
+                                enum:
+                                - ''
+                                - holding
+                                - input
+                                description: "For Type 'modbus': which register bank — 'holding' (function 3) or 'input' (function 4)."
+                              DataType:
+                                type: string
+                                enum:
+                                - ''
+                                - uint16
+                                - int16
+                                - uint32
+                                - int32
+                                - float32
+                                description: "For Type 'modbus': how to decode the register(s) — uint16, int16, uint32, int32, or float32."
+                              WordOrder:
+                                type: string
+                                enum:
+                                - ''
+                                - big
+                                - little
+                                description: "For Type 'modbus' 32-bit values: word order — 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped)."
                           description: Live value bindings for this node, one per metric. Each binds a metric to an external source (Type 'mqtt' today). Supersedes Value.
                         Mqtt:
                           type: array
@@ -771,7 +802,8 @@ spec:
                                 enum:
                                 - ''
                                 - mqtt
-                                description: Where this value comes from. Currently only 'mqtt' (subscribe to a broker topic); more ingest types can be added later.
+                                - modbus
+                                description: "Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection)."
                               Metric:
                                 type: string
                                 enum:
@@ -801,6 +833,36 @@ spec:
                                 description: Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).
                                 minimum: 0
                                 maximum: 86400
+                              Connection:
+                                type: string
+                                description: "For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from."
+                              Register:
+                                type: integer
+                                description: "For Type 'modbus': the register address to read (0-based)."
+                              RegisterType:
+                                type: string
+                                enum:
+                                - ''
+                                - holding
+                                - input
+                                description: "For Type 'modbus': which register bank — 'holding' (function 3) or 'input' (function 4)."
+                              DataType:
+                                type: string
+                                enum:
+                                - ''
+                                - uint16
+                                - int16
+                                - uint32
+                                - int32
+                                - float32
+                                description: "For Type 'modbus': how to decode the register(s) — uint16, int16, uint32, int32, or float32."
+                              WordOrder:
+                                type: string
+                                enum:
+                                - ''
+                                - big
+                                - little
+                                description: "For Type 'modbus' 32-bit values: word order — 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped)."
                           description: "Deprecated: use Sources. Legacy MQTT bindings (implicitly Type 'mqtt'); still honored for back-compat."
                     description: Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.
                   Links:
@@ -829,6 +891,41 @@ spec:
                     type: string
                     description: "Template for each tier's MQTT topic. Placeholders: {parent} (MQTT parent topic), {id}, {label}, {kind}, {metric}, {units}. e.g. '{parent}/energyflow/{id}'."
                 description: Virtual upstream nodes (breakers, transfer switches, a “Total”) and their feeder wiring for the energy-flow hierarchy. Edited visually on the Flow tab.
+              Modbus:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  Connections:
+                    type: array
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        Id:
+                          type: string
+                          description: Stable id used to reference this connection from a source binding.
+                        Name:
+                          type: string
+                          description: Friendly name for the device (shown in the editor).
+                        Host:
+                          type: string
+                          description: Hostname or IP address of the Modbus TCP device.
+                        Port:
+                          type: integer
+                          description: TCP port the device listens on (Modbus default 502).
+                        UnitId:
+                          type: integer
+                          description: Modbus unit / slave id.
+                        PollIntervalSeconds:
+                          type: integer
+                          description: How often to poll this device, in seconds.
+                          minimum: 1
+                          maximum: 86400
+                        Enabled:
+                          type: boolean
+                          description: Poll this device. Turn off to disable it without deleting the connection.
+                    description: Modbus TCP devices to poll. Add one per device, then reference it from a source binding's Connection.
+                description: Modbus TCP connections that energy-flow nodes can be bound to (inverters, meters, PLCs).
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -713,10 +713,11 @@ spec:
                           enum:
                           - ''
                           - auto
+                          - static
                           - residual
                           - untracked
                           - none
-                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live/static Value always wins."
+                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'static' (a fixed leaf at Value), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins."
                         Sources:
                           type: array
                           items:

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -693,6 +693,14 @@ spec:
                         Value:
                           type: number
                           description: Optional fixed value for a leaf node. Used only when no live MQTT source has reported for it.
+                        Mode:
+                          type: string
+                          enum:
+                          - ''
+                          - auto
+                          - residual
+                          - none
+                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand), or 'none' (never inferred). A live/static Value always wins."
                         Mqtt:
                           type: array
                           items:

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -690,9 +690,24 @@ spec:
                         Label:
                           type: string
                           description: Human-readable label shown in the flow diagram.
+                        Kind:
+                          type: string
+                          enum:
+                          - ''
+                          - node
+                          - panel
+                          - inverter
+                          - battery
+                          - solar
+                          - grid
+                          - load
+                          description: "What this node represents: 'node' (generic), 'panel', 'inverter', 'battery', 'solar', 'grid', or 'load'. Drives styling and the fields the editor offers."
                         Value:
                           type: number
-                          description: Optional fixed value for a leaf node. Used only when no live MQTT source has reported for it.
+                          description: Optional fixed value for a leaf node. Used only when no live source has reported for it.
+                        StorageKwh:
+                          type: number
+                          description: 'For a battery node: usable storage capacity in kWh (display metadata; optional).'
                         Mode:
                           type: string
                           enum:
@@ -702,15 +717,18 @@ spec:
                           - untracked
                           - none
                           description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live/static Value always wins."
-                        Mqtt:
+                        Sources:
                           type: array
                           items:
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                             properties:
-                              Topic:
+                              Type:
                                 type: string
-                                description: MQTT topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.
+                                enum:
+                                - ''
+                                - mqtt
+                                description: Where this value comes from. Currently only 'mqtt' (subscribe to a broker topic); more ingest types can be added later.
                               Metric:
                                 type: string
                                 enum:
@@ -722,7 +740,10 @@ spec:
                                 - voltage
                                 - frequency
                                 - powerfactor
-                                description: Which measurement this topic supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                                description: Which measurement this source supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                              Topic:
+                                type: string
+                                description: "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker."
                               JsonField:
                                 type: string
                                 description: For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.
@@ -734,7 +755,46 @@ spec:
                                 description: Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).
                                 minimum: 0
                                 maximum: 86400
-                          description: Live values for this node read from MQTT topics (e.g. Solar Assistant). One entry per metric; supersedes Value.
+                          description: Live value bindings for this node, one per metric. Each binds a metric to an external source (Type 'mqtt' today). Supersedes Value.
+                        Mqtt:
+                          type: array
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                            properties:
+                              Type:
+                                type: string
+                                enum:
+                                - ''
+                                - mqtt
+                                description: Where this value comes from. Currently only 'mqtt' (subscribe to a broker topic); more ingest types can be added later.
+                              Metric:
+                                type: string
+                                enum:
+                                - ''
+                                - realpower
+                                - apparentpower
+                                - energy
+                                - current
+                                - voltage
+                                - frequency
+                                - powerfactor
+                                description: Which measurement this source supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.
+                              Topic:
+                                type: string
+                                description: "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker."
+                              JsonField:
+                                type: string
+                                description: For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.
+                              Scale:
+                                type: number
+                                description: Multiplier applied to the received value — for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.
+                              StaleAfterSeconds:
+                                type: integer
+                                description: Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).
+                                minimum: 0
+                                maximum: 86400
+                          description: "Deprecated: use Sources. Legacy MQTT bindings (implicitly Type 'mqtt'); still honored for back-compat."
                     description: Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.
                   Links:
                     type: array

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -699,8 +699,9 @@ spec:
                           - ''
                           - auto
                           - residual
+                          - untracked
                           - none
-                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand), or 'none' (never inferred). A live/static Value always wins."
+                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live/static Value always wins."
                         Mqtt:
                           type: array
                           items:

--- a/rPDU2MQTT.Core/Flow/CompositeFlowValueSource.cs
+++ b/rPDU2MQTT.Core/Flow/CompositeFlowValueSource.cs
@@ -1,0 +1,22 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// Merges several <see cref="IFlowValueSource"/>s into one (#129): the first that has a fresh reading for a
+/// (node, metric) wins. Lets the graph draw live values from more than one ingest at once — MQTT and Modbus
+/// TCP today — without <see cref="FlowGraphBuilder"/> or any exporter knowing there's more than one source.
+/// </summary>
+public sealed class CompositeFlowValueSource : IFlowValueSource
+{
+    private readonly IReadOnlyList<IFlowValueSource> sources;
+
+    public CompositeFlowValueSource(params IFlowValueSource[] sources) => this.sources = sources;
+
+    public bool TryGetValue(string nodeId, string metric, out double value)
+    {
+        foreach (var s in sources)
+            if (s.TryGetValue(nodeId, metric, out value))
+                return true;
+        value = 0;
+        return false;
+    }
+}

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -100,7 +100,9 @@ public static class FlowGraphBuilder
             if (!string.IsNullOrEmpty(n.Id))
             {
                 label[n.Id] = string.IsNullOrEmpty(n.Label) ? n.Id : n.Label;
-                if (!kind.ContainsKey(n.Id)) kind[n.Id] = "node";
+                // The node's declared kind (battery, inverter, panel, …) styles the diagram; fall back to
+                // the generic "node" when unset. Don't override an auto id that already resolved to pdu/outlet.
+                if (!kind.ContainsKey(n.Id)) kind[n.Id] = string.IsNullOrWhiteSpace(n.Kind) ? "node" : n.Kind.Trim().ToLowerInvariant();
                 if (live is not null && live.TryGetValue(n.Id, metric, out var liveValue))
                 {
                     // A live reading is authoritative even at 0: solar at night generates nothing, and the

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -125,13 +125,24 @@ public static class FlowGraphBuilder
             if (!string.IsNullOrEmpty(child) && !string.IsNullOrEmpty(parent) && label.ContainsKey(child) && label.ContainsKey(parent))
                 AddEdgeSafe(parent, child);
 
-        // How many feeders does each node have? A node's demand is split equally among them so a node
-        // reachable by several paths (e.g. a panel fed both directly and via a sub-panel) isn't counted
-        // multiple times — otherwise the inflow inflates and the Sankey can't balance.
-        var inCount = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        foreach (var (_, kids) in outgoing)
+        // Which feeders point into each node — used to split a node's demand across them (so a node
+        // reachable by several paths isn't counted multiple times) and, crucially, to let measured feeders
+        // supply their real figure before the untracked remainder is shared out among the rest.
+        var incoming = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (from, kids) in outgoing)
             foreach (var to in kids)
-                inCount[to] = inCount.GetValueOrDefault(to) + 1;
+            {
+                if (!incoming.TryGetValue(to, out var fs)) incoming[to] = fs = new();
+                fs.Add(from);
+            }
+
+        // Per-node value mode (#129): governs how an unmeasured node is valued. A node with a live/static
+        // value ignores this. Unknown/blank -> "auto" (the historical behaviour).
+        var mode = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var n in flow.Nodes)
+            if (!string.IsNullOrEmpty(n.Id))
+                mode[n.Id] = string.IsNullOrWhiteSpace(n.Mode) ? "auto" : n.Mode.Trim().ToLowerInvariant();
+        string Mode(string id) => mode.TryGetValue(id, out var m) ? m : "auto";
 
         // Need(id): power this node must receive = its known value (outlet sink or producer), else the sum
         // of the flows on its outgoing links. Memoized + cycle-guarded.
@@ -147,19 +158,39 @@ public static class FlowGraphBuilder
             needMemo[id] = v;
             return v;
         }
-        // EdgeFlow(from -> to): a demand link carries the target's demand split among its feeders. A
-        // producer supplies its measured generation, divided across the things it powers in proportion to
-        // their downstream demand (equal split if none draw anything) — so a producer feeding several
-        // consumers isn't counted once per link.
+        // EdgeFlow(from -> to): how much flows along one link.
+        //  - A producer (a measured leaf feeding others) supplies its generation, divided across the things
+        //    it powers in proportion to their downstream demand (equal split if none draw anything) — so a
+        //    producer feeding several consumers isn't counted once per link.
+        //  - An unmeasured feeder conveys part of the target's *remaining* demand: measured siblings supply
+        //    their real figure first, and only what's left over (the untracked portion) is shared out. That
+        //    stops the graph fabricating a value for, say, Grid when Solar already covers the load. Which
+        //    unmeasured feeders share the remainder is set by their Mode: an explicit 'residual' node is the
+        //    designated absorber, 'none' takes nothing, and plain 'auto' feeders split it when no 'residual'
+        //    node is present.
         double EdgeFlow(string from, string to, HashSet<string> path)
         {
-            if (!leaf.TryGetValue(from, out var produced))
-                return Need(to, path) / Math.Max(1, inCount.GetValueOrDefault(to));
+            if (leaf.TryGetValue(from, out var produced))
+            {
+                var kids = outgoing.TryGetValue(from, out var k) ? k : new List<string>();
+                if (kids.Count <= 1) return produced;
+                var totalDemand = kids.Sum(c => Need(c, path));
+                return totalDemand > 0 ? produced * Need(to, path) / totalDemand : produced / kids.Count;
+            }
 
-            var kids = outgoing.TryGetValue(from, out var k) ? k : new List<string>();
-            if (kids.Count <= 1) return produced;
-            var totalDemand = kids.Sum(c => Need(c, path));
-            return totalDemand > 0 ? produced * Need(to, path) / totalDemand : produced / kids.Count;
+            if (Mode(from) == "none") return 0;   // explicitly contributes nothing ("leave unset")
+
+            var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
+            var measured = feeders.Where(leaf.ContainsKey).Sum(f => EdgeFlow(f, to, path));
+            var remainder = Math.Max(0, Need(to, path) - measured);
+
+            // Unmeasured, non-'none' feeders that may absorb the remainder. If any is 'residual', only those
+            // share it; otherwise the 'auto' feeders split it (back-compat when nothing is measured).
+            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && Mode(f) != "none").ToList();
+            var residual = unmeasured.Where(f => Mode(f) == "residual").ToList();
+            var absorbers = residual.Count > 0 ? residual : unmeasured;
+            if (absorbers.Count == 0 || !absorbers.Contains(from, StringComparer.OrdinalIgnoreCase)) return 0;
+            return remainder / absorbers.Count;
         }
 
         // Emit one link per edge, valued by the flow it carries.

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -198,15 +198,18 @@ public static class FlowGraphBuilder
                 return totalDemand > 0 ? produced * Need(to, path) / totalDemand : produced / kids.Count;
             }
 
-            if (Mode(from) == "none") return 0;   // explicitly contributes nothing ("leave unset")
+            // A 'none' node never infers a value, and a 'static' node with no value here (a valued one is
+            // already a leaf above) has nothing to give — both contribute zero rather than absorbing demand.
+            static bool Inert(string m) => m is "none" or "static";
+            if (Inert(Mode(from))) return 0;
 
             var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
             var measured = feeders.Where(leaf.ContainsKey).Sum(f => EdgeFlow(f, to, path));
             var remainder = Math.Max(0, Need(to, path) - measured);
 
-            // Unmeasured, non-'none' feeders that may absorb the remainder. If any is 'residual', only those
-            // share it; otherwise the 'auto' feeders split it (back-compat when nothing is measured).
-            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && Mode(f) != "none").ToList();
+            // Unmeasured feeders that may absorb the remainder. If any is 'residual', only those share it;
+            // otherwise the 'auto' feeders split it (back-compat when nothing is measured).
+            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f))).ToList();
             var residual = unmeasured.Where(f => Mode(f) == "residual").ToList();
             var absorbers = residual.Count > 0 ? residual : unmeasured;
             if (absorbers.Count == 0 || !absorbers.Contains(from, StringComparer.OrdinalIgnoreCase)) return 0;

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -158,10 +158,18 @@ public static class FlowGraphBuilder
             needMemo[id] = v;
             return v;
         }
+        // Demand a single child draws through one of its feeders (its downstream need, split if it has
+        // several feeders) — used when a measured parent distributes its total across tracked children.
+        double DemandShare(string child, HashSet<string> path)
+            => Need(child, path) / Math.Max(1, incoming.TryGetValue(child, out var f) ? f.Count : 1);
+
         // EdgeFlow(from -> to): how much flows along one link.
         //  - A producer (a measured leaf feeding others) supplies its generation, divided across the things
         //    it powers in proportion to their downstream demand (equal split if none draw anything) — so a
-        //    producer feeding several consumers isn't counted once per link.
+        //    producer feeding several consumers isn't counted once per link. Except: if one of its children
+        //    is marked 'untracked', the tracked children draw their real demand and the untracked child mops
+        //    up the parent's remaining measured throughput (HA-style untracked consumption) — so the parent's
+        //    total is conserved rather than scaled to fill the tracked children.
         //  - An unmeasured feeder conveys part of the target's *remaining* demand: measured siblings supply
         //    their real figure first, and only what's left over (the untracked portion) is shared out. That
         //    stops the graph fabricating a value for, say, Grid when Solar already covers the load. Which
@@ -173,6 +181,16 @@ public static class FlowGraphBuilder
             if (leaf.TryGetValue(from, out var produced))
             {
                 var kids = outgoing.TryGetValue(from, out var k) ? k : new List<string>();
+
+                // Untracked children only make sense under a parent with a known total (this measured leaf).
+                var untracked = kids.Where(c => Mode(c) == "untracked").ToList();
+                if (untracked.Count > 0)
+                {
+                    var trackedDraw = kids.Where(c => Mode(c) != "untracked").Sum(c => DemandShare(c, path));
+                    var spare = Math.Max(0, produced - trackedDraw);
+                    return Mode(to) == "untracked" ? spare / untracked.Count : DemandShare(to, path);
+                }
+
                 if (kids.Count <= 1) return produced;
                 var totalDemand = kids.Sum(c => Need(c, path));
                 return totalDemand > 0 ? produced * Need(to, path) / totalDemand : produced / kids.Count;

--- a/rPDU2MQTT.Core/Flow/FlowUnits.cs
+++ b/rPDU2MQTT.Core/Flow/FlowUnits.cs
@@ -1,0 +1,41 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// Per-metric unit vocabulary and conversion (#129). A live source can publish in whatever unit its device
+/// speaks (Solar Assistant's kW, a meter's Wh); binding a <c>Unit</c> lets us normalise every reading to the
+/// metric's canonical unit on ingest, so the flow roll-up and every export stay in one consistent unit
+/// (W for power, kWh for energy, …) regardless of where the number came from.
+/// </summary>
+public static class FlowUnits
+{
+    // metric key (matches the PDU Measurement.Type / graph metric) -> canonical unit + {unit -> factor to it}.
+    private static readonly Dictionary<string, (string Canonical, Dictionary<string, double> Factors)> Table =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["realpower"] = ("W", new(StringComparer.OrdinalIgnoreCase) { ["W"] = 1, ["kW"] = 1_000, ["MW"] = 1_000_000 }),
+            ["apparentpower"] = ("VA", new(StringComparer.OrdinalIgnoreCase) { ["VA"] = 1, ["kVA"] = 1_000 }),
+            ["energy"] = ("kWh", new(StringComparer.OrdinalIgnoreCase) { ["kWh"] = 1, ["Wh"] = 0.001, ["MWh"] = 1_000 }),
+            ["current"] = ("A", new(StringComparer.OrdinalIgnoreCase) { ["A"] = 1, ["mA"] = 0.001 }),
+            ["voltage"] = ("V", new(StringComparer.OrdinalIgnoreCase) { ["mV"] = 0.001, ["V"] = 1, ["kV"] = 1_000 }),
+            ["frequency"] = ("Hz", new(StringComparer.OrdinalIgnoreCase) { ["Hz"] = 1 }),
+            ["powerfactor"] = ("", new(StringComparer.OrdinalIgnoreCase) { [""] = 1 }),
+        };
+
+    /// <summary>The unit the flow/exports express <paramref name="metric"/> in (blank for the unitless power factor).</summary>
+    public static string Canonical(string metric) => Table.TryGetValue(metric, out var t) ? t.Canonical : "";
+
+    /// <summary>The input units offered for <paramref name="metric"/>, canonical first-or-natural order.</summary>
+    public static IReadOnlyList<string> UnitsFor(string metric)
+        => Table.TryGetValue(metric, out var t) ? t.Factors.Keys.ToList() : Array.Empty<string>();
+
+    /// <summary>
+    /// Factor to multiply a reading in <paramref name="unit"/> by to express it in <paramref name="metric"/>'s
+    /// canonical unit. A blank/unknown unit is treated as already canonical (factor 1), so a binding with no
+    /// declared unit behaves exactly as before this existed.
+    /// </summary>
+    public static double ToCanonicalFactor(string metric, string? unit)
+    {
+        if (string.IsNullOrWhiteSpace(unit)) return 1;
+        return Table.TryGetValue(metric, out var t) && t.Factors.TryGetValue(unit.Trim(), out var f) ? f : 1;
+    }
+}

--- a/rPDU2MQTT.Core/Flow/ModbusDecode.cs
+++ b/rPDU2MQTT.Core/Flow/ModbusDecode.cs
@@ -1,0 +1,48 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// Decodes raw Modbus holding/input registers into a number (#129). Kept transport-free so the register
+/// maths — data types and 32-bit word order, the parts that actually vary between devices — are testable
+/// without a socket, exactly like the MQTT payload parsing is. Byte order within each 16-bit register is
+/// the Modbus-standard big-endian and handled by the client; only the word order across a 32-bit pair is a
+/// per-device choice we expose here.
+/// </summary>
+public static class ModbusDecode
+{
+    /// <summary>How many 16-bit registers a data type spans.</summary>
+    public static int RegisterCount(string? dataType) => Normalize(dataType) switch
+    {
+        "int32" or "uint32" or "float32" => 2,
+        _ => 1,   // int16 / uint16
+    };
+
+    /// <summary>
+    /// Combine <paramref name="registers"/> (in device/register order) into a value per
+    /// <paramref name="dataType"/>. For 32-bit types, <paramref name="wordOrder"/> "big" reads the high word
+    /// first (ABCD) and "little" the low word first (CDAB, the common word-swapped layout).
+    /// </summary>
+    public static double Decode(ushort[] registers, string? dataType, string? wordOrder)
+    {
+        if (registers is null || registers.Length == 0) return 0;
+        switch (Normalize(dataType))
+        {
+            case "int16": return (short)registers[0];
+            case "uint16": return registers[0];
+        }
+        if (registers.Length < 2) return registers[0];   // asked for 32-bit but only got one register
+
+        var little = string.Equals(wordOrder, "little", StringComparison.OrdinalIgnoreCase);
+        uint high = little ? registers[1] : registers[0];
+        uint low = little ? registers[0] : registers[1];
+        var combined = (high << 16) | low;
+
+        return Normalize(dataType) switch
+        {
+            "int32" => unchecked((int)combined),
+            "float32" => BitConverter.Int32BitsToSingle(unchecked((int)combined)),
+            _ => combined,   // uint32
+        };
+    }
+
+    private static string Normalize(string? dataType) => string.IsNullOrWhiteSpace(dataType) ? "uint16" : dataType.Trim().ToLowerInvariant();
+}

--- a/rPDU2MQTT.Core/Models/Config/Config.cs
+++ b/rPDU2MQTT.Core/Models/Config/Config.cs
@@ -72,6 +72,9 @@ public class Config
     [YamlMember(Alias = "EnergyFlow", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Virtual upstream nodes (breakers, transfer switches, a “Total”) and their feeder wiring for the energy-flow hierarchy. Edited visually on the Flow tab.")]
     public EnergyFlowConfig EnergyFlow { get; set; } = new EnergyFlowConfig();
 
+    [YamlMember(Alias = "Modbus", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Modbus TCP connections that energy-flow nodes can be bound to (inverters, meters, PLCs).")]
+    public ModbusConfig Modbus { get; set; } = new ModbusConfig();
+
     /// <summary>
     /// Replace this instance's settings with another's. Used to hot-reload the shared singleton on
     /// rediscovery (services read these sections live). Connection-level settings (MQTT/PDU host/port,
@@ -91,5 +94,6 @@ public class Config
         Health = other.Health;
         Api = other.Api;
         EnergyFlow = other.EnergyFlow;
+        Modbus = other.Modbus;
     }
 }

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -65,12 +65,28 @@ public class EnergyFlowNode
     public string Label { get; set; } = "";
 
     /// <summary>
-    /// A directly-known value for this node, used when it has no children (a leaf) and no <see cref="Mqtt"/>
-    /// source has reported. A manual/known figure — e.g. an untracked load, or a panel you're modelling
-    /// before its CT clamp is ingested. Ignored when the node aggregates children.
+    /// What this node represents (#129). Purely descriptive today — it drives the diagram's styling and
+    /// which fields/metrics the editor offers (a battery has storage but no frequency, etc.) — but leaves
+    /// room for kind-specific behaviour (battery charge/discharge, inverter efficiency) later. <c>node</c>
+    /// is the plain virtual node it has always been.
     /// </summary>
-    [Description("Optional fixed value for a leaf node. Used only when no live MQTT source has reported for it.")]
+    [DefaultValue("node")]
+    [Description("What this node represents: 'node' (generic), 'panel', 'inverter', 'battery', 'solar', 'grid', or 'load'. Drives styling and the fields the editor offers.")]
+    [AllowedValues("node", "panel", "inverter", "battery", "solar", "grid", "load")]
+    public string Kind { get; set; } = "node";
+
+    /// <summary>
+    /// A directly-known value for this node, used when it has no children (a leaf) and no live
+    /// <see cref="Sources"/> reading has arrived. A manual/known figure — e.g. an untracked load, or a
+    /// panel you're modelling before its CT clamp is ingested. Ignored when the node aggregates children.
+    /// </summary>
+    [Description("Optional fixed value for a leaf node. Used only when no live source has reported for it.")]
     public double? Value { get; set; }
+
+    /// <summary>For <see cref="Kind"/> <c>battery</c>: usable storage capacity in kWh. Metadata for the
+    /// diagram/state-of-charge display; does not affect the power roll-up.</summary>
+    [Description("For a battery node: usable storage capacity in kWh (display metadata; optional).")]
+    public double? StorageKwh { get; set; }
 
     /// <summary>
     /// How this node's value is decided when it has no direct measurement (#129). A live source or static
@@ -97,29 +113,46 @@ public class EnergyFlowNode
     public string Mode { get; set; } = "auto";
 
     /// <summary>
-    /// Live measurements for this leaf node, read straight off the broker (#205) — the seam
-    /// <see cref="Value"/> always described. One entry per metric, so the same node can feed both the
-    /// power and the energy roll-up (e.g. Solar Assistant's <c>pv_power</c> and <c>pv_energy</c> topics).
-    /// A live reading supersedes <see cref="Value"/>; ignored when the node aggregates children.
+    /// Live value bindings for this node (#205), one per metric — the seam <see cref="Value"/> always
+    /// described. Each binds a metric (realpower, energy, …) to an external source; a fresh reading
+    /// supersedes <see cref="Value"/>, and binding several metrics lets the same node drive the power, the
+    /// energy roll-up, voltage, etc. Every binding carries a <see cref="EnergyFlowSource.Type"/> (only
+    /// <c>mqtt</c> today) so more ingest kinds can be added without reshaping the model.
     /// </summary>
-    [Description("Live values for this node read from MQTT topics (e.g. Solar Assistant). One entry per metric; supersedes Value.")]
-    public List<EnergyFlowMqttSource> Mqtt { get; set; } = new();
+    [Description("Live value bindings for this node, one per metric. Each binds a metric to an external source (Type 'mqtt' today). Supersedes Value.")]
+    public List<EnergyFlowSource> Sources { get; set; } = new();
+
+    /// <summary>
+    /// Legacy pre-<see cref="Sources"/> MQTT bindings (#205). Still honored on load so older configs keep
+    /// working; the GUI migrates these into <see cref="Sources"/> (each was implicitly <c>Type: mqtt</c>).
+    /// </summary>
+    [Description("Deprecated: use Sources. Legacy MQTT bindings (implicitly Type 'mqtt'); still honored for back-compat.")]
+    public List<EnergyFlowSource> Mqtt { get; set; } = new();
+
+    /// <summary>Every effective binding — the new <see cref="Sources"/> plus any legacy <see cref="Mqtt"/>.</summary>
+    public IEnumerable<EnergyFlowSource> AllSources() => Sources.Concat(Mqtt);
 }
 
 /// <summary>
-/// Binds one MQTT topic to one metric of a flow node (#205). Built for producers that already publish to
-/// the broker — Solar Assistant, CT clamps, an inverter bridge — so their data joins the same hierarchy,
-/// roll-ups and exports as the PDU outlets.
+/// Binds one external source to one metric of a flow node (#205). Built for producers that already publish
+/// their data — Solar Assistant, CT clamps, an inverter bridge — so it joins the same hierarchy, roll-ups
+/// and exports as the PDU outlets. <see cref="Type"/> selects the ingest; the transport-specific fields
+/// (today just the MQTT ones) apply per type.
 /// </summary>
-public class EnergyFlowMqttSource
+public class EnergyFlowSource
 {
-    [Description("MQTT topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.")]
-    public string Topic { get; set; } = "";
+    [DefaultValue("mqtt")]
+    [Description("Where this value comes from. Currently only 'mqtt' (subscribe to a broker topic); more ingest types can be added later.")]
+    [AllowedValues("mqtt")]
+    public string Type { get; set; } = "mqtt";
 
     [DefaultValue("realpower")]
-    [Description("Which measurement this topic supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.")]
+    [Description("Which measurement this source supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.")]
     [AllowedValues("realpower", "apparentpower", "energy", "current", "voltage", "frequency", "powerfactor")]
     public string Metric { get; set; } = "realpower";
+
+    [Description("For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.")]
+    public string Topic { get; set; } = "";
 
     /// <summary>
     /// For JSON payloads: the field to read, dotted for nesting (<c>battery.power</c>). Blank treats the

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -149,9 +149,17 @@ public class EnergyFlowSource
     public string Type { get; set; } = "mqtt";
 
     [DefaultValue("realpower")]
-    [Description("Which measurement this source supplies. The flow is rolled up per metric, so use realpower for live power and energy for cumulative kWh.")]
+    [Description("Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.")]
     [AllowedValues("realpower", "apparentpower", "energy", "current", "voltage", "frequency", "powerfactor")]
     public string Metric { get; set; } = "realpower";
+
+    /// <summary>
+    /// The unit the source publishes this value in (e.g. <c>kW</c>, <c>Wh</c>). The reading is converted to
+    /// the metric's canonical unit (W, kWh, V, …) on ingest so every export stays consistent. Blank assumes
+    /// the value is already canonical. See <see cref="rPDU2MQTT.Core.Flow.FlowUnits"/>.
+    /// </summary>
+    [Description("Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.")]
+    public string? Unit { get; set; }
 
     [Description("For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.")]
     public string Topic { get; set; } = "";

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -79,16 +79,21 @@ public class EnergyFlowNode
     /// <list type="bullet">
     /// <item><c>auto</c> (default): aggregate children, and as an upstream feeder take a share of what's
     /// left after measured siblings — the historical behaviour.</item>
-    /// <item><c>residual</c>: the designated "untracked" absorber — takes the demand a node still needs
-    /// after every measured feeder has supplied its bit (e.g. house load not behind a PDU or CT clamp).</item>
+    /// <item><c>residual</c>: the designated "untracked" absorber on the <em>feeder</em> side — takes the
+    /// demand a node still needs after every measured feeder has supplied its bit (e.g. house load not
+    /// behind a PDU or CT clamp).</item>
+    /// <item><c>untracked</c>: the mirror on the <em>child</em> side — placed under a parent that has a
+    /// measured total (a bound source / fixed value), it shows the slice of that total the parent's tracked
+    /// children don't account for (HA-style untracked consumption). Contributes nothing if the parent has no
+    /// measured total.</item>
     /// <item><c>none</c>: never inferred — contributes nothing unless it has a real value/children, so an
     /// unmeasured source (e.g. Grid, when solar already covers the load) simply drops out instead of being
     /// assigned a fabricated figure.</item>
     /// </list>
     /// </summary>
     [DefaultValue("auto")]
-    [Description("How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand), or 'none' (never inferred). A live/static Value always wins.")]
-    [AllowedValues("auto", "residual", "none")]
+    [Description("How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live/static Value always wins.")]
+    [AllowedValues("auto", "residual", "untracked", "none")]
     public string Mode { get; set; } = "auto";
 
     /// <summary>

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -73,6 +73,25 @@ public class EnergyFlowNode
     public double? Value { get; set; }
 
     /// <summary>
+    /// How this node's value is decided when it has no direct measurement (#129). A live source or static
+    /// <see cref="Value"/> always wins regardless — this only governs nodes the graph would otherwise have
+    /// to infer:
+    /// <list type="bullet">
+    /// <item><c>auto</c> (default): aggregate children, and as an upstream feeder take a share of what's
+    /// left after measured siblings — the historical behaviour.</item>
+    /// <item><c>residual</c>: the designated "untracked" absorber — takes the demand a node still needs
+    /// after every measured feeder has supplied its bit (e.g. house load not behind a PDU or CT clamp).</item>
+    /// <item><c>none</c>: never inferred — contributes nothing unless it has a real value/children, so an
+    /// unmeasured source (e.g. Grid, when solar already covers the load) simply drops out instead of being
+    /// assigned a fabricated figure.</item>
+    /// </list>
+    /// </summary>
+    [DefaultValue("auto")]
+    [Description("How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand), or 'none' (never inferred). A live/static Value always wins.")]
+    [AllowedValues("auto", "residual", "none")]
+    public string Mode { get; set; } = "auto";
+
+    /// <summary>
     /// Live measurements for this leaf node, read straight off the broker (#205) — the seam
     /// <see cref="Value"/> always described. One entry per metric, so the same node can feed both the
     /// power and the energy roll-up (e.g. Solar Assistant's <c>pv_power</c> and <c>pv_energy</c> topics).

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -95,6 +95,8 @@ public class EnergyFlowNode
     /// <list type="bullet">
     /// <item><c>auto</c> (default): aggregate children, and as an upstream feeder take a share of what's
     /// left after measured siblings — the historical behaviour.</item>
+    /// <item><c>static</c>: a fixed leaf valued at <see cref="Value"/> (still superseded by a live source).
+    /// This is the mode that gives the fixed value meaning; with no value set it contributes nothing.</item>
     /// <item><c>residual</c>: the designated "untracked" absorber on the <em>feeder</em> side — takes the
     /// demand a node still needs after every measured feeder has supplied its bit (e.g. house load not
     /// behind a PDU or CT clamp).</item>
@@ -108,8 +110,8 @@ public class EnergyFlowNode
     /// </list>
     /// </summary>
     [DefaultValue("auto")]
-    [Description("How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live/static Value always wins.")]
-    [AllowedValues("auto", "residual", "untracked", "none")]
+    [Description("How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'static' (a fixed leaf at Value), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins.")]
+    [AllowedValues("auto", "static", "residual", "untracked", "none")]
     public string Mode { get; set; } = "auto";
 
     /// <summary>

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -144,8 +144,8 @@ public class EnergyFlowNode
 public class EnergyFlowSource
 {
     [DefaultValue("mqtt")]
-    [Description("Where this value comes from. Currently only 'mqtt' (subscribe to a broker topic); more ingest types can be added later.")]
-    [AllowedValues("mqtt")]
+    [Description("Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection).")]
+    [AllowedValues("mqtt", "modbus")]
     public string Type { get; set; } = "mqtt";
 
     [DefaultValue("realpower")]
@@ -179,4 +179,27 @@ public class EnergyFlowSource
     [Range(0, 86400, ErrorMessage = "StaleAfterSeconds must be between 0 and 86400.")]
     [Description("Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).")]
     public int StaleAfterSeconds { get; set; } = 900;
+
+    // --- Type 'modbus' -----------------------------------------------------------------------------
+
+    [Description("For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from.")]
+    public string? Connection { get; set; }
+
+    [Description("For Type 'modbus': the register address to read (0-based).")]
+    public int Register { get; set; }
+
+    [DefaultValue("holding")]
+    [Description("For Type 'modbus': which register bank — 'holding' (function 3) or 'input' (function 4).")]
+    [AllowedValues("holding", "input")]
+    public string RegisterType { get; set; } = "holding";
+
+    [DefaultValue("uint16")]
+    [Description("For Type 'modbus': how to decode the register(s) — uint16, int16, uint32, int32, or float32.")]
+    [AllowedValues("uint16", "int16", "uint32", "int32", "float32")]
+    public string DataType { get; set; } = "uint16";
+
+    [DefaultValue("big")]
+    [Description("For Type 'modbus' 32-bit values: word order — 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped).")]
+    [AllowedValues("big", "little")]
+    public string WordOrder { get; set; } = "big";
 }

--- a/rPDU2MQTT.Core/Models/Config/ModbusConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/ModbusConfig.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>
+/// Modbus TCP connections (#129) an energy-flow node can be fed from — an inverter, a meter, a PLC that
+/// already speaks Modbus. Set the connections up here once, then bind a node's value to one by picking the
+/// connection and a register in the Flow editor. Polled by <c>EnergyFlowModbusSourceService</c> into the
+/// same live-value seam as the MQTT sources.
+/// </summary>
+public class ModbusConfig
+{
+    [Description("Modbus TCP devices to poll. Add one per device, then reference it from a source binding's Connection.")]
+    public List<ModbusConnection> Connections { get; set; } = new();
+}
+
+/// <summary>One Modbus TCP device.</summary>
+public class ModbusConnection
+{
+    [Description("Stable id used to reference this connection from a source binding.")]
+    public string Id { get; set; } = "";
+
+    [Description("Friendly name for the device (shown in the editor).")]
+    public string Name { get; set; } = "";
+
+    [Description("Hostname or IP address of the Modbus TCP device.")]
+    public string Host { get; set; } = "";
+
+    [DefaultValue(502)]
+    [Description("TCP port the device listens on (Modbus default 502).")]
+    public int Port { get; set; } = 502;
+
+    [DefaultValue(1)]
+    [Description("Modbus unit / slave id.")]
+    public int UnitId { get; set; } = 1;
+
+    [DefaultValue(10)]
+    [Range(1, 86400, ErrorMessage = "PollIntervalSeconds must be between 1 and 86400.")]
+    [Description("How often to poll this device, in seconds.")]
+    public int PollIntervalSeconds { get; set; } = 10;
+
+    [DefaultValue(true)]
+    [Description("Poll this device. Turn off to disable it without deleting the connection.")]
+    public bool Enabled { get; set; } = true;
+}

--- a/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using FluentModbus;
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Feeds energy-flow nodes from Modbus TCP devices (#129) — inverters, meters, PLCs — by polling the
+/// registers bound in <c>EnergyFlow.Nodes[].Sources</c> with Type 'modbus' and keeping the latest value per
+/// (node, metric). Shares the <see cref="IFlowValueSource"/> seam with the MQTT ingest (via
+/// <see cref="CompositeFlowValueSource"/>), so a Modbus-sourced node rolls up, exports and appears in Home
+/// Assistant exactly like an MQTT- or PDU-sourced one.
+///
+/// Each connection is polled on its own interval; connections + bindings are re-read every tick, so editing
+/// them in the GUI takes effect without a restart. A device is opened per poll (connect → read → close),
+/// which is simplest and robust for the seconds-scale cadence energy monitoring needs.
+/// </summary>
+public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValueSource
+{
+    private readonly Config cfg;
+    private readonly FlowValueCache latest = new();
+    private readonly Dictionary<string, DateTime> lastPolled = new(StringComparer.Ordinal);
+
+    public EnergyFlowModbusSourceService(Config cfg) => this.cfg = cfg;
+
+    public bool TryGetValue(string nodeId, string metric, out double value)
+        => latest.TryGetValue(nodeId, metric, out value);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            // A 1s base tick; each connection fires on its own PollIntervalSeconds.
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+            do
+            {
+                try { Reconcile(DateTime.UtcNow); }
+                catch (OperationCanceledException) { return; }
+                catch (Exception ex) { Log.Warning($"Energy-flow Modbus: {ex.Message}"); }
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+        catch (OperationCanceledException) { /* shutting down */ }
+    }
+
+    /// <summary>Poll each due connection, and drop cached readings whose binding has gone away.</summary>
+    private void Reconcile(DateTime nowUtc)
+    {
+        var bindings = BuildBindings(cfg.EnergyFlow.Nodes);
+
+        // Prune readings no longer produced by any current modbus binding (a removed/retyped source).
+        var live = bindings.Values.SelectMany(v => v).Select(b => (b.NodeId, b.Source.Metric)).ToHashSet();
+        foreach (var key in latest.Keys.Where(k => !live.Contains((k.Node, k.Metric))).ToList())
+            latest.Remove(key.Node, key.Metric);
+
+        foreach (var conn in cfg.Modbus.Connections)
+        {
+            if (!conn.Enabled || string.IsNullOrWhiteSpace(conn.Id) || string.IsNullOrWhiteSpace(conn.Host)) continue;
+            if (!bindings.TryGetValue(conn.Id, out var forConn) || forConn.Count == 0) continue;
+
+            var interval = TimeSpan.FromSeconds(Math.Max(1, conn.PollIntervalSeconds));
+            if (lastPolled.TryGetValue(conn.Id, out var last) && nowUtc - last < interval) continue;
+            lastPolled[conn.Id] = nowUtc;
+
+            try { Poll(conn, forConn, nowUtc); }
+            catch (Exception ex) { Log.Warning($"Energy-flow Modbus: {conn.Name ?? conn.Id} ({conn.Host}:{conn.Port}) — {ex.Message}"); }
+        }
+    }
+
+    private void Poll(ModbusConnection conn, List<(string NodeId, EnergyFlowSource Source)> forConn, DateTime nowUtc)
+    {
+        var endpoint = new IPEndPoint(ResolveHost(conn.Host), conn.Port);
+        using var client = new ModbusTcpClient { ReadTimeout = 3000, WriteTimeout = 3000 };
+        client.Connect(endpoint, ModbusEndianness.BigEndian);
+
+        foreach (var (nodeId, src) in forConn)
+        {
+            try
+            {
+                var count = ModbusDecode.RegisterCount(src.DataType);
+                var regs = string.Equals(src.RegisterType, "input", StringComparison.OrdinalIgnoreCase)
+                    ? client.ReadInputRegisters<ushort>(conn.UnitId, src.Register, count).ToArray()
+                    : client.ReadHoldingRegisters<ushort>(conn.UnitId, src.Register, count).ToArray();
+
+                var raw = ModbusDecode.Decode(regs, src.DataType, src.WordOrder);
+                // Normalise the declared unit, then apply the manual Scale — the same pipeline as MQTT.
+                var value = raw * FlowUnits.ToCanonicalFactor(src.Metric, src.Unit) * src.Scale;
+                latest.Set(nodeId, src.Metric, value, src.StaleAfterSeconds, nowUtc);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug($"Energy-flow Modbus: node '{nodeId}' register {src.Register} on {conn.Id} — {ex.Message}");
+            }
+        }
+    }
+
+    private static IPAddress ResolveHost(string host)
+        => IPAddress.TryParse(host, out var ip)
+            ? ip
+            : Dns.GetHostAddresses(host).FirstOrDefault(a => a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+              ?? Dns.GetHostAddresses(host).First();
+
+    /// <summary>Group the nodes' Modbus-type bindings by connection id for the poller. Testable without a device.</summary>
+    internal static Dictionary<string, List<(string NodeId, EnergyFlowSource Source)>> BuildBindings(IEnumerable<EnergyFlowNode> nodes)
+    {
+        var byConn = new Dictionary<string, List<(string, EnergyFlowSource)>>(StringComparer.Ordinal);
+        foreach (var node in nodes)
+        {
+            if (string.IsNullOrWhiteSpace(node.Id)) continue;
+            foreach (var src in node.AllSources())
+            {
+                if (!string.Equals(src.Type, "modbus", StringComparison.OrdinalIgnoreCase)) continue;
+                if (string.IsNullOrWhiteSpace(src.Connection) || string.IsNullOrWhiteSpace(src.Metric)) continue;
+                var conn = src.Connection.Trim();
+                if (!byConn.TryGetValue(conn, out var list)) byConn[conn] = list = new();
+                list.Add((node.Id.Trim(), src));
+            }
+        }
+        return byConn;
+    }
+}

--- a/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
@@ -72,29 +72,84 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
 
     private void Poll(ModbusConnection conn, List<(string NodeId, EnergyFlowSource Source)> forConn, DateTime nowUtc)
     {
-        var endpoint = new IPEndPoint(ResolveHost(conn.Host), conn.Port);
-        using var client = new ModbusTcpClient { ReadTimeout = 3000, WriteTimeout = 3000 };
-        client.Connect(endpoint, ModbusEndianness.BigEndian);
+        var nodeOf = new Dictionary<EnergyFlowSource, string>(ReferenceEqualityComparer.Instance);
+        foreach (var (nodeId, src) in forConn) nodeOf[src] = nodeId;
 
-        foreach (var (nodeId, src) in forConn)
+        ReadBatch(conn.Host, conn.Port, conn.UnitId, forConn.Select(f => f.Source).ToList(),
+            onValue: (src, value) => latest.Set(nodeOf[src], src.Metric, value, src.StaleAfterSeconds, nowUtc),
+            onError: (src, msg) => Log.Debug($"Energy-flow Modbus: node '{nodeOf[src]}' register {src.Register} on {conn.Id} — {msg}"));
+    }
+
+    /// <summary>Read + decode one source's register(s), then normalise the unit and apply Scale (same pipeline as MQTT).</summary>
+    private static double ReadValue(ModbusTcpClient client, int unitId, EnergyFlowSource src)
+    {
+        var count = ModbusDecode.RegisterCount(src.DataType);
+        var regs = string.Equals(src.RegisterType, "input", StringComparison.OrdinalIgnoreCase)
+            ? client.ReadInputRegisters<ushort>(unitId, src.Register, count).ToArray()
+            : client.ReadHoldingRegisters<ushort>(unitId, src.Register, count).ToArray();
+        return ModbusDecode.Decode(regs, src.DataType, src.WordOrder) * FlowUnits.ToCanonicalFactor(src.Metric, src.Unit) * src.Scale;
+    }
+
+    /// <summary>
+    /// Read a batch of sources on one connection, reconnecting on a read error before the next register. A
+    /// failed read (an exception response, or cross-talk on a serial gateway shared by another master) can
+    /// leave the TCP stream misaligned, so the following reads come back as *another* register's data — a
+    /// silent-corruption risk. Reconnecting after any error closes that window and retries the register once.
+    /// Throws only if the initial connect fails (so callers can report "unreachable").
+    /// </summary>
+    private static void ReadBatch(string host, int port, int unitId, IReadOnlyList<EnergyFlowSource> items,
+        Action<EnergyFlowSource, double> onValue, Action<EnergyFlowSource, string>? onError = null)
+    {
+        var endpoint = new IPEndPoint(ResolveHost(host), port);
+        ModbusTcpClient? client = null;
+        void Reconnect()
         {
-            try
-            {
-                var count = ModbusDecode.RegisterCount(src.DataType);
-                var regs = string.Equals(src.RegisterType, "input", StringComparison.OrdinalIgnoreCase)
-                    ? client.ReadInputRegisters<ushort>(conn.UnitId, src.Register, count).ToArray()
-                    : client.ReadHoldingRegisters<ushort>(conn.UnitId, src.Register, count).ToArray();
+            client?.Dispose();
+            client = new ModbusTcpClient { ReadTimeout = 3000, WriteTimeout = 3000 };
+            client.Connect(endpoint, ModbusEndianness.BigEndian);
+        }
 
-                var raw = ModbusDecode.Decode(regs, src.DataType, src.WordOrder);
-                // Normalise the declared unit, then apply the manual Scale — the same pipeline as MQTT.
-                var value = raw * FlowUnits.ToCanonicalFactor(src.Metric, src.Unit) * src.Scale;
-                latest.Set(nodeId, src.Metric, value, src.StaleAfterSeconds, nowUtc);
-            }
-            catch (Exception ex)
+        try
+        {
+            Reconnect();   // an initial-connect failure propagates to the caller
+            foreach (var src in items)
             {
-                Log.Debug($"Energy-flow Modbus: node '{nodeId}' register {src.Register} on {conn.Id} — {ex.Message}");
+                for (var attempt = 0; ; attempt++)
+                {
+                    try { onValue(src, ReadValue(client!, unitId, src)); break; }
+                    catch (Exception ex)
+                    {
+                        if (attempt >= 1) { onError?.Invoke(src, ex.Message); break; }
+                        try { Reconnect(); } catch { onError?.Invoke(src, ex.Message); break; }  // reconnect + retry once
+                    }
+                }
             }
         }
+        finally { client?.Dispose(); }
+    }
+
+    /// <summary>One probed register value (or the error hit reading it), in the request's item order.</summary>
+    public sealed record ModbusReading(int Register, string Metric, double? Value, string? Error);
+
+    /// <summary>
+    /// Connect to a device once and (optionally) read a set of register specs — powers the GUI's "Test
+    /// connection" button and the live per-binding value display, so a mapping can be verified before it's
+    /// wired into the flow. Read-only; opens and closes a throwaway connection.
+    /// </summary>
+    public static (bool Ok, string Message, List<ModbusReading> Readings) Probe(string host, int port, int unitId, IReadOnlyList<EnergyFlowSource>? items)
+    {
+        var readings = new List<ModbusReading>();
+        try
+        {
+            ReadBatch(host, port, unitId, items ?? Array.Empty<EnergyFlowSource>(),
+                onValue: (src, value) => readings.Add(new ModbusReading(src.Register, src.Metric, value, null)),
+                onError: (src, msg) => readings.Add(new ModbusReading(src.Register, src.Metric, null, msg)));
+        }
+        catch (Exception ex) { return (false, $"Could not connect to {host}:{port} — {ex.Message}", readings); }
+
+        var okCount = readings.Count(r => r.Error is null);
+        var suffix = readings.Count > 0 ? $" Read {okCount}/{readings.Count} register(s)." : "";
+        return (true, $"Connected to {host}:{port}.{suffix}", readings);
     }
 
     private static IPAddress ResolveHost(string host)

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -27,7 +27,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     // The staleness rules live in the cache (Core) so they're testable without a broker.
     private readonly FlowValueCache latest = new();
     // Topic -> the bindings fed by it. One topic may drive several nodes/metrics.
-    private volatile Dictionary<string, List<(string NodeId, EnergyFlowMqttSource Source)>> bindings = new(StringComparer.Ordinal);
+    private volatile Dictionary<string, List<(string NodeId, EnergyFlowSource Source)>> bindings = new(StringComparer.Ordinal);
     private readonly HashSet<string> subscribed = new(StringComparer.Ordinal);
 
     public EnergyFlowMqttSourceService(MQTTServiceDependencies deps)
@@ -113,15 +113,20 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     private void OnMessageReceived(object? sender, OnMessageReceivedEventArgs e)
         => Apply(bindings, latest, e.PublishMessage.Topic, e.PublishMessage.PayloadAsString, DateTime.UtcNow);
 
-    /// <summary>Flatten the nodes' MQTT bindings into a topic → (node, source) lookup for the subscriber.</summary>
-    internal static Dictionary<string, List<(string NodeId, EnergyFlowMqttSource Source)>> BuildBindings(IEnumerable<EnergyFlowNode> nodes)
+    /// <summary>
+    /// Flatten the nodes' MQTT-type bindings into a topic → (node, source) lookup for the subscriber. Reads
+    /// the new <see cref="EnergyFlowNode.Sources"/> and the legacy <see cref="EnergyFlowNode.Mqtt"/> together,
+    /// and skips any binding whose <see cref="EnergyFlowSource.Type"/> this ingest doesn't handle.
+    /// </summary>
+    internal static Dictionary<string, List<(string NodeId, EnergyFlowSource Source)>> BuildBindings(IEnumerable<EnergyFlowNode> nodes)
     {
-        var desired = new Dictionary<string, List<(string, EnergyFlowMqttSource)>>(StringComparer.Ordinal);
+        var desired = new Dictionary<string, List<(string, EnergyFlowSource)>>(StringComparer.Ordinal);
         foreach (var node in nodes)
         {
-            if (string.IsNullOrWhiteSpace(node.Id) || node.Mqtt is null) continue;
-            foreach (var src in node.Mqtt)
+            if (string.IsNullOrWhiteSpace(node.Id)) continue;
+            foreach (var src in node.AllSources())
             {
+                if (!string.Equals(src.Type, "mqtt", StringComparison.OrdinalIgnoreCase)) continue;   // this ingest only
                 if (string.IsNullOrWhiteSpace(src.Topic) || string.IsNullOrWhiteSpace(src.Metric)) continue;
                 var topic = src.Topic.Trim();
                 if (!desired.TryGetValue(topic, out var list)) desired[topic] = list = new();
@@ -137,7 +142,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     /// subscribe → parse → cache glue is exercised without a live broker.
     /// </summary>
     internal static void Apply(
-        IReadOnlyDictionary<string, List<(string NodeId, EnergyFlowMqttSource Source)>> bindings,
+        IReadOnlyDictionary<string, List<(string NodeId, EnergyFlowSource Source)>> bindings,
         FlowValueCache cache, string? topic, string? payload, DateTime nowUtc)
     {
         if (topic is null || !bindings.TryGetValue(topic, out var list) || string.IsNullOrWhiteSpace(payload))

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -155,7 +155,10 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
                 Log.Debug($"Energy-flow: could not read a number from {topic} for node '{nodeId}' (payload: {Truncate(payload)}).");
                 continue;
             }
-            cache.Set(nodeId, src.Metric, raw * src.Scale, src.StaleAfterSeconds, nowUtc);
+            // Normalise to the metric's canonical unit (kW -> W, Wh -> kWh, …) so the roll-up and exports are
+            // consistent, then apply the manual Scale (sign flips / oddball adjustments) on top.
+            var value = raw * FlowUnits.ToCanonicalFactor(src.Metric, src.Unit) * src.Scale;
+            cache.Set(nodeId, src.Metric, value, src.StaleAfterSeconds, nowUtc);
         }
     }
 

--- a/rPDU2MQTT.Engine/rPDU2MQTT.Engine.csproj
+++ b/rPDU2MQTT.Engine/rPDU2MQTT.Engine.csproj
@@ -12,6 +12,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="FluentModbus" Version="5.3.2" />
 		<PackageReference Include="HiveMQtt" Version="0.45.0" />
 		<PackageReference Include="KubernetesClient" Version="19.0.2" />
 		<PackageReference Include="prometheus-net" Version="8.2.1" />

--- a/rPDU2MQTT.Tests/ConfigSchemaTests.cs
+++ b/rPDU2MQTT.Tests/ConfigSchemaTests.cs
@@ -238,19 +238,19 @@ public class ConfigSchemaTests
     }
 
     [Fact]
-    public void EnergyFlowMqttSources_SurviveTheSaveThenReloadRoundTrip()
+    public void EnergyFlowSources_SurviveTheSaveThenReloadRoundTrip()
     {
-        // Same path as above, for the live MQTT bindings (#205). The GUI is the only way to set these, so
+        // Same path as above, for the live value bindings (#205). The GUI is the only way to set these, so
         // if they don't survive JSON -> YAML -> load, a bound topic silently disappears on save.
         var posted = new Config();
         posted.EnergyFlow.Nodes.Add(new EnergyFlowNode
         {
             Id = "solar",
             Label = "Solar",
-            Mqtt =
+            Sources =
             {
-                new EnergyFlowMqttSource { Topic = "solar_assistant/inverter_1/pv_power/state", Metric = "realpower" },
-                new EnergyFlowMqttSource { Topic = "solar_assistant/inverter_1/pv_energy/state", Metric = "energy", JsonField = "value", Scale = 0.001, StaleAfterSeconds = 0 },
+                new EnergyFlowSource { Type = "mqtt", Topic = "solar_assistant/inverter_1/pv_power/state", Metric = "realpower" },
+                new EnergyFlowSource { Type = "mqtt", Topic = "solar_assistant/inverter_1/pv_energy/state", Metric = "energy", JsonField = "value", Scale = 0.001, StaleAfterSeconds = 0 },
             },
         });
 
@@ -259,17 +259,41 @@ public class ConfigSchemaTests
         var reloaded = YamlConfigLoader.DeserializeString(yaml);
 
         var node = Assert.Single(reloaded.EnergyFlow.Nodes);
-        Assert.Equal(2, node.Mqtt.Count);
+        Assert.Equal(2, node.Sources.Count);
 
-        var power = Assert.Single(node.Mqtt, s => s.Metric == "realpower");
+        var power = Assert.Single(node.Sources, s => s.Metric == "realpower");
+        Assert.Equal("mqtt", power.Type);
         Assert.Equal("solar_assistant/inverter_1/pv_power/state", power.Topic);
         Assert.Equal(1.0, power.Scale);                 // default survives
         Assert.Equal(900, power.StaleAfterSeconds);     // default survives
 
-        var energy = Assert.Single(node.Mqtt, s => s.Metric == "energy");
+        var energy = Assert.Single(node.Sources, s => s.Metric == "energy");
         Assert.Equal("value", energy.JsonField);
         Assert.Equal(0.001, energy.Scale);
         Assert.Equal(0, energy.StaleAfterSeconds);      // an explicit 0 must not be lost to the default
+    }
+
+    [Fact]
+    public void EnergyFlow_LegacyMqttBindings_StillDeserializeAndCountAsSources()
+    {
+        // Pre-Sources configs wrote the bindings under 'Mqtt:'. They must still load and be visible via
+        // AllSources() so a topic bound before the rename keeps feeding the graph.
+        var yaml = """
+        EnergyFlow:
+          Nodes:
+          - Id: solar
+            Label: Solar
+            Mqtt:
+            - Topic: solar_assistant/inverter_1/pv_power/state
+              Metric: realpower
+        """;
+
+        var reloaded = YamlConfigLoader.DeserializeString(yaml);
+        var node = Assert.Single(reloaded.EnergyFlow.Nodes);
+
+        var src = Assert.Single(node.AllSources());
+        Assert.Equal("mqtt", src.Type);   // legacy entries are implicitly Type 'mqtt'
+        Assert.Equal("solar_assistant/inverter_1/pv_power/state", src.Topic);
     }
 
     [Fact]

--- a/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
+++ b/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
@@ -177,17 +177,17 @@ public class EnergyFlowMqttSourceTests
 
     // --- Subscribe → parse → cache glue (BuildBindings + Apply) ------------------------------------
 
-    private static EnergyFlowNode NodeWith(string id, params EnergyFlowMqttSource[] sources)
+    private static EnergyFlowNode NodeWith(string id, params EnergyFlowSource[] sources)
     {
         var n = new EnergyFlowNode { Id = id, Label = id };
-        n.Mqtt.AddRange(sources);
+        n.Sources.AddRange(sources);
         return n;
     }
 
     [Fact]
     public void Apply_RoutesAPayloadToTheBoundNodeAndMetric()
     {
-        var nodes = new[] { NodeWith("solar", new EnergyFlowMqttSource { Topic = "sa/pv_power", Metric = "realpower" }) };
+        var nodes = new[] { NodeWith("solar", new EnergyFlowSource { Topic = "sa/pv_power", Metric = "realpower" }) };
         var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
         var cache = new FlowValueCache();
 
@@ -200,7 +200,7 @@ public class EnergyFlowMqttSourceTests
     [Fact]
     public void Apply_AppliesScaleAndReadsAJsonField()
     {
-        var nodes = new[] { NodeWith("meter", new EnergyFlowMqttSource { Topic = "sa/energy", Metric = "energy", JsonField = "wh", Scale = 0.001 }) };
+        var nodes = new[] { NodeWith("meter", new EnergyFlowSource { Topic = "sa/energy", Metric = "energy", JsonField = "wh", Scale = 0.001 }) };
         var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
         var cache = new FlowValueCache();
 
@@ -214,7 +214,7 @@ public class EnergyFlowMqttSourceTests
     public void Apply_IgnoresAnUnboundTopic()
     {
         var bindings = EnergyFlowMqttSourceService.BuildBindings(
-            new[] { NodeWith("solar", new EnergyFlowMqttSource { Topic = "sa/pv_power", Metric = "realpower" }) });
+            new[] { NodeWith("solar", new EnergyFlowSource { Topic = "sa/pv_power", Metric = "realpower" }) });
         var cache = new FlowValueCache();
 
         EnergyFlowMqttSourceService.Apply(bindings, cache, "some/other/topic", "999", DateTime.UtcNow);
@@ -226,7 +226,7 @@ public class EnergyFlowMqttSourceTests
     public void Apply_LeavesTheCacheUntouchedForAnUnparseablePayload()
     {
         var bindings = EnergyFlowMqttSourceService.BuildBindings(
-            new[] { NodeWith("solar", new EnergyFlowMqttSource { Topic = "sa/pv_power", Metric = "realpower" }) });
+            new[] { NodeWith("solar", new EnergyFlowSource { Topic = "sa/pv_power", Metric = "realpower" }) });
         var cache = new FlowValueCache();
 
         EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_power", "unavailable", DateTime.UtcNow);
@@ -240,8 +240,8 @@ public class EnergyFlowMqttSourceTests
         // A shared bus topic can legitimately feed more than one node.
         var nodes = new[]
         {
-            NodeWith("a", new EnergyFlowMqttSource { Topic = "shared/power", Metric = "realpower" }),
-            NodeWith("b", new EnergyFlowMqttSource { Topic = "shared/power", Metric = "realpower", Scale = 2 }),
+            NodeWith("a", new EnergyFlowSource { Topic = "shared/power", Metric = "realpower" }),
+            NodeWith("b", new EnergyFlowSource { Topic = "shared/power", Metric = "realpower", Scale = 2 }),
         };
         var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
         var cache = new FlowValueCache();
@@ -257,9 +257,9 @@ public class EnergyFlowMqttSourceTests
     {
         var nodes = new[]
         {
-            NodeWith("", new EnergyFlowMqttSource { Topic = "t1", Metric = "realpower" }),         // no id
-            NodeWith("ok", new EnergyFlowMqttSource { Topic = "", Metric = "realpower" }),          // no topic
-            NodeWith("solar", new EnergyFlowMqttSource { Topic = "  sa/pv  ", Metric = "realpower" }), // trimmed
+            NodeWith("", new EnergyFlowSource { Topic = "t1", Metric = "realpower" }),         // no id
+            NodeWith("ok", new EnergyFlowSource { Topic = "", Metric = "realpower" }),          // no topic
+            NodeWith("solar", new EnergyFlowSource { Topic = "  sa/pv  ", Metric = "realpower" }), // trimmed
         };
         var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
 

--- a/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
+++ b/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
@@ -197,6 +197,52 @@ public class EnergyFlowMqttSourceTests
         Assert.Equal(812.5, v);
     }
 
+    [Theory]
+    [InlineData("realpower", "kW", 1000)]        // 1 kW -> 1000 W
+    [InlineData("energy", "Wh", 0.001)]          // 1 Wh -> 0.001 kWh
+    [InlineData("voltage", "mV", 0.001)]         // 1 mV -> 0.001 V
+    [InlineData("realpower", "W", 1)]            // already canonical
+    [InlineData("realpower", null, 1)]           // no unit -> assumed canonical
+    [InlineData("realpower", "bogus", 1)]        // unknown unit -> no-op, never scales wildly
+    public void FlowUnits_ConvertsToTheCanonicalUnit(string metric, string? unit, double factor)
+        => Assert.Equal(factor, FlowUnits.ToCanonicalFactor(metric, unit));
+
+    [Fact]
+    public void FlowUnits_ExposesTheCanonicalUnitPerMetric()
+    {
+        Assert.Equal("W", FlowUnits.Canonical("realpower"));
+        Assert.Equal("kWh", FlowUnits.Canonical("energy"));
+        Assert.Contains("kW", FlowUnits.UnitsFor("realpower"));
+    }
+
+    [Fact]
+    public void Apply_ConvertsTheSourceUnitToCanonicalBeforeCaching()
+    {
+        // Solar Assistant publishing kW must land in the cache as W, so it lines up with the PDU's watts.
+        var nodes = new[] { NodeWith("solar", new EnergyFlowSource { Topic = "sa/pv_power", Metric = "realpower", Unit = "kW" }) };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+        var cache = new FlowValueCache();
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_power", "6", DateTime.UtcNow);
+
+        Assert.True(cache.TryGetValue("solar", "realpower", out var v));
+        Assert.Equal(6000, v);   // 6 kW -> 6000 W
+    }
+
+    [Fact]
+    public void Apply_UnitConversionAndScaleCompose()
+    {
+        // Unit normalises (kW -> W), then Scale flips the sign convention on top.
+        var nodes = new[] { NodeWith("batt", new EnergyFlowSource { Topic = "sa/batt", Metric = "realpower", Unit = "kW", Scale = -1 }) };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+        var cache = new FlowValueCache();
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/batt", "2", DateTime.UtcNow);
+
+        Assert.True(cache.TryGetValue("batt", "realpower", out var v));
+        Assert.Equal(-2000, v);   // 2 kW -> 2000 W, then * -1
+    }
+
     [Fact]
     public void Apply_AppliesScaleAndReadsAJsonField()
     {

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -377,6 +377,60 @@ public class FlowGraphTests
         Assert.DoesNotContain(graph.Links, l => l.Source == "spare");
     }
 
+    [Fact]
+    public void Build_UntrackedChild_ShowsTheMeasuredParentsUnaccountedConsumption()
+    {
+        // A panel with a measured total (CT clamp = 250W) feeds a PDU that only accounts for 100W of it.
+        // An 'untracked' child surfaces the missing 150W instead of the PDU being scaled up to fill 250.
+        var data = OnePdu(Outlet(0, "Server", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "panel", Label = "Main Panel", Value = 250 }, // measured total
+                new EnergyFlowNode { Id = "rest", Label = "Untracked", Mode = "untracked" },
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "panel", To = "pdu:pdu1" }, // tracked child (100W)
+                new EnergyFlowLink { From = "panel", To = "rest" },     // untracked child
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal(100, graph.Links.Single(l => l.Target == "pdu:pdu1").Value); // tracked child keeps its real draw
+        Assert.Equal(150, graph.Links.Single(l => l.Target == "rest").Value);     // untracked child = 250 - 100
+        // The parent's measured total is conserved across its children.
+        Assert.Equal(250, graph.Links.Where(l => l.Source == "panel").Sum(l => l.Value));
+    }
+
+    [Fact]
+    public void Build_UntrackedChild_ContributesNothing_WhenParentHasNoMeasuredTotal()
+    {
+        // Without a measured total on the parent there's no known figure to take a remainder from, so the
+        // untracked child stays at zero (and drops out) rather than inventing a number.
+        var data = OnePdu(Outlet(0, "Server", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "panel", Label = "Main Panel" }, // aggregator, no measured total
+                new EnergyFlowNode { Id = "rest", Label = "Untracked", Mode = "untracked" },
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "panel", To = "pdu:pdu1" },
+                new EnergyFlowLink { From = "panel", To = "rest" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.DoesNotContain(graph.Links, l => l.Target == "rest");
+        Assert.Equal(100, graph.Links.Single(l => l.Target == "pdu:pdu1").Value); // panel still carries its tracked load
+    }
+
     // Walk the emitted links; true if they contain a directed cycle.
     private static bool HasCycle(FlowGraph graph)
     {

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -266,6 +266,117 @@ public class FlowGraphTests
         Assert.Equal(100, graph.Links.Where(l => l.Source == "boss").Sum(l => l.Value));
     }
 
+    [Fact]
+    public void Build_MeasuredFeeder_AbsorbsDemand_UnmeasuredSiblingIsNotFabricated()
+    {
+        // The reported bug: Grid + Solar both feed the Grid Boss, Solar is measured (6000W) and comfortably
+        // covers the 100W of real load. Grid must NOT be handed a fabricated ~half-the-load figure; the
+        // measured feeder supplies it all and Grid drops out.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "gridboss", Label = "Grid Boss" },
+                new EnergyFlowNode { Id = "solar", Label = "Solar", Value = 6000 },
+                new EnergyFlowNode { Id = "grid", Label = "Grid" }, // unmeasured, default 'auto'
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "gridboss", To = "pdu:pdu1" },
+                new EnergyFlowLink { From = "solar", To = "gridboss" },
+                new EnergyFlowLink { From = "grid", To = "gridboss" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal(6000, graph.Links.Single(l => l.Source == "solar").Value); // measured generation shown as-is
+        Assert.DoesNotContain(graph.Links, l => l.Source == "grid");            // no fabricated grid draw
+        Assert.DoesNotContain(graph.Nodes, n => n.Id == "grid");
+    }
+
+    [Fact]
+    public void Build_ResidualNode_AbsorbsTheUntrackedRemainderAfterMeasuredFeeders()
+    {
+        // Solar supplies 40 of the 100W load; the rest (60) is untracked. A node marked 'residual' is the
+        // designated absorber and carries exactly that remainder.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "gridboss", Label = "Grid Boss" },
+                new EnergyFlowNode { Id = "solar", Label = "Solar", Value = 40 },
+                new EnergyFlowNode { Id = "grid", Label = "Grid (untracked)", Mode = "residual" },
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "gridboss", To = "pdu:pdu1" },
+                new EnergyFlowLink { From = "solar", To = "gridboss" },
+                new EnergyFlowLink { From = "grid", To = "gridboss" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal(40, graph.Links.Single(l => l.Source == "solar").Value);
+        Assert.Equal(60, graph.Links.Single(l => l.Source == "grid").Value);   // absorbs the untracked remainder
+    }
+
+    [Fact]
+    public void Build_NoneNode_ContributesNothing_EvenWhenNothingElseIsMeasured()
+    {
+        // 'none' opts a node out of inference entirely: with no measured feeder to cover the load, the node
+        // still supplies nothing (rather than the historical equal split), so it never invents a number.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "gridboss", Label = "Grid Boss" },
+                new EnergyFlowNode { Id = "grid", Label = "Grid", Mode = "none" },
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "gridboss", To = "pdu:pdu1" },
+                new EnergyFlowLink { From = "grid", To = "gridboss" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.DoesNotContain(graph.Links, l => l.Source == "grid");
+    }
+
+    [Fact]
+    public void Build_ResidualTakesPrecedenceOverAutoSiblings_ForTheRemainder()
+    {
+        // When a 'residual' node is present, plain 'auto' unmeasured siblings do not also split the
+        // remainder — the residual node is the sole absorber, so the untracked load isn't double-assigned.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "gridboss", Label = "Grid Boss" },
+                new EnergyFlowNode { Id = "untracked", Label = "Untracked", Mode = "residual" },
+                new EnergyFlowNode { Id = "spare", Label = "Spare" }, // 'auto', but a residual sibling exists
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "gridboss", To = "pdu:pdu1" },
+                new EnergyFlowLink { From = "untracked", To = "gridboss" },
+                new EnergyFlowLink { From = "spare", To = "gridboss" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal(100, graph.Links.Single(l => l.Source == "untracked").Value);
+        Assert.DoesNotContain(graph.Links, l => l.Source == "spare");
+    }
+
     // Walk the emitted links; true if they contain a directed cycle.
     private static bool HasCycle(FlowGraph graph)
     {

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -378,6 +378,38 @@ public class FlowGraphTests
     }
 
     [Fact]
+    public void Build_StaticNode_WithAValue_IsAFixedLeaf()
+    {
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes = { new EnergyFlowNode { Id = "solar", Label = "Solar", Mode = "static", Value = 500 } },
+            Links = { new EnergyFlowLink { From = "solar", To = "pdu:pdu1" } },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal(500, graph.Links.Single(l => l.Source == "solar").Value);
+    }
+
+    [Fact]
+    public void Build_StaticNode_WithNoValue_ContributesNothing()
+    {
+        // 'static' means "valued at the fixed number"; with none set there's nothing to give, so it drops
+        // out rather than absorbing its target's demand the way an 'auto' feeder would.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes = { new EnergyFlowNode { Id = "solar", Label = "Solar", Mode = "static" } },
+            Links = { new EnergyFlowLink { From = "solar", To = "pdu:pdu1" } },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.DoesNotContain(graph.Links, l => l.Source == "solar");
+    }
+
+    [Fact]
     public void Build_UsesTheNodesDeclaredKindForStyling()
     {
         // A custom node's Kind (battery, inverter, …) flows through to the graph node so the diagram can

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -378,6 +378,32 @@ public class FlowGraphTests
     }
 
     [Fact]
+    public void Build_UsesTheNodesDeclaredKindForStyling()
+    {
+        // A custom node's Kind (battery, inverter, …) flows through to the graph node so the diagram can
+        // style it; unset stays the generic "node".
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "batt", Label = "Battery", Kind = "battery", Value = 40 },
+                new EnergyFlowNode { Id = "plain", Label = "Plain", Value = 10 },
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "batt", To = "pdu:pdu1" },
+                new EnergyFlowLink { From = "plain", To = "pdu:pdu1" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Equal("battery", graph.Nodes.Single(n => n.Id == "batt").Kind);
+        Assert.Equal("node", graph.Nodes.Single(n => n.Id == "plain").Kind);
+    }
+
+    [Fact]
     public void Build_UntrackedChild_ShowsTheMeasuredParentsUnaccountedConsumption()
     {
         // A panel with a measured total (CT clamp = 250W) feeds a PDU that only accounts for 100W of it.

--- a/rPDU2MQTT.Tests/ModbusSourceTests.cs
+++ b/rPDU2MQTT.Tests/ModbusSourceTests.cs
@@ -1,0 +1,87 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Services;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Modbus TCP energy-flow sources (#129): register decoding, binding flatten, and the composite that merges
+/// several ingests. The socket I/O isn't exercised here (no device), but every decision the decode makes is.
+/// </summary>
+public class ModbusSourceTests
+{
+    [Fact]
+    public void Decode_Uint16_AndInt16()
+    {
+        Assert.Equal(40000, ModbusDecode.Decode(new ushort[] { 40000 }, "uint16", "big"));
+        Assert.Equal(-1, ModbusDecode.Decode(new ushort[] { 0xFFFF }, "int16", "big"));
+    }
+
+    [Fact]
+    public void Decode_Uint32_HonoursWordOrder()
+    {
+        // 0x0001_0000 = 65536. Big = high word first; little = word-swapped.
+        Assert.Equal(65536, ModbusDecode.Decode(new ushort[] { 0x0001, 0x0000 }, "uint32", "big"));
+        Assert.Equal(65536, ModbusDecode.Decode(new ushort[] { 0x0000, 0x0001 }, "uint32", "little"));
+    }
+
+    [Fact]
+    public void Decode_Int32_IsSigned()
+        => Assert.Equal(-2, ModbusDecode.Decode(new ushort[] { 0xFFFF, 0xFFFE }, "int32", "big"));
+
+    [Fact]
+    public void Decode_Float32_ReadsIeee754()
+    {
+        // 1.0f = 0x3F800000; 230.5f = 0x43668000.
+        Assert.Equal(1.0, ModbusDecode.Decode(new ushort[] { 0x3F80, 0x0000 }, "float32", "big"));
+        Assert.Equal(230.5, ModbusDecode.Decode(new ushort[] { 0x4366, 0x8000 }, "float32", "big"), 3);
+    }
+
+    [Fact]
+    public void RegisterCount_Is1For16Bit_2For32Bit()
+    {
+        Assert.Equal(1, ModbusDecode.RegisterCount("uint16"));
+        Assert.Equal(1, ModbusDecode.RegisterCount("int16"));
+        Assert.Equal(2, ModbusDecode.RegisterCount("uint32"));
+        Assert.Equal(2, ModbusDecode.RegisterCount("float32"));
+        Assert.Equal(1, ModbusDecode.RegisterCount(null));   // defaults to uint16
+    }
+
+    [Fact]
+    public void BuildBindings_GroupsModbusSourcesByConnection_AndIgnoresMqtt()
+    {
+        var nodes = new[]
+        {
+            Node("solar", new EnergyFlowSource { Type = "modbus", Connection = "inv1", Register = 100, Metric = "realpower" }),
+            Node("meter", new EnergyFlowSource { Type = "modbus", Connection = "inv1", Register = 200, Metric = "energy" }),
+            Node("grid",  new EnergyFlowSource { Type = "mqtt", Topic = "x", Metric = "realpower" }),   // not modbus
+            Node("bad",   new EnergyFlowSource { Type = "modbus", Register = 1, Metric = "realpower" }), // no connection
+        };
+
+        var byConn = EnergyFlowModbusSourceService.BuildBindings(nodes);
+
+        Assert.Single(byConn);
+        Assert.Equal(2, byConn["inv1"].Count);
+    }
+
+    [Fact]
+    public void Composite_ReturnsTheFirstSourceWithAValue()
+    {
+        var mqtt = new FlowValueCache();
+        var modbus = new FlowValueCache();
+        modbus.Set("solar", "realpower", 6000, 900, DateTime.UtcNow);
+        var composite = new CompositeFlowValueSource(mqtt, modbus);
+
+        Assert.True(composite.TryGetValue("solar", "realpower", out var v));
+        Assert.Equal(6000, v);
+        Assert.False(composite.TryGetValue("solar", "energy", out _));
+    }
+
+    private static EnergyFlowNode Node(string id, params EnergyFlowSource[] sources)
+    {
+        var n = new EnergyFlowNode { Id = id, Label = id };
+        n.Sources.AddRange(sources);
+        return n;
+    }
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -581,6 +581,25 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             catch (Exception ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
         });
 
+        // Current live value per (node, metric) as the running ingests hold it — reads the shared
+        // IFlowValueSource (MQTT + Modbus + any future source), so the Nodes editor can show a "Current"
+        // value for every binding type uniformly. Returns null for anything not currently reported/fresh.
+        app.MapPost("/api/flow/live", async (HttpContext ctx) =>
+        {
+            try
+            {
+                var reqs = await System.Text.Json.JsonSerializer.DeserializeAsync<List<LiveValueQuery>>(
+                    ctx.Request.Body, ProbeJson, ctx.RequestAborted) ?? new();
+                var values = reqs.Select(q =>
+                {
+                    double? v = live is not null && live.TryGetValue(q.Node ?? "", q.Metric ?? "", out var got) ? got : null;
+                    return new { node = q.Node, metric = q.Metric, value = v };
+                });
+                return Results.Json(new { ok = true, values }, ConfigSchema.Json);
+            }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
+        });
+
         // Validate the EmonCMS configuration (HTTP: reach the server + check the API key; MQTT: broker up).
         app.MapPost("/api/test/emoncms", async (HttpContext ctx) =>
         {
@@ -1172,4 +1191,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
 
     /// <summary>Body of POST /api/modbus/probe: a device to reach + the register specs to read.</summary>
     private sealed record ModbusProbeRequest(string Host, int Port, int UnitId, List<EnergyFlowSource>? Items);
+
+    /// <summary>One (node, metric) whose current live value the Nodes editor wants.</summary>
+    private sealed record LiveValueQuery(string? Node, string? Metric);
 }

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -559,6 +559,28 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             }
         });
 
+        // Probe a Modbus TCP device: connect, and optionally read a set of register specs, returning the
+        // decoded values. Powers the "Test connection" button and the live per-binding value display in the
+        // Flow editor. Read-only; uses a throwaway connection so it works before the config is saved.
+        app.MapPost("/api/modbus/probe", async (HttpContext ctx) =>
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ctx.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(15));
+            try
+            {
+                var req = await System.Text.Json.JsonSerializer.DeserializeAsync<ModbusProbeRequest>(
+                    ctx.Request.Body, ProbeJson, cts.Token);
+                if (req is null || string.IsNullOrWhiteSpace(req.Host))
+                    return Results.Json(new { ok = false, message = "A host is required." }, ConfigSchema.Json);
+
+                var (ok, message, readings) = await Task.Run(() => EnergyFlowModbusSourceService.Probe(
+                    req.Host, req.Port <= 0 ? 502 : req.Port, req.UnitId <= 0 ? 1 : req.UnitId, req.Items), cts.Token);
+                return Results.Json(new { ok, message, readings }, ConfigSchema.Json);
+            }
+            catch (OperationCanceledException) { return Results.Json(new { ok = false, message = "Modbus probe timed out." }, ConfigSchema.Json); }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
+        });
+
         // Validate the EmonCMS configuration (HTTP: reach the server + check the API key; MQTT: broker up).
         app.MapPost("/api/test/emoncms", async (HttpContext ctx) =>
         {
@@ -1144,4 +1166,10 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         using var reader = new StreamReader(stream);
         return reader.ReadToEnd();
     }
+
+    // Case-insensitive so the GUI can post {host,...} or {Host,...}; Items map onto EnergyFlowSource's fields.
+    private static readonly System.Text.Json.JsonSerializerOptions ProbeJson = new() { PropertyNameCaseInsensitive = true };
+
+    /// <summary>Body of POST /api/modbus/probe: a device to reach + the register specs to read.</summary>
+    private sealed record ModbusProbeRequest(string Host, int Port, int UnitId, List<EnergyFlowSource>? Items);
 }

--- a/rPDU2MQTT.Web/web/schema.fixture.json
+++ b/rPDU2MQTT.Web/web/schema.fixture.json
@@ -1469,11 +1469,334 @@
        "required": false
       },
       {
+       "key": "Kind",
+       "label": "Kind",
+       "description": "What this node represents: 'node' (generic), 'panel', 'inverter', 'battery', 'solar', 'grid', or 'load'. Drives styling and the fields the editor offers.",
+       "type": "enum",
+       "required": false,
+       "default": "node",
+       "enumValues": [
+        "",
+        "node",
+        "panel",
+        "inverter",
+        "battery",
+        "solar",
+        "grid",
+        "load"
+       ]
+      },
+      {
        "key": "Value",
        "label": "Value",
-       "description": "Optional directly-known value for a leaf node (used until a live sensor is bound).",
+       "description": "Optional fixed value for a leaf node. Used only when no live source has reported for it.",
        "type": "double",
        "required": false
+      },
+      {
+       "key": "StorageKwh",
+       "label": "StorageKwh",
+       "description": "For a battery node: usable storage capacity in kWh (display metadata; optional).",
+       "type": "double",
+       "required": false
+      },
+      {
+       "key": "Mode",
+       "label": "Mode",
+       "description": "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'static' (a fixed leaf at Value), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins.",
+       "type": "enum",
+       "required": false,
+       "default": "auto",
+       "enumValues": [
+        "",
+        "auto",
+        "static",
+        "residual",
+        "untracked",
+        "none"
+       ]
+      },
+      {
+       "key": "Sources",
+       "label": "Sources",
+       "description": "Live value bindings for this node, one per metric. Each binds a metric to an external source (Type 'mqtt' today). Supersedes Value.",
+       "type": "list",
+       "required": false,
+       "valueSchema": {
+        "key": "",
+        "label": "",
+        "type": "object",
+        "required": false,
+        "properties": [
+         {
+          "key": "Type",
+          "label": "Type",
+          "description": "Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection).",
+          "type": "enum",
+          "required": false,
+          "default": "mqtt",
+          "enumValues": [
+           "",
+           "mqtt",
+           "modbus"
+          ]
+         },
+         {
+          "key": "Metric",
+          "label": "Metric",
+          "description": "Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.",
+          "type": "enum",
+          "required": false,
+          "default": "realpower",
+          "enumValues": [
+           "",
+           "realpower",
+           "apparentpower",
+           "energy",
+           "current",
+           "voltage",
+           "frequency",
+           "powerfactor"
+          ]
+         },
+         {
+          "key": "Unit",
+          "label": "Unit",
+          "description": "Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, \u2026) on ingest. Blank = already canonical.",
+          "type": "string",
+          "required": false
+         },
+         {
+          "key": "Topic",
+          "label": "Topic",
+          "description": "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.",
+          "type": "string",
+          "required": false
+         },
+         {
+          "key": "JsonField",
+          "label": "JsonField",
+          "description": "For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.",
+          "type": "string",
+          "required": false
+         },
+         {
+          "key": "Scale",
+          "label": "Scale",
+          "description": "Multiplier applied to the received value \u2014 for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.",
+          "type": "double",
+          "required": false,
+          "default": 1
+         },
+         {
+          "key": "StaleAfterSeconds",
+          "label": "StaleAfterSeconds",
+          "description": "Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).",
+          "type": "int",
+          "required": false,
+          "default": 900,
+          "min": 0,
+          "max": 86400
+         },
+         {
+          "key": "Connection",
+          "label": "Connection",
+          "description": "For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from.",
+          "type": "string",
+          "required": false
+         },
+         {
+          "key": "Register",
+          "label": "Register",
+          "description": "For Type 'modbus': the register address to read (0-based).",
+          "type": "int",
+          "required": false
+         },
+         {
+          "key": "RegisterType",
+          "label": "RegisterType",
+          "description": "For Type 'modbus': which register bank \u2014 'holding' (function 3) or 'input' (function 4).",
+          "type": "enum",
+          "required": false,
+          "default": "holding",
+          "enumValues": [
+           "",
+           "holding",
+           "input"
+          ]
+         },
+         {
+          "key": "DataType",
+          "label": "DataType",
+          "description": "For Type 'modbus': how to decode the register(s) \u2014 uint16, int16, uint32, int32, or float32.",
+          "type": "enum",
+          "required": false,
+          "default": "uint16",
+          "enumValues": [
+           "",
+           "uint16",
+           "int16",
+           "uint32",
+           "int32",
+           "float32"
+          ]
+         },
+         {
+          "key": "WordOrder",
+          "label": "WordOrder",
+          "description": "For Type 'modbus' 32-bit values: word order \u2014 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped).",
+          "type": "enum",
+          "required": false,
+          "default": "big",
+          "enumValues": [
+           "",
+           "big",
+           "little"
+          ]
+         }
+        ]
+       }
+      },
+      {
+       "key": "Mqtt",
+       "label": "Mqtt",
+       "description": "Deprecated: use Sources. Legacy MQTT bindings (implicitly Type 'mqtt'); still honored for back-compat.",
+       "type": "list",
+       "required": false,
+       "valueSchema": {
+        "key": "",
+        "label": "",
+        "type": "object",
+        "required": false,
+        "properties": [
+         {
+          "key": "Type",
+          "label": "Type",
+          "description": "Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection).",
+          "type": "enum",
+          "required": false,
+          "default": "mqtt",
+          "enumValues": [
+           "",
+           "mqtt",
+           "modbus"
+          ]
+         },
+         {
+          "key": "Metric",
+          "label": "Metric",
+          "description": "Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.",
+          "type": "enum",
+          "required": false,
+          "default": "realpower",
+          "enumValues": [
+           "",
+           "realpower",
+           "apparentpower",
+           "energy",
+           "current",
+           "voltage",
+           "frequency",
+           "powerfactor"
+          ]
+         },
+         {
+          "key": "Unit",
+          "label": "Unit",
+          "description": "Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, \u2026) on ingest. Blank = already canonical.",
+          "type": "string",
+          "required": false
+         },
+         {
+          "key": "Topic",
+          "label": "Topic",
+          "description": "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.",
+          "type": "string",
+          "required": false
+         },
+         {
+          "key": "JsonField",
+          "label": "JsonField",
+          "description": "For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.",
+          "type": "string",
+          "required": false
+         },
+         {
+          "key": "Scale",
+          "label": "Scale",
+          "description": "Multiplier applied to the received value \u2014 for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.",
+          "type": "double",
+          "required": false,
+          "default": 1
+         },
+         {
+          "key": "StaleAfterSeconds",
+          "label": "StaleAfterSeconds",
+          "description": "Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).",
+          "type": "int",
+          "required": false,
+          "default": 900,
+          "min": 0,
+          "max": 86400
+         },
+         {
+          "key": "Connection",
+          "label": "Connection",
+          "description": "For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from.",
+          "type": "string",
+          "required": false
+         },
+         {
+          "key": "Register",
+          "label": "Register",
+          "description": "For Type 'modbus': the register address to read (0-based).",
+          "type": "int",
+          "required": false
+         },
+         {
+          "key": "RegisterType",
+          "label": "RegisterType",
+          "description": "For Type 'modbus': which register bank \u2014 'holding' (function 3) or 'input' (function 4).",
+          "type": "enum",
+          "required": false,
+          "default": "holding",
+          "enumValues": [
+           "",
+           "holding",
+           "input"
+          ]
+         },
+         {
+          "key": "DataType",
+          "label": "DataType",
+          "description": "For Type 'modbus': how to decode the register(s) \u2014 uint16, int16, uint32, int32, or float32.",
+          "type": "enum",
+          "required": false,
+          "default": "uint16",
+          "enumValues": [
+           "",
+           "uint16",
+           "int16",
+           "uint32",
+           "int32",
+           "float32"
+          ]
+         },
+         {
+          "key": "WordOrder",
+          "label": "WordOrder",
+          "description": "For Type 'modbus' 32-bit values: word order \u2014 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped).",
+          "type": "enum",
+          "required": false,
+          "default": "big",
+          "enumValues": [
+           "",
+           "big",
+           "little"
+          ]
+         }
+        ]
+       }
       }
      ]
     }
@@ -1544,6 +1867,85 @@
      "metric",
      "units"
     ]
+   }
+  ]
+ },
+ {
+  "key": "Modbus",
+  "label": "Modbus",
+  "description": "Modbus TCP connections that energy-flow nodes can be bound to (inverters, meters, PLCs).",
+  "type": "object",
+  "required": false,
+  "properties": [
+   {
+    "key": "Connections",
+    "label": "Connections",
+    "description": "Modbus TCP devices to poll. Add one per device, then reference it from a source binding's Connection.",
+    "type": "list",
+    "required": false,
+    "valueSchema": {
+     "key": "",
+     "label": "",
+     "type": "object",
+     "required": false,
+     "properties": [
+      {
+       "key": "Id",
+       "label": "Id",
+       "description": "Stable id used to reference this connection from a source binding.",
+       "type": "string",
+       "required": false
+      },
+      {
+       "key": "Name",
+       "label": "Name",
+       "description": "Friendly name for the device (shown in the editor).",
+       "type": "string",
+       "required": false
+      },
+      {
+       "key": "Host",
+       "label": "Host",
+       "description": "Hostname or IP address of the Modbus TCP device.",
+       "type": "string",
+       "required": false
+      },
+      {
+       "key": "Port",
+       "label": "Port",
+       "description": "TCP port the device listens on (Modbus default 502).",
+       "type": "int",
+       "required": false,
+       "default": 502
+      },
+      {
+       "key": "UnitId",
+       "label": "UnitId",
+       "description": "Modbus unit / slave id.",
+       "type": "int",
+       "required": false,
+       "default": 1
+      },
+      {
+       "key": "PollIntervalSeconds",
+       "label": "PollIntervalSeconds",
+       "description": "How often to poll this device, in seconds.",
+       "type": "int",
+       "required": false,
+       "default": 10,
+       "min": 1,
+       "max": 86400
+      },
+      {
+       "key": "Enabled",
+       "label": "Enabled",
+       "description": "Poll this device. Turn off to disable it without deleting the connection.",
+       "type": "bool",
+       "required": false,
+       "default": true
+      }
+     ]
+    }
    }
   ]
  }

--- a/rPDU2MQTT.Web/web/smoke.mjs
+++ b/rPDU2MQTT.Web/web/smoke.mjs
@@ -165,16 +165,26 @@ if (linkText.includes('EnergyFlow')) fail('EnergyFlow should be hidden from the 
 if (!query(getEl('sections'), '.section', true).length) fail('no sections were rendered');
 
 // Tabs build their body lazily on first click, so build() alone never touches the bespoke editors. Open
-// the Flow tab to exercise the hierarchy editor + the MQTT live-sources binding table (#205).
+// the Flow tab to exercise the hierarchy editor + the virtual-node manager (#129/#205).
 const flowLink = query(nav, 'a', true).find(a => a.textContent === 'Flow');
 if (!flowLink) fail('no Flow tab');
 flowLink.click();
 await new Promise(r => setTimeout(r, 50));
 
 const sectionsText = query(getEl('sections'), '.section', true).map(s => s.textContent).join(' ');
-if (!sectionsText.includes('Live sources (MQTT)')) fail('the Flow tab did not render the live-sources editor');
-// The configured binding must show in the table — proves it read Nodes[].Mqtt, not just the empty state.
-if (!sectionsText.includes('solar_assistant/inverter_1/pv_power/state'))
-  fail('the live-sources table did not list the configured MQTT binding');
+if (!sectionsText.includes('Virtual nodes')) fail('the Flow tab did not render the virtual-node manager');
 
-console.log(`smoke: build() rendered ${linkText.length} nav links across ${groups.length} groups; Flow editor + MQTT sources OK`);
+// The live value bindings now live inside a node's editor — open it. Clicking Edit for the 'solar' node
+// must surface its bound topic, which proves both the legacy Nodes[].Mqtt → Sources migration and that the
+// per-node editor renders the (now editable) binding rows.
+const editBtn = query(getEl('sections'), 'button', true).find(b => b.textContent === 'Edit');
+if (!editBtn) fail('the virtual-node manager rendered no Edit button');
+editBtn.click();
+await new Promise(r => setTimeout(r, 20));
+
+const editorText = query(getEl('sections'), '.section', true).map(s => s.textContent).join(' ');
+if (!editorText.includes('Live value bindings')) fail('opening a node did not render its bindings editor');
+if (!query(getEl('sections'), 'input', true).some(i => i.attrs.value === 'solar_assistant/inverter_1/pv_power/state'))
+  fail('the node editor did not surface the migrated MQTT binding as an editable topic');
+
+console.log(`smoke: build() rendered ${linkText.length} nav links across ${groups.length} groups; Flow editor + virtual-node editor OK`);

--- a/rPDU2MQTT.Web/web/smoke.mjs
+++ b/rPDU2MQTT.Web/web/smoke.mjs
@@ -94,12 +94,17 @@ root.appendChild(getEl('sections'));
 const config = {
   EnergyFlow: {
     Nodes: [
-      { Id: 'solar', Label: 'Solar', Mqtt: [{ Topic: 'solar_assistant/inverter_1/pv_power/state', Metric: 'realpower' }] },
+      // A legacy MQTT binding (migrates to Sources) plus a Modbus binding, so the editor exercises both
+      // source-type branches of the binding row.
+      { Id: 'solar', Label: 'Solar',
+        Mqtt: [{ Topic: 'solar_assistant/inverter_1/pv_power/state', Metric: 'realpower' }],
+        Sources: [{ Type: 'modbus', Connection: 'inv1', Register: 100, Metric: 'energy', DataType: 'float32' }] },
       { Id: 'panel', Label: 'Panel', Value: 100 },
     ],
     Links: [{ From: 'solar', To: 'panel' }],
     MqttExport: true,
   },
+  Modbus: { Connections: [{ Id: 'inv1', Name: 'Inverter', Host: '10.0.0.5', Port: 502, UnitId: 1 }] },
 };
 const flowGraph = {
   ok: true,
@@ -186,5 +191,7 @@ const editorText = query(getEl('sections'), '.section', true).map(s => s.textCon
 if (!editorText.includes('Live value bindings')) fail('opening a node did not render its bindings editor');
 if (!query(getEl('sections'), 'input', true).some(i => i.attrs.value === 'solar_assistant/inverter_1/pv_power/state'))
   fail('the node editor did not surface the migrated MQTT binding as an editable topic');
+// The Modbus binding row must render its connection picker, listing the configured connection.
+if (!editorText.includes('Inverter')) fail('the Modbus binding row did not list the configured connection');
 
 console.log(`smoke: build() rendered ${linkText.length} nav links across ${groups.length} groups; Flow editor + virtual-node editor OK`);

--- a/rPDU2MQTT.Web/web/smoke.mjs
+++ b/rPDU2MQTT.Web/web/smoke.mjs
@@ -170,18 +170,24 @@ if (linkText.includes('EnergyFlow')) fail('EnergyFlow should be hidden from the 
 if (!query(getEl('sections'), '.section', true).length) fail('no sections were rendered');
 
 // Tabs build their body lazily on first click, so build() alone never touches the bespoke editors. Open
-// the Flow tab to exercise the hierarchy editor + the virtual-node manager (#129/#205).
+// the Flow tab to exercise the Sankey + hierarchy drag-graph (#129).
 const flowLink = query(nav, 'a', true).find(a => a.textContent === 'Flow');
 if (!flowLink) fail('no Flow tab');
 flowLink.click();
 await new Promise(r => setTimeout(r, 50));
+if (!query(getEl('sections'), '.section', true).map(s => s.textContent).join(' ').includes('Hierarchy'))
+  fail('the Flow tab did not render the hierarchy editor');
+
+// Node configuration now lives on its own Nodes tab. Open it, open the 'solar' node's editor, and confirm
+// it surfaces the migrated MQTT topic, the Modbus connection picker, and the feeders/children wiring.
+const nodesLink = query(nav, 'a', true).find(a => a.textContent === 'Nodes');
+if (!nodesLink) fail('no Nodes tab');
+nodesLink.click();
+await new Promise(r => setTimeout(r, 50));
 
 const sectionsText = query(getEl('sections'), '.section', true).map(s => s.textContent).join(' ');
-if (!sectionsText.includes('Virtual nodes')) fail('the Flow tab did not render the virtual-node manager');
+if (!sectionsText.includes('Virtual nodes')) fail('the Nodes tab did not render the virtual-node manager');
 
-// The live value bindings now live inside a node's editor — open it. Clicking Edit for the 'solar' node
-// must surface its bound topic, which proves both the legacy Nodes[].Mqtt → Sources migration and that the
-// per-node editor renders the (now editable) binding rows.
 const editBtn = query(getEl('sections'), 'button', true).find(b => b.textContent === 'Edit');
 if (!editBtn) fail('the virtual-node manager rendered no Edit button');
 editBtn.click();
@@ -189,9 +195,10 @@ await new Promise(r => setTimeout(r, 20));
 
 const editorText = query(getEl('sections'), '.section', true).map(s => s.textContent).join(' ');
 if (!editorText.includes('Live value bindings')) fail('opening a node did not render its bindings editor');
+if (!editorText.includes('Feeders & children')) fail('the node editor did not render the feeders/children wiring');
 if (!query(getEl('sections'), 'input', true).some(i => i.attrs.value === 'solar_assistant/inverter_1/pv_power/state'))
   fail('the node editor did not surface the migrated MQTT binding as an editable topic');
 // The Modbus binding row must render its connection picker, listing the configured connection.
 if (!editorText.includes('Inverter')) fail('the Modbus binding row did not list the configured connection');
 
-console.log(`smoke: build() rendered ${linkText.length} nav links across ${groups.length} groups; Flow editor + virtual-node editor OK`);
+console.log(`smoke: build() rendered ${linkText.length} nav links across ${groups.length} groups; Flow + Nodes editors OK`);

--- a/rPDU2MQTT.Web/web/src/actions.ts
+++ b/rPDU2MQTT.Web/web/src/actions.ts
@@ -1,6 +1,19 @@
 // Section-level connection tests + Home Assistant discovery actions (wired from sectionActions()).
 import { api, toast } from './helpers.js';
+import { state } from './state.js';
 import { refreshStatus } from './main.js';
+
+// Test every configured Modbus TCP connection by opening a throwaway connection to each.
+export async function testModbus() {
+  const conns = (state.data?.Modbus?.Connections) || [];
+  if (!conns.length) { toast('No Modbus connections configured — add one first.', false); return; }
+  toast(`Testing ${conns.length} Modbus connection(s)…`, true);
+  for (const c of conns) {
+    if (!c.Host) { toast(`${c.Name || c.Id || 'connection'}: no host set.`, false); continue; }
+    const r = await api('/api/modbus/probe', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ Host: c.Host, Port: c.Port, UnitId: c.UnitId }) });
+    toast(`${c.Name || c.Id}: ${r.body.message || (r.body.ok ? 'OK' : 'failed')}`, r.body.ok);
+  }
+}
 
 export async function testMqtt() { const r = await api('/api/test/mqtt', { method: 'POST' }); toast(r.body.message, r.body.ok); refreshStatus(); }
 export async function testPdu() { toast('Testing PDU…', true); const r = await api('/api/test/pdu', { method: 'POST' }); toast(r.body.message, r.body.ok); }

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -8,7 +8,7 @@ import { addPathsSection } from './sections/paths.js';
 import { addDiagnosticsSection } from './sections/diagnostics.js';
 import { addControlSection } from './sections/control.js';
 import { addLiveDataSection } from './sections/livedata.js';
-import { addFlowSection } from './sections/flow.js';
+import { addFlowSection, addNodesSection } from './sections/flow.js';
 import { addExportSection } from './sections/export.js';
 import { addHaEnergySection } from './sections/ha-energy.js';
 import { addHomeSection } from './sections/home.js';
@@ -236,6 +236,7 @@ export function build() {
   navHeader(nav, 'Tools');
   addControlSection(nav, sections);
   addLiveDataSection(nav, sections);
+  addNodesSection(nav, sections);
   addFlowSection(nav, sections);
   addPathsSection(nav, sections);
   addHaEnergySection(nav, sections);

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -3,7 +3,7 @@
 import { ensure, el, btn, activate, slug } from './helpers.js';
 import { state } from './state.js';
 import { renderOverrides, previewOverridePaths } from './overrides.js';
-import { testMqtt, testPdu, testEmonCms, provisionEmonCmsFeeds, deleteEmonCmsFeeds, rediscoverHa, clearHa } from './actions.js';
+import { testMqtt, testPdu, testEmonCms, provisionEmonCmsFeeds, deleteEmonCmsFeeds, rediscoverHa, clearHa, testModbus } from './actions.js';
 import { addPathsSection } from './sections/paths.js';
 import { addDiagnosticsSection } from './sections/diagnostics.js';
 import { addControlSection } from './sections/control.js';
@@ -347,6 +347,7 @@ function sectionActions(node: any) {
 
   if (node.key === 'MQTT') add('Test MQTT connection', testMqtt);
   else if (node.key === 'PDU') add('Test PDU connection', testPdu);
+  else if (node.key === 'Modbus') add('Test connections', testModbus);
   else if (node.key === 'EmonCMS') { add('Test EmonCMS connection', testEmonCms); add('Provision feeds now', provisionEmonCmsFeeds); add('Delete all feeds', deleteEmonCmsFeeds, 'danger'); }
   else if (node.key === 'HomeAssistant') {
     if ((state.data.HomeAssistant || {}).DiscoveryEnabled === false) return null;

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -27,6 +27,7 @@ const SOURCE_TYPES: [string, string][] = [['mqtt', 'MQTT topic']];
 // always wins; this only governs nodes the graph would otherwise infer.
 const NODE_MODES: [string, string, string][] = [
   ['auto', 'Auto (aggregate / share)', 'Sums its children, and as a feeder takes a share of whatever load measured siblings don’t cover — the default.'],
+  ['static', 'Static (fixed value)', 'A fixed leaf valued at the number you enter (still superseded by a bound live source). Reveals the Fixed value field.'],
   ['residual', 'Residual (untracked feeder)', 'The designated absorber on the feeder side: carries the demand still needed after every measured feeder has supplied its part.'],
   ['untracked', 'Untracked (child of a measured parent)', 'Place under a parent that has a measured total (a bound source or fixed value): shows the slice of that total its tracked siblings don’t account for. Contributes nothing if the parent has no measured total.'],
   ['none', 'None (leave unset)', 'Never inferred — contributes nothing unless it has a real value or children, so an unmeasured source simply drops out instead of showing a fabricated figure.'],
@@ -70,12 +71,19 @@ function renderNodeEditor(node: any, rerender: () => void) {
   const modeSel = el('select');
   NODE_MODES.forEach(([v, label, desc]) => { const o = el('option', { value: v, text: label }); o.title = desc; modeSel.appendChild(o); });
   modeSel.value = node.Mode || 'auto';
-  modeSel.onchange = () => { node.Mode = modeSel.value === 'auto' ? undefined : modeSel.value; };
+  modeSel.onchange = () => {
+    node.Mode = modeSel.value === 'auto' ? undefined : modeSel.value;
+    if (node.Mode !== 'static') node.Value = undefined;  // a fixed value only belongs to a static node
+    rerender();  // toggle the Fixed value field
+  };
   grid.appendChild(field('Mode', modeSel, 'How it’s valued with no measurement.'));
 
-  const valIn = el('input', { type: 'number', step: 'any', value: node.Value ?? '', placeholder: '—' });
-  valIn.onchange = () => { const v = +valIn.value; node.Value = (valIn.value !== '' && !isNaN(v)) ? v : undefined; };
-  grid.appendChild(field('Fixed value', valIn, 'Used only if nothing live reports.'));
+  // The fixed value only makes sense for a static leaf — show it only in that mode.
+  if ((node.Mode || 'auto') === 'static') {
+    const valIn = el('input', { type: 'number', step: 'any', value: node.Value ?? '', placeholder: '—' });
+    valIn.onchange = () => { const v = +valIn.value; node.Value = (valIn.value !== '' && !isNaN(v)) ? v : undefined; };
+    grid.appendChild(field('Fixed value', valIn, 'Used unless a bound source reports.'));
+  }
 
   if ((node.Kind || 'node') === 'battery') {
     const stoIn = el('input', { type: 'number', step: 'any', value: node.StorageKwh ?? '', placeholder: 'kWh' });
@@ -326,6 +334,9 @@ export function addFlowSection(nav: any, sections: any) {
         n.Sources = (n.Sources || []).concat(n.Mqtt.map((s: any) => ({ Type: 'mqtt', ...s })));
         delete n.Mqtt;
       }
+      // A fixed value now belongs to the 'static' mode — adopt it for older nodes that carried a value under
+      // the default mode, so the editor shows their value field and the roll-up is unchanged.
+      if (n.Value != null && (!n.Mode || n.Mode === 'auto')) n.Mode = 'static';
     });
     ed.innerHTML = '';
 

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -61,7 +61,7 @@ function field(labelText: string, control: HTMLElement, hint?: string) {
 // Per-node editor (#129): name, kind, mode, fixed value, a battery's storage, and the live value bindings —
 // one row per metric, each carrying a Type (MQTT today) and its transport fields, all editable in place
 // (including the topic, which the old flat table couldn't change).
-function renderNodeEditor(node: any, rerender: () => void) {
+function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, rerender: (close?: boolean) => void) {
   const meta = kindMeta(node.Kind);
   const allowed = meta[2];
   const box = el('div', { style: { margin: '10px 0 4px', padding: '14px', border: '1px solid var(--accent, #4f8cff)', borderRadius: '8px', background: 'var(--panel2)' } });
@@ -250,13 +250,82 @@ function renderNodeEditor(node: any, rerender: () => void) {
     rerender();
   };
   box.appendChild(el('div', { class: 'ld-toolbar', style: { marginTop: '8px' } }, addBind));
+
+  // --- Feeders & children (wiring) — the parent/child specification, alongside the visual Flow tab. ---
+  box.appendChild(el('h5', { text: 'Feeders & children', style: { margin: '12px 0 2px', fontSize: '12px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'Which nodes feed this one, and which it feeds. The same wiring you can drag on the Flow tab.', style: { margin: '0 0 6px' } }));
+
+  const nm = (id: string) => (cand.get(id) || {}).label || id;
+  const wouldLoop = (from: string, to: string) => {
+    const adj: any = {}; links.forEach(l => (adj[l.From] = adj[l.From] || []).push(l.To));
+    const stack = [to]; const seen = new Set<string>();
+    while (stack.length) { const x = stack.pop()!; if (x === from) return true; if (seen.has(x)) continue; seen.add(x); (adj[x] || []).forEach((t: string) => stack.push(t)); }
+    return false;
+  };
+  const addLink = (from: string, to: string) => {
+    if (from === to || links.some(l => l.From === from && l.To === to)) return;
+    if (wouldLoop(from, to)) { toast('That would create a feeder loop.', false); return; }
+    links.push({ From: from, To: to });
+  };
+  const removeLink = (from: string, to: string) => { const i = links.findIndex(l => l.From === from && l.To === to); if (i >= 0) links.splice(i, 1); };
+  const wireRow = (title: string, current: string[], onAdd: (o: string) => void, onRemove: (o: string) => void) => {
+    const row = el('div', { style: { display: 'flex', gap: '6px', alignItems: 'center', flexWrap: 'wrap', margin: '3px 0' } });
+    row.appendChild(el('span', { class: 'desc', style: { margin: '0', minWidth: '64px' }, text: title }));
+    current.forEach(other => {
+      const chip = el('span', { style: { display: 'inline-flex', gap: '5px', alignItems: 'center', background: 'var(--panel)', border: '1px solid var(--line)', borderRadius: '10px', padding: '1px 8px', fontSize: '12px' } });
+      const x = el('span', { text: '✕', style: { cursor: 'pointer', color: 'var(--bad)' } });
+      x.onclick = () => { onRemove(other); rerender(); };
+      chip.append(nm(other), x); row.appendChild(chip);
+    });
+    const sel = el('select', { style: { width: 'auto' } });
+    sel.appendChild(el('option', { value: '', text: '+ add…' }));
+    [...cand.keys()].filter(id => id !== node.Id && !current.includes(id)).sort((a, b) => nm(a).localeCompare(nm(b)))
+      .forEach(id => sel.appendChild(el('option', { value: id, text: nm(id) })));
+    sel.onchange = () => { if (sel.value) { onAdd(sel.value); rerender(); } };
+    row.appendChild(sel);
+    return row;
+  };
+  box.appendChild(wireRow('Fed by', links.filter(l => l.To === node.Id).map(l => l.From), o => addLink(o, node.Id), o => removeLink(o, node.Id)));
+  box.appendChild(wireRow('Feeds', links.filter(l => l.From === node.Id).map(l => l.To), o => addLink(node.Id, o), o => removeLink(node.Id, o)));
+
   return box;
 }
 
-// Virtual-node manager (#129): the "page to manage those" the graph editor alone didn't cover. Each row is
-// a node; Edit opens the full editor (name, kind, mode, value, bindings) below the table. Deleting a node
-// takes its bound sources with it (they live on the node).
-function renderNodeManager(customNodes: any[], links: any[], editing: { id: string | null }, rerender: (close?: boolean) => void) {
+// Bring an EnergyFlow config up to the current shape in place (idempotent) — run on load by both the Flow
+// and Nodes tabs since either can be opened first: legacy single-feeder Parents → directed Links, per-node
+// Mqtt → the general Sources list, and a bare Value → the explicit 'static' mode.
+function migrateEnergyFlow(flow: any) {
+  const links = ensure(flow, 'Links', []);
+  const legacy = ensure(flow, 'Parents', {});
+  if (Object.keys(legacy).length) {
+    Object.entries(legacy).forEach(([child, parent]) => { if (parent && child && !links.some((l: any) => l.From === parent && l.To === child)) links.push({ From: parent, To: child }); });
+    Object.keys(legacy).forEach(k => delete legacy[k]);
+  }
+  ensure(flow, 'Nodes', []).forEach((n: any) => {
+    if (n.Mqtt && n.Mqtt.length) { n.Sources = (n.Sources || []).concat(n.Mqtt.map((s: any) => ({ Type: 'mqtt', ...s }))); delete n.Mqtt; }
+    if (n.Value != null && (!n.Mode || n.Mode === 'auto')) n.Mode = 'static';
+  });
+}
+
+// Save the whole config (both tabs edit the shared EnergyFlow object; either Save persists everything).
+async function saveConfig(onSaved: () => void) {
+  const r = await api('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(exportData()) });
+  toast(r.body.message || (r.ok ? 'Saved.' : 'Save failed.'), r.ok && r.body.ok);
+  if (r.ok && r.body.ok) onSaved();
+}
+
+// The candidate node universe for wiring: the built graph's nodes (pdu/outlet/…) plus the custom defs.
+function flowCandidates(lastGraph: any, customNodes: any[]) {
+  const cand = new Map<string, any>();
+  (lastGraph?.nodes || []).forEach((n: any) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
+  customNodes.forEach((n: any) => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: n.Kind || 'node', custom: true }));
+  return cand;
+}
+
+// Virtual-node manager (#129): the dedicated node-configuration surface (its own Nodes tab). Each row is a
+// node; Edit opens the full editor (name, kind, mode, value, bindings, feeders/children) below the table.
+// Deleting a node takes its bound sources with it (they live on the node).
+function renderNodeManager(customNodes: any[], links: any[], cand: Map<string, any>, editing: { id: string | null }, rerender: (close?: boolean) => void) {
   const box = el('div', { style: { margin: '18px 0' } });
   box.appendChild(el('h3', { text: 'Virtual nodes', style: { margin: '4px 0', fontSize: '15px' } }));
   box.appendChild(el('div', { class: 'desc', text: 'The custom nodes you’ve added (panels, breakers, batteries, producers, a “Total”). Click Edit to set the name, kind, how it’s valued, and bind live values from your broker.' }));
@@ -301,7 +370,7 @@ function renderNodeManager(customNodes: any[], links: any[], editing: { id: stri
   box.appendChild(tbl);
 
   const editingNode = editing.id ? customNodes.find((n: any) => n.Id === editing.id) : null;
-  if (editingNode) box.appendChild(renderNodeEditor(editingNode, (close?: boolean) => { if (close) editing.id = null; rerender(); }));
+  if (editingNode) box.appendChild(renderNodeEditor(editingNode, links, cand, (close?: boolean) => { if (close) editing.id = null; rerender(); }));
   return box;
 }
 
@@ -321,7 +390,6 @@ export function addFlowSection(nav: any, sections: any) {
   const wrap = document.createElement('div'); sec.appendChild(wrap);
   const ed: any = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
   let lastGraph: any = null;
-  const editing: { id: string | null } = { id: null };  // which virtual node's editor is open (persists across rerenders)
 
   // Layered Sankey: columns = longest path from a root (energy flows left->right, parent->child).
   const draw = (graph: any) => {
@@ -419,37 +487,18 @@ export function addFlowSection(nav: any, sections: any) {
   const renderEditor = () => {
     if (ed._cleanup) ed._cleanup();
     const flow = ensure(state.data, 'EnergyFlow', {});
+    migrateEnergyFlow(flow);
     const customNodes = ensure(flow, 'Nodes', []);
     const links = ensure(flow, 'Links', []);
-    const legacy = ensure(flow, 'Parents', {});
-    // One-time migration: fold any legacy single-feeder Parents (child→parent) into directed Links.
-    if (Object.keys(legacy).length) {
-      Object.entries(legacy).forEach(([child, parent]) => { if (parent && child && !links.some((l: any) => l.From === parent && l.To === child)) links.push({ From: parent, To: child }); });
-      Object.keys(legacy).forEach(k => delete legacy[k]);
-    }
-    // Fold legacy per-node Mqtt bindings into the general Sources list (each was implicitly Type: mqtt), so
-    // the new editor manages them in one place. The engine still reads both, so this is safe on save.
-    customNodes.forEach((n: any) => {
-      if (n.Mqtt && n.Mqtt.length) {
-        n.Sources = (n.Sources || []).concat(n.Mqtt.map((s: any) => ({ Type: 'mqtt', ...s })));
-        delete n.Mqtt;
-      }
-      // A fixed value now belongs to the 'static' mode — adopt it for older nodes that carried a value under
-      // the default mode, so the editor shows their value field and the roll-up is unchanged.
-      if (n.Value != null && (!n.Mode || n.Mode === 'auto')) n.Mode = 'static';
-    });
     ed.innerHTML = '';
 
     ed.appendChild(el('h3', { text: 'Hierarchy', style: { margin: '4px 0' } }));
-    ed.appendChild(el('div', { class: 'desc', text: 'Energy flows left → right. Drag from a node’s right ● onto another node to add a feed (source powers target). A node can have several feeders, and a producer is just a feed into what it powers — e.g. drag from Solar onto your inverter. The target highlights green when in range; click ✕ on a link to remove it. Double-click a custom node to rename it. PDU → outlet links are auto-derived (dashed) until you wire an explicit feeder.' }));
+    ed.appendChild(el('div', { class: 'desc', text: 'Energy flows left → right. Drag from a node’s right ● onto another node to add a feed (source powers target); click ✕ on a link to remove it. Double-click a custom node to rename it. PDU → outlet links are auto-derived (dashed) until you wire an explicit feeder. Add and configure nodes on the Nodes tab.' }));
 
-    const addBar = el('div', { class: 'ld-toolbar' });
-    const idIn = el('input', { type: 'text', placeholder: 'id (e.g. gridboss)' });
-    const labIn = el('input', { type: 'text', placeholder: 'label (e.g. Grid Boss)' });
-    const valIn = el('input', { type: 'number', placeholder: 'known value (optional)', style: { width: '150px' } });
-    const addBtn = btn('Add node', 'primary');
-    const save = btn('Save hierarchy', 'primary');
-    addBar.append(idIn, labIn, valIn, addBtn, save); ed.appendChild(addBar);
+    const bar2 = el('div', { class: 'ld-toolbar' });
+    const save = btn('Save', 'primary');
+    save.onclick = () => saveConfig(load);
+    bar2.append(save); ed.appendChild(bar2);
 
     // MQTT export of the hierarchy (#164): each tier's rolled-up value is published per poll. Saved with
     // the hierarchy (the Save button posts the whole config).
@@ -463,12 +512,8 @@ export function addFlowSection(nav: any, sections: any) {
     exportRow.append(el('label', {}, expChk, ' Export tiers to MQTT'), el('span', { class: 'desc', style: { margin: '0' }, text: 'Topic:' }), topicIn);
     ed.appendChild(exportRow);
 
-    ed.appendChild(renderNodeManager(customNodes, links, editing, renderEditor));
-
     // Candidate nodes (from the built graph + custom defs).
-    const cand = new Map();
-    (lastGraph?.nodes || []).forEach((n: any) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
-    customNodes.forEach((n: any) => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: 'node', custom: true }));
+    const cand = flowCandidates(lastGraph, customNodes);
     const nm = (id: string): string => (cand.get(id) || {}).label || id;
     const byLabel = (a: string, b: string) => (cand.get(a).label || a).localeCompare(cand.get(b).label || b);
 
@@ -602,19 +647,6 @@ export function addFlowSection(nav: any, sections: any) {
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
     ed._cleanup = () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); detachZoom(); };
-
-    addBtn.onclick = () => {
-      const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
-      if (cand.has(id)) { toast('That id already exists.', false); return; }
-      const node: any = { Id: id, Label: (labIn.value || '').trim() || id };
-      if (valIn.value !== '' && !isNaN(+valIn.value)) node.Value = +valIn.value;
-      customNodes.push(node); editing.id = id; renderEditor();  // open the new node's editor straight away
-    };
-    save.onclick = async () => {
-      const r = await api('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(exportData()) });
-      toast(r.body.message || (r.ok ? 'Saved.' : 'Save failed.'), r.ok && r.body.ok);
-      if (r.ok && r.body.ok) load();
-    };
   };
 
   const load = async () => {
@@ -625,5 +657,62 @@ export function addFlowSection(nav: any, sections: any) {
     renderEditor();
   };
   refresh.onclick = load;
+  link.onclick = () => { activate(link, sec); load(); };
+}
+
+// The dedicated Nodes tab (#129): configure the virtual nodes — kind, how they're valued, live-value
+// bindings, and feeders/children — separate from the Flow visualization. Both edit the shared EnergyFlow.
+export function addNodesSection(nav: any, sections: any) {
+  const link = document.createElement('a'); link.textContent = 'Nodes'; nav.appendChild(link);
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  const h = document.createElement('h2'); h.textContent = 'Energy Nodes'; sec.appendChild(h);
+  const d = document.createElement('div'); d.className = 'desc';
+  d.textContent = 'Configure the virtual nodes in your energy hierarchy — panels, breakers, batteries, producers, a “Total”. Set each node’s kind, how it’s valued, its live-value bindings (MQTT / Modbus), and its feeders & children. The wiring also shows visually on the Flow tab.';
+  sec.appendChild(d);
+
+  const bar = document.createElement('div'); bar.className = 'ld-toolbar';
+  const instSel = instanceSelector(() => load());
+  const count = document.createElement('span'); count.className = 'ld-count';
+  bar.appendChild(instSel.wrap); bar.appendChild(count); sec.appendChild(bar);
+  const ed: any = document.createElement('div'); ed.style.marginTop = '8px'; sec.appendChild(ed);
+  let lastGraph: any = null;
+  const editing: { id: string | null } = { id: null };
+
+  const render = () => {
+    const flow = ensure(state.data, 'EnergyFlow', {});
+    migrateEnergyFlow(flow);
+    const customNodes = ensure(flow, 'Nodes', []);
+    const links = ensure(flow, 'Links', []);
+    count.textContent = `${customNodes.length} node(s)`;
+    ed.innerHTML = '';
+
+    const addBar = el('div', { class: 'ld-toolbar' });
+    const idIn = el('input', { type: 'text', placeholder: 'id (e.g. gridboss)' });
+    const labIn = el('input', { type: 'text', placeholder: 'label (e.g. Grid Boss)' });
+    const kindSel = el('select', { style: { width: 'auto' } });
+    NODE_KINDS.forEach(([v, label]) => kindSel.appendChild(el('option', { value: v, text: label })));
+    const addBtn = btn('Add node', 'primary');
+    const save = btn('Save', 'primary');
+    addBtn.onclick = () => {
+      const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
+      if (customNodes.some((n: any) => n.Id === id) || (lastGraph?.nodes || []).some((n: any) => n.id === id)) { toast('That id already exists.', false); return; }
+      const node: any = { Id: id, Label: (labIn.value || '').trim() || id };
+      if (kindSel.value !== 'node') node.Kind = kindSel.value;
+      customNodes.push(node); editing.id = id; render();  // open the new node's editor straight away
+    };
+    save.onclick = () => saveConfig(load);
+    addBar.append(idIn, labIn, kindSel, addBtn, save); ed.appendChild(addBar);
+
+    const cand = flowCandidates(lastGraph, customNodes);
+    ed.appendChild(renderNodeManager(customNodes, links, cand, editing, (close?: boolean) => { if (close) editing.id = null; render(); }));
+  };
+
+  const load = async () => {
+    // The flow graph gives the auto (pdu/outlet) node ids for the feeder/children pickers; node config itself
+    // is global, so a failed/empty graph just means fewer wiring candidates, not an error.
+    const r = await api(withInstance('/api/flow', instSel));
+    lastGraph = r.body?.ok ? r.body : null;
+    render();
+  };
   link.onclick = () => { activate(link, sec); load(); };
 }

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -32,9 +32,12 @@ const NODE_KINDS: [string, string, string[]][] = [
 ];
 const kindMeta = (kind?: string) => NODE_KINDS.find(k => k[0] === (kind || 'node')) || NODE_KINDS[0];
 
-// Source binding types — mirrors [AllowedValues] on EnergyFlowSource.Type. Only MQTT today; the editor is
-// shaped so another ingest is just another entry here plus its own fields.
-const SOURCE_TYPES: [string, string][] = [['mqtt', 'MQTT topic']];
+// Source binding types — mirrors [AllowedValues] on EnergyFlowSource.Type. Each type renders its own fields
+// in the two source columns; adding an ingest is another entry here plus a branch in the row renderer.
+const SOURCE_TYPES: [string, string][] = [['mqtt', 'MQTT topic'], ['modbus', 'Modbus TCP']];
+const MODBUS_REGISTER_TYPES = ['holding', 'input'];
+const MODBUS_DATATYPES = ['uint16', 'int16', 'uint32', 'int32', 'float32'];
+const MODBUS_WORDORDERS = ['big', 'little'];
 
 // How an unmeasured node is valued — mirrors [AllowedValues] on EnergyFlowNode.Mode. A live/static value
 // always wins; this only governs nodes the graph would otherwise infer.
@@ -107,13 +110,13 @@ function renderNodeEditor(node: any, rerender: () => void) {
 
   // --- Live value bindings ---
   box.appendChild(el('h5', { text: 'Live value bindings', style: { margin: '6px 0 2px', fontSize: '12px' } }));
-  box.appendChild(el('div', { class: 'desc', text: 'Bind a metric to a source already on your broker. One binding per metric drives that metric’s power/energy/… roll-up; a fresh reading supersedes the fixed value. Takes effect without a restart once saved.', style: { margin: '0 0 8px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'Bind a metric to a live source — an MQTT topic, or a register on a Modbus TCP connection (set those up in the Modbus section). One binding per metric drives that metric’s power/energy/… roll-up; a fresh reading supersedes the fixed value. Takes effect without a restart once saved.', style: { margin: '0 0 8px' } }));
 
   const sources: any[] = ensure(node, 'Sources', []);
   if (sources.length) {
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
-    ['Type', 'Metric', 'Unit', 'Topic', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
+    ['Type', 'Metric', 'Unit', 'Source', 'Details', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
     tbl.appendChild(el('thead', {}, head));
     const body = el('tbody');
     sources.forEach((src: any) => {
@@ -122,7 +125,7 @@ function renderNodeEditor(node: any, rerender: () => void) {
       const typeSel = el('select', { style: { width: 'auto' } });
       SOURCE_TYPES.forEach(([v, label]) => typeSel.appendChild(el('option', { value: v, text: label })));
       typeSel.value = src.Type || 'mqtt';
-      typeSel.onchange = () => { src.Type = typeSel.value; };
+      typeSel.onchange = () => { src.Type = typeSel.value; rerender(); };  // the Source/Details fields differ per type
       tr.appendChild(el('td', {}, typeSel));
 
       // Offer this kind's metrics (friendly labels), but keep an already-chosen one even if the kind wouldn't
@@ -144,13 +147,46 @@ function renderNodeEditor(node: any, rerender: () => void) {
       unitSel.onchange = () => { src.Unit = unitSel.value === canonical ? undefined : unitSel.value; };
       tr.appendChild(el('td', {}, unitSel));
 
-      const topicIn = el('input', { type: 'text', value: src.Topic || '', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '300px' } });
-      topicIn.onchange = () => { src.Topic = topicIn.value.trim(); };
-      tr.appendChild(el('td', {}, topicIn));
+      // The Source + Details columns are type-specific.
+      if ((src.Type || 'mqtt') === 'modbus') {
+        // Source = which configured Modbus connection; Details = the register spec.
+        const connections: any[] = (state.data?.Modbus?.Connections) || [];
+        const connSel = el('select', { style: { width: '160px' } });
+        connSel.appendChild(el('option', { value: '', text: connections.length ? '— pick a connection —' : 'none — add one in Modbus' }));
+        connections.forEach((c: any) => connSel.appendChild(el('option', { value: c.Id, text: c.Name || c.Id })));
+        connSel.value = src.Connection || '';
+        connSel.onchange = () => { src.Connection = connSel.value || undefined; };
+        tr.appendChild(el('td', {}, connSel));
 
-      const fieldIn = el('input', { type: 'text', value: src.JsonField || '', placeholder: '(optional)', style: { width: '120px' } });
-      fieldIn.onchange = () => { src.JsonField = fieldIn.value.trim() || undefined; };
-      tr.appendChild(el('td', {}, fieldIn));
+        const details = el('div', { style: { display: 'flex', gap: '6px', flexWrap: 'wrap', alignItems: 'center' } });
+        const regIn = el('input', { type: 'number', value: src.Register ?? 0, title: 'Register address', style: { width: '80px' } });
+        regIn.onchange = () => { const v = +regIn.value; src.Register = !isNaN(v) ? v : 0; };
+        const regTypeSel = el('select', { title: 'Register bank', style: { width: 'auto' } });
+        MODBUS_REGISTER_TYPES.forEach(t => regTypeSel.appendChild(el('option', { value: t, text: t })));
+        regTypeSel.value = src.RegisterType || 'holding';
+        regTypeSel.onchange = () => { src.RegisterType = regTypeSel.value === 'holding' ? undefined : regTypeSel.value; };
+        const dtSel = el('select', { title: 'Data type', style: { width: 'auto' } });
+        MODBUS_DATATYPES.forEach(t => dtSel.appendChild(el('option', { value: t, text: t })));
+        dtSel.value = src.DataType || 'uint16';
+        const woSel = el('select', { title: 'Word order (32-bit)', style: { width: 'auto' } });
+        MODBUS_WORDORDERS.forEach(t => woSel.appendChild(el('option', { value: t, text: t })));
+        woSel.value = src.WordOrder || 'big';
+        woSel.onchange = () => { src.WordOrder = woSel.value === 'big' ? undefined : woSel.value; };
+        // Word order only matters for 32-bit types; keep it enabled only then.
+        const is32 = () => ['uint32', 'int32', 'float32'].includes(dtSel.value);
+        woSel.disabled = !is32();
+        dtSel.onchange = () => { src.DataType = dtSel.value === 'uint16' ? undefined : dtSel.value; woSel.disabled = !is32(); };
+        details.append(regIn, regTypeSel, dtSel, woSel);
+        tr.appendChild(el('td', {}, details));
+      } else {
+        const topicIn = el('input', { type: 'text', value: src.Topic || '', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '300px' } });
+        topicIn.onchange = () => { src.Topic = topicIn.value.trim(); };
+        tr.appendChild(el('td', {}, topicIn));
+
+        const fieldIn = el('input', { type: 'text', value: src.JsonField || '', placeholder: 'JSON field (optional)', style: { width: '120px' } });
+        fieldIn.onchange = () => { src.JsonField = fieldIn.value.trim() || undefined; };
+        tr.appendChild(el('td', {}, fieldIn));
+      }
 
       const scaleIn = el('input', { type: 'number', step: 'any', value: src.Scale ?? 1, style: { width: '80px' } });
       scaleIn.onchange = () => { const v = +scaleIn.value; src.Scale = (scaleIn.value !== '' && !isNaN(v) && v !== 1) ? v : undefined; };

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -6,6 +6,70 @@ import { exportData } from '../overrides.js';
 // Metrics a live source can supply — mirrors [AllowedValues] on EnergyFlowMqttSource.Metric.
 const SOURCE_METRICS = ['realpower', 'apparentpower', 'energy', 'current', 'voltage', 'frequency', 'powerfactor'];
 
+// How an unmeasured node is valued — mirrors [AllowedValues] on EnergyFlowNode.Mode. A live/static value
+// always wins; this only governs nodes the graph would otherwise infer.
+const NODE_MODES: [string, string, string][] = [
+  ['auto', 'Auto (aggregate / share)', 'Sums its children, and as a feeder takes a share of whatever load measured siblings don’t cover — the default.'],
+  ['residual', 'Residual (untracked)', 'The designated absorber for untracked load: carries the demand still needed after every measured feeder has supplied its part.'],
+  ['none', 'None (leave unset)', 'Never inferred — contributes nothing unless it has a real value or children, so an unmeasured source simply drops out instead of showing a fabricated figure.'],
+];
+
+// Virtual-node manager (#129): rename, retype, set a fixed value or mode, and delete the custom nodes — the
+// "page to manage those" that the graph editor alone didn't cover. Value population is source-agnostic: a
+// node's number can come from a fixed value, or a bound live source (MQTT today, other ingests later) shown
+// in the Sources column; the Mode governs only what happens when neither is present.
+function renderNodeManager(customNodes: any[], links: any[], rerender: () => void) {
+  const box = el('div', { style: { margin: '18px 0' } });
+  box.appendChild(el('h3', { text: 'Virtual nodes', style: { margin: '4px 0', fontSize: '15px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'The custom nodes you’ve added (panels, breakers, a “Total”, producers). Rename them, give a leaf a fixed value, or set how an unmeasured node is valued. A fixed value or a bound live source always wins over the mode; the mode only decides what an otherwise-unknown node does.' }));
+
+  if (!customNodes.length) {
+    box.appendChild(el('div', { class: 'desc', text: 'No virtual nodes yet — add one above.' }));
+    return box;
+  }
+
+  const tbl = el('table', { class: 'ld' });
+  const head = el('tr');
+  ['Id', 'Label', 'Fixed value', 'Mode', 'Sources', ''].forEach(h => head.appendChild(el('th', { text: h })));
+  tbl.appendChild(el('thead', {}, head));
+  const body = el('tbody');
+  customNodes.forEach((n: any) => {
+    const tr = el('tr');
+    tr.appendChild(el('td', {}, el('code', { text: n.Id, style: { color: 'var(--muted)' } })));
+
+    const labIn = el('input', { type: 'text', value: n.Label || '', placeholder: n.Id, style: { width: '180px' } });
+    labIn.onchange = () => { n.Label = labIn.value.trim() || undefined; };
+    tr.appendChild(el('td', {}, labIn));
+
+    const valIn = el('input', { type: 'number', step: 'any', value: n.Value ?? '', placeholder: '—', style: { width: '110px' } });
+    valIn.onchange = () => { const v = +valIn.value; n.Value = (valIn.value !== '' && !isNaN(v)) ? v : undefined; };
+    tr.appendChild(el('td', {}, valIn));
+
+    const modeSel = el('select', { style: { width: 'auto' } });
+    NODE_MODES.forEach(([v, label, desc]) => { const o = el('option', { value: v, text: label }); o.title = desc; modeSel.appendChild(o); });
+    modeSel.value = n.Mode || 'auto';
+    modeSel.onchange = () => { n.Mode = modeSel.value === 'auto' ? undefined : modeSel.value; };
+    tr.appendChild(el('td', {}, modeSel));
+
+    // Bound live sources (MQTT today) — the seam other ingests plug into. Detail/editing lives below.
+    const srcMetrics = (n.Mqtt || []).map((s: any) => s.Metric || 'realpower');
+    tr.appendChild(el('td', { text: srcMetrics.length ? srcMetrics.join(', ') : '—', class: srcMetrics.length ? '' : 'num' }));
+
+    const rm = btn('Delete', 'danger');
+    rm.onclick = () => {
+      customNodes.splice(customNodes.indexOf(n), 1);
+      for (let j = links.length - 1; j >= 0; j--) if (links[j].From === n.Id || links[j].To === n.Id) links.splice(j, 1);
+      toast(`${n.Label || n.Id} deleted.`, true);
+      rerender();
+    };
+    tr.appendChild(el('td', {}, rm));
+    body.appendChild(tr);
+  });
+  tbl.appendChild(body);
+  box.appendChild(tbl);
+  return box;
+}
+
 // Binds custom nodes to live MQTT topics (#205): the values a producer (Solar Assistant, a CT clamp)
 // already publishes become this node's reading, so it rolls up and exports like a PDU outlet. Only custom
 // nodes appear — PDU/outlet nodes get their values from the poll.
@@ -199,7 +263,7 @@ export function addFlowSection(nav: any, sections: any) {
     ed.innerHTML = '';
 
     ed.appendChild(el('h3', { text: 'Hierarchy', style: { margin: '4px 0' } }));
-    ed.appendChild(el('div', { class: 'desc', text: 'Energy flows left → right. Drag from a node’s right ● onto another node to add a feed (source powers target). A node can have several feeders, and a producer is just a feed into what it powers — e.g. drag from Solar onto your inverter. The target highlights green when in range; click ✕ on a link to remove it. PDU → outlet links are auto-derived (dashed) until you wire an explicit feeder.' }));
+    ed.appendChild(el('div', { class: 'desc', text: 'Energy flows left → right. Drag from a node’s right ● onto another node to add a feed (source powers target). A node can have several feeders, and a producer is just a feed into what it powers — e.g. drag from Solar onto your inverter. The target highlights green when in range; click ✕ on a link to remove it. Double-click a custom node to rename it. PDU → outlet links are auto-derived (dashed) until you wire an explicit feeder.' }));
 
     const addBar = el('div', { class: 'ld-toolbar' });
     const idIn = el('input', { type: 'text', placeholder: 'id (e.g. gridboss)' });
@@ -221,6 +285,7 @@ export function addFlowSection(nav: any, sections: any) {
     exportRow.append(el('label', {}, expChk, ' Export tiers to MQTT'), el('span', { class: 'desc', style: { margin: '0' }, text: 'Topic:' }), topicIn);
     ed.appendChild(exportRow);
 
+    ed.appendChild(renderNodeManager(customNodes, links, renderEditor));
     ed.appendChild(renderMqttSources(customNodes, renderEditor));
 
     // Candidate nodes (from the built graph + custom defs).
@@ -304,7 +369,21 @@ export function addFlowSection(nav: any, sections: any) {
       const t1 = svgEl('text', { x: 11, y: 19, fill: 'var(--fg)', 'font-size': '12', 'font-weight': '600' }); t1.textContent = c.label.length > 26 ? c.label.slice(0, 25) + '…' : c.label; g.appendChild(t1);
       const t2 = svgEl('text', { x: 11, y: 35, fill: 'var(--muted)', 'font-size': '10' }); t2.textContent = c.id; g.appendChild(t2);
       g.appendChild(svgEl('circle', { cx: NW, cy: NH / 2, r: 7, fill: color, style: 'cursor:crosshair', 'data-port': c.id }));
-      if (c.custom) { const rm = svgEl('text', { x: NW - 13, y: 15, fill: 'var(--bad)', 'font-size': '13', style: 'cursor:pointer', 'data-rm': c.id }); rm.textContent = '✕'; g.appendChild(rm); }
+      if (c.custom) {
+        const rm = svgEl('text', { x: NW - 13, y: 15, fill: 'var(--bad)', 'font-size': '13', style: 'cursor:pointer', 'data-rm': c.id }); rm.textContent = '✕'; g.appendChild(rm);
+        // Rename in place: double-click the node to relabel it. Only the Label changes — Id stays fixed, so
+        // every link/source keyed off it survives. (Ids aren't editable here for exactly that reason.)
+        t1.setAttribute('title', 'Double-click to rename'); g.style.cursor = 'pointer';
+        g.addEventListener('dblclick', (e: any) => {
+          e.preventDefault();
+          const node = customNodes.find((n: any) => n.Id === c.id); if (!node) return;
+          const next = window.prompt(`Rename “${node.Label || node.Id}” (id ${node.Id} is unchanged)`, node.Label || node.Id);
+          if (next == null) return; // cancelled
+          node.Label = next.trim() || node.Id;
+          toast(`Renamed to ${node.Label}. Save the hierarchy to keep it.`, true);
+          renderEditor();
+        });
+      }
       nodeLayer.appendChild(g); nodeG[c.id] = g;
     });
 

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -116,9 +116,11 @@ function renderNodeEditor(node: any, rerender: () => void) {
   if (sources.length) {
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
-    ['Type', 'Metric', 'Unit', 'Source', 'Details', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
+    ['Type', 'Metric', 'Unit', 'Source', 'Details', 'Scale', 'Current', ''].forEach(h => head.appendChild(el('th', { text: h })));
     tbl.appendChild(el('thead', {}, head));
     const body = el('tbody');
+    // Cells that a live probe fills in, keyed to their source so a refresh can update them in place.
+    const liveCells: { src: any, cell: any }[] = [];
     sources.forEach((src: any) => {
       const tr = el('tr');
 
@@ -192,6 +194,11 @@ function renderNodeEditor(node: any, rerender: () => void) {
       scaleIn.onchange = () => { const v = +scaleIn.value; src.Scale = (scaleIn.value !== '' && !isNaN(v) && v !== 1) ? v : undefined; };
       tr.appendChild(el('td', {}, scaleIn));
 
+      // Live value (Modbus only for now): filled by a probe so you can confirm a mapping reads correctly.
+      const liveCell = el('td', { class: 'num', style: { minWidth: '90px', color: 'var(--muted)' }, text: (src.Type === 'modbus') ? '…' : '—' });
+      if (src.Type === 'modbus') liveCells.push({ src, cell: liveCell });
+      tr.appendChild(liveCell);
+
       const rm = btn('Remove', 'danger');
       rm.onclick = () => { sources.splice(sources.indexOf(src), 1); rerender(); };
       tr.appendChild(el('td', {}, rm));
@@ -199,6 +206,39 @@ function renderNodeEditor(node: any, rerender: () => void) {
     });
     tbl.appendChild(body);
     box.appendChild(tbl);
+
+    // Live values for Modbus mappings: probe the device(s) and fill the Current column, so you can confirm a
+    // register/type/scale reads what you expect before saving. Auto-refreshes while the editor is open.
+    if (liveCells.length) {
+      const status = el('span', { class: 'desc', style: { margin: '0 0 0 8px' } });
+      const refresh = async () => {
+        const conns: any[] = (state.data?.Modbus?.Connections) || [];
+        const byConn = new Map<string, { src: any, cell: any }[]>();
+        liveCells.forEach(lc => { const id = lc.src.Connection || ''; (byConn.get(id) || byConn.set(id, []).get(id)!).push(lc); });
+        for (const [connId, cells] of byConn) {
+          const conn = conns.find(c => c.Id === connId);
+          if (!conn) { cells.forEach(lc => { lc.cell.textContent = 'pick a connection'; lc.cell.style.color = 'var(--muted)'; }); continue; }
+          try {
+            const r = await api('/api/modbus/probe', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ Host: conn.Host, Port: conn.Port, UnitId: conn.UnitId, Items: cells.map(lc => lc.src) }) });
+            if (!r.body.ok) { cells.forEach(lc => { lc.cell.textContent = 'err'; lc.cell.style.color = 'var(--bad)'; }); status.textContent = r.body.message || 'probe failed'; continue; }
+            const readings = r.body.readings || [];
+            cells.forEach((lc, i) => {
+              const rd = readings[i];
+              if (!rd || rd.value == null) { lc.cell.textContent = rd?.error ? 'err' : '—'; lc.cell.style.color = 'var(--bad)'; lc.cell.title = rd?.error || ''; }
+              else { const cu = metricMeta(lc.src.Metric)[2]; lc.cell.textContent = `${formatNum(rd.value)} ${cu}`.trim(); lc.cell.style.color = 'var(--good)'; lc.cell.title = ''; }
+            });
+            status.textContent = `updated ${new Date().toLocaleTimeString()}`;
+          } catch (e: any) { cells.forEach(lc => { lc.cell.textContent = 'err'; }); status.textContent = String(e?.message || e); }
+        }
+      };
+      const refreshBtn = btn('Refresh values');
+      refreshBtn.onclick = refresh;
+      box.appendChild(el('div', { class: 'ld-toolbar', style: { marginTop: '6px' } }, refreshBtn, status));
+      refresh();
+      // Self-cleaning: once this editor is replaced/closed its box leaves the DOM and the poll stops.
+      const timer = setInterval(() => { if (!document.body.contains(box)) { clearInterval(timer); return; } refresh(); }, 5000);
+    }
   }
 
   const addBind = btn('Add binding', 'primary');

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -194,9 +194,10 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
       scaleIn.onchange = () => { const v = +scaleIn.value; src.Scale = (scaleIn.value !== '' && !isNaN(v) && v !== 1) ? v : undefined; };
       tr.appendChild(el('td', {}, scaleIn));
 
-      // Live value (Modbus only for now): filled by a probe so you can confirm a mapping reads correctly.
-      const liveCell = el('td', { class: 'num', style: { minWidth: '90px', color: 'var(--muted)' }, text: (src.Type === 'modbus') ? '…' : '—' });
-      if (src.Type === 'modbus') liveCells.push({ src, cell: liveCell });
+      // Live value for every binding type: Modbus is read from the device; the rest (MQTT, future types)
+      // come from the shared live cache the running ingests fill — so you can confirm a mapping reads right.
+      const liveCell = el('td', { class: 'num', style: { minWidth: '90px', color: 'var(--muted)' }, text: '…' });
+      liveCells.push({ src, cell: liveCell });
       tr.appendChild(liveCell);
 
       const rm = btn('Remove', 'danger');
@@ -207,30 +208,43 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
     tbl.appendChild(body);
     box.appendChild(tbl);
 
-    // Live values for Modbus mappings: probe the device(s) and fill the Current column, so you can confirm a
-    // register/type/scale reads what you expect before saving. Auto-refreshes while the editor is open.
+    // Live "Current" value for every binding: Modbus is read straight from the device (works before saving);
+    // MQTT and any future type come from the shared live cache the running ingests fill. Auto-refreshes.
     if (liveCells.length) {
       const status = el('span', { class: 'desc', style: { margin: '0 0 0 8px' } });
+      const setCell = (cell: any, value: number | null, err?: string, metric?: string) => {
+        if (value == null) { cell.textContent = err ? 'err' : '—'; cell.style.color = err ? 'var(--bad)' : 'var(--muted)'; cell.title = err || 'no live value yet'; }
+        else { const cu = metricMeta(metric)[2]; cell.textContent = `${formatNum(value)} ${cu}`.trim(); cell.style.color = 'var(--good)'; cell.title = ''; }
+      };
       const refresh = async () => {
+        // Modbus: probe the device(s), grouped by connection so each is read once.
+        const modbus = liveCells.filter(lc => (lc.src.Type || 'mqtt') === 'modbus');
         const conns: any[] = (state.data?.Modbus?.Connections) || [];
         const byConn = new Map<string, { src: any, cell: any }[]>();
-        liveCells.forEach(lc => { const id = lc.src.Connection || ''; (byConn.get(id) || byConn.set(id, []).get(id)!).push(lc); });
+        modbus.forEach(lc => { const id = lc.src.Connection || ''; (byConn.get(id) || byConn.set(id, []).get(id)!).push(lc); });
         for (const [connId, cells] of byConn) {
           const conn = conns.find(c => c.Id === connId);
-          if (!conn) { cells.forEach(lc => { lc.cell.textContent = 'pick a connection'; lc.cell.style.color = 'var(--muted)'; }); continue; }
+          if (!conn) { cells.forEach(lc => setCell(lc.cell, null, 'pick a connection')); continue; }
           try {
             const r = await api('/api/modbus/probe', { method: 'POST', headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ Host: conn.Host, Port: conn.Port, UnitId: conn.UnitId, Items: cells.map(lc => lc.src) }) });
-            if (!r.body.ok) { cells.forEach(lc => { lc.cell.textContent = 'err'; lc.cell.style.color = 'var(--bad)'; }); status.textContent = r.body.message || 'probe failed'; continue; }
+            if (!r.body.ok) { cells.forEach(lc => setCell(lc.cell, null, 'err')); status.textContent = r.body.message || 'probe failed'; continue; }
             const readings = r.body.readings || [];
-            cells.forEach((lc, i) => {
-              const rd = readings[i];
-              if (!rd || rd.value == null) { lc.cell.textContent = rd?.error ? 'err' : '—'; lc.cell.style.color = 'var(--bad)'; lc.cell.title = rd?.error || ''; }
-              else { const cu = metricMeta(lc.src.Metric)[2]; lc.cell.textContent = `${formatNum(rd.value)} ${cu}`.trim(); lc.cell.style.color = 'var(--good)'; lc.cell.title = ''; }
-            });
-            status.textContent = `updated ${new Date().toLocaleTimeString()}`;
-          } catch (e: any) { cells.forEach(lc => { lc.cell.textContent = 'err'; }); status.textContent = String(e?.message || e); }
+            cells.forEach((lc, i) => setCell(lc.cell, readings[i]?.value ?? null, readings[i]?.error, lc.src.Metric));
+          } catch (e: any) { cells.forEach(lc => setCell(lc.cell, null, 'err')); status.textContent = String(e?.message || e); }
         }
+
+        // MQTT + future types: whatever the running ingest currently holds in the shared cache.
+        const others = liveCells.filter(lc => (lc.src.Type || 'mqtt') !== 'modbus');
+        if (others.length) {
+          try {
+            const r = await api('/api/flow/live', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(others.map(lc => ({ Node: node.Id, Metric: lc.src.Metric || 'realpower' }))) });
+            const vals = (r.body && r.body.values) || [];
+            others.forEach((lc, i) => setCell(lc.cell, vals[i]?.value ?? null, undefined, lc.src.Metric));
+          } catch (e: any) { others.forEach(lc => setCell(lc.cell, null, 'err')); }
+        }
+        status.textContent = `updated ${new Date().toLocaleTimeString()}`;
       };
       const refreshBtn = btn('Refresh values');
       refreshBtn.onclick = refresh;

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -3,8 +3,21 @@ import { api, btn, el, ensure, formatNum, svgEl, attachZoom, activate, toast, in
 import { state } from '../state.js';
 import { exportData } from '../overrides.js';
 
-// Metrics a live source can supply — mirrors [AllowedValues] on EnergyFlowSource.Metric.
-const SOURCE_METRICS = ['realpower', 'apparentpower', 'energy', 'current', 'voltage', 'frequency', 'powerfactor'];
+// Metrics a live source can supply: [stored key (matches PDU Measurement.Type), friendly label, canonical
+// unit, selectable input units]. The key stays the PDU vocabulary so live values roll up with outlets; the
+// UI shows the friendly name and a unit picker. Mirrors EnergyFlowSource.Metric + FlowUnits (Core).
+const METRICS: [string, string, string, string[]][] = [
+  ['realpower', 'Power', 'W', ['W', 'kW', 'MW']],
+  ['apparentpower', 'Apparent power', 'VA', ['VA', 'kVA']],
+  ['energy', 'Energy', 'kWh', ['Wh', 'kWh', 'MWh']],
+  ['current', 'Current', 'A', ['A', 'mA']],
+  ['voltage', 'Voltage', 'V', ['mV', 'V', 'kV']],
+  ['frequency', 'Frequency', 'Hz', ['Hz']],
+  ['powerfactor', 'Power factor', '', ['']],
+];
+const SOURCE_METRICS = METRICS.map(m => m[0]);
+const metricMeta = (key?: string) => METRICS.find(m => m[0] === key) || METRICS[0];
+const metricLabel = (key?: string) => metricMeta(key)[1];
 
 // What a virtual node represents — mirrors [AllowedValues] on EnergyFlowNode.Kind. Each kind offers only
 // the metrics that make sense for it (a battery has no frequency); 'battery' also gets a storage field.
@@ -100,7 +113,7 @@ function renderNodeEditor(node: any, rerender: () => void) {
   if (sources.length) {
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
-    ['Type', 'Metric', 'Topic', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
+    ['Type', 'Metric', 'Unit', 'Topic', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
     tbl.appendChild(el('thead', {}, head));
     const body = el('tbody');
     sources.forEach((src: any) => {
@@ -112,13 +125,24 @@ function renderNodeEditor(node: any, rerender: () => void) {
       typeSel.onchange = () => { src.Type = typeSel.value; };
       tr.appendChild(el('td', {}, typeSel));
 
-      // Offer this kind's metrics, but keep an already-chosen metric even if the kind wouldn't list it.
+      // Offer this kind's metrics (friendly labels), but keep an already-chosen one even if the kind wouldn't
+      // list it. Changing the metric resets the unit (units differ per metric) and re-renders the row.
       const metricSel = el('select', { style: { width: 'auto' } });
-      const opts = allowed.includes(src.Metric || 'realpower') ? allowed : [src.Metric, ...allowed];
-      opts.forEach((m: string) => metricSel.appendChild(el('option', { value: m, text: m })));
-      metricSel.value = src.Metric || 'realpower';
-      metricSel.onchange = () => { src.Metric = metricSel.value; };
+      const metric = src.Metric || 'realpower';
+      const opts = allowed.includes(metric) ? allowed : [metric, ...allowed];
+      opts.forEach((m: string) => metricSel.appendChild(el('option', { value: m, text: metricLabel(m) })));
+      metricSel.value = metric;
+      metricSel.onchange = () => { src.Metric = metricSel.value; src.Unit = undefined; rerender(); };
       tr.appendChild(el('td', {}, metricSel));
+
+      // Input unit → converted to the metric's canonical unit on ingest. Store only a non-canonical choice.
+      const [, , canonical, units] = metricMeta(metric);
+      const unitSel = el('select', { style: { width: 'auto' } });
+      units.forEach((u: string) => unitSel.appendChild(el('option', { value: u, text: u || '—' })));
+      unitSel.value = src.Unit || canonical;
+      unitSel.disabled = units.length <= 1;
+      unitSel.onchange = () => { src.Unit = unitSel.value === canonical ? undefined : unitSel.value; };
+      tr.appendChild(el('td', {}, unitSel));
 
       const topicIn = el('input', { type: 'text', value: src.Topic || '', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '300px' } });
       topicIn.onchange = () => { src.Topic = topicIn.value.trim(); };

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -10,7 +10,8 @@ const SOURCE_METRICS = ['realpower', 'apparentpower', 'energy', 'current', 'volt
 // always wins; this only governs nodes the graph would otherwise infer.
 const NODE_MODES: [string, string, string][] = [
   ['auto', 'Auto (aggregate / share)', 'Sums its children, and as a feeder takes a share of whatever load measured siblings don’t cover — the default.'],
-  ['residual', 'Residual (untracked)', 'The designated absorber for untracked load: carries the demand still needed after every measured feeder has supplied its part.'],
+  ['residual', 'Residual (untracked feeder)', 'The designated absorber on the feeder side: carries the demand still needed after every measured feeder has supplied its part.'],
+  ['untracked', 'Untracked (child of a measured parent)', 'Place under a parent that has a measured total (a bound source or fixed value): shows the slice of that total its tracked siblings don’t account for. Contributes nothing if the parent has no measured total.'],
   ['none', 'None (leave unset)', 'Never inferred — contributes nothing unless it has a real value or children, so an unmeasured source simply drops out instead of showing a fabricated figure.'],
 ];
 

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -3,8 +3,25 @@ import { api, btn, el, ensure, formatNum, svgEl, attachZoom, activate, toast, in
 import { state } from '../state.js';
 import { exportData } from '../overrides.js';
 
-// Metrics a live source can supply — mirrors [AllowedValues] on EnergyFlowMqttSource.Metric.
+// Metrics a live source can supply — mirrors [AllowedValues] on EnergyFlowSource.Metric.
 const SOURCE_METRICS = ['realpower', 'apparentpower', 'energy', 'current', 'voltage', 'frequency', 'powerfactor'];
+
+// What a virtual node represents — mirrors [AllowedValues] on EnergyFlowNode.Kind. Each kind offers only
+// the metrics that make sense for it (a battery has no frequency); 'battery' also gets a storage field.
+const NODE_KINDS: [string, string, string[]][] = [
+  ['node', 'Virtual node', SOURCE_METRICS],
+  ['panel', 'Electrical panel', ['realpower', 'apparentpower', 'current', 'voltage', 'energy', 'powerfactor']],
+  ['inverter', 'Inverter', SOURCE_METRICS],
+  ['battery', 'Battery', ['realpower', 'energy', 'current', 'voltage']],
+  ['solar', 'Solar / PV', ['realpower', 'energy', 'current', 'voltage']],
+  ['grid', 'Grid', SOURCE_METRICS],
+  ['load', 'Load', ['realpower', 'apparentpower', 'energy', 'current', 'voltage', 'powerfactor']],
+];
+const kindMeta = (kind?: string) => NODE_KINDS.find(k => k[0] === (kind || 'node')) || NODE_KINDS[0];
+
+// Source binding types — mirrors [AllowedValues] on EnergyFlowSource.Type. Only MQTT today; the editor is
+// shaped so another ingest is just another entry here plus its own fields.
+const SOURCE_TYPES: [string, string][] = [['mqtt', 'MQTT topic']];
 
 // How an unmeasured node is valued — mirrors [AllowedValues] on EnergyFlowNode.Mode. A live/static value
 // always wins; this only governs nodes the graph would otherwise infer.
@@ -15,14 +32,126 @@ const NODE_MODES: [string, string, string][] = [
   ['none', 'None (leave unset)', 'Never inferred — contributes nothing unless it has a real value or children, so an unmeasured source simply drops out instead of showing a fabricated figure.'],
 ];
 
-// Virtual-node manager (#129): rename, retype, set a fixed value or mode, and delete the custom nodes — the
-// "page to manage those" that the graph editor alone didn't cover. Value population is source-agnostic: a
-// node's number can come from a fixed value, or a bound live source (MQTT today, other ingests later) shown
-// in the Sources column; the Mode governs only what happens when neither is present.
-function renderNodeManager(customNodes: any[], links: any[], rerender: () => void) {
+// A labelled field (label above a control) for the node editor's form grid.
+function field(labelText: string, control: HTMLElement, hint?: string) {
+  const f = el('div', { style: { display: 'flex', flexDirection: 'column', gap: '3px' } });
+  f.appendChild(el('label', { text: labelText, style: { fontSize: '11px', color: 'var(--muted)' } }));
+  f.appendChild(control);
+  if (hint) f.appendChild(el('div', { class: 'desc', text: hint, style: { margin: '0', fontSize: '11px' } }));
+  return f;
+}
+
+// Per-node editor (#129): name, kind, mode, fixed value, a battery's storage, and the live value bindings —
+// one row per metric, each carrying a Type (MQTT today) and its transport fields, all editable in place
+// (including the topic, which the old flat table couldn't change).
+function renderNodeEditor(node: any, rerender: () => void) {
+  const meta = kindMeta(node.Kind);
+  const allowed = meta[2];
+  const box = el('div', { style: { margin: '10px 0 4px', padding: '14px', border: '1px solid var(--accent, #4f8cff)', borderRadius: '8px', background: 'var(--panel2)' } });
+
+  const header = el('div', { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' } });
+  header.appendChild(el('h4', { text: `Editing ${node.Label || node.Id}`, style: { margin: '0', fontSize: '14px' } }));
+  const close = btn('Close'); close.onclick = () => rerender(true);
+  header.appendChild(close);
+  box.appendChild(header);
+
+  const grid = el('div', { style: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '12px', marginBottom: '12px' } });
+
+  const labIn = el('input', { type: 'text', value: node.Label || '', placeholder: node.Id });
+  labIn.onchange = () => { node.Label = labIn.value.trim() || undefined; };
+  grid.appendChild(field('Name', labIn));
+
+  const kindSel = el('select');
+  NODE_KINDS.forEach(([v, label]) => kindSel.appendChild(el('option', { value: v, text: label })));
+  kindSel.value = node.Kind || 'node';
+  kindSel.onchange = () => { node.Kind = kindSel.value === 'node' ? undefined : kindSel.value; rerender(); };
+  grid.appendChild(field('Kind', kindSel));
+
+  const modeSel = el('select');
+  NODE_MODES.forEach(([v, label, desc]) => { const o = el('option', { value: v, text: label }); o.title = desc; modeSel.appendChild(o); });
+  modeSel.value = node.Mode || 'auto';
+  modeSel.onchange = () => { node.Mode = modeSel.value === 'auto' ? undefined : modeSel.value; };
+  grid.appendChild(field('Mode', modeSel, 'How it’s valued with no measurement.'));
+
+  const valIn = el('input', { type: 'number', step: 'any', value: node.Value ?? '', placeholder: '—' });
+  valIn.onchange = () => { const v = +valIn.value; node.Value = (valIn.value !== '' && !isNaN(v)) ? v : undefined; };
+  grid.appendChild(field('Fixed value', valIn, 'Used only if nothing live reports.'));
+
+  if ((node.Kind || 'node') === 'battery') {
+    const stoIn = el('input', { type: 'number', step: 'any', value: node.StorageKwh ?? '', placeholder: 'kWh' });
+    stoIn.onchange = () => { const v = +stoIn.value; node.StorageKwh = (stoIn.value !== '' && !isNaN(v)) ? v : undefined; };
+    grid.appendChild(field('Storage (kWh)', stoIn));
+  }
+  box.appendChild(grid);
+
+  // --- Live value bindings ---
+  box.appendChild(el('h5', { text: 'Live value bindings', style: { margin: '6px 0 2px', fontSize: '12px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'Bind a metric to a source already on your broker. One binding per metric drives that metric’s power/energy/… roll-up; a fresh reading supersedes the fixed value. Takes effect without a restart once saved.', style: { margin: '0 0 8px' } }));
+
+  const sources: any[] = ensure(node, 'Sources', []);
+  if (sources.length) {
+    const tbl = el('table', { class: 'ld' });
+    const head = el('tr');
+    ['Type', 'Metric', 'Topic', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
+    tbl.appendChild(el('thead', {}, head));
+    const body = el('tbody');
+    sources.forEach((src: any) => {
+      const tr = el('tr');
+
+      const typeSel = el('select', { style: { width: 'auto' } });
+      SOURCE_TYPES.forEach(([v, label]) => typeSel.appendChild(el('option', { value: v, text: label })));
+      typeSel.value = src.Type || 'mqtt';
+      typeSel.onchange = () => { src.Type = typeSel.value; };
+      tr.appendChild(el('td', {}, typeSel));
+
+      // Offer this kind's metrics, but keep an already-chosen metric even if the kind wouldn't list it.
+      const metricSel = el('select', { style: { width: 'auto' } });
+      const opts = allowed.includes(src.Metric || 'realpower') ? allowed : [src.Metric, ...allowed];
+      opts.forEach((m: string) => metricSel.appendChild(el('option', { value: m, text: m })));
+      metricSel.value = src.Metric || 'realpower';
+      metricSel.onchange = () => { src.Metric = metricSel.value; };
+      tr.appendChild(el('td', {}, metricSel));
+
+      const topicIn = el('input', { type: 'text', value: src.Topic || '', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '300px' } });
+      topicIn.onchange = () => { src.Topic = topicIn.value.trim(); };
+      tr.appendChild(el('td', {}, topicIn));
+
+      const fieldIn = el('input', { type: 'text', value: src.JsonField || '', placeholder: '(optional)', style: { width: '120px' } });
+      fieldIn.onchange = () => { src.JsonField = fieldIn.value.trim() || undefined; };
+      tr.appendChild(el('td', {}, fieldIn));
+
+      const scaleIn = el('input', { type: 'number', step: 'any', value: src.Scale ?? 1, style: { width: '80px' } });
+      scaleIn.onchange = () => { const v = +scaleIn.value; src.Scale = (scaleIn.value !== '' && !isNaN(v) && v !== 1) ? v : undefined; };
+      tr.appendChild(el('td', {}, scaleIn));
+
+      const rm = btn('Remove', 'danger');
+      rm.onclick = () => { sources.splice(sources.indexOf(src), 1); rerender(); };
+      tr.appendChild(el('td', {}, rm));
+      body.appendChild(tr);
+    });
+    tbl.appendChild(body);
+    box.appendChild(tbl);
+  }
+
+  const addBind = btn('Add binding', 'primary');
+  addBind.onclick = () => {
+    // Default to the first metric this kind offers that isn't bound yet, so a click rarely needs a re-pick.
+    const used = new Set(sources.map((s: any) => s.Metric || 'realpower'));
+    const metric = allowed.find((m: string) => !used.has(m)) || allowed[0];
+    sources.push({ Type: 'mqtt', Metric: metric, Topic: '' });
+    rerender();
+  };
+  box.appendChild(el('div', { class: 'ld-toolbar', style: { marginTop: '8px' } }, addBind));
+  return box;
+}
+
+// Virtual-node manager (#129): the "page to manage those" the graph editor alone didn't cover. Each row is
+// a node; Edit opens the full editor (name, kind, mode, value, bindings) below the table. Deleting a node
+// takes its bound sources with it (they live on the node).
+function renderNodeManager(customNodes: any[], links: any[], editing: { id: string | null }, rerender: (close?: boolean) => void) {
   const box = el('div', { style: { margin: '18px 0' } });
   box.appendChild(el('h3', { text: 'Virtual nodes', style: { margin: '4px 0', fontSize: '15px' } }));
-  box.appendChild(el('div', { class: 'desc', text: 'The custom nodes you’ve added (panels, breakers, a “Total”, producers). Rename them, give a leaf a fixed value, or set how an unmeasured node is valued. A fixed value or a bound live source always wins over the mode; the mode only decides what an otherwise-unknown node does.' }));
+  box.appendChild(el('div', { class: 'desc', text: 'The custom nodes you’ve added (panels, breakers, batteries, producers, a “Total”). Click Edit to set the name, kind, how it’s valued, and bind live values from your broker.' }));
 
   if (!customNodes.length) {
     box.appendChild(el('div', { class: 'desc', text: 'No virtual nodes yet — add one above.' }));
@@ -31,112 +160,40 @@ function renderNodeManager(customNodes: any[], links: any[], rerender: () => voi
 
   const tbl = el('table', { class: 'ld' });
   const head = el('tr');
-  ['Id', 'Label', 'Fixed value', 'Mode', 'Sources', ''].forEach(h => head.appendChild(el('th', { text: h })));
+  ['Id', 'Label', 'Kind', 'Mode', 'Value', 'Bindings', ''].forEach(h => head.appendChild(el('th', { text: h })));
   tbl.appendChild(el('thead', {}, head));
   const body = el('tbody');
   customNodes.forEach((n: any) => {
     const tr = el('tr');
+    if (editing.id === n.Id) tr.style.outline = '2px solid var(--accent, #4f8cff)';
     tr.appendChild(el('td', {}, el('code', { text: n.Id, style: { color: 'var(--muted)' } })));
+    tr.appendChild(el('td', { text: n.Label || n.Id }));
+    tr.appendChild(el('td', { text: kindMeta(n.Kind)[1] }));
+    tr.appendChild(el('td', { text: n.Mode || 'auto' }));
+    tr.appendChild(el('td', { class: 'num', text: n.Value ?? '—' }));
+    const nb = (n.Sources || []).length;
+    tr.appendChild(el('td', { text: nb ? String(nb) : '—', class: nb ? '' : 'num' }));
 
-    const labIn = el('input', { type: 'text', value: n.Label || '', placeholder: n.Id, style: { width: '180px' } });
-    labIn.onchange = () => { n.Label = labIn.value.trim() || undefined; };
-    tr.appendChild(el('td', {}, labIn));
-
-    const valIn = el('input', { type: 'number', step: 'any', value: n.Value ?? '', placeholder: '—', style: { width: '110px' } });
-    valIn.onchange = () => { const v = +valIn.value; n.Value = (valIn.value !== '' && !isNaN(v)) ? v : undefined; };
-    tr.appendChild(el('td', {}, valIn));
-
-    const modeSel = el('select', { style: { width: 'auto' } });
-    NODE_MODES.forEach(([v, label, desc]) => { const o = el('option', { value: v, text: label }); o.title = desc; modeSel.appendChild(o); });
-    modeSel.value = n.Mode || 'auto';
-    modeSel.onchange = () => { n.Mode = modeSel.value === 'auto' ? undefined : modeSel.value; };
-    tr.appendChild(el('td', {}, modeSel));
-
-    // Bound live sources (MQTT today) — the seam other ingests plug into. Detail/editing lives below.
-    const srcMetrics = (n.Mqtt || []).map((s: any) => s.Metric || 'realpower');
-    tr.appendChild(el('td', { text: srcMetrics.length ? srcMetrics.join(', ') : '—', class: srcMetrics.length ? '' : 'num' }));
-
+    const actions = el('td', { style: { whiteSpace: 'nowrap' } });
+    const edit = btn(editing.id === n.Id ? 'Editing…' : 'Edit');
+    edit.onclick = () => { editing.id = editing.id === n.Id ? null : n.Id; rerender(); };
     const rm = btn('Delete', 'danger');
     rm.onclick = () => {
       customNodes.splice(customNodes.indexOf(n), 1);
       for (let j = links.length - 1; j >= 0; j--) if (links[j].From === n.Id || links[j].To === n.Id) links.splice(j, 1);
+      if (editing.id === n.Id) editing.id = null;
       toast(`${n.Label || n.Id} deleted.`, true);
       rerender();
     };
-    tr.appendChild(el('td', {}, rm));
+    actions.append(edit, ' ', rm);
+    tr.appendChild(actions);
     body.appendChild(tr);
   });
   tbl.appendChild(body);
   box.appendChild(tbl);
-  return box;
-}
 
-// Binds custom nodes to live MQTT topics (#205): the values a producer (Solar Assistant, a CT clamp)
-// already publishes become this node's reading, so it rolls up and exports like a PDU outlet. Only custom
-// nodes appear — PDU/outlet nodes get their values from the poll.
-function renderMqttSources(customNodes: any[], rerender: () => void) {
-  const box = el('div', { style: { margin: '18px 0' } });
-  box.appendChild(el('h3', { text: 'Live sources (MQTT)', style: { margin: '4px 0', fontSize: '15px' } }));
-  box.appendChild(el('div', { class: 'desc', text: 'Feed a node from a topic already on your broker — e.g. Solar Assistant’s solar_assistant/inverter_1/pv_power/state. A live reading replaces the node’s fixed value; bind one topic per metric to drive both the power and the energy roll-up. Takes effect without a restart once saved.' }));
-
-  if (!customNodes.length) {
-    box.appendChild(el('div', { class: 'desc', text: 'Add a node above first — live sources attach to custom nodes.' }));
-    return box;
-  }
-
-  // Existing bindings, flattened across nodes.
-  const rows = customNodes.flatMap((n: any) => (n.Mqtt || []).map((s: any) => ({ node: n, src: s })));
-  if (rows.length) {
-    const tbl = el('table', { class: 'ld' });
-    const head = el('tr');
-    ['Node', 'Topic', 'Metric', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
-    tbl.appendChild(el('thead', {}, head));
-    const body = el('tbody');
-    rows.forEach(({ node, src }: any) => {
-      const tr = el('tr');
-      tr.appendChild(el('td', { text: node.Label || node.Id }));
-      tr.appendChild(el('td', {}, el('code', { text: src.Topic })));
-      tr.appendChild(el('td', { text: src.Metric || 'realpower' }));
-      tr.appendChild(el('td', { text: src.JsonField || '—' }));
-      tr.appendChild(el('td', { class: 'num', text: String(src.Scale ?? 1) }));
-      const rm = btn('Remove', 'danger');
-      rm.onclick = () => { node.Mqtt.splice(node.Mqtt.indexOf(src), 1); rerender(); };
-      tr.appendChild(el('td', {}, rm));
-      body.appendChild(tr);
-    });
-    tbl.appendChild(body);
-    box.appendChild(tbl);
-  }
-
-  const bar = el('div', { class: 'ld-toolbar' });
-  const nodeSel = el('select', { style: { width: 'auto' } });
-  customNodes.forEach((n: any) => nodeSel.appendChild(el('option', { value: n.Id, text: n.Label || n.Id })));
-  const topicIn = el('input', { type: 'text', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '320px' } });
-  const metricSel = el('select', { style: { width: 'auto' } });
-  SOURCE_METRICS.forEach(m => metricSel.appendChild(el('option', { value: m, text: m })));
-  const fieldIn = el('input', { type: 'text', placeholder: 'JSON field (optional)', style: { width: '150px' } });
-  const scaleIn = el('input', { type: 'number', step: 'any', placeholder: 'scale', value: '1', style: { width: '90px' } });
-  const add = btn('Bind topic', 'primary');
-  add.onclick = () => {
-    const topic = (topicIn.value || '').trim();
-    if (!topic) { toast('A topic is required.', false); return; }
-    const node = customNodes.find((n: any) => n.Id === nodeSel.value);
-    if (!node) { toast('Pick a node to bind.', false); return; }
-    const metric = metricSel.value;
-    const mqtt = ensure(node, 'Mqtt', []);
-    // One reading per metric per node — a second binding would just race the first.
-    if (mqtt.some((s: any) => (s.Metric || 'realpower') === metric)) {
-      toast(`${node.Label || node.Id} already has a ${metric} source.`, false); return;
-    }
-    const src: any = { Topic: topic, Metric: metric };
-    const field = (fieldIn.value || '').trim(); if (field) src.JsonField = field;
-    const scale = +scaleIn.value; if (scaleIn.value !== '' && !isNaN(scale) && scale !== 1) src.Scale = scale;
-    mqtt.push(src);
-    toast(`${topic} → ${node.Label || node.Id} (${metric}).`, true);
-    rerender();
-  };
-  bar.append(nodeSel, topicIn, metricSel, fieldIn, scaleIn, add);
-  box.appendChild(bar);
+  const editingNode = editing.id ? customNodes.find((n: any) => n.Id === editing.id) : null;
+  if (editingNode) box.appendChild(renderNodeEditor(editingNode, (close?: boolean) => { if (close) editing.id = null; rerender(); }));
   return box;
 }
 
@@ -156,6 +213,7 @@ export function addFlowSection(nav: any, sections: any) {
   const wrap = document.createElement('div'); sec.appendChild(wrap);
   const ed: any = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
   let lastGraph: any = null;
+  const editing: { id: string | null } = { id: null };  // which virtual node's editor is open (persists across rerenders)
 
   // Layered Sankey: columns = longest path from a root (energy flows left->right, parent->child).
   const draw = (graph: any) => {
@@ -261,6 +319,14 @@ export function addFlowSection(nav: any, sections: any) {
       Object.entries(legacy).forEach(([child, parent]) => { if (parent && child && !links.some((l: any) => l.From === parent && l.To === child)) links.push({ From: parent, To: child }); });
       Object.keys(legacy).forEach(k => delete legacy[k]);
     }
+    // Fold legacy per-node Mqtt bindings into the general Sources list (each was implicitly Type: mqtt), so
+    // the new editor manages them in one place. The engine still reads both, so this is safe on save.
+    customNodes.forEach((n: any) => {
+      if (n.Mqtt && n.Mqtt.length) {
+        n.Sources = (n.Sources || []).concat(n.Mqtt.map((s: any) => ({ Type: 'mqtt', ...s })));
+        delete n.Mqtt;
+      }
+    });
     ed.innerHTML = '';
 
     ed.appendChild(el('h3', { text: 'Hierarchy', style: { margin: '4px 0' } }));
@@ -286,8 +352,7 @@ export function addFlowSection(nav: any, sections: any) {
     exportRow.append(el('label', {}, expChk, ' Export tiers to MQTT'), el('span', { class: 'desc', style: { margin: '0' }, text: 'Topic:' }), topicIn);
     ed.appendChild(exportRow);
 
-    ed.appendChild(renderNodeManager(customNodes, links, renderEditor));
-    ed.appendChild(renderMqttSources(customNodes, renderEditor));
+    ed.appendChild(renderNodeManager(customNodes, links, editing, renderEditor));
 
     // Candidate nodes (from the built graph + custom defs).
     const cand = new Map();
@@ -432,7 +497,7 @@ export function addFlowSection(nav: any, sections: any) {
       if (cand.has(id)) { toast('That id already exists.', false); return; }
       const node: any = { Id: id, Label: (labIn.value || '').trim() || id };
       if (valIn.value !== '' && !isNaN(+valIn.value)) node.Value = +valIn.value;
-      customNodes.push(node); renderEditor();
+      customNodes.push(node); editing.id = id; renderEditor();  // open the new node's editor straight away
     };
     save.onclick = async () => {
       const r = await api('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(exportData()) });

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -781,9 +781,12 @@ const NODE_KINDS                               = [
 ];
 const kindMeta = (kind         ) => NODE_KINDS.find(k => k[0] === (kind || 'node')) || NODE_KINDS[0];
 
-// Source binding types — mirrors [AllowedValues] on EnergyFlowSource.Type. Only MQTT today; the editor is
-// shaped so another ingest is just another entry here plus its own fields.
-const SOURCE_TYPES                     = [['mqtt', 'MQTT topic']];
+// Source binding types — mirrors [AllowedValues] on EnergyFlowSource.Type. Each type renders its own fields
+// in the two source columns; adding an ingest is another entry here plus a branch in the row renderer.
+const SOURCE_TYPES                     = [['mqtt', 'MQTT topic'], ['modbus', 'Modbus TCP']];
+const MODBUS_REGISTER_TYPES = ['holding', 'input'];
+const MODBUS_DATATYPES = ['uint16', 'int16', 'uint32', 'int32', 'float32'];
+const MODBUS_WORDORDERS = ['big', 'little'];
 
 // How an unmeasured node is valued — mirrors [AllowedValues] on EnergyFlowNode.Mode. A live/static value
 // always wins; this only governs nodes the graph would otherwise infer.
@@ -856,13 +859,13 @@ function renderNodeEditor(node     , rerender            ) {
 
   // --- Live value bindings ---
   box.appendChild(el('h5', { text: 'Live value bindings', style: { margin: '6px 0 2px', fontSize: '12px' } }));
-  box.appendChild(el('div', { class: 'desc', text: 'Bind a metric to a source already on your broker. One binding per metric drives that metric’s power/energy/… roll-up; a fresh reading supersedes the fixed value. Takes effect without a restart once saved.', style: { margin: '0 0 8px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'Bind a metric to a live source — an MQTT topic, or a register on a Modbus TCP connection (set those up in the Modbus section). One binding per metric drives that metric’s power/energy/… roll-up; a fresh reading supersedes the fixed value. Takes effect without a restart once saved.', style: { margin: '0 0 8px' } }));
 
   const sources        = ensure(node, 'Sources', []);
   if (sources.length) {
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
-    ['Type', 'Metric', 'Unit', 'Topic', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
+    ['Type', 'Metric', 'Unit', 'Source', 'Details', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
     tbl.appendChild(el('thead', {}, head));
     const body = el('tbody');
     sources.forEach((src     ) => {
@@ -871,7 +874,7 @@ function renderNodeEditor(node     , rerender            ) {
       const typeSel = el('select', { style: { width: 'auto' } });
       SOURCE_TYPES.forEach(([v, label]) => typeSel.appendChild(el('option', { value: v, text: label })));
       typeSel.value = src.Type || 'mqtt';
-      typeSel.onchange = () => { src.Type = typeSel.value; };
+      typeSel.onchange = () => { src.Type = typeSel.value; rerender(); };  // the Source/Details fields differ per type
       tr.appendChild(el('td', {}, typeSel));
 
       // Offer this kind's metrics (friendly labels), but keep an already-chosen one even if the kind wouldn't
@@ -893,13 +896,46 @@ function renderNodeEditor(node     , rerender            ) {
       unitSel.onchange = () => { src.Unit = unitSel.value === canonical ? undefined : unitSel.value; };
       tr.appendChild(el('td', {}, unitSel));
 
-      const topicIn = el('input', { type: 'text', value: src.Topic || '', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '300px' } });
-      topicIn.onchange = () => { src.Topic = topicIn.value.trim(); };
-      tr.appendChild(el('td', {}, topicIn));
+      // The Source + Details columns are type-specific.
+      if ((src.Type || 'mqtt') === 'modbus') {
+        // Source = which configured Modbus connection; Details = the register spec.
+        const connections        = (state.data?.Modbus?.Connections) || [];
+        const connSel = el('select', { style: { width: '160px' } });
+        connSel.appendChild(el('option', { value: '', text: connections.length ? '— pick a connection —' : 'none — add one in Modbus' }));
+        connections.forEach((c     ) => connSel.appendChild(el('option', { value: c.Id, text: c.Name || c.Id })));
+        connSel.value = src.Connection || '';
+        connSel.onchange = () => { src.Connection = connSel.value || undefined; };
+        tr.appendChild(el('td', {}, connSel));
 
-      const fieldIn = el('input', { type: 'text', value: src.JsonField || '', placeholder: '(optional)', style: { width: '120px' } });
-      fieldIn.onchange = () => { src.JsonField = fieldIn.value.trim() || undefined; };
-      tr.appendChild(el('td', {}, fieldIn));
+        const details = el('div', { style: { display: 'flex', gap: '6px', flexWrap: 'wrap', alignItems: 'center' } });
+        const regIn = el('input', { type: 'number', value: src.Register ?? 0, title: 'Register address', style: { width: '80px' } });
+        regIn.onchange = () => { const v = +regIn.value; src.Register = !isNaN(v) ? v : 0; };
+        const regTypeSel = el('select', { title: 'Register bank', style: { width: 'auto' } });
+        MODBUS_REGISTER_TYPES.forEach(t => regTypeSel.appendChild(el('option', { value: t, text: t })));
+        regTypeSel.value = src.RegisterType || 'holding';
+        regTypeSel.onchange = () => { src.RegisterType = regTypeSel.value === 'holding' ? undefined : regTypeSel.value; };
+        const dtSel = el('select', { title: 'Data type', style: { width: 'auto' } });
+        MODBUS_DATATYPES.forEach(t => dtSel.appendChild(el('option', { value: t, text: t })));
+        dtSel.value = src.DataType || 'uint16';
+        const woSel = el('select', { title: 'Word order (32-bit)', style: { width: 'auto' } });
+        MODBUS_WORDORDERS.forEach(t => woSel.appendChild(el('option', { value: t, text: t })));
+        woSel.value = src.WordOrder || 'big';
+        woSel.onchange = () => { src.WordOrder = woSel.value === 'big' ? undefined : woSel.value; };
+        // Word order only matters for 32-bit types; keep it enabled only then.
+        const is32 = () => ['uint32', 'int32', 'float32'].includes(dtSel.value);
+        woSel.disabled = !is32();
+        dtSel.onchange = () => { src.DataType = dtSel.value === 'uint16' ? undefined : dtSel.value; woSel.disabled = !is32(); };
+        details.append(regIn, regTypeSel, dtSel, woSel);
+        tr.appendChild(el('td', {}, details));
+      } else {
+        const topicIn = el('input', { type: 'text', value: src.Topic || '', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '300px' } });
+        topicIn.onchange = () => { src.Topic = topicIn.value.trim(); };
+        tr.appendChild(el('td', {}, topicIn));
+
+        const fieldIn = el('input', { type: 'text', value: src.JsonField || '', placeholder: 'JSON field (optional)', style: { width: '120px' } });
+        fieldIn.onchange = () => { src.JsonField = fieldIn.value.trim() || undefined; };
+        tr.appendChild(el('td', {}, fieldIn));
+      }
 
       const scaleIn = el('input', { type: 'number', step: 'any', value: src.Scale ?? 1, style: { width: '80px' } });
       scaleIn.onchange = () => { const v = +scaleIn.value; src.Scale = (scaleIn.value !== '' && !isNaN(v) && v !== 1) ? v : undefined; };

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -943,9 +943,10 @@ function renderNodeEditor(node     , links       , cand                  , reren
       scaleIn.onchange = () => { const v = +scaleIn.value; src.Scale = (scaleIn.value !== '' && !isNaN(v) && v !== 1) ? v : undefined; };
       tr.appendChild(el('td', {}, scaleIn));
 
-      // Live value (Modbus only for now): filled by a probe so you can confirm a mapping reads correctly.
-      const liveCell = el('td', { class: 'num', style: { minWidth: '90px', color: 'var(--muted)' }, text: (src.Type === 'modbus') ? '…' : '—' });
-      if (src.Type === 'modbus') liveCells.push({ src, cell: liveCell });
+      // Live value for every binding type: Modbus is read from the device; the rest (MQTT, future types)
+      // come from the shared live cache the running ingests fill — so you can confirm a mapping reads right.
+      const liveCell = el('td', { class: 'num', style: { minWidth: '90px', color: 'var(--muted)' }, text: '…' });
+      liveCells.push({ src, cell: liveCell });
       tr.appendChild(liveCell);
 
       const rm = btn('Remove', 'danger');
@@ -956,30 +957,43 @@ function renderNodeEditor(node     , links       , cand                  , reren
     tbl.appendChild(body);
     box.appendChild(tbl);
 
-    // Live values for Modbus mappings: probe the device(s) and fill the Current column, so you can confirm a
-    // register/type/scale reads what you expect before saving. Auto-refreshes while the editor is open.
+    // Live "Current" value for every binding: Modbus is read straight from the device (works before saving);
+    // MQTT and any future type come from the shared live cache the running ingests fill. Auto-refreshes.
     if (liveCells.length) {
       const status = el('span', { class: 'desc', style: { margin: '0 0 0 8px' } });
+      const setCell = (cell     , value               , err         , metric         ) => {
+        if (value == null) { cell.textContent = err ? 'err' : '—'; cell.style.color = err ? 'var(--bad)' : 'var(--muted)'; cell.title = err || 'no live value yet'; }
+        else { const cu = metricMeta(metric)[2]; cell.textContent = `${formatNum(value)} ${cu}`.trim(); cell.style.color = 'var(--good)'; cell.title = ''; }
+      };
       const refresh = async () => {
+        // Modbus: probe the device(s), grouped by connection so each is read once.
+        const modbus = liveCells.filter(lc => (lc.src.Type || 'mqtt') === 'modbus');
         const conns        = (state.data?.Modbus?.Connections) || [];
         const byConn = new Map                                   ();
-        liveCells.forEach(lc => { const id = lc.src.Connection || ''; (byConn.get(id) || byConn.set(id, []).get(id) ).push(lc); });
+        modbus.forEach(lc => { const id = lc.src.Connection || ''; (byConn.get(id) || byConn.set(id, []).get(id) ).push(lc); });
         for (const [connId, cells] of byConn) {
           const conn = conns.find(c => c.Id === connId);
-          if (!conn) { cells.forEach(lc => { lc.cell.textContent = 'pick a connection'; lc.cell.style.color = 'var(--muted)'; }); continue; }
+          if (!conn) { cells.forEach(lc => setCell(lc.cell, null, 'pick a connection')); continue; }
           try {
             const r = await api('/api/modbus/probe', { method: 'POST', headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ Host: conn.Host, Port: conn.Port, UnitId: conn.UnitId, Items: cells.map(lc => lc.src) }) });
-            if (!r.body.ok) { cells.forEach(lc => { lc.cell.textContent = 'err'; lc.cell.style.color = 'var(--bad)'; }); status.textContent = r.body.message || 'probe failed'; continue; }
+            if (!r.body.ok) { cells.forEach(lc => setCell(lc.cell, null, 'err')); status.textContent = r.body.message || 'probe failed'; continue; }
             const readings = r.body.readings || [];
-            cells.forEach((lc, i) => {
-              const rd = readings[i];
-              if (!rd || rd.value == null) { lc.cell.textContent = rd?.error ? 'err' : '—'; lc.cell.style.color = 'var(--bad)'; lc.cell.title = rd?.error || ''; }
-              else { const cu = metricMeta(lc.src.Metric)[2]; lc.cell.textContent = `${formatNum(rd.value)} ${cu}`.trim(); lc.cell.style.color = 'var(--good)'; lc.cell.title = ''; }
-            });
-            status.textContent = `updated ${new Date().toLocaleTimeString()}`;
-          } catch (e     ) { cells.forEach(lc => { lc.cell.textContent = 'err'; }); status.textContent = String(e?.message || e); }
+            cells.forEach((lc, i) => setCell(lc.cell, readings[i]?.value ?? null, readings[i]?.error, lc.src.Metric));
+          } catch (e     ) { cells.forEach(lc => setCell(lc.cell, null, 'err')); status.textContent = String(e?.message || e); }
         }
+
+        // MQTT + future types: whatever the running ingest currently holds in the shared cache.
+        const others = liveCells.filter(lc => (lc.src.Type || 'mqtt') !== 'modbus');
+        if (others.length) {
+          try {
+            const r = await api('/api/flow/live', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(others.map(lc => ({ Node: node.Id, Metric: lc.src.Metric || 'realpower' }))) });
+            const vals = (r.body && r.body.values) || [];
+            others.forEach((lc, i) => setCell(lc.cell, vals[i]?.value ?? null, undefined, lc.src.Metric));
+          } catch (e     ) { others.forEach(lc => setCell(lc.cell, null, 'err')); }
+        }
+        status.textContent = `updated ${new Date().toLocaleTimeString()}`;
       };
       const refreshBtn = btn('Refresh values');
       refreshBtn.onclick = refresh;

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -810,7 +810,7 @@ function field(labelText        , control             , hint         ) {
 // Per-node editor (#129): name, kind, mode, fixed value, a battery's storage, and the live value bindings —
 // one row per metric, each carrying a Type (MQTT today) and its transport fields, all editable in place
 // (including the topic, which the old flat table couldn't change).
-function renderNodeEditor(node     , rerender            ) {
+function renderNodeEditor(node     , links       , cand                  , rerender                           ) {
   const meta = kindMeta(node.Kind);
   const allowed = meta[2];
   const box = el('div', { style: { margin: '10px 0 4px', padding: '14px', border: '1px solid var(--accent, #4f8cff)', borderRadius: '8px', background: 'var(--panel2)' } });
@@ -999,13 +999,82 @@ function renderNodeEditor(node     , rerender            ) {
     rerender();
   };
   box.appendChild(el('div', { class: 'ld-toolbar', style: { marginTop: '8px' } }, addBind));
+
+  // --- Feeders & children (wiring) — the parent/child specification, alongside the visual Flow tab. ---
+  box.appendChild(el('h5', { text: 'Feeders & children', style: { margin: '12px 0 2px', fontSize: '12px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'Which nodes feed this one, and which it feeds. The same wiring you can drag on the Flow tab.', style: { margin: '0 0 6px' } }));
+
+  const nm = (id        ) => (cand.get(id) || {}).label || id;
+  const wouldLoop = (from        , to        ) => {
+    const adj      = {}; links.forEach(l => (adj[l.From] = adj[l.From] || []).push(l.To));
+    const stack = [to]; const seen = new Set        ();
+    while (stack.length) { const x = stack.pop() ; if (x === from) return true; if (seen.has(x)) continue; seen.add(x); (adj[x] || []).forEach((t        ) => stack.push(t)); }
+    return false;
+  };
+  const addLink = (from        , to        ) => {
+    if (from === to || links.some(l => l.From === from && l.To === to)) return;
+    if (wouldLoop(from, to)) { toast('That would create a feeder loop.', false); return; }
+    links.push({ From: from, To: to });
+  };
+  const removeLink = (from        , to        ) => { const i = links.findIndex(l => l.From === from && l.To === to); if (i >= 0) links.splice(i, 1); };
+  const wireRow = (title        , current          , onAdd                     , onRemove                     ) => {
+    const row = el('div', { style: { display: 'flex', gap: '6px', alignItems: 'center', flexWrap: 'wrap', margin: '3px 0' } });
+    row.appendChild(el('span', { class: 'desc', style: { margin: '0', minWidth: '64px' }, text: title }));
+    current.forEach(other => {
+      const chip = el('span', { style: { display: 'inline-flex', gap: '5px', alignItems: 'center', background: 'var(--panel)', border: '1px solid var(--line)', borderRadius: '10px', padding: '1px 8px', fontSize: '12px' } });
+      const x = el('span', { text: '✕', style: { cursor: 'pointer', color: 'var(--bad)' } });
+      x.onclick = () => { onRemove(other); rerender(); };
+      chip.append(nm(other), x); row.appendChild(chip);
+    });
+    const sel = el('select', { style: { width: 'auto' } });
+    sel.appendChild(el('option', { value: '', text: '+ add…' }));
+    [...cand.keys()].filter(id => id !== node.Id && !current.includes(id)).sort((a, b) => nm(a).localeCompare(nm(b)))
+      .forEach(id => sel.appendChild(el('option', { value: id, text: nm(id) })));
+    sel.onchange = () => { if (sel.value) { onAdd(sel.value); rerender(); } };
+    row.appendChild(sel);
+    return row;
+  };
+  box.appendChild(wireRow('Fed by', links.filter(l => l.To === node.Id).map(l => l.From), o => addLink(o, node.Id), o => removeLink(o, node.Id)));
+  box.appendChild(wireRow('Feeds', links.filter(l => l.From === node.Id).map(l => l.To), o => addLink(node.Id, o), o => removeLink(node.Id, o)));
+
   return box;
 }
 
-// Virtual-node manager (#129): the "page to manage those" the graph editor alone didn't cover. Each row is
-// a node; Edit opens the full editor (name, kind, mode, value, bindings) below the table. Deleting a node
-// takes its bound sources with it (they live on the node).
-function renderNodeManager(customNodes       , links       , editing                       , rerender                           ) {
+// Bring an EnergyFlow config up to the current shape in place (idempotent) — run on load by both the Flow
+// and Nodes tabs since either can be opened first: legacy single-feeder Parents → directed Links, per-node
+// Mqtt → the general Sources list, and a bare Value → the explicit 'static' mode.
+function migrateEnergyFlow(flow     ) {
+  const links = ensure(flow, 'Links', []);
+  const legacy = ensure(flow, 'Parents', {});
+  if (Object.keys(legacy).length) {
+    Object.entries(legacy).forEach(([child, parent]) => { if (parent && child && !links.some((l     ) => l.From === parent && l.To === child)) links.push({ From: parent, To: child }); });
+    Object.keys(legacy).forEach(k => delete legacy[k]);
+  }
+  ensure(flow, 'Nodes', []).forEach((n     ) => {
+    if (n.Mqtt && n.Mqtt.length) { n.Sources = (n.Sources || []).concat(n.Mqtt.map((s     ) => ({ Type: 'mqtt', ...s }))); delete n.Mqtt; }
+    if (n.Value != null && (!n.Mode || n.Mode === 'auto')) n.Mode = 'static';
+  });
+}
+
+// Save the whole config (both tabs edit the shared EnergyFlow object; either Save persists everything).
+async function saveConfig(onSaved            ) {
+  const r = await api('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(exportData()) });
+  toast(r.body.message || (r.ok ? 'Saved.' : 'Save failed.'), r.ok && r.body.ok);
+  if (r.ok && r.body.ok) onSaved();
+}
+
+// The candidate node universe for wiring: the built graph's nodes (pdu/outlet/…) plus the custom defs.
+function flowCandidates(lastGraph     , customNodes       ) {
+  const cand = new Map             ();
+  (lastGraph?.nodes || []).forEach((n     ) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
+  customNodes.forEach((n     ) => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: n.Kind || 'node', custom: true }));
+  return cand;
+}
+
+// Virtual-node manager (#129): the dedicated node-configuration surface (its own Nodes tab). Each row is a
+// node; Edit opens the full editor (name, kind, mode, value, bindings, feeders/children) below the table.
+// Deleting a node takes its bound sources with it (they live on the node).
+function renderNodeManager(customNodes       , links       , cand                  , editing                       , rerender                           ) {
   const box = el('div', { style: { margin: '18px 0' } });
   box.appendChild(el('h3', { text: 'Virtual nodes', style: { margin: '4px 0', fontSize: '15px' } }));
   box.appendChild(el('div', { class: 'desc', text: 'The custom nodes you’ve added (panels, breakers, batteries, producers, a “Total”). Click Edit to set the name, kind, how it’s valued, and bind live values from your broker.' }));
@@ -1050,7 +1119,7 @@ function renderNodeManager(customNodes       , links       , editing            
   box.appendChild(tbl);
 
   const editingNode = editing.id ? customNodes.find((n     ) => n.Id === editing.id) : null;
-  if (editingNode) box.appendChild(renderNodeEditor(editingNode, (close          ) => { if (close) editing.id = null; rerender(); }));
+  if (editingNode) box.appendChild(renderNodeEditor(editingNode, links, cand, (close          ) => { if (close) editing.id = null; rerender(); }));
   return box;
 }
 
@@ -1070,7 +1139,6 @@ function addFlowSection(nav     , sections     ) {
   const wrap = document.createElement('div'); sec.appendChild(wrap);
   const ed      = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
   let lastGraph      = null;
-  const editing                        = { id: null };  // which virtual node's editor is open (persists across rerenders)
 
   // Layered Sankey: columns = longest path from a root (energy flows left->right, parent->child).
   const draw = (graph     ) => {
@@ -1168,37 +1236,18 @@ function addFlowSection(nav     , sections     ) {
   const renderEditor = () => {
     if (ed._cleanup) ed._cleanup();
     const flow = ensure(state.data, 'EnergyFlow', {});
+    migrateEnergyFlow(flow);
     const customNodes = ensure(flow, 'Nodes', []);
     const links = ensure(flow, 'Links', []);
-    const legacy = ensure(flow, 'Parents', {});
-    // One-time migration: fold any legacy single-feeder Parents (child→parent) into directed Links.
-    if (Object.keys(legacy).length) {
-      Object.entries(legacy).forEach(([child, parent]) => { if (parent && child && !links.some((l     ) => l.From === parent && l.To === child)) links.push({ From: parent, To: child }); });
-      Object.keys(legacy).forEach(k => delete legacy[k]);
-    }
-    // Fold legacy per-node Mqtt bindings into the general Sources list (each was implicitly Type: mqtt), so
-    // the new editor manages them in one place. The engine still reads both, so this is safe on save.
-    customNodes.forEach((n     ) => {
-      if (n.Mqtt && n.Mqtt.length) {
-        n.Sources = (n.Sources || []).concat(n.Mqtt.map((s     ) => ({ Type: 'mqtt', ...s })));
-        delete n.Mqtt;
-      }
-      // A fixed value now belongs to the 'static' mode — adopt it for older nodes that carried a value under
-      // the default mode, so the editor shows their value field and the roll-up is unchanged.
-      if (n.Value != null && (!n.Mode || n.Mode === 'auto')) n.Mode = 'static';
-    });
     ed.innerHTML = '';
 
     ed.appendChild(el('h3', { text: 'Hierarchy', style: { margin: '4px 0' } }));
-    ed.appendChild(el('div', { class: 'desc', text: 'Energy flows left → right. Drag from a node’s right ● onto another node to add a feed (source powers target). A node can have several feeders, and a producer is just a feed into what it powers — e.g. drag from Solar onto your inverter. The target highlights green when in range; click ✕ on a link to remove it. Double-click a custom node to rename it. PDU → outlet links are auto-derived (dashed) until you wire an explicit feeder.' }));
+    ed.appendChild(el('div', { class: 'desc', text: 'Energy flows left → right. Drag from a node’s right ● onto another node to add a feed (source powers target); click ✕ on a link to remove it. Double-click a custom node to rename it. PDU → outlet links are auto-derived (dashed) until you wire an explicit feeder. Add and configure nodes on the Nodes tab.' }));
 
-    const addBar = el('div', { class: 'ld-toolbar' });
-    const idIn = el('input', { type: 'text', placeholder: 'id (e.g. gridboss)' });
-    const labIn = el('input', { type: 'text', placeholder: 'label (e.g. Grid Boss)' });
-    const valIn = el('input', { type: 'number', placeholder: 'known value (optional)', style: { width: '150px' } });
-    const addBtn = btn('Add node', 'primary');
-    const save = btn('Save hierarchy', 'primary');
-    addBar.append(idIn, labIn, valIn, addBtn, save); ed.appendChild(addBar);
+    const bar2 = el('div', { class: 'ld-toolbar' });
+    const save = btn('Save', 'primary');
+    save.onclick = () => saveConfig(load);
+    bar2.append(save); ed.appendChild(bar2);
 
     // MQTT export of the hierarchy (#164): each tier's rolled-up value is published per poll. Saved with
     // the hierarchy (the Save button posts the whole config).
@@ -1212,12 +1261,8 @@ function addFlowSection(nav     , sections     ) {
     exportRow.append(el('label', {}, expChk, ' Export tiers to MQTT'), el('span', { class: 'desc', style: { margin: '0' }, text: 'Topic:' }), topicIn);
     ed.appendChild(exportRow);
 
-    ed.appendChild(renderNodeManager(customNodes, links, editing, renderEditor));
-
     // Candidate nodes (from the built graph + custom defs).
-    const cand = new Map();
-    (lastGraph?.nodes || []).forEach((n     ) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
-    customNodes.forEach((n     ) => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: 'node', custom: true }));
+    const cand = flowCandidates(lastGraph, customNodes);
     const nm = (id        )         => (cand.get(id) || {}).label || id;
     const byLabel = (a        , b        ) => (cand.get(a).label || a).localeCompare(cand.get(b).label || b);
 
@@ -1351,19 +1396,6 @@ function addFlowSection(nav     , sections     ) {
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
     ed._cleanup = () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); detachZoom(); };
-
-    addBtn.onclick = () => {
-      const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
-      if (cand.has(id)) { toast('That id already exists.', false); return; }
-      const node      = { Id: id, Label: (labIn.value || '').trim() || id };
-      if (valIn.value !== '' && !isNaN(+valIn.value)) node.Value = +valIn.value;
-      customNodes.push(node); editing.id = id; renderEditor();  // open the new node's editor straight away
-    };
-    save.onclick = async () => {
-      const r = await api('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(exportData()) });
-      toast(r.body.message || (r.ok ? 'Saved.' : 'Save failed.'), r.ok && r.body.ok);
-      if (r.ok && r.body.ok) load();
-    };
   };
 
   const load = async () => {
@@ -1374,6 +1406,63 @@ function addFlowSection(nav     , sections     ) {
     renderEditor();
   };
   refresh.onclick = load;
+  link.onclick = () => { activate(link, sec); load(); };
+}
+
+// The dedicated Nodes tab (#129): configure the virtual nodes — kind, how they're valued, live-value
+// bindings, and feeders/children — separate from the Flow visualization. Both edit the shared EnergyFlow.
+function addNodesSection(nav     , sections     ) {
+  const link = document.createElement('a'); link.textContent = 'Nodes'; nav.appendChild(link);
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  const h = document.createElement('h2'); h.textContent = 'Energy Nodes'; sec.appendChild(h);
+  const d = document.createElement('div'); d.className = 'desc';
+  d.textContent = 'Configure the virtual nodes in your energy hierarchy — panels, breakers, batteries, producers, a “Total”. Set each node’s kind, how it’s valued, its live-value bindings (MQTT / Modbus), and its feeders & children. The wiring also shows visually on the Flow tab.';
+  sec.appendChild(d);
+
+  const bar = document.createElement('div'); bar.className = 'ld-toolbar';
+  const instSel = instanceSelector(() => load());
+  const count = document.createElement('span'); count.className = 'ld-count';
+  bar.appendChild(instSel.wrap); bar.appendChild(count); sec.appendChild(bar);
+  const ed      = document.createElement('div'); ed.style.marginTop = '8px'; sec.appendChild(ed);
+  let lastGraph      = null;
+  const editing                        = { id: null };
+
+  const render = () => {
+    const flow = ensure(state.data, 'EnergyFlow', {});
+    migrateEnergyFlow(flow);
+    const customNodes = ensure(flow, 'Nodes', []);
+    const links = ensure(flow, 'Links', []);
+    count.textContent = `${customNodes.length} node(s)`;
+    ed.innerHTML = '';
+
+    const addBar = el('div', { class: 'ld-toolbar' });
+    const idIn = el('input', { type: 'text', placeholder: 'id (e.g. gridboss)' });
+    const labIn = el('input', { type: 'text', placeholder: 'label (e.g. Grid Boss)' });
+    const kindSel = el('select', { style: { width: 'auto' } });
+    NODE_KINDS.forEach(([v, label]) => kindSel.appendChild(el('option', { value: v, text: label })));
+    const addBtn = btn('Add node', 'primary');
+    const save = btn('Save', 'primary');
+    addBtn.onclick = () => {
+      const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
+      if (customNodes.some((n     ) => n.Id === id) || (lastGraph?.nodes || []).some((n     ) => n.id === id)) { toast('That id already exists.', false); return; }
+      const node      = { Id: id, Label: (labIn.value || '').trim() || id };
+      if (kindSel.value !== 'node') node.Kind = kindSel.value;
+      customNodes.push(node); editing.id = id; render();  // open the new node's editor straight away
+    };
+    save.onclick = () => saveConfig(load);
+    addBar.append(idIn, labIn, kindSel, addBtn, save); ed.appendChild(addBar);
+
+    const cand = flowCandidates(lastGraph, customNodes);
+    ed.appendChild(renderNodeManager(customNodes, links, cand, editing, (close          ) => { if (close) editing.id = null; render(); }));
+  };
+
+  const load = async () => {
+    // The flow graph gives the auto (pdu/outlet) node ids for the feeder/children pickers; node config itself
+    // is global, so a failed/empty graph just means fewer wiring candidates, not an error.
+    const r = await api(withInstance('/api/flow', instSel));
+    lastGraph = r.body?.ok ? r.body : null;
+    render();
+  };
   link.onclick = () => { activate(link, sec); load(); };
 }
 
@@ -1773,6 +1862,7 @@ function build() {
   navHeader(nav, 'Tools');
   addControlSection(nav, sections);
   addLiveDataSection(nav, sections);
+  addNodesSection(nav, sections);
   addFlowSection(nav, sections);
   addPathsSection(nav, sections);
   addHaEnergySection(nav, sections);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -776,6 +776,7 @@ const SOURCE_TYPES                     = [['mqtt', 'MQTT topic']];
 // always wins; this only governs nodes the graph would otherwise infer.
 const NODE_MODES                             = [
   ['auto', 'Auto (aggregate / share)', 'Sums its children, and as a feeder takes a share of whatever load measured siblings don’t cover — the default.'],
+  ['static', 'Static (fixed value)', 'A fixed leaf valued at the number you enter (still superseded by a bound live source). Reveals the Fixed value field.'],
   ['residual', 'Residual (untracked feeder)', 'The designated absorber on the feeder side: carries the demand still needed after every measured feeder has supplied its part.'],
   ['untracked', 'Untracked (child of a measured parent)', 'Place under a parent that has a measured total (a bound source or fixed value): shows the slice of that total its tracked siblings don’t account for. Contributes nothing if the parent has no measured total.'],
   ['none', 'None (leave unset)', 'Never inferred — contributes nothing unless it has a real value or children, so an unmeasured source simply drops out instead of showing a fabricated figure.'],
@@ -819,12 +820,19 @@ function renderNodeEditor(node     , rerender            ) {
   const modeSel = el('select');
   NODE_MODES.forEach(([v, label, desc]) => { const o = el('option', { value: v, text: label }); o.title = desc; modeSel.appendChild(o); });
   modeSel.value = node.Mode || 'auto';
-  modeSel.onchange = () => { node.Mode = modeSel.value === 'auto' ? undefined : modeSel.value; };
+  modeSel.onchange = () => {
+    node.Mode = modeSel.value === 'auto' ? undefined : modeSel.value;
+    if (node.Mode !== 'static') node.Value = undefined;  // a fixed value only belongs to a static node
+    rerender();  // toggle the Fixed value field
+  };
   grid.appendChild(field('Mode', modeSel, 'How it’s valued with no measurement.'));
 
-  const valIn = el('input', { type: 'number', step: 'any', value: node.Value ?? '', placeholder: '—' });
-  valIn.onchange = () => { const v = +valIn.value; node.Value = (valIn.value !== '' && !isNaN(v)) ? v : undefined; };
-  grid.appendChild(field('Fixed value', valIn, 'Used only if nothing live reports.'));
+  // The fixed value only makes sense for a static leaf — show it only in that mode.
+  if ((node.Mode || 'auto') === 'static') {
+    const valIn = el('input', { type: 'number', step: 'any', value: node.Value ?? '', placeholder: '—' });
+    valIn.onchange = () => { const v = +valIn.value; node.Value = (valIn.value !== '' && !isNaN(v)) ? v : undefined; };
+    grid.appendChild(field('Fixed value', valIn, 'Used unless a bound source reports.'));
+  }
 
   if ((node.Kind || 'node') === 'battery') {
     const stoIn = el('input', { type: 'number', step: 'any', value: node.StorageKwh ?? '', placeholder: 'kWh' });
@@ -1075,6 +1083,9 @@ function addFlowSection(nav     , sections     ) {
         n.Sources = (n.Sources || []).concat(n.Mqtt.map((s     ) => ({ Type: 'mqtt', ...s })));
         delete n.Mqtt;
       }
+      // A fixed value now belongs to the 'static' mode — adopt it for older nodes that carried a value under
+      // the default mode, so the editor shows their value field and the roll-up is unchanged.
+      if (n.Value != null && (!n.Mode || n.Mode === 'auto')) n.Mode = 'static';
     });
     ed.innerHTML = '';
 

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -752,8 +752,25 @@ function addLiveDataSection(nav     , sections     ) {
 // ── sections/flow.ts ────────────────────────────────────────────
 // Energy Flow: a read-only Sankey + the layered arrow-graph hierarchy editor.
 
-// Metrics a live source can supply — mirrors [AllowedValues] on EnergyFlowMqttSource.Metric.
+// Metrics a live source can supply — mirrors [AllowedValues] on EnergyFlowSource.Metric.
 const SOURCE_METRICS = ['realpower', 'apparentpower', 'energy', 'current', 'voltage', 'frequency', 'powerfactor'];
+
+// What a virtual node represents — mirrors [AllowedValues] on EnergyFlowNode.Kind. Each kind offers only
+// the metrics that make sense for it (a battery has no frequency); 'battery' also gets a storage field.
+const NODE_KINDS                               = [
+  ['node', 'Virtual node', SOURCE_METRICS],
+  ['panel', 'Electrical panel', ['realpower', 'apparentpower', 'current', 'voltage', 'energy', 'powerfactor']],
+  ['inverter', 'Inverter', SOURCE_METRICS],
+  ['battery', 'Battery', ['realpower', 'energy', 'current', 'voltage']],
+  ['solar', 'Solar / PV', ['realpower', 'energy', 'current', 'voltage']],
+  ['grid', 'Grid', SOURCE_METRICS],
+  ['load', 'Load', ['realpower', 'apparentpower', 'energy', 'current', 'voltage', 'powerfactor']],
+];
+const kindMeta = (kind         ) => NODE_KINDS.find(k => k[0] === (kind || 'node')) || NODE_KINDS[0];
+
+// Source binding types — mirrors [AllowedValues] on EnergyFlowSource.Type. Only MQTT today; the editor is
+// shaped so another ingest is just another entry here plus its own fields.
+const SOURCE_TYPES                     = [['mqtt', 'MQTT topic']];
 
 // How an unmeasured node is valued — mirrors [AllowedValues] on EnergyFlowNode.Mode. A live/static value
 // always wins; this only governs nodes the graph would otherwise infer.
@@ -764,14 +781,126 @@ const NODE_MODES                             = [
   ['none', 'None (leave unset)', 'Never inferred — contributes nothing unless it has a real value or children, so an unmeasured source simply drops out instead of showing a fabricated figure.'],
 ];
 
-// Virtual-node manager (#129): rename, retype, set a fixed value or mode, and delete the custom nodes — the
-// "page to manage those" that the graph editor alone didn't cover. Value population is source-agnostic: a
-// node's number can come from a fixed value, or a bound live source (MQTT today, other ingests later) shown
-// in the Sources column; the Mode governs only what happens when neither is present.
-function renderNodeManager(customNodes       , links       , rerender            ) {
+// A labelled field (label above a control) for the node editor's form grid.
+function field(labelText        , control             , hint         ) {
+  const f = el('div', { style: { display: 'flex', flexDirection: 'column', gap: '3px' } });
+  f.appendChild(el('label', { text: labelText, style: { fontSize: '11px', color: 'var(--muted)' } }));
+  f.appendChild(control);
+  if (hint) f.appendChild(el('div', { class: 'desc', text: hint, style: { margin: '0', fontSize: '11px' } }));
+  return f;
+}
+
+// Per-node editor (#129): name, kind, mode, fixed value, a battery's storage, and the live value bindings —
+// one row per metric, each carrying a Type (MQTT today) and its transport fields, all editable in place
+// (including the topic, which the old flat table couldn't change).
+function renderNodeEditor(node     , rerender            ) {
+  const meta = kindMeta(node.Kind);
+  const allowed = meta[2];
+  const box = el('div', { style: { margin: '10px 0 4px', padding: '14px', border: '1px solid var(--accent, #4f8cff)', borderRadius: '8px', background: 'var(--panel2)' } });
+
+  const header = el('div', { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' } });
+  header.appendChild(el('h4', { text: `Editing ${node.Label || node.Id}`, style: { margin: '0', fontSize: '14px' } }));
+  const close = btn('Close'); close.onclick = () => rerender(true);
+  header.appendChild(close);
+  box.appendChild(header);
+
+  const grid = el('div', { style: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '12px', marginBottom: '12px' } });
+
+  const labIn = el('input', { type: 'text', value: node.Label || '', placeholder: node.Id });
+  labIn.onchange = () => { node.Label = labIn.value.trim() || undefined; };
+  grid.appendChild(field('Name', labIn));
+
+  const kindSel = el('select');
+  NODE_KINDS.forEach(([v, label]) => kindSel.appendChild(el('option', { value: v, text: label })));
+  kindSel.value = node.Kind || 'node';
+  kindSel.onchange = () => { node.Kind = kindSel.value === 'node' ? undefined : kindSel.value; rerender(); };
+  grid.appendChild(field('Kind', kindSel));
+
+  const modeSel = el('select');
+  NODE_MODES.forEach(([v, label, desc]) => { const o = el('option', { value: v, text: label }); o.title = desc; modeSel.appendChild(o); });
+  modeSel.value = node.Mode || 'auto';
+  modeSel.onchange = () => { node.Mode = modeSel.value === 'auto' ? undefined : modeSel.value; };
+  grid.appendChild(field('Mode', modeSel, 'How it’s valued with no measurement.'));
+
+  const valIn = el('input', { type: 'number', step: 'any', value: node.Value ?? '', placeholder: '—' });
+  valIn.onchange = () => { const v = +valIn.value; node.Value = (valIn.value !== '' && !isNaN(v)) ? v : undefined; };
+  grid.appendChild(field('Fixed value', valIn, 'Used only if nothing live reports.'));
+
+  if ((node.Kind || 'node') === 'battery') {
+    const stoIn = el('input', { type: 'number', step: 'any', value: node.StorageKwh ?? '', placeholder: 'kWh' });
+    stoIn.onchange = () => { const v = +stoIn.value; node.StorageKwh = (stoIn.value !== '' && !isNaN(v)) ? v : undefined; };
+    grid.appendChild(field('Storage (kWh)', stoIn));
+  }
+  box.appendChild(grid);
+
+  // --- Live value bindings ---
+  box.appendChild(el('h5', { text: 'Live value bindings', style: { margin: '6px 0 2px', fontSize: '12px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'Bind a metric to a source already on your broker. One binding per metric drives that metric’s power/energy/… roll-up; a fresh reading supersedes the fixed value. Takes effect without a restart once saved.', style: { margin: '0 0 8px' } }));
+
+  const sources        = ensure(node, 'Sources', []);
+  if (sources.length) {
+    const tbl = el('table', { class: 'ld' });
+    const head = el('tr');
+    ['Type', 'Metric', 'Topic', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
+    tbl.appendChild(el('thead', {}, head));
+    const body = el('tbody');
+    sources.forEach((src     ) => {
+      const tr = el('tr');
+
+      const typeSel = el('select', { style: { width: 'auto' } });
+      SOURCE_TYPES.forEach(([v, label]) => typeSel.appendChild(el('option', { value: v, text: label })));
+      typeSel.value = src.Type || 'mqtt';
+      typeSel.onchange = () => { src.Type = typeSel.value; };
+      tr.appendChild(el('td', {}, typeSel));
+
+      // Offer this kind's metrics, but keep an already-chosen metric even if the kind wouldn't list it.
+      const metricSel = el('select', { style: { width: 'auto' } });
+      const opts = allowed.includes(src.Metric || 'realpower') ? allowed : [src.Metric, ...allowed];
+      opts.forEach((m        ) => metricSel.appendChild(el('option', { value: m, text: m })));
+      metricSel.value = src.Metric || 'realpower';
+      metricSel.onchange = () => { src.Metric = metricSel.value; };
+      tr.appendChild(el('td', {}, metricSel));
+
+      const topicIn = el('input', { type: 'text', value: src.Topic || '', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '300px' } });
+      topicIn.onchange = () => { src.Topic = topicIn.value.trim(); };
+      tr.appendChild(el('td', {}, topicIn));
+
+      const fieldIn = el('input', { type: 'text', value: src.JsonField || '', placeholder: '(optional)', style: { width: '120px' } });
+      fieldIn.onchange = () => { src.JsonField = fieldIn.value.trim() || undefined; };
+      tr.appendChild(el('td', {}, fieldIn));
+
+      const scaleIn = el('input', { type: 'number', step: 'any', value: src.Scale ?? 1, style: { width: '80px' } });
+      scaleIn.onchange = () => { const v = +scaleIn.value; src.Scale = (scaleIn.value !== '' && !isNaN(v) && v !== 1) ? v : undefined; };
+      tr.appendChild(el('td', {}, scaleIn));
+
+      const rm = btn('Remove', 'danger');
+      rm.onclick = () => { sources.splice(sources.indexOf(src), 1); rerender(); };
+      tr.appendChild(el('td', {}, rm));
+      body.appendChild(tr);
+    });
+    tbl.appendChild(body);
+    box.appendChild(tbl);
+  }
+
+  const addBind = btn('Add binding', 'primary');
+  addBind.onclick = () => {
+    // Default to the first metric this kind offers that isn't bound yet, so a click rarely needs a re-pick.
+    const used = new Set(sources.map((s     ) => s.Metric || 'realpower'));
+    const metric = allowed.find((m        ) => !used.has(m)) || allowed[0];
+    sources.push({ Type: 'mqtt', Metric: metric, Topic: '' });
+    rerender();
+  };
+  box.appendChild(el('div', { class: 'ld-toolbar', style: { marginTop: '8px' } }, addBind));
+  return box;
+}
+
+// Virtual-node manager (#129): the "page to manage those" the graph editor alone didn't cover. Each row is
+// a node; Edit opens the full editor (name, kind, mode, value, bindings) below the table. Deleting a node
+// takes its bound sources with it (they live on the node).
+function renderNodeManager(customNodes       , links       , editing                       , rerender                           ) {
   const box = el('div', { style: { margin: '18px 0' } });
   box.appendChild(el('h3', { text: 'Virtual nodes', style: { margin: '4px 0', fontSize: '15px' } }));
-  box.appendChild(el('div', { class: 'desc', text: 'The custom nodes you’ve added (panels, breakers, a “Total”, producers). Rename them, give a leaf a fixed value, or set how an unmeasured node is valued. A fixed value or a bound live source always wins over the mode; the mode only decides what an otherwise-unknown node does.' }));
+  box.appendChild(el('div', { class: 'desc', text: 'The custom nodes you’ve added (panels, breakers, batteries, producers, a “Total”). Click Edit to set the name, kind, how it’s valued, and bind live values from your broker.' }));
 
   if (!customNodes.length) {
     box.appendChild(el('div', { class: 'desc', text: 'No virtual nodes yet — add one above.' }));
@@ -780,112 +909,40 @@ function renderNodeManager(customNodes       , links       , rerender           
 
   const tbl = el('table', { class: 'ld' });
   const head = el('tr');
-  ['Id', 'Label', 'Fixed value', 'Mode', 'Sources', ''].forEach(h => head.appendChild(el('th', { text: h })));
+  ['Id', 'Label', 'Kind', 'Mode', 'Value', 'Bindings', ''].forEach(h => head.appendChild(el('th', { text: h })));
   tbl.appendChild(el('thead', {}, head));
   const body = el('tbody');
   customNodes.forEach((n     ) => {
     const tr = el('tr');
+    if (editing.id === n.Id) tr.style.outline = '2px solid var(--accent, #4f8cff)';
     tr.appendChild(el('td', {}, el('code', { text: n.Id, style: { color: 'var(--muted)' } })));
+    tr.appendChild(el('td', { text: n.Label || n.Id }));
+    tr.appendChild(el('td', { text: kindMeta(n.Kind)[1] }));
+    tr.appendChild(el('td', { text: n.Mode || 'auto' }));
+    tr.appendChild(el('td', { class: 'num', text: n.Value ?? '—' }));
+    const nb = (n.Sources || []).length;
+    tr.appendChild(el('td', { text: nb ? String(nb) : '—', class: nb ? '' : 'num' }));
 
-    const labIn = el('input', { type: 'text', value: n.Label || '', placeholder: n.Id, style: { width: '180px' } });
-    labIn.onchange = () => { n.Label = labIn.value.trim() || undefined; };
-    tr.appendChild(el('td', {}, labIn));
-
-    const valIn = el('input', { type: 'number', step: 'any', value: n.Value ?? '', placeholder: '—', style: { width: '110px' } });
-    valIn.onchange = () => { const v = +valIn.value; n.Value = (valIn.value !== '' && !isNaN(v)) ? v : undefined; };
-    tr.appendChild(el('td', {}, valIn));
-
-    const modeSel = el('select', { style: { width: 'auto' } });
-    NODE_MODES.forEach(([v, label, desc]) => { const o = el('option', { value: v, text: label }); o.title = desc; modeSel.appendChild(o); });
-    modeSel.value = n.Mode || 'auto';
-    modeSel.onchange = () => { n.Mode = modeSel.value === 'auto' ? undefined : modeSel.value; };
-    tr.appendChild(el('td', {}, modeSel));
-
-    // Bound live sources (MQTT today) — the seam other ingests plug into. Detail/editing lives below.
-    const srcMetrics = (n.Mqtt || []).map((s     ) => s.Metric || 'realpower');
-    tr.appendChild(el('td', { text: srcMetrics.length ? srcMetrics.join(', ') : '—', class: srcMetrics.length ? '' : 'num' }));
-
+    const actions = el('td', { style: { whiteSpace: 'nowrap' } });
+    const edit = btn(editing.id === n.Id ? 'Editing…' : 'Edit');
+    edit.onclick = () => { editing.id = editing.id === n.Id ? null : n.Id; rerender(); };
     const rm = btn('Delete', 'danger');
     rm.onclick = () => {
       customNodes.splice(customNodes.indexOf(n), 1);
       for (let j = links.length - 1; j >= 0; j--) if (links[j].From === n.Id || links[j].To === n.Id) links.splice(j, 1);
+      if (editing.id === n.Id) editing.id = null;
       toast(`${n.Label || n.Id} deleted.`, true);
       rerender();
     };
-    tr.appendChild(el('td', {}, rm));
+    actions.append(edit, ' ', rm);
+    tr.appendChild(actions);
     body.appendChild(tr);
   });
   tbl.appendChild(body);
   box.appendChild(tbl);
-  return box;
-}
 
-// Binds custom nodes to live MQTT topics (#205): the values a producer (Solar Assistant, a CT clamp)
-// already publishes become this node's reading, so it rolls up and exports like a PDU outlet. Only custom
-// nodes appear — PDU/outlet nodes get their values from the poll.
-function renderMqttSources(customNodes       , rerender            ) {
-  const box = el('div', { style: { margin: '18px 0' } });
-  box.appendChild(el('h3', { text: 'Live sources (MQTT)', style: { margin: '4px 0', fontSize: '15px' } }));
-  box.appendChild(el('div', { class: 'desc', text: 'Feed a node from a topic already on your broker — e.g. Solar Assistant’s solar_assistant/inverter_1/pv_power/state. A live reading replaces the node’s fixed value; bind one topic per metric to drive both the power and the energy roll-up. Takes effect without a restart once saved.' }));
-
-  if (!customNodes.length) {
-    box.appendChild(el('div', { class: 'desc', text: 'Add a node above first — live sources attach to custom nodes.' }));
-    return box;
-  }
-
-  // Existing bindings, flattened across nodes.
-  const rows = customNodes.flatMap((n     ) => (n.Mqtt || []).map((s     ) => ({ node: n, src: s })));
-  if (rows.length) {
-    const tbl = el('table', { class: 'ld' });
-    const head = el('tr');
-    ['Node', 'Topic', 'Metric', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
-    tbl.appendChild(el('thead', {}, head));
-    const body = el('tbody');
-    rows.forEach(({ node, src }     ) => {
-      const tr = el('tr');
-      tr.appendChild(el('td', { text: node.Label || node.Id }));
-      tr.appendChild(el('td', {}, el('code', { text: src.Topic })));
-      tr.appendChild(el('td', { text: src.Metric || 'realpower' }));
-      tr.appendChild(el('td', { text: src.JsonField || '—' }));
-      tr.appendChild(el('td', { class: 'num', text: String(src.Scale ?? 1) }));
-      const rm = btn('Remove', 'danger');
-      rm.onclick = () => { node.Mqtt.splice(node.Mqtt.indexOf(src), 1); rerender(); };
-      tr.appendChild(el('td', {}, rm));
-      body.appendChild(tr);
-    });
-    tbl.appendChild(body);
-    box.appendChild(tbl);
-  }
-
-  const bar = el('div', { class: 'ld-toolbar' });
-  const nodeSel = el('select', { style: { width: 'auto' } });
-  customNodes.forEach((n     ) => nodeSel.appendChild(el('option', { value: n.Id, text: n.Label || n.Id })));
-  const topicIn = el('input', { type: 'text', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '320px' } });
-  const metricSel = el('select', { style: { width: 'auto' } });
-  SOURCE_METRICS.forEach(m => metricSel.appendChild(el('option', { value: m, text: m })));
-  const fieldIn = el('input', { type: 'text', placeholder: 'JSON field (optional)', style: { width: '150px' } });
-  const scaleIn = el('input', { type: 'number', step: 'any', placeholder: 'scale', value: '1', style: { width: '90px' } });
-  const add = btn('Bind topic', 'primary');
-  add.onclick = () => {
-    const topic = (topicIn.value || '').trim();
-    if (!topic) { toast('A topic is required.', false); return; }
-    const node = customNodes.find((n     ) => n.Id === nodeSel.value);
-    if (!node) { toast('Pick a node to bind.', false); return; }
-    const metric = metricSel.value;
-    const mqtt = ensure(node, 'Mqtt', []);
-    // One reading per metric per node — a second binding would just race the first.
-    if (mqtt.some((s     ) => (s.Metric || 'realpower') === metric)) {
-      toast(`${node.Label || node.Id} already has a ${metric} source.`, false); return;
-    }
-    const src      = { Topic: topic, Metric: metric };
-    const field = (fieldIn.value || '').trim(); if (field) src.JsonField = field;
-    const scale = +scaleIn.value; if (scaleIn.value !== '' && !isNaN(scale) && scale !== 1) src.Scale = scale;
-    mqtt.push(src);
-    toast(`${topic} → ${node.Label || node.Id} (${metric}).`, true);
-    rerender();
-  };
-  bar.append(nodeSel, topicIn, metricSel, fieldIn, scaleIn, add);
-  box.appendChild(bar);
+  const editingNode = editing.id ? customNodes.find((n     ) => n.Id === editing.id) : null;
+  if (editingNode) box.appendChild(renderNodeEditor(editingNode, (close          ) => { if (close) editing.id = null; rerender(); }));
   return box;
 }
 
@@ -905,6 +962,7 @@ function addFlowSection(nav     , sections     ) {
   const wrap = document.createElement('div'); sec.appendChild(wrap);
   const ed      = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
   let lastGraph      = null;
+  const editing                        = { id: null };  // which virtual node's editor is open (persists across rerenders)
 
   // Layered Sankey: columns = longest path from a root (energy flows left->right, parent->child).
   const draw = (graph     ) => {
@@ -1010,6 +1068,14 @@ function addFlowSection(nav     , sections     ) {
       Object.entries(legacy).forEach(([child, parent]) => { if (parent && child && !links.some((l     ) => l.From === parent && l.To === child)) links.push({ From: parent, To: child }); });
       Object.keys(legacy).forEach(k => delete legacy[k]);
     }
+    // Fold legacy per-node Mqtt bindings into the general Sources list (each was implicitly Type: mqtt), so
+    // the new editor manages them in one place. The engine still reads both, so this is safe on save.
+    customNodes.forEach((n     ) => {
+      if (n.Mqtt && n.Mqtt.length) {
+        n.Sources = (n.Sources || []).concat(n.Mqtt.map((s     ) => ({ Type: 'mqtt', ...s })));
+        delete n.Mqtt;
+      }
+    });
     ed.innerHTML = '';
 
     ed.appendChild(el('h3', { text: 'Hierarchy', style: { margin: '4px 0' } }));
@@ -1035,8 +1101,7 @@ function addFlowSection(nav     , sections     ) {
     exportRow.append(el('label', {}, expChk, ' Export tiers to MQTT'), el('span', { class: 'desc', style: { margin: '0' }, text: 'Topic:' }), topicIn);
     ed.appendChild(exportRow);
 
-    ed.appendChild(renderNodeManager(customNodes, links, renderEditor));
-    ed.appendChild(renderMqttSources(customNodes, renderEditor));
+    ed.appendChild(renderNodeManager(customNodes, links, editing, renderEditor));
 
     // Candidate nodes (from the built graph + custom defs).
     const cand = new Map();
@@ -1181,7 +1246,7 @@ function addFlowSection(nav     , sections     ) {
       if (cand.has(id)) { toast('That id already exists.', false); return; }
       const node      = { Id: id, Label: (labIn.value || '').trim() || id };
       if (valIn.value !== '' && !isNaN(+valIn.value)) node.Value = +valIn.value;
-      customNodes.push(node); renderEditor();
+      customNodes.push(node); editing.id = id; renderEditor();  // open the new node's editor straight away
     };
     save.onclick = async () => {
       const r = await api('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(exportData()) });

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -865,9 +865,11 @@ function renderNodeEditor(node     , rerender            ) {
   if (sources.length) {
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
-    ['Type', 'Metric', 'Unit', 'Source', 'Details', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
+    ['Type', 'Metric', 'Unit', 'Source', 'Details', 'Scale', 'Current', ''].forEach(h => head.appendChild(el('th', { text: h })));
     tbl.appendChild(el('thead', {}, head));
     const body = el('tbody');
+    // Cells that a live probe fills in, keyed to their source so a refresh can update them in place.
+    const liveCells                            = [];
     sources.forEach((src     ) => {
       const tr = el('tr');
 
@@ -941,6 +943,11 @@ function renderNodeEditor(node     , rerender            ) {
       scaleIn.onchange = () => { const v = +scaleIn.value; src.Scale = (scaleIn.value !== '' && !isNaN(v) && v !== 1) ? v : undefined; };
       tr.appendChild(el('td', {}, scaleIn));
 
+      // Live value (Modbus only for now): filled by a probe so you can confirm a mapping reads correctly.
+      const liveCell = el('td', { class: 'num', style: { minWidth: '90px', color: 'var(--muted)' }, text: (src.Type === 'modbus') ? '…' : '—' });
+      if (src.Type === 'modbus') liveCells.push({ src, cell: liveCell });
+      tr.appendChild(liveCell);
+
       const rm = btn('Remove', 'danger');
       rm.onclick = () => { sources.splice(sources.indexOf(src), 1); rerender(); };
       tr.appendChild(el('td', {}, rm));
@@ -948,6 +955,39 @@ function renderNodeEditor(node     , rerender            ) {
     });
     tbl.appendChild(body);
     box.appendChild(tbl);
+
+    // Live values for Modbus mappings: probe the device(s) and fill the Current column, so you can confirm a
+    // register/type/scale reads what you expect before saving. Auto-refreshes while the editor is open.
+    if (liveCells.length) {
+      const status = el('span', { class: 'desc', style: { margin: '0 0 0 8px' } });
+      const refresh = async () => {
+        const conns        = (state.data?.Modbus?.Connections) || [];
+        const byConn = new Map                                   ();
+        liveCells.forEach(lc => { const id = lc.src.Connection || ''; (byConn.get(id) || byConn.set(id, []).get(id) ).push(lc); });
+        for (const [connId, cells] of byConn) {
+          const conn = conns.find(c => c.Id === connId);
+          if (!conn) { cells.forEach(lc => { lc.cell.textContent = 'pick a connection'; lc.cell.style.color = 'var(--muted)'; }); continue; }
+          try {
+            const r = await api('/api/modbus/probe', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ Host: conn.Host, Port: conn.Port, UnitId: conn.UnitId, Items: cells.map(lc => lc.src) }) });
+            if (!r.body.ok) { cells.forEach(lc => { lc.cell.textContent = 'err'; lc.cell.style.color = 'var(--bad)'; }); status.textContent = r.body.message || 'probe failed'; continue; }
+            const readings = r.body.readings || [];
+            cells.forEach((lc, i) => {
+              const rd = readings[i];
+              if (!rd || rd.value == null) { lc.cell.textContent = rd?.error ? 'err' : '—'; lc.cell.style.color = 'var(--bad)'; lc.cell.title = rd?.error || ''; }
+              else { const cu = metricMeta(lc.src.Metric)[2]; lc.cell.textContent = `${formatNum(rd.value)} ${cu}`.trim(); lc.cell.style.color = 'var(--good)'; lc.cell.title = ''; }
+            });
+            status.textContent = `updated ${new Date().toLocaleTimeString()}`;
+          } catch (e     ) { cells.forEach(lc => { lc.cell.textContent = 'err'; }); status.textContent = String(e?.message || e); }
+        }
+      };
+      const refreshBtn = btn('Refresh values');
+      refreshBtn.onclick = refresh;
+      box.appendChild(el('div', { class: 'ld-toolbar', style: { marginTop: '6px' } }, refreshBtn, status));
+      refresh();
+      // Self-cleaning: once this editor is replaced/closed its box leaves the DOM and the poll stops.
+      const timer = setInterval(() => { if (!document.body.contains(box)) { clearInterval(timer); return; } refresh(); }, 5000);
+    }
   }
 
   const addBind = btn('Add binding', 'primary');
@@ -1844,6 +1884,7 @@ function sectionActions(node     ) {
 
   if (node.key === 'MQTT') add('Test MQTT connection', testMqtt);
   else if (node.key === 'PDU') add('Test PDU connection', testPdu);
+  else if (node.key === 'Modbus') add('Test connections', testModbus);
   else if (node.key === 'EmonCMS') { add('Test EmonCMS connection', testEmonCms); add('Provision feeds now', provisionEmonCmsFeeds); add('Delete all feeds', deleteEmonCmsFeeds, 'danger'); }
   else if (node.key === 'HomeAssistant') {
     if ((state.data.HomeAssistant || {}).DiscoveryEnabled === false) return null;
@@ -1856,6 +1897,18 @@ function sectionActions(node     ) {
 
 // ── actions.ts ──────────────────────────────────────────────────
 // Section-level connection tests + Home Assistant discovery actions (wired from sectionActions()).
+
+// Test every configured Modbus TCP connection by opening a throwaway connection to each.
+async function testModbus() {
+  const conns = (state.data?.Modbus?.Connections) || [];
+  if (!conns.length) { toast('No Modbus connections configured — add one first.', false); return; }
+  toast(`Testing ${conns.length} Modbus connection(s)…`, true);
+  for (const c of conns) {
+    if (!c.Host) { toast(`${c.Name || c.Id || 'connection'}: no host set.`, false); continue; }
+    const r = await api('/api/modbus/probe', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ Host: c.Host, Port: c.Port, UnitId: c.UnitId }) });
+    toast(`${c.Name || c.Id}: ${r.body.message || (r.body.ok ? 'OK' : 'failed')}`, r.body.ok);
+  }
+}
 
 async function testMqtt() { const r = await api('/api/test/mqtt', { method: 'POST' }); toast(r.body.message, r.body.ok); refreshStatus(); }
 async function testPdu() { toast('Testing PDU…', true); const r = await api('/api/test/pdu', { method: 'POST' }); toast(r.body.message, r.body.ok); }

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -755,6 +755,70 @@ function addLiveDataSection(nav     , sections     ) {
 // Metrics a live source can supply — mirrors [AllowedValues] on EnergyFlowMqttSource.Metric.
 const SOURCE_METRICS = ['realpower', 'apparentpower', 'energy', 'current', 'voltage', 'frequency', 'powerfactor'];
 
+// How an unmeasured node is valued — mirrors [AllowedValues] on EnergyFlowNode.Mode. A live/static value
+// always wins; this only governs nodes the graph would otherwise infer.
+const NODE_MODES                             = [
+  ['auto', 'Auto (aggregate / share)', 'Sums its children, and as a feeder takes a share of whatever load measured siblings don’t cover — the default.'],
+  ['residual', 'Residual (untracked)', 'The designated absorber for untracked load: carries the demand still needed after every measured feeder has supplied its part.'],
+  ['none', 'None (leave unset)', 'Never inferred — contributes nothing unless it has a real value or children, so an unmeasured source simply drops out instead of showing a fabricated figure.'],
+];
+
+// Virtual-node manager (#129): rename, retype, set a fixed value or mode, and delete the custom nodes — the
+// "page to manage those" that the graph editor alone didn't cover. Value population is source-agnostic: a
+// node's number can come from a fixed value, or a bound live source (MQTT today, other ingests later) shown
+// in the Sources column; the Mode governs only what happens when neither is present.
+function renderNodeManager(customNodes       , links       , rerender            ) {
+  const box = el('div', { style: { margin: '18px 0' } });
+  box.appendChild(el('h3', { text: 'Virtual nodes', style: { margin: '4px 0', fontSize: '15px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'The custom nodes you’ve added (panels, breakers, a “Total”, producers). Rename them, give a leaf a fixed value, or set how an unmeasured node is valued. A fixed value or a bound live source always wins over the mode; the mode only decides what an otherwise-unknown node does.' }));
+
+  if (!customNodes.length) {
+    box.appendChild(el('div', { class: 'desc', text: 'No virtual nodes yet — add one above.' }));
+    return box;
+  }
+
+  const tbl = el('table', { class: 'ld' });
+  const head = el('tr');
+  ['Id', 'Label', 'Fixed value', 'Mode', 'Sources', ''].forEach(h => head.appendChild(el('th', { text: h })));
+  tbl.appendChild(el('thead', {}, head));
+  const body = el('tbody');
+  customNodes.forEach((n     ) => {
+    const tr = el('tr');
+    tr.appendChild(el('td', {}, el('code', { text: n.Id, style: { color: 'var(--muted)' } })));
+
+    const labIn = el('input', { type: 'text', value: n.Label || '', placeholder: n.Id, style: { width: '180px' } });
+    labIn.onchange = () => { n.Label = labIn.value.trim() || undefined; };
+    tr.appendChild(el('td', {}, labIn));
+
+    const valIn = el('input', { type: 'number', step: 'any', value: n.Value ?? '', placeholder: '—', style: { width: '110px' } });
+    valIn.onchange = () => { const v = +valIn.value; n.Value = (valIn.value !== '' && !isNaN(v)) ? v : undefined; };
+    tr.appendChild(el('td', {}, valIn));
+
+    const modeSel = el('select', { style: { width: 'auto' } });
+    NODE_MODES.forEach(([v, label, desc]) => { const o = el('option', { value: v, text: label }); o.title = desc; modeSel.appendChild(o); });
+    modeSel.value = n.Mode || 'auto';
+    modeSel.onchange = () => { n.Mode = modeSel.value === 'auto' ? undefined : modeSel.value; };
+    tr.appendChild(el('td', {}, modeSel));
+
+    // Bound live sources (MQTT today) — the seam other ingests plug into. Detail/editing lives below.
+    const srcMetrics = (n.Mqtt || []).map((s     ) => s.Metric || 'realpower');
+    tr.appendChild(el('td', { text: srcMetrics.length ? srcMetrics.join(', ') : '—', class: srcMetrics.length ? '' : 'num' }));
+
+    const rm = btn('Delete', 'danger');
+    rm.onclick = () => {
+      customNodes.splice(customNodes.indexOf(n), 1);
+      for (let j = links.length - 1; j >= 0; j--) if (links[j].From === n.Id || links[j].To === n.Id) links.splice(j, 1);
+      toast(`${n.Label || n.Id} deleted.`, true);
+      rerender();
+    };
+    tr.appendChild(el('td', {}, rm));
+    body.appendChild(tr);
+  });
+  tbl.appendChild(body);
+  box.appendChild(tbl);
+  return box;
+}
+
 // Binds custom nodes to live MQTT topics (#205): the values a producer (Solar Assistant, a CT clamp)
 // already publishes become this node's reading, so it rolls up and exports like a PDU outlet. Only custom
 // nodes appear — PDU/outlet nodes get their values from the poll.
@@ -948,7 +1012,7 @@ function addFlowSection(nav     , sections     ) {
     ed.innerHTML = '';
 
     ed.appendChild(el('h3', { text: 'Hierarchy', style: { margin: '4px 0' } }));
-    ed.appendChild(el('div', { class: 'desc', text: 'Energy flows left → right. Drag from a node’s right ● onto another node to add a feed (source powers target). A node can have several feeders, and a producer is just a feed into what it powers — e.g. drag from Solar onto your inverter. The target highlights green when in range; click ✕ on a link to remove it. PDU → outlet links are auto-derived (dashed) until you wire an explicit feeder.' }));
+    ed.appendChild(el('div', { class: 'desc', text: 'Energy flows left → right. Drag from a node’s right ● onto another node to add a feed (source powers target). A node can have several feeders, and a producer is just a feed into what it powers — e.g. drag from Solar onto your inverter. The target highlights green when in range; click ✕ on a link to remove it. Double-click a custom node to rename it. PDU → outlet links are auto-derived (dashed) until you wire an explicit feeder.' }));
 
     const addBar = el('div', { class: 'ld-toolbar' });
     const idIn = el('input', { type: 'text', placeholder: 'id (e.g. gridboss)' });
@@ -970,6 +1034,7 @@ function addFlowSection(nav     , sections     ) {
     exportRow.append(el('label', {}, expChk, ' Export tiers to MQTT'), el('span', { class: 'desc', style: { margin: '0' }, text: 'Topic:' }), topicIn);
     ed.appendChild(exportRow);
 
+    ed.appendChild(renderNodeManager(customNodes, links, renderEditor));
     ed.appendChild(renderMqttSources(customNodes, renderEditor));
 
     // Candidate nodes (from the built graph + custom defs).
@@ -1053,7 +1118,21 @@ function addFlowSection(nav     , sections     ) {
       const t1 = svgEl('text', { x: 11, y: 19, fill: 'var(--fg)', 'font-size': '12', 'font-weight': '600' }); t1.textContent = c.label.length > 26 ? c.label.slice(0, 25) + '…' : c.label; g.appendChild(t1);
       const t2 = svgEl('text', { x: 11, y: 35, fill: 'var(--muted)', 'font-size': '10' }); t2.textContent = c.id; g.appendChild(t2);
       g.appendChild(svgEl('circle', { cx: NW, cy: NH / 2, r: 7, fill: color, style: 'cursor:crosshair', 'data-port': c.id }));
-      if (c.custom) { const rm = svgEl('text', { x: NW - 13, y: 15, fill: 'var(--bad)', 'font-size': '13', style: 'cursor:pointer', 'data-rm': c.id }); rm.textContent = '✕'; g.appendChild(rm); }
+      if (c.custom) {
+        const rm = svgEl('text', { x: NW - 13, y: 15, fill: 'var(--bad)', 'font-size': '13', style: 'cursor:pointer', 'data-rm': c.id }); rm.textContent = '✕'; g.appendChild(rm);
+        // Rename in place: double-click the node to relabel it. Only the Label changes — Id stays fixed, so
+        // every link/source keyed off it survives. (Ids aren't editable here for exactly that reason.)
+        t1.setAttribute('title', 'Double-click to rename'); g.style.cursor = 'pointer';
+        g.addEventListener('dblclick', (e     ) => {
+          e.preventDefault();
+          const node = customNodes.find((n     ) => n.Id === c.id); if (!node) return;
+          const next = window.prompt(`Rename “${node.Label || node.Id}” (id ${node.Id} is unchanged)`, node.Label || node.Id);
+          if (next == null) return; // cancelled
+          node.Label = next.trim() || node.Id;
+          toast(`Renamed to ${node.Label}. Save the hierarchy to keep it.`, true);
+          renderEditor();
+        });
+      }
       nodeLayer.appendChild(g); nodeG[c.id] = g;
     });
 

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -759,7 +759,8 @@ const SOURCE_METRICS = ['realpower', 'apparentpower', 'energy', 'current', 'volt
 // always wins; this only governs nodes the graph would otherwise infer.
 const NODE_MODES                             = [
   ['auto', 'Auto (aggregate / share)', 'Sums its children, and as a feeder takes a share of whatever load measured siblings don’t cover — the default.'],
-  ['residual', 'Residual (untracked)', 'The designated absorber for untracked load: carries the demand still needed after every measured feeder has supplied its part.'],
+  ['residual', 'Residual (untracked feeder)', 'The designated absorber on the feeder side: carries the demand still needed after every measured feeder has supplied its part.'],
+  ['untracked', 'Untracked (child of a measured parent)', 'Place under a parent that has a measured total (a bound source or fixed value): shows the slice of that total its tracked siblings don’t account for. Contributes nothing if the parent has no measured total.'],
   ['none', 'None (leave unset)', 'Never inferred — contributes nothing unless it has a real value or children, so an unmeasured source simply drops out instead of showing a fabricated figure.'],
 ];
 

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -752,8 +752,21 @@ function addLiveDataSection(nav     , sections     ) {
 // ── sections/flow.ts ────────────────────────────────────────────
 // Energy Flow: a read-only Sankey + the layered arrow-graph hierarchy editor.
 
-// Metrics a live source can supply — mirrors [AllowedValues] on EnergyFlowSource.Metric.
-const SOURCE_METRICS = ['realpower', 'apparentpower', 'energy', 'current', 'voltage', 'frequency', 'powerfactor'];
+// Metrics a live source can supply: [stored key (matches PDU Measurement.Type), friendly label, canonical
+// unit, selectable input units]. The key stays the PDU vocabulary so live values roll up with outlets; the
+// UI shows the friendly name and a unit picker. Mirrors EnergyFlowSource.Metric + FlowUnits (Core).
+const METRICS                                       = [
+  ['realpower', 'Power', 'W', ['W', 'kW', 'MW']],
+  ['apparentpower', 'Apparent power', 'VA', ['VA', 'kVA']],
+  ['energy', 'Energy', 'kWh', ['Wh', 'kWh', 'MWh']],
+  ['current', 'Current', 'A', ['A', 'mA']],
+  ['voltage', 'Voltage', 'V', ['mV', 'V', 'kV']],
+  ['frequency', 'Frequency', 'Hz', ['Hz']],
+  ['powerfactor', 'Power factor', '', ['']],
+];
+const SOURCE_METRICS = METRICS.map(m => m[0]);
+const metricMeta = (key         ) => METRICS.find(m => m[0] === key) || METRICS[0];
+const metricLabel = (key         ) => metricMeta(key)[1];
 
 // What a virtual node represents — mirrors [AllowedValues] on EnergyFlowNode.Kind. Each kind offers only
 // the metrics that make sense for it (a battery has no frequency); 'battery' also gets a storage field.
@@ -849,7 +862,7 @@ function renderNodeEditor(node     , rerender            ) {
   if (sources.length) {
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
-    ['Type', 'Metric', 'Topic', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
+    ['Type', 'Metric', 'Unit', 'Topic', 'JSON field', 'Scale', ''].forEach(h => head.appendChild(el('th', { text: h })));
     tbl.appendChild(el('thead', {}, head));
     const body = el('tbody');
     sources.forEach((src     ) => {
@@ -861,13 +874,24 @@ function renderNodeEditor(node     , rerender            ) {
       typeSel.onchange = () => { src.Type = typeSel.value; };
       tr.appendChild(el('td', {}, typeSel));
 
-      // Offer this kind's metrics, but keep an already-chosen metric even if the kind wouldn't list it.
+      // Offer this kind's metrics (friendly labels), but keep an already-chosen one even if the kind wouldn't
+      // list it. Changing the metric resets the unit (units differ per metric) and re-renders the row.
       const metricSel = el('select', { style: { width: 'auto' } });
-      const opts = allowed.includes(src.Metric || 'realpower') ? allowed : [src.Metric, ...allowed];
-      opts.forEach((m        ) => metricSel.appendChild(el('option', { value: m, text: m })));
-      metricSel.value = src.Metric || 'realpower';
-      metricSel.onchange = () => { src.Metric = metricSel.value; };
+      const metric = src.Metric || 'realpower';
+      const opts = allowed.includes(metric) ? allowed : [metric, ...allowed];
+      opts.forEach((m        ) => metricSel.appendChild(el('option', { value: m, text: metricLabel(m) })));
+      metricSel.value = metric;
+      metricSel.onchange = () => { src.Metric = metricSel.value; src.Unit = undefined; rerender(); };
       tr.appendChild(el('td', {}, metricSel));
+
+      // Input unit → converted to the metric's canonical unit on ingest. Store only a non-canonical choice.
+      const [, , canonical, units] = metricMeta(metric);
+      const unitSel = el('select', { style: { width: 'auto' } });
+      units.forEach((u        ) => unitSel.appendChild(el('option', { value: u, text: u || '—' })));
+      unitSel.value = src.Unit || canonical;
+      unitSel.disabled = units.length <= 1;
+      unitSel.onchange = () => { src.Unit = unitSel.value === canonical ? undefined : unitSel.value; };
+      tr.appendChild(el('td', {}, unitSel));
 
       const topicIn = el('input', { type: 'text', value: src.Topic || '', placeholder: 'solar_assistant/inverter_1/pv_power/state', style: { width: '300px' } });
       topicIn.onchange = () => { src.Topic = topicIn.value.trim(); };

--- a/rPDU2MQTT/Program.cs
+++ b/rPDU2MQTT/Program.cs
@@ -14,6 +14,14 @@ if (args.Contains("--emit-crd"))
     return 0;
 }
 
+// Emit the config schema JSON the GUI renders from (used to regenerate web/schema.fixture.json for smoke).
+if (args.Contains("--emit-schema"))
+{
+    Console.Write(System.Text.Json.JsonSerializer.Serialize(
+        rPDU2MQTT.Services.Gui.ConfigSchema.Build(), rPDU2MQTT.Services.Gui.ConfigSchema.Json));
+    return 0;
+}
+
 Log.Logger = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .WriteTo.Console()

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -104,8 +104,17 @@ public static class ServiceConfiguration
         // the live values, and it self-gates — with no Mqtt bindings configured it subscribes to nothing.
         // It reconciles subscriptions on a timer, so binding a topic in the GUI needs no restart.
         services.AddSingleton<Services.EnergyFlowMqttSourceService>();
-        services.AddSingleton<Core.Flow.IFlowValueSource>(sp => sp.GetRequiredService<Services.EnergyFlowMqttSourceService>());
         services.AddHostedService(sp => sp.GetRequiredService<Services.EnergyFlowMqttSourceService>());
+
+        // Modbus TCP is a second live-value ingest (#129): poll inverters/meters/PLCs into the same seam.
+        // Self-gating too — with no connections/bindings configured it opens no sockets.
+        services.AddSingleton<Services.EnergyFlowModbusSourceService>();
+        services.AddHostedService(sp => sp.GetRequiredService<Services.EnergyFlowModbusSourceService>());
+
+        // The graph/exporters see one IFlowValueSource; the composite merges every ingest (MQTT + Modbus).
+        services.AddSingleton<Core.Flow.IFlowValueSource>(sp => new Core.Flow.CompositeFlowValueSource(
+            sp.GetRequiredService<Services.EnergyFlowMqttSourceService>(),
+            sp.GetRequiredService<Services.EnergyFlowModbusSourceService>()));
 
         // When roles are split across processes, bridge the in-process snapshot bus over MQTT: a Worker
         // mirrors its snapshots to the broker; a consumer-only node ingests them onto its own bus/cache.


### PR DESCRIPTION
Reworks the energy-flow feature around maintainer feedback, over 9 focused commits. Everything below is on the same shared `EnergyFlow` config; the GUI splits it across a **Flow** tab (visualization + wiring) and a new **Nodes** tab (node configuration).

## Correctness
- **Stop fabricating unmeasured feeders.** The graph used to split a node's demand evenly across its feeders, so a measured producer (Solar = 6000 W) still handed an unmeasured sibling (Grid) ~half the load. Now measured feeders supply their real figure and only the *remainder* is shared among the unmeasured ones. ([FlowGraphBuilder.cs](rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs))

## Node model
- **Per-node `Mode`**: `auto` (aggregate / share), `static` (fixed value — the only mode that shows the value field), `residual` (absorb untracked remainder on the feeder side), `untracked` (a measured parent's unaccounted consumption on the child side), `none` (never inferred — drops out instead of inventing a number).
- **Per-node `Kind`** (node / panel / inverter / battery / solar / grid / load) — styles the diagram and tailors the editor (a battery gets `StorageKwh`, no frequency).

## Bindings (mappings)
- **Typed sources**: `EnergyFlowMqttSource` → `EnergyFlowSource` with a `Type` discriminator (`mqtt` / `modbus`). Node `.Mqtt` → `.Sources`; legacy `Mqtt` is still read and migrated in the GUI, so nothing bound before the rename is lost.
- **Friendly metric names** (Power / Energy / Voltage / …) with the stored key kept as the PDU vocabulary so live values still roll up with outlets.
- **Per-source `Unit`** with conversion to a canonical unit (kW → W, Wh → kWh, …) via `FlowUnits`, so exports stay consistent; manual `Scale` still applies on top.

## Modbus TCP (new source type)
- A **Modbus** config section of named TCP connections (auto-rendered by the schema form).
- `ModbusDecode` (uint16/int16/uint32/int32/float32, big/little word order) + `EnergyFlowModbusSourceService` (FluentModbus) polling each connection into the shared value cache via `CompositeFlowValueSource` — same `IFlowValueSource` seam MQTT uses.
- **Test connection** button + a live **Current** column in the node editor. Reads hardened with reconnect-on-error so a bad frame can't desync the stream into silently-wrong values.
- Verified against a real inverter (54.1 V battery, 367 V PV, ~1600 W decode correctly). Note: serial→TCP gateways don't isolate concurrent masters — don't double-poll a device already read by e.g. ESPHome.

## GUI
- **Dedicated Nodes tab**: add/edit/delete nodes; set kind/mode/value; manage bindings; wire **feeders & children** per node (loop-guarded) — alongside the visual Flow tab.
- **Live "Current" value for every binding type**: Modbus from a device probe (works pre-save), MQTT and future types from the shared live cache (`/api/flow/live`).

## Testing
- `dotnet test` — **239 pass** (new: feeder residual/none/static/untracked, Kind styling, unit conversion, Modbus decode/compose/flatten, legacy-binding back-compat).
- `dotnet build` — 0 warnings. CRD manifests + GUI schema fixture regenerated (added `--emit-schema`). GUI smoke drives both tabs and both binding types.
- Live Modbus socket I/O verified manually against real hardware; the decode/scale/unit logic is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)