### PR TITLE
feat(diagnostics): restart specific tiers or everything, incl. Kubernetes rollout restart

### DIFF
--- a/charts/rpdu2mqtt/templates/rbac.yaml
+++ b/charts/rpdu2mqtt/templates/rbac.yaml
@@ -16,6 +16,10 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events"]
     verbs: ["get", "list"]
+  # Lets the GUI Diagnostics page roll-restart this release's Deployment(s) (restart a tier / update image).
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch"]
   # Lets the GUI persist credentials (incl. OIDC client secret) into the companion Secret,
   # instead of the CR spec. Scoped to just that Secret (the chart pre-creates it).
   - apiGroups: [""]

--- a/rPDU2MQTT.Core/Core/RestartCommand.cs
+++ b/rPDU2MQTT.Core/Core/RestartCommand.cs
@@ -1,0 +1,24 @@
+using rPDU2MQTT.Helpers;
+
+namespace rPDU2MQTT.Core;
+
+/// <summary>
+/// A restart request broadcast over the bus so a split deployment can be restarted tier-by-tier from the
+/// GUI. Every process listens on <see cref="TopicFor"/>; one whose role matches the
+/// <see cref="Target"/> ("all" or a role name) stops itself, and its orchestrator brings it back. In
+/// Kubernetes the GUI prefers a rollout restart instead (which also pulls the latest image), so this is the
+/// mechanism for non-Kubernetes split deployments.
+/// </summary>
+public sealed record RestartCommand(string Target, DateTime AtUtc)
+{
+    /// <summary>The <see cref="Target"/> value that matches every process.</summary>
+    public const string TargetAll = "all";
+
+    /// <summary>The (non-retained) bus topic restart requests are published to.</summary>
+    public static string TopicFor(string parentTopic) => MQTTHelper.JoinPaths(parentTopic, "_bus", "command", "restart");
+
+    /// <summary>Does a process running <paramref name="roles"/> match this command's target ("all" or a role name)?</summary>
+    public bool MatchesRoles(IEnumerable<string> roles)
+        => string.Equals(Target, TargetAll, StringComparison.OrdinalIgnoreCase)
+           || roles.Any(r => string.Equals(r, Target, StringComparison.OrdinalIgnoreCase));
+}

--- a/rPDU2MQTT.Engine/Services/RestartCommandService.cs
+++ b/rPDU2MQTT.Engine/Services/RestartCommandService.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Events;
+using HiveMQtt.MQTT5.Types;
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Lets the GUI restart this process (and, in a split deployment, sibling tiers) over the bus: every
+/// process subscribes to <see cref="RestartCommand.TopicFor"/> and stops itself when a request targets
+/// "all" or one of its roles — the orchestrator then restarts it. Loaded in every role so any process can
+/// be told to restart; in Kubernetes the GUI prefers a rollout restart, so this covers the other
+/// deployment shapes (compose, split-by-process, single node).
+/// </summary>
+public sealed class RestartCommandService : IHostedService
+{
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private readonly HiveMQClient mqtt;
+    private readonly Config cfg;
+    private readonly IHostApplicationLifetime lifetime;
+    private readonly string[] roles;
+    private readonly DateTime startedUtc = DateTime.UtcNow;
+
+    public RestartCommandService(IHiveMQClient mqtt, Config cfg, HostRole roles, IHostApplicationLifetime lifetime)
+    {
+        this.mqtt = (HiveMQClient)mqtt;
+        this.cfg = cfg;
+        this.lifetime = lifetime;
+        this.roles = new[] { HostRole.Worker, HostRole.Api, HostRole.Ui }
+            .Where(r => roles.HasFlag(r)).Select(r => r.ToString().ToLowerInvariant()).ToArray();
+    }
+
+    private string Topic => RestartCommand.TopicFor(cfg.MQTT.ParentTopic);
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        mqtt.OnMessageReceived += OnMessageReceived;
+        try { await mqtt.SubscribeAsync(Topic, QualityOfService.AtLeastOnceDelivery); }
+        catch (Exception ex) { Log.Warning($"Restart-command: could not subscribe to {Topic}: {ex.Message}"); }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        mqtt.OnMessageReceived -= OnMessageReceived;
+        return Task.CompletedTask;
+    }
+
+    private void OnMessageReceived(object? sender, OnMessageReceivedEventArgs e)
+    {
+        if (!string.Equals(e.PublishMessage.Topic, Topic, StringComparison.Ordinal)) return;
+
+        RestartCommand? cmd;
+        try { cmd = JsonSerializer.Deserialize<RestartCommand>(e.PublishMessage.PayloadAsString ?? "", Json); }
+        catch { return; }
+        if (cmd is null || string.IsNullOrWhiteSpace(cmd.Target)) return;
+
+        // Ignore anything issued before we came up — guards against a redelivered/stale command restarting a
+        // freshly-started process in a loop (the topic is non-retained, so this is belt-and-braces).
+        if (cmd.AtUtc < startedUtc.AddSeconds(-5)) return;
+        if (!cmd.MatchesRoles(roles)) return;
+
+        Log.Warning($"Restart requested over the bus (target '{cmd.Target}'); stopping this process [{string.Join('+', roles)}].");
+        // Let any in-flight work / the broker ack settle before the host tears down.
+        _ = Task.Run(async () => { await Task.Delay(500); lifetime.StopApplication(); });
+    }
+}

--- a/rPDU2MQTT.Tests/RestartCommandTests.cs
+++ b/rPDU2MQTT.Tests/RestartCommandTests.cs
@@ -1,0 +1,31 @@
+using rPDU2MQTT.Core;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>The bus restart command's target matching (#210) — a process obeys "all" or its own role.</summary>
+public class RestartCommandTests
+{
+    private static RestartCommand Cmd(string target) => new(target, DateTime.UtcNow);
+
+    [Fact]
+    public void All_MatchesEveryProcess()
+    {
+        Assert.True(Cmd("all").MatchesRoles(new[] { "worker" }));
+        Assert.True(Cmd("all").MatchesRoles(new[] { "worker", "api", "ui" }));
+        Assert.True(Cmd("ALL").MatchesRoles(new[] { "ui" }));   // case-insensitive
+    }
+
+    [Fact]
+    public void Role_MatchesOnlyProcessesRunningThatRole()
+    {
+        Assert.True(Cmd("worker").MatchesRoles(new[] { "worker" }));
+        Assert.True(Cmd("api").MatchesRoles(new[] { "worker", "api", "ui" }));   // an all-in-one runs every role
+        Assert.False(Cmd("worker").MatchesRoles(new[] { "api", "ui" }));
+        Assert.False(Cmd("ui").MatchesRoles(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void TopicFor_IsUnderTheBusNamespace()
+        => Assert.Equal("rpdu2mqtt/_bus/command/restart", RestartCommand.TopicFor("rpdu2mqtt"));
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -3,7 +3,9 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
 using HiveMQtt.Client;
+using HiveMQtt.MQTT5.Types;
 using k8s;
+using k8s.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -474,13 +476,75 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             }, ConfigSchema.Json);
         });
 
-        // Stop the app so the container/host restarts it (same mechanism as the HA Restart button).
-        app.MapPost("/api/restart", () =>
+        // Restart a tier — or everything. In Kubernetes this is a rollout restart of the matching
+        // Deployment(s), which also rolls to the latest image; elsewhere it's a bus request every matching
+        // process obeys; "local" just stops this process (the classic behaviour).
+        app.MapPost("/api/restart", async (HttpContext ctx) =>
         {
-            Log.Information("Restart requested via GUI; stopping application.");
-            // Let the HTTP response flush before the host shuts down.
-            _ = Task.Run(async () => { await Task.Delay(300); lifetime.StopApplication(); });
-            return Results.Json(new { ok = true, message = "Restarting…" }, ConfigSchema.Json);
+            var target = (ctx.Request.Query["target"].FirstOrDefault() ?? "local").Trim().ToLowerInvariant();
+
+            if (target is "" or "local")
+            {
+                Log.Information("Restart requested via GUI; stopping this process.");
+                _ = Task.Run(async () => { await Task.Delay(300); lifetime.StopApplication(); });
+                return Results.Json(new { ok = true, message = "Restarting this process…" }, ConfigSchema.Json);
+            }
+
+            if (configSource is KubernetesConfigSource kube)
+            {
+                try
+                {
+                    var restarted = await RolloutRestartAsync(kube, target, ctx.RequestAborted);
+                    return restarted.Count == 0
+                        ? Results.Json(new { ok = false, message = $"No deployment matched '{target}'." }, ConfigSchema.Json)
+                        : Results.Json(new { ok = true, message = $"Rollout restart: {string.Join(", ", restarted)}." }, ConfigSchema.Json);
+                }
+                catch (Exception ex) { return Results.Json(new { ok = false, message = $"Rollout restart failed: {ex.Message}" }, ConfigSchema.Json); }
+            }
+
+            // Non-Kubernetes: ask the matching process(es) to restart over the bus.
+            try
+            {
+                var cmd = new Core.RestartCommand(target, DateTime.UtcNow);
+                await ((HiveMQClient)mqtt).PublishAsync(new MQTT5PublishMessage(Core.RestartCommand.TopicFor(config.MQTT.ParentTopic), QualityOfService.AtLeastOnceDelivery)
+                {
+                    PayloadAsString = System.Text.Json.JsonSerializer.Serialize(cmd, ConfigSchema.Json),
+                    Retain = false,
+                });
+                return Results.Json(new { ok = true, message = $"Restart requested for '{target}'." }, ConfigSchema.Json);
+            }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = $"Could not publish restart: {ex.Message}" }, ConfigSchema.Json); }
+        });
+
+        // What can be restarted, and how, so the Diagnostics page renders the right buttons.
+        app.MapGet("/api/restart/targets", async (HttpContext ctx) =>
+        {
+            if (configSource is KubernetesConfigSource kube)
+            {
+                var targets = new List<object> { new { id = "all", label = "Everything" } };
+                try
+                {
+                    // Only the tiers of a split deployment need their own button; an all-in-one Deployment
+                    // (no component label) is covered by "Everything".
+                    foreach (var d in (await AppDeploymentsAsync(kube, ctx.RequestAborted)).OrderBy(d => d.Metadata?.Name))
+                    {
+                        var comp = ComponentOf(d);
+                        if (!string.IsNullOrEmpty(comp)) targets.Add(new { id = comp, label = $"{comp} ({d.Metadata?.Name})" });
+                    }
+                }
+                catch { /* fall back to just "Everything" */ }
+                return Results.Json(new { ok = true, method = "rollout", targets }, ConfigSchema.Json);
+            }
+
+            // Non-Kubernetes: offer whole roles seen on the bus (split deployment), else just this process.
+            var roles = heartbeats.Processes.SelectMany(p => p.Roles).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(r => r).ToList();
+            if (heartbeats.Processes.Count > 1 && roles.Count > 0)
+            {
+                var targets = new List<object> { new { id = "all", label = "Everything" } };
+                targets.AddRange(roles.Select(r => (object)new { id = r, label = r }));
+                return Results.Json(new { ok = true, method = "signal", targets }, ConfigSchema.Json);
+            }
+            return Results.Json(new { ok = true, method = "local", targets = new[] { new { id = "local", label = "This process" } } }, ConfigSchema.Json);
         });
 
         // Tail of this pod's container logs (Kubernetes config source only).
@@ -1192,6 +1256,62 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         using var stream = asm.GetManifestResourceStream(name)!;
         using var reader = new StreamReader(stream);
         return reader.ReadToEnd();
+    }
+
+    // --- Kubernetes rollout restart ------------------------------------------------------------
+
+    /// <summary>Deployment's component (tier) label, or "" — Metadata.Labels is IDictionary (no GetValueOrDefault).</summary>
+    private static string ComponentOf(V1Deployment d)
+        => d.Metadata?.Labels is { } l && l.TryGetValue("app.kubernetes.io/component", out var c) ? c : "";
+
+    /// <summary>This app's Deployments, found via the running pod's own labels so we only touch our own.</summary>
+    private async Task<IList<V1Deployment>> AppDeploymentsAsync(KubernetesConfigSource kube, CancellationToken ct)
+    {
+        var list = await kube.Client.AppsV1.ListNamespacedDeploymentAsync(kube.Namespace, labelSelector: await AppSelectorAsync(kube, ct), cancellationToken: ct);
+        return list.Items;
+    }
+
+    /// <summary>Label selector scoping to this release — read off this pod, else a sensible default.</summary>
+    private static async Task<string> AppSelectorAsync(KubernetesConfigSource kube, CancellationToken ct)
+    {
+        var podName = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME");
+        if (!string.IsNullOrEmpty(podName))
+        {
+            try
+            {
+                var labels = (await kube.Client.CoreV1.ReadNamespacedPodAsync(podName, kube.Namespace, cancellationToken: ct)).Metadata?.Labels;
+                if (labels is not null)
+                {
+                    if (labels.TryGetValue("app.kubernetes.io/instance", out var inst) && !string.IsNullOrEmpty(inst)) return $"app.kubernetes.io/instance={inst}";
+                    if (labels.TryGetValue("app.kubernetes.io/name", out var nm) && !string.IsNullOrEmpty(nm)) return $"app.kubernetes.io/name={nm}";
+                }
+            }
+            catch { /* fall through to the default */ }
+        }
+        return "app.kubernetes.io/name=rpdu2mqtt";
+    }
+
+    /// <summary>
+    /// Roll restart the Deployment(s) matching <paramref name="target"/> ("all" or a component/role) by
+    /// stamping the pod template's <c>restartedAt</c> annotation — exactly what <c>kubectl rollout restart</c>
+    /// does, so pods cycle gracefully and re-pull the image. Returns the names actually patched.
+    /// </summary>
+    private async Task<List<string>> RolloutRestartAsync(KubernetesConfigSource kube, string target, CancellationToken ct)
+    {
+        var restarted = new List<string>();
+        var annotations = new Dictionary<string, string> { ["kubectl.kubernetes.io/restartedAt"] = DateTime.UtcNow.ToString("o") };
+        var body = new V1Patch(
+            System.Text.Json.JsonSerializer.Serialize(new { spec = new { template = new { metadata = new { annotations } } } }),
+            V1Patch.PatchType.MergePatch);
+        foreach (var d in await AppDeploymentsAsync(kube, ct))
+        {
+            var comp = ComponentOf(d);
+            if (d.Metadata?.Name is null) continue;
+            if (!string.Equals(target, "all", StringComparison.OrdinalIgnoreCase) && !string.Equals(comp, target, StringComparison.OrdinalIgnoreCase)) continue;
+            await kube.Client.AppsV1.PatchNamespacedDeploymentAsync(body, d.Metadata.Name, kube.Namespace, cancellationToken: ct);
+            restarted.Add(d.Metadata.Name);
+        }
+        return restarted;
     }
 
     // Case-insensitive so the GUI can post {host,...} or {Host,...}; Items map onto EnergyFlowSource's fields.

--- a/rPDU2MQTT.Web/web/src/sections/diagnostics.ts
+++ b/rPDU2MQTT.Web/web/src/sections/diagnostics.ts
@@ -9,8 +9,31 @@ export function addDiagnosticsSection(nav: any, sections: any) {
 
   const bar = document.createElement('div'); bar.className = 'sec-actions';
   const refresh = btn('Refresh');
-  const restart = btn('Restart bridge', 'danger');
-  bar.appendChild(refresh); bar.appendChild(restart); sec.appendChild(bar);
+  bar.appendChild(refresh); sec.appendChild(bar);
+
+  // Restart panel: one button per restartable target. In Kubernetes these roll-restart the matching
+  // Deployment(s) (which also pulls the latest image); in a split non-k8s deployment they signal the tier
+  // over the bus; otherwise it's just this process. Populated from /api/restart/targets.
+  const restartBar = document.createElement('div'); restartBar.className = 'sec-actions'; sec.appendChild(restartBar);
+  const loadRestartTargets = async () => {
+    restartBar.innerHTML = '';
+    const r = await api('/api/restart/targets');
+    const method = r.body.method || 'local';
+    const targets = r.body.targets || [];
+    const verb = method === 'rollout' ? 'Rollout restart' : method === 'signal' ? 'Restart' : 'Restart';
+    const label = document.createElement('span'); label.className = 'desc'; label.style.cssText = 'margin:0 6px 0 0;align-self:center;';
+    label.textContent = method === 'rollout' ? 'Rollout restart (also updates the image):' : method === 'signal' ? 'Restart a tier:' : 'Restart:';
+    restartBar.appendChild(label);
+    targets.forEach((t: any) => {
+      const b = btn(`${verb} — ${t.label}`, t.id === 'all' ? 'danger' : '');
+      b.onclick = async () => {
+        if (!confirm(`${verb} ${t.label}? It will disconnect briefly while it restarts.`)) return;
+        const rr = await api('/api/restart?target=' + encodeURIComponent(t.id), { method: 'POST' });
+        toast(rr.body.message || 'Restarting…', rr.ok && rr.body.ok);
+      };
+      restartBar.appendChild(b);
+    });
+  };
 
   const comp = document.createElement('div'); comp.style.margin = '6px 0 14px'; sec.appendChild(comp);
   const info = document.createElement('table'); info.className = 'ld'; sec.appendChild(info);
@@ -65,12 +88,7 @@ export function addDiagnosticsSection(nav: any, sections: any) {
     if (b.kubernetes) buildK8sTools(k8sWrap);
   };
   refresh.onclick = load;
-  restart.onclick = async () => {
-    if (!confirm('Restart the bridge? It will disconnect briefly while the container restarts.')) return;
-    const r = await api('/api/restart', { method: 'POST' });
-    toast(r.body.message || 'Restarting…', r.ok && r.body.ok);
-  };
-  link.onclick = () => { activate(link, sec); load(); };
+  link.onclick = () => { activate(link, sec); load(); loadRestartTargets(); };
 }
 
 // Kubernetes-only: on-demand pod logs + recent events.

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -347,8 +347,31 @@ function addDiagnosticsSection(nav     , sections     ) {
 
   const bar = document.createElement('div'); bar.className = 'sec-actions';
   const refresh = btn('Refresh');
-  const restart = btn('Restart bridge', 'danger');
-  bar.appendChild(refresh); bar.appendChild(restart); sec.appendChild(bar);
+  bar.appendChild(refresh); sec.appendChild(bar);
+
+  // Restart panel: one button per restartable target. In Kubernetes these roll-restart the matching
+  // Deployment(s) (which also pulls the latest image); in a split non-k8s deployment they signal the tier
+  // over the bus; otherwise it's just this process. Populated from /api/restart/targets.
+  const restartBar = document.createElement('div'); restartBar.className = 'sec-actions'; sec.appendChild(restartBar);
+  const loadRestartTargets = async () => {
+    restartBar.innerHTML = '';
+    const r = await api('/api/restart/targets');
+    const method = r.body.method || 'local';
+    const targets = r.body.targets || [];
+    const verb = method === 'rollout' ? 'Rollout restart' : method === 'signal' ? 'Restart' : 'Restart';
+    const label = document.createElement('span'); label.className = 'desc'; label.style.cssText = 'margin:0 6px 0 0;align-self:center;';
+    label.textContent = method === 'rollout' ? 'Rollout restart (also updates the image):' : method === 'signal' ? 'Restart a tier:' : 'Restart:';
+    restartBar.appendChild(label);
+    targets.forEach((t     ) => {
+      const b = btn(`${verb} — ${t.label}`, t.id === 'all' ? 'danger' : '');
+      b.onclick = async () => {
+        if (!confirm(`${verb} ${t.label}? It will disconnect briefly while it restarts.`)) return;
+        const rr = await api('/api/restart?target=' + encodeURIComponent(t.id), { method: 'POST' });
+        toast(rr.body.message || 'Restarting…', rr.ok && rr.body.ok);
+      };
+      restartBar.appendChild(b);
+    });
+  };
 
   const comp = document.createElement('div'); comp.style.margin = '6px 0 14px'; sec.appendChild(comp);
   const info = document.createElement('table'); info.className = 'ld'; sec.appendChild(info);
@@ -403,12 +426,7 @@ function addDiagnosticsSection(nav     , sections     ) {
     if (b.kubernetes) buildK8sTools(k8sWrap);
   };
   refresh.onclick = load;
-  restart.onclick = async () => {
-    if (!confirm('Restart the bridge? It will disconnect briefly while the container restarts.')) return;
-    const r = await api('/api/restart', { method: 'POST' });
-    toast(r.body.message || 'Restarting…', r.ok && r.body.ok);
-  };
-  link.onclick = () => { activate(link, sec); load(); };
+  link.onclick = () => { activate(link, sec); load(); loadRestartTargets(); };
 }
 
 // Kubernetes-only: on-demand pod logs + recent events.

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -132,6 +132,10 @@ public static class ServiceConfiguration
         if (roles != HostRole.All)
             services.AddHostedService(sp => sp.GetRequiredService<Services.HeartbeatService>());
 
+        // Listens for GUI-issued restart requests over the bus (#210), so a tier can be restarted remotely.
+        // Loaded in every role/process; a matching request stops the process and the orchestrator restarts it.
+        services.AddHostedService<Services.RestartCommandService>();
+
         // ---- Worker role: the data-processing workload (publish, export, discovery, control). ----
         if (worker)
         {


### PR DESCRIPTION
The Diagnostics page had a single **Restart bridge** button that only stopped the local process — useless for restarting a specific tier of a split Kubernetes deployment, and it couldn't pull a new image. This replaces it with a restart panel that adapts to how the app is deployed.

## Behavior by deployment
- **Kubernetes** → **rollout restart** of the matching Deployment(s): an **Everything** button plus one per split tier (`worker` / `api` / `ui`). It stamps the pod template's `kubectl.kubernetes.io/restartedAt` annotation — exactly what `kubectl rollout restart` does — so pods cycle gracefully **and re-pull the image** (the "update to the latest release" path the issue asked for). Deployments are found via the running pod's own `app.kubernetes.io/instance` label, so it only ever touches this release.
- **Non-Kubernetes split** → a **bus restart request**: every process runs `RestartCommandService` and subscribes to `<parent>/_bus/command/restart`; one whose role matches the target (`all` or `worker`/`api`/`ui`) stops itself and the orchestrator restarts it.
- **Single node** → unchanged: restarts this process.

## API
- `POST /api/restart?target=…` — `local` (default, stop this process), `all`, or a role/component.
- `GET /api/restart/targets` — returns the method (`rollout` / `signal` / `local`) and the target buttons to render, so the GUI shows the right options for the environment.

## Chart
- RBAC gains `apps/deployments` `get,list,patch` (guarded by the existing `kubernetesConfigSource.enabled`).

## Testing
- `dotnet test` — 242 pass (3 new: `RestartCommand` target matching + topic).
- `dotnet build` 0 warnings; GUI rebuilt + smoke passes.
- The **k8s rollout** and **multi-process bus** paths need a real cluster / broker to exercise end-to-end — flagging those as manual verification. Target-matching and the (non-k8s) single-node path are covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)