### PR TITLE
feat(operator): Kubernetes operator role — registry update checks + optional self-update (#210)

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -27,6 +27,9 @@ spec:
     - name: LastPoll
       type: string
       jsonPath: .status.lastPoll
+    - name: Update
+      type: string
+      jsonPath: .status.update.latest
     schema:
       openAPIV3Schema:
         type: object
@@ -926,6 +929,36 @@ spec:
                           description: Poll this device. Turn off to disable it without deleting the connection.
                     description: Modbus TCP devices to poll. Add one per device, then reference it from a source binding's Connection.
                 description: Modbus TCP connections that energy-flow nodes can be bound to (inverters, meters, PLCs).
+              Operator:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  Enabled:
+                    type: boolean
+                    description: "Enable the Kubernetes operator: let this release manage its own Deployment (registry update checks, optional self-update). Requires the Kubernetes config source and the 'operator' role. No effect otherwise."
+                  CheckForUpdates:
+                    type: boolean
+                    description: Periodically check the container registry for a newer image and report it (in the CR status and the GUI Diagnostics page). Read-only — never changes the Deployment on its own.
+                  CheckIntervalHours:
+                    type: integer
+                    description: How often to check the registry for updates, in hours.
+                  Policy:
+                    type: string
+                    enum:
+                    - Patch
+                    - Minor
+                    - Major
+                    description: 'How far an update may move the deployed version: Patch (same major.minor), Minor (same major, no breaking changes), or Major (any newer release).'
+                  AutoUpdate:
+                    type: boolean
+                    description: Automatically roll the Deployment to the newest eligible release (bounded by Policy). Off by default — checking is safe, but applying an update restarts the workload.
+                  Registry:
+                    type: string
+                    description: Override the registry host to query (e.g. ghcr.io). Defaults to the registry of the currently-deployed image.
+                  Repository:
+                    type: string
+                    description: Override the repository to query (e.g. xtremeownage/rpdu2mqtt). Defaults to the repository of the currently-deployed image.
+                description: 'Kubernetes operator: let this release manage its own Deployment (registry update checks, optional self-update).'
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
@@ -938,3 +971,23 @@ spec:
                 type: string
               message:
                 type: string
+              update:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  available:
+                    type: boolean
+                  current:
+                    type: string
+                  latest:
+                    type: string
+                  policy:
+                    type: string
+                  autoUpdate:
+                    type: boolean
+                  applied:
+                    type: string
+                  checkedAt:
+                    type: string
+                  message:
+                    type: string

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -27,6 +27,9 @@ spec:
     - name: LastPoll
       type: string
       jsonPath: .status.lastPoll
+    - name: Update
+      type: string
+      jsonPath: .status.update.latest
     schema:
       openAPIV3Schema:
         type: object
@@ -926,6 +929,36 @@ spec:
                           description: Poll this device. Turn off to disable it without deleting the connection.
                     description: Modbus TCP devices to poll. Add one per device, then reference it from a source binding's Connection.
                 description: Modbus TCP connections that energy-flow nodes can be bound to (inverters, meters, PLCs).
+              Operator:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  Enabled:
+                    type: boolean
+                    description: "Enable the Kubernetes operator: let this release manage its own Deployment (registry update checks, optional self-update). Requires the Kubernetes config source and the 'operator' role. No effect otherwise."
+                  CheckForUpdates:
+                    type: boolean
+                    description: Periodically check the container registry for a newer image and report it (in the CR status and the GUI Diagnostics page). Read-only — never changes the Deployment on its own.
+                  CheckIntervalHours:
+                    type: integer
+                    description: How often to check the registry for updates, in hours.
+                  Policy:
+                    type: string
+                    enum:
+                    - Patch
+                    - Minor
+                    - Major
+                    description: 'How far an update may move the deployed version: Patch (same major.minor), Minor (same major, no breaking changes), or Major (any newer release).'
+                  AutoUpdate:
+                    type: boolean
+                    description: Automatically roll the Deployment to the newest eligible release (bounded by Policy). Off by default — checking is safe, but applying an update restarts the workload.
+                  Registry:
+                    type: string
+                    description: Override the registry host to query (e.g. ghcr.io). Defaults to the registry of the currently-deployed image.
+                  Repository:
+                    type: string
+                    description: Override the repository to query (e.g. xtremeownage/rpdu2mqtt). Defaults to the repository of the currently-deployed image.
+                description: 'Kubernetes operator: let this release manage its own Deployment (registry update checks, optional self-update).'
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true
@@ -938,3 +971,23 @@ spec:
                 type: string
               message:
                 type: string
+              update:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+                properties:
+                  available:
+                    type: boolean
+                  current:
+                    type: string
+                  latest:
+                    type: string
+                  policy:
+                    type: string
+                  autoUpdate:
+                    type: boolean
+                  applied:
+                    type: string
+                  checkedAt:
+                    type: string
+                  message:
+                    type: string

--- a/charts/rpdu2mqtt/templates/deployment.yaml
+++ b/charts/rpdu2mqtt/templates/deployment.yaml
@@ -10,6 +10,10 @@
       (dict "suffix" "-api"    "role" "api"    "component" "api"    "replicas" (.Values.split.api.replicaCount    | int) "strategy" "RollingUpdate")
       (dict "suffix" "-ui"     "role" "ui"     "component" "ui"     "replicas" (.Values.split.ui.replicaCount     | int) "strategy" "RollingUpdate") }}
 {{- end }}
+{{- /* The operator (#210) manages this release's own Deployment; run it as its own single-replica process. */}}
+{{- if .Values.operator.enabled }}
+{{- $roles = append $roles (dict "suffix" "-operator" "role" "operator" "component" "operator" "replicas" 1 "strategy" "Recreate") }}
+{{- end }}
 {{- range $r := $roles }}
 ---
 apiVersion: apps/v1

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -28,6 +28,13 @@ split:
     replicaCount: 1
     resources: {}
 
+# Kubernetes operator (#210): run a dedicated single-replica process that manages this release's own
+# Deployment — checks the registry for newer images and (if config.Operator.AutoUpdate) rolls to them.
+# Needs kubernetesConfigSource.enabled (it patches the CR status + Deployments). Also switch on the
+# behaviour with config.Operator.Enabled below.
+operator:
+  enabled: false
+
 # ---------------------------------------------------------------------------
 # Application configuration.
 # This whole block is rendered verbatim into config.yaml (mounted at /config).

--- a/docs/KubernetesCRD.md
+++ b/docs/KubernetesCRD.md
@@ -217,6 +217,56 @@ the pod's logs/events on demand (using the RBAC the chart grants):
 
 ![GUI Diagnostics in Kubernetes — RpduConfig source + pod logs](images/gui-diagnostics-kubernetes.webp)
 
+## Operator role: self-managed updates (#210)
+
+With the Kubernetes config source, the app can run as its own lightweight operator to manage the
+Deployment it lives in. It runs as a dedicated role (`--role operator` / `RPDU2MQTT_ROLE=operator`),
+so — like the worker/api/ui split — it's a separate process you opt into; it is **not** part of the
+default `all` role.
+
+What it does today:
+
+- **Update checks (read-only).** On a timer it reads the currently-deployed image (`RPDU2MQTT_IMAGE`),
+  lists the repository's tags from the container registry (anonymous pull, OCI/Docker Registry v2), and
+  works out the newest eligible release under a **policy**:
+  - `Patch` — newer patches on the same `MAJOR.MINOR` (e.g. `1.2.3 → 1.2.9`).
+  - `Minor` — newer minors within the same `MAJOR`, no breaking changes (default).
+  - `Major` — any newer release, including a new major.
+
+  Pre-releases and moving channel tags (`stable`, `edge`, …) are never chosen as an update target; a
+  deployment pinned to a moving channel simply reports "not a release version".
+- **Reporting.** The result is written to the CR `.status.update` (`available`, `current`, `latest`,
+  `policy`, `checkedAt`, …) so it shows in `kubectl get rpduconfig` (an **Update** printer column) and on
+  the GUI **Diagnostics** page. Status is merge-patched, so it composes with the worker's connectivity
+  status rather than clobbering it.
+- **Self-update (opt-in).** With `Operator.AutoUpdate: true`, when an eligible newer release exists the
+  operator rolls the managed Deployment(s) to that tag (a strategic-merge patch of the `rpdu2mqtt`
+  container image) — a normal rolling update. Off by default: checking is safe, applying restarts the
+  workload.
+
+Config (see `Operator` in [Configuration.md](Configuration.md)): `Enabled`, `CheckForUpdates`,
+`CheckIntervalHours`, `Policy`, `AutoUpdate`, and optional `Registry` / `Repository` overrides.
+
+Enabling it with the chart:
+
+```yaml
+operator:
+  enabled: true            # deploy the operator as its own single-replica process
+kubernetesConfigSource:
+  enabled: true            # the operator patches the CR status + Deployments
+config:
+  Operator:
+    Enabled: true          # activate the checks (toggleable live from the GUI)
+    Policy: Minor
+    AutoUpdate: false
+```
+
+RBAC is already covered by the CRD config source's Role: `get,list,patch` on `apps/deployments`,
+`get,list` on `pods`, and `patch` on `rpduconfigs/status`.
+
+Deferred (future work): reconciling infrastructure objects (Service/Ingress/HTTPRoute) from config
+toggles — that overlaps with Helm's ownership of those resources and needs its own design.
+
 ## Manifests to ship
 
 Under `Examples/Kubernetes/crd/`:

--- a/rPDU2MQTT.Core/Core/HostRole.cs
+++ b/rPDU2MQTT.Core/Core/HostRole.cs
@@ -17,5 +17,12 @@ public enum HostRole
     Api = 2,
     /// <summary>The configuration GUI.</summary>
     Ui = 4,
+    /// <summary>
+    /// Kubernetes operator (#210): reconciles this release's own deployment — checks the container
+    /// registry for newer images and can roll the Deployment to a chosen/newer tag. Opt-in, so it is
+    /// <b>not</b> part of <see cref="All"/>; run it as its own process (<c>--role operator</c>) or alongside
+    /// others. Only meaningful with the Kubernetes config source.
+    /// </summary>
+    Operator = 8,
     All = Worker | Api | Ui,
 }

--- a/rPDU2MQTT.Core/Models/Config/Config.cs
+++ b/rPDU2MQTT.Core/Models/Config/Config.cs
@@ -75,6 +75,9 @@ public class Config
     [YamlMember(Alias = "Modbus", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Modbus TCP connections that energy-flow nodes can be bound to (inverters, meters, PLCs).")]
     public ModbusConfig Modbus { get; set; } = new ModbusConfig();
 
+    [YamlMember(Alias = "Operator", DefaultValuesHandling = DefaultValuesHandling.OmitDefaults, Description = "Kubernetes operator: let this release manage its own Deployment (registry update checks, optional self-update).")]
+    public OperatorConfig Operator { get; set; } = new OperatorConfig();
+
     /// <summary>
     /// Replace this instance's settings with another's. Used to hot-reload the shared singleton on
     /// rediscovery (services read these sections live). Connection-level settings (MQTT/PDU host/port,
@@ -95,5 +98,6 @@ public class Config
         Api = other.Api;
         EnergyFlow = other.EnergyFlow;
         Modbus = other.Modbus;
+        Operator = other.Operator;
     }
 }

--- a/rPDU2MQTT.Core/Models/Config/OperatorConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/OperatorConfig.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using rPDU2MQTT.Updates;
+
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>
+/// Kubernetes operator settings (#210). When enabled (and running the <c>operator</c> role with the
+/// Kubernetes config source), the app manages its own Deployment: it periodically checks the container
+/// registry for newer images and, optionally, rolls the Deployment to a newer tag under a bounded policy.
+/// A no-op outside Kubernetes.
+/// </summary>
+public class OperatorConfig
+{
+    [DefaultValue(false)]
+    [Description("Enable the Kubernetes operator: let this release manage its own Deployment (registry update checks, optional self-update). Requires the Kubernetes config source and the 'operator' role. No effect otherwise.")]
+    public bool Enabled { get; set; } = false;
+
+    [DefaultValue(true)]
+    [Description("Periodically check the container registry for a newer image and report it (in the CR status and the GUI Diagnostics page). Read-only — never changes the Deployment on its own.")]
+    public bool CheckForUpdates { get; set; } = true;
+
+    [DefaultValue(6)]
+    [Description("How often to check the registry for updates, in hours.")]
+    public int CheckIntervalHours { get; set; } = 6;
+
+    [DefaultValue(UpdatePolicy.Minor)]
+    [Description("How far an update may move the deployed version: Patch (same major.minor), Minor (same major, no breaking changes), or Major (any newer release).")]
+    public UpdatePolicy Policy { get; set; } = UpdatePolicy.Minor;
+
+    [DefaultValue(false)]
+    [Description("Automatically roll the Deployment to the newest eligible release (bounded by Policy). Off by default — checking is safe, but applying an update restarts the workload.")]
+    public bool AutoUpdate { get; set; } = false;
+
+    [DefaultValue(null)]
+    [Description("Override the registry host to query (e.g. ghcr.io). Defaults to the registry of the currently-deployed image.")]
+    public string? Registry { get; set; } = null;
+
+    [DefaultValue(null)]
+    [Description("Override the repository to query (e.g. xtremeownage/rpdu2mqtt). Defaults to the repository of the currently-deployed image.")]
+    public string? Repository { get; set; } = null;
+}

--- a/rPDU2MQTT.Core/Updates/ImageReference.cs
+++ b/rPDU2MQTT.Core/Updates/ImageReference.cs
@@ -1,0 +1,73 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace rPDU2MQTT.Updates;
+
+/// <summary>
+/// A parsed OCI image reference (<c>[registry/]repository[:tag][@digest]</c>) — e.g.
+/// <c>ghcr.io/xtremeownage/rpdu2mqtt:1.2.3</c>. The operator (#210) uses it to learn which registry and
+/// repository to query for available tags, and which tag is currently deployed.
+/// </summary>
+public sealed record ImageReference(string Registry, string Repository, string? Tag, string? Digest)
+{
+    /// <summary>Registry used when a reference omits one (Docker Hub's implicit default).</summary>
+    public const string DefaultRegistry = "docker.io";
+
+    /// <summary>The registry's HTTPS API host. Docker Hub's registry lives at registry-1.docker.io.</summary>
+    public string RegistryHost => Registry == DefaultRegistry ? "registry-1.docker.io" : Registry;
+
+    public static bool TryParse([NotNullWhen(true)] string? image, [NotNullWhen(true)] out ImageReference? reference)
+    {
+        reference = null;
+        if (string.IsNullOrWhiteSpace(image)) return false;
+        var s = image.Trim();
+
+        string? digest = null;
+        var at = s.IndexOf('@');
+        if (at >= 0)
+        {
+            digest = s[(at + 1)..];
+            s = s[..at];
+            if (digest.Length == 0 || s.Length == 0) return false;
+        }
+
+        // A registry is the first path segment only if it looks like a host (has a '.' or ':' or is
+        // "localhost") — otherwise the whole thing is a Docker-Hub-style repository (e.g. "library/nginx").
+        string registry = DefaultRegistry;
+        var firstSlash = s.IndexOf('/');
+        if (firstSlash > 0)
+        {
+            var candidate = s[..firstSlash];
+            if (candidate.Contains('.') || candidate.Contains(':') || candidate == "localhost")
+            {
+                registry = candidate;
+                s = s[(firstSlash + 1)..];
+            }
+        }
+
+        // A ':' after the last '/' is a tag; a ':' inside the registry host (port) was already split off.
+        string? tag = null;
+        var lastSlash = s.LastIndexOf('/');
+        var colon = s.LastIndexOf(':');
+        if (colon > lastSlash)
+        {
+            tag = s[(colon + 1)..];
+            s = s[..colon];
+            if (tag.Length == 0) return false;
+        }
+
+        if (s.Length == 0) return false;
+        reference = new ImageReference(registry, s, tag, digest);
+        return true;
+    }
+
+    public override string ToString()
+    {
+        var baseRef = $"{Registry}/{Repository}";
+        if (Tag is not null) baseRef += $":{Tag}";
+        if (Digest is not null) baseRef += $"@{Digest}";
+        return baseRef;
+    }
+
+    /// <summary>This reference with a different tag and no digest (used to roll the deployment to a new tag).</summary>
+    public string WithTag(string tag) => $"{Registry}/{Repository}:{tag}";
+}

--- a/rPDU2MQTT.Core/Updates/SemVer.cs
+++ b/rPDU2MQTT.Core/Updates/SemVer.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace rPDU2MQTT.Updates;
+
+/// <summary>
+/// A minimal semantic version (<c>MAJOR.MINOR.PATCH</c> with an optional pre-release suffix) — just enough
+/// to compare release image tags for the operator's update check (#210). A leading <c>v</c> is tolerated.
+/// Build metadata (<c>+…</c>) is ignored for comparison, matching SemVer. Anything that isn't a clean
+/// numeric version (e.g. moving channel tags like <c>stable</c>/<c>edge</c>) fails to parse.
+/// </summary>
+public sealed record SemVer(int Major, int Minor, int Patch, string? PreRelease = null) : IComparable<SemVer>
+{
+    /// <summary>True when this is a pre-release (e.g. <c>1.2.3-beta.1</c>), which the update check skips.</summary>
+    public bool IsPreRelease => !string.IsNullOrEmpty(PreRelease);
+
+    public static bool TryParse([NotNullWhen(true)] string? tag, [NotNullWhen(true)] out SemVer? version)
+    {
+        version = null;
+        if (string.IsNullOrWhiteSpace(tag)) return false;
+
+        var s = tag.Trim();
+        if (s.StartsWith('v') || s.StartsWith('V')) s = s[1..];
+
+        // Drop build metadata; keep the pre-release for ordering.
+        var plus = s.IndexOf('+');
+        if (plus >= 0) s = s[..plus];
+
+        string? pre = null;
+        var dash = s.IndexOf('-');
+        if (dash >= 0)
+        {
+            pre = s[(dash + 1)..];
+            s = s[..dash];
+            if (pre.Length == 0) return false;
+        }
+
+        var parts = s.Split('.');
+        if (parts.Length is < 1 or > 3) return false;
+
+        var nums = new int[3];
+        for (int i = 0; i < 3; i++)
+        {
+            if (i >= parts.Length) { nums[i] = 0; continue; }
+            if (!int.TryParse(parts[i], out var n) || n < 0) return false;
+            nums[i] = n;
+        }
+
+        version = new SemVer(nums[0], nums[1], nums[2], pre);
+        return true;
+    }
+
+    public int CompareTo(SemVer? other)
+    {
+        if (other is null) return 1;
+        var c = Major.CompareTo(other.Major);
+        if (c != 0) return c;
+        c = Minor.CompareTo(other.Minor);
+        if (c != 0) return c;
+        c = Patch.CompareTo(other.Patch);
+        if (c != 0) return c;
+
+        // A release outranks a pre-release of the same core version (1.2.3 > 1.2.3-rc.1).
+        if (IsPreRelease && !other.IsPreRelease) return -1;
+        if (!IsPreRelease && other.IsPreRelease) return 1;
+        return string.CompareOrdinal(PreRelease ?? "", other.PreRelease ?? "");
+    }
+
+    public override string ToString() =>
+        IsPreRelease ? $"{Major}.{Minor}.{Patch}-{PreRelease}" : $"{Major}.{Minor}.{Patch}";
+}

--- a/rPDU2MQTT.Core/Updates/UpdatePolicy.cs
+++ b/rPDU2MQTT.Core/Updates/UpdatePolicy.cs
@@ -1,0 +1,16 @@
+namespace rPDU2MQTT.Updates;
+
+/// <summary>
+/// How far the operator (#210) is allowed to move the deployed image when checking for updates. Bounds
+/// the newest candidate relative to the currently-deployed version so an update never silently crosses a
+/// boundary the operator wasn't told it could.
+/// </summary>
+public enum UpdatePolicy
+{
+    /// <summary>Only newer patches on the same <c>MAJOR.MINOR</c> line (e.g. 1.2.3 → 1.2.9).</summary>
+    Patch,
+    /// <summary>Newer patches or minors within the same <c>MAJOR</c> line (e.g. 1.2.3 → 1.5.0). No breaking changes.</summary>
+    Minor,
+    /// <summary>Any newer release, including a new major (e.g. 1.2.3 → 2.0.0). May include breaking changes.</summary>
+    Major,
+}

--- a/rPDU2MQTT.Core/Updates/UpdateResolver.cs
+++ b/rPDU2MQTT.Core/Updates/UpdateResolver.cs
@@ -1,0 +1,49 @@
+namespace rPDU2MQTT.Updates;
+
+/// <summary>The outcome of an update check — deployable-tag decisions, no I/O.</summary>
+/// <param name="Applicable">
+/// False when the deployed tag isn't a clean release version (e.g. a moving channel like <c>stable</c>/
+/// <c>edge</c>, or a digest pin) — there's nothing to compare by version, so the resolver stays silent.
+/// </param>
+/// <param name="Current">The currently-deployed release, when parseable.</param>
+/// <param name="Latest">The newest eligible release found under the policy (may equal <see cref="Current"/>).</param>
+public readonly record struct UpdateCheck(bool Applicable, SemVer? Current, SemVer? Latest)
+{
+    /// <summary>True when a strictly-newer eligible release than the deployed one exists.</summary>
+    public bool UpdateAvailable => Applicable && Current is not null && Latest is not null && Latest.CompareTo(Current) > 0;
+
+    public static UpdateCheck NotApplicable => new(false, null, null);
+}
+
+/// <summary>
+/// Pure update-resolution logic for the operator (#210): given the currently-deployed image tag and the
+/// list of tags the registry offers, decide the newest release the operator may move to under a
+/// <see cref="UpdatePolicy"/>. Pre-releases and non-version (channel) tags are ignored as candidates.
+/// </summary>
+public static class UpdateResolver
+{
+    public static UpdateCheck Resolve(string? currentTag, IEnumerable<string> availableTags, UpdatePolicy policy)
+    {
+        if (!SemVer.TryParse(currentTag, out var current))
+            return UpdateCheck.NotApplicable;
+
+        SemVer? best = current;
+        foreach (var tag in availableTags)
+        {
+            if (!SemVer.TryParse(tag, out var candidate)) continue;
+            if (candidate.IsPreRelease) continue;              // never auto-move onto a pre-release
+            if (!WithinPolicy(current, candidate, policy)) continue;
+            if (candidate.CompareTo(best!) > 0) best = candidate;
+        }
+
+        return new UpdateCheck(true, current, best);
+    }
+
+    private static bool WithinPolicy(SemVer current, SemVer candidate, UpdatePolicy policy) => policy switch
+    {
+        UpdatePolicy.Patch => candidate.Major == current.Major && candidate.Minor == current.Minor,
+        UpdatePolicy.Minor => candidate.Major == current.Major,
+        UpdatePolicy.Major => true,
+        _ => false,
+    };
+}

--- a/rPDU2MQTT.Engine/ConfigSources/CrdGenerator.cs
+++ b/rPDU2MQTT.Engine/ConfigSources/CrdGenerator.cs
@@ -29,6 +29,23 @@ public static class CrdGenerator
                 ["deviceCount"] = new Dictionary<string, object?> { ["type"] = "integer" },
                 ["lastPoll"] = new Dictionary<string, object?> { ["type"] = "string" },
                 ["message"] = new Dictionary<string, object?> { ["type"] = "string" },
+                // Operator update check (#210): reported by the operator role, merged alongside the fields above.
+                ["update"] = new Dictionary<string, object?>
+                {
+                    ["type"] = "object",
+                    ["x-kubernetes-preserve-unknown-fields"] = true,
+                    ["properties"] = new Dictionary<string, object?>
+                    {
+                        ["available"] = new Dictionary<string, object?> { ["type"] = "boolean" },
+                        ["current"] = new Dictionary<string, object?> { ["type"] = "string" },
+                        ["latest"] = new Dictionary<string, object?> { ["type"] = "string" },
+                        ["policy"] = new Dictionary<string, object?> { ["type"] = "string" },
+                        ["autoUpdate"] = new Dictionary<string, object?> { ["type"] = "boolean" },
+                        ["applied"] = new Dictionary<string, object?> { ["type"] = "string" },
+                        ["checkedAt"] = new Dictionary<string, object?> { ["type"] = "string" },
+                        ["message"] = new Dictionary<string, object?> { ["type"] = "string" },
+                    },
+                },
             },
         };
 
@@ -64,6 +81,7 @@ public static class CrdGenerator
                             PrinterColumn("Connected", "string", ".status.connected"),
                             PrinterColumn("Devices", "integer", ".status.deviceCount"),
                             PrinterColumn("LastPoll", "string", ".status.lastPoll"),
+                            PrinterColumn("Update", "string", ".status.update.latest"),
                         },
                         ["schema"] = new Dictionary<string, object?>
                         {

--- a/rPDU2MQTT.Engine/ConfigSources/KubernetesConfigSource.cs
+++ b/rPDU2MQTT.Engine/ConfigSources/KubernetesConfigSource.cs
@@ -152,13 +152,26 @@ public sealed class KubernetesConfigSource : IConfigSource
         }
     }
 
-    /// <summary>Patch the CR's status subresource.</summary>
+    /// <summary>
+    /// Merge-patch the CR's status subresource. Only the keys present in <paramref name="status"/> are
+    /// touched, so independent writers compose rather than clobber each other — the worker reports
+    /// connectivity while the operator reports update availability (#210), both under <c>.status</c>.
+    /// </summary>
     public async Task PatchStatusAsync(object status, CancellationToken cancellationToken)
     {
         var statusJson = JsonSerializer.Serialize(status, ConfigSchema.Json);
-        var patch = new V1Patch($"[{{\"op\":\"add\",\"path\":\"/status\",\"value\":{statusJson}}}]", V1Patch.PatchType.JsonPatch);
+        var patch = new V1Patch($"{{\"status\":{statusJson}}}", V1Patch.PatchType.MergePatch);
         await Client.CustomObjects.PatchNamespacedCustomObjectStatusAsync(
             patch, RpduCrd.Group, RpduCrd.Version, Namespace, RpduCrd.Plural, Name, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>Read the CR's <c>status</c> subresource (e.g. the operator's update report), or null if unset.</summary>
+    public async Task<JsonElement?> ReadStatusAsync(CancellationToken cancellationToken)
+    {
+        var obj = await Client.CustomObjects.GetNamespacedCustomObjectAsync(
+            RpduCrd.Group, RpduCrd.Version, Namespace, RpduCrd.Plural, Name, cancellationToken: cancellationToken);
+        var root = obj is JsonElement je ? je : JsonSerializer.SerializeToElement(obj);
+        return root.TryGetProperty("status", out var status) && status.ValueKind == JsonValueKind.Object ? status : null;
     }
 
     /// <summary>Serialize the current CR's spec to a stable string for change detection.</summary>

--- a/rPDU2MQTT.Engine/Services/Kubernetes/KubernetesConfigWatcher.cs
+++ b/rPDU2MQTT.Engine/Services/Kubernetes/KubernetesConfigWatcher.cs
@@ -83,6 +83,7 @@ public sealed class KubernetesConfigWatcher : IHostedService, IDisposable
         config.Debug = reloaded.Debug;
         config.Pdus = reloaded.Pdus;
         config.MQTT = reloaded.MQTT;
+        config.Operator = reloaded.Operator;
 
         // Re-point the broker connection in place rather than exiting to be restarted (#192).
         await mqtt.ApplyAsync(stoppingCts.Token);

--- a/rPDU2MQTT.Engine/Services/Operator/ContainerRegistryClient.cs
+++ b/rPDU2MQTT.Engine/Services/Operator/ContainerRegistryClient.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+
+namespace rPDU2MQTT.Services.Operator;
+
+/// <summary>
+/// Minimal OCI/Docker Registry v2 client for the operator's update check (#210). Lists tags for a public
+/// repository, performing the anonymous token dance a registry asks for on the first 401 and following
+/// tag-list pagination. Read-only — it never pulls image layers, only the tag catalogue.
+/// </summary>
+public sealed class ContainerRegistryClient : IContainerRegistry
+{
+    // One shared client: registry hosts are few and long-lived, so pooling connections is correct here.
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(20) };
+
+    public async Task<IReadOnlyList<string>> ListTagsAsync(string registryHost, string repository, CancellationToken ct)
+    {
+        var tags = new List<string>();
+        string? token = null;
+        // The catalogue can paginate; the registry returns a Link header with rel="next".
+        var next = $"https://{registryHost}/v2/{repository}/tags/list?n=200";
+
+        while (next is not null)
+        {
+            using var response = await SendAsync(next, token, ct);
+
+            // First request is unauthenticated; a public registry answers 401 with the token realm to use.
+            if (response.StatusCode == HttpStatusCode.Unauthorized && token is null)
+            {
+                token = await AcquireTokenAsync(response, repository, ct);
+                if (token is null) response.EnsureSuccessStatusCode(); // no realm offered -> surface the 401
+                using var retried = await SendAsync(next, token, ct);
+                retried.EnsureSuccessStatusCode();
+                next = await ReadPageAsync(retried, tags, ct);
+                continue;
+            }
+
+            response.EnsureSuccessStatusCode();
+            next = await ReadPageAsync(response, tags, ct);
+        }
+
+        return tags;
+    }
+
+    private static Task<HttpResponseMessage> SendAsync(string url, string? token, CancellationToken ct)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Accept.ParseAdd("application/json");
+        if (token is not null)
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return Http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+    }
+
+    private static async Task<string?> ReadPageAsync(HttpResponseMessage response, List<string> tags, CancellationToken ct)
+    {
+        var page = await response.Content.ReadFromJsonAsync<TagList>(ct);
+        if (page?.Tags is { } t) tags.AddRange(t);
+
+        // Follow pagination: Link: <.../tags/list?...&last=...>; rel="next"
+        if (response.Headers.TryGetValues("Link", out var links))
+        {
+            foreach (var link in links)
+            {
+                if (!link.Contains("rel=\"next\"", StringComparison.OrdinalIgnoreCase)) continue;
+                var start = link.IndexOf('<');
+                var end = link.IndexOf('>');
+                if (start >= 0 && end > start)
+                {
+                    var rel = link[(start + 1)..end];
+                    var host = response.RequestMessage?.RequestUri is { } u ? $"{u.Scheme}://{u.Authority}" : "";
+                    return rel.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? rel : host + rel;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// <summary>Parse the <c>WWW-Authenticate: Bearer realm=…,service=…</c> challenge and fetch a pull token.</summary>
+    private static async Task<string?> AcquireTokenAsync(HttpResponseMessage challenge, string repository, CancellationToken ct)
+    {
+        var bearer = challenge.Headers.WwwAuthenticate.FirstOrDefault(h => h.Scheme.Equals("Bearer", StringComparison.OrdinalIgnoreCase));
+        if (bearer?.Parameter is null) return null;
+
+        var parms = ParseChallenge(bearer.Parameter);
+        if (!parms.TryGetValue("realm", out var realm)) return null;
+
+        var query = new List<string>();
+        if (parms.TryGetValue("service", out var service)) query.Add($"service={Uri.EscapeDataString(service)}");
+        query.Add($"scope={Uri.EscapeDataString(parms.GetValueOrDefault("scope", $"repository:{repository}:pull"))}");
+        var tokenUrl = $"{realm}?{string.Join('&', query)}";
+
+        using var response = await Http.GetAsync(tokenUrl, ct);
+        response.EnsureSuccessStatusCode();
+        var tok = await response.Content.ReadFromJsonAsync<TokenResponse>(ct);
+        return tok?.Token ?? tok?.AccessToken;
+    }
+
+    private static Dictionary<string, string> ParseChallenge(string parameter)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var part in parameter.Split(','))
+        {
+            var eq = part.IndexOf('=');
+            if (eq <= 0) continue;
+            var key = part[..eq].Trim();
+            var value = part[(eq + 1)..].Trim().Trim('"');
+            result[key] = value;
+        }
+        return result;
+    }
+
+    private sealed class TagList
+    {
+        [JsonPropertyName("tags")] public List<string>? Tags { get; set; }
+    }
+
+    private sealed class TokenResponse
+    {
+        [JsonPropertyName("token")] public string? Token { get; set; }
+        [JsonPropertyName("access_token")] public string? AccessToken { get; set; }
+    }
+}

--- a/rPDU2MQTT.Engine/Services/Operator/IContainerRegistry.cs
+++ b/rPDU2MQTT.Engine/Services/Operator/IContainerRegistry.cs
@@ -1,0 +1,15 @@
+namespace rPDU2MQTT.Services.Operator;
+
+/// <summary>
+/// Reads the tags a container image repository offers, so the operator (#210) can decide whether a newer
+/// release than the deployed one exists.
+/// </summary>
+public interface IContainerRegistry
+{
+    /// <summary>
+    /// List every tag published for <paramref name="repository"/> on <paramref name="registryHost"/>
+    /// (the OCI/Docker Registry v2 <c>/v2/&lt;repo&gt;/tags/list</c> endpoint, with anonymous token auth
+    /// for public images and pagination followed).
+    /// </summary>
+    Task<IReadOnlyList<string>> ListTagsAsync(string registryHost, string repository, CancellationToken ct);
+}

--- a/rPDU2MQTT.Engine/Services/Operator/OperatorService.cs
+++ b/rPDU2MQTT.Engine/Services/Operator/OperatorService.cs
@@ -1,0 +1,200 @@
+using k8s;
+using k8s.Autorest;
+using k8s.Models;
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Startup.ConfigSources;
+using rPDU2MQTT.Updates;
+
+namespace rPDU2MQTT.Services.Operator;
+
+/// <summary>
+/// The Kubernetes operator (#210): periodically asks the container registry whether a newer release than
+/// the one deployed exists, reports it on the CR <c>status</c> (visible via <c>kubectl get rpduconfig</c>
+/// and the GUI Diagnostics page), and — only when <see cref="OperatorConfig.AutoUpdate"/> is on — rolls
+/// this release's Deployment(s) to the newest eligible tag. Runs in the <c>operator</c> role with the
+/// Kubernetes config source; a no-op otherwise.
+/// </summary>
+public sealed class OperatorService : IHostedService, IDisposable
+{
+    private readonly KubernetesConfigSource source;
+    private readonly Config cfg;
+    private readonly IContainerRegistry registry;
+    private readonly CancellationTokenSource stoppingCts = new();
+    private Task loop = Task.CompletedTask;
+
+    // Container images this app publishes; used to pick the right container(s) to read/patch in a pod spec.
+    private const string ContainerName = "rpdu2mqtt";
+
+    public OperatorService(KubernetesConfigSource source, Config cfg, IContainerRegistry registry)
+    {
+        this.source = source;
+        this.cfg = cfg;
+        this.registry = registry;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        loop = RunAsync(stoppingCts.Token);
+        return Task.CompletedTask;
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        // Small initial delay so the pod is settled and the API is reachable before the first check.
+        try { await Task.Delay(TimeSpan.FromSeconds(20), ct); } catch (OperationCanceledException) { return; }
+
+        while (!ct.IsCancellationRequested)
+        {
+            if (cfg.Operator.Enabled && cfg.Operator.CheckForUpdates)
+            {
+                try { await CheckOnceAsync(ct); }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex) { Log.Warning($"Operator: update check failed: {ex.Message}"); }
+            }
+
+            var hours = Math.Max(1, cfg.Operator.CheckIntervalHours);
+            try { await Task.Delay(TimeSpan.FromHours(hours), ct); }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    private async Task CheckOnceAsync(CancellationToken ct)
+    {
+        var deployedImage = Environment.GetEnvironmentVariable("RPDU2MQTT_IMAGE");
+        if (!ImageReference.TryParse(deployedImage, out var image))
+        {
+            Log.Debug($"Operator: can't determine the deployed image (RPDU2MQTT_IMAGE='{deployedImage}'); skipping update check.");
+            return;
+        }
+
+        var registryHost = ResolveRegistryHost(image);
+        var repository = cfg.Operator.Repository ?? image.Repository;
+
+        var tags = await registry.ListTagsAsync(registryHost, repository, ct);
+        var check = UpdateResolver.Resolve(image.Tag, tags, cfg.Operator.Policy);
+
+        if (!check.Applicable)
+        {
+            Log.Debug($"Operator: deployed tag '{image.Tag}' isn't a release version (moving channel or digest); no version comparison.");
+            await PatchUpdateStatusAsync(new
+            {
+                available = false,
+                current = image.Tag,
+                latest = (string?)null,
+                policy = cfg.Operator.Policy.ToString(),
+                checkedAt = DateTime.UtcNow.ToString("o"),
+                message = "Deployed tag is not a release version; tracking a moving channel.",
+            }, ct);
+            return;
+        }
+
+        var current = check.Current!.ToString();
+        var latest = check.Latest!.ToString();
+
+        if (check.UpdateAvailable)
+            Log.Information($"Operator: update available — deployed {current}, newest eligible {latest} (policy {cfg.Operator.Policy}).");
+        else
+            Log.Debug($"Operator: up to date — deployed {current} is the newest eligible ({cfg.Operator.Policy}).");
+
+        string? applied = null;
+        if (check.UpdateAvailable && cfg.Operator.AutoUpdate)
+        {
+            var newImage = image.WithTag(latest);
+            var patched = await SetImageAsync(repository, newImage, ct);
+            if (patched.Count > 0)
+            {
+                applied = latest;
+                Log.Warning($"Operator: auto-update applied — rolled {string.Join(", ", patched)} to {newImage}.");
+            }
+        }
+
+        await PatchUpdateStatusAsync(new
+        {
+            available = check.UpdateAvailable,
+            current,
+            latest,
+            policy = cfg.Operator.Policy.ToString(),
+            autoUpdate = cfg.Operator.AutoUpdate,
+            applied,
+            checkedAt = DateTime.UtcNow.ToString("o"),
+            message = check.UpdateAvailable
+                ? (applied is not null ? $"Auto-updated to {applied}." : $"Update available: {latest}.")
+                : "Up to date.",
+        }, ct);
+    }
+
+    private string ResolveRegistryHost(ImageReference image)
+    {
+        var registryName = cfg.Operator.Registry ?? image.Registry;
+        return registryName == ImageReference.DefaultRegistry ? "registry-1.docker.io" : registryName;
+    }
+
+    private Task PatchUpdateStatusAsync(object update, CancellationToken ct) =>
+        source.PatchStatusAsync(new { update }, ct);
+
+    // --- Deployment access (this release's own Deployments, scoped by label) ---------------------
+
+    /// <summary>Patch every managed Deployment's rpdu2mqtt container image to <paramref name="newImage"/>.</summary>
+    private async Task<List<string>> SetImageAsync(string repository, string newImage, CancellationToken ct)
+    {
+        var patched = new List<string>();
+        foreach (var d in await AppDeploymentsAsync(ct))
+        {
+            if (d.Metadata?.Name is not { } name) continue;
+            var containers = d.Spec?.Template?.Spec?.Containers;
+            if (containers is null) continue;
+
+            // Patch the container(s) whose current image is this repository, so a sidecar is left alone.
+            var targets = containers
+                .Where(c => ImageReference.TryParse(c.Image, out var r) && r.Repository == repository)
+                .Select(c => c.Name)
+                .DefaultIfEmpty(ContainerName)
+                .ToArray();
+
+            var body = new V1Patch(
+                System.Text.Json.JsonSerializer.Serialize(new
+                {
+                    spec = new { template = new { spec = new { containers = targets.Select(n => new { name = n, image = newImage }) } } }
+                }),
+                V1Patch.PatchType.StrategicMergePatch);
+            await source.Client.AppsV1.PatchNamespacedDeploymentAsync(body, name, source.Namespace, cancellationToken: ct);
+            patched.Add(name);
+        }
+        return patched;
+    }
+
+    private async Task<IList<V1Deployment>> AppDeploymentsAsync(CancellationToken ct)
+    {
+        var list = await source.Client.AppsV1.ListNamespacedDeploymentAsync(source.Namespace, labelSelector: await AppSelectorAsync(ct), cancellationToken: ct);
+        return list.Items;
+    }
+
+    /// <summary>Label selector scoping to this release — read off this pod, else a sensible default.</summary>
+    private async Task<string> AppSelectorAsync(CancellationToken ct)
+    {
+        var podName = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME");
+        if (!string.IsNullOrEmpty(podName))
+        {
+            try
+            {
+                var labels = (await source.Client.CoreV1.ReadNamespacedPodAsync(podName, source.Namespace, cancellationToken: ct)).Metadata?.Labels;
+                if (labels is not null)
+                {
+                    if (labels.TryGetValue("app.kubernetes.io/instance", out var inst) && !string.IsNullOrEmpty(inst)) return $"app.kubernetes.io/instance={inst}";
+                    if (labels.TryGetValue("app.kubernetes.io/name", out var nm) && !string.IsNullOrEmpty(nm)) return $"app.kubernetes.io/name={nm}";
+                }
+            }
+            catch (HttpOperationException) { /* fall through to the default */ }
+        }
+        return "app.kubernetes.io/name=rpdu2mqtt";
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await stoppingCts.CancelAsync();
+        await Task.WhenAny(loop, Task.Delay(Timeout.Infinite, cancellationToken));
+    }
+
+    public void Dispose() => stoppingCts.Dispose();
+}

--- a/rPDU2MQTT.Tests/HostRoleTests.cs
+++ b/rPDU2MQTT.Tests/HostRoleTests.cs
@@ -24,8 +24,16 @@ public class HostRoleTests
     [InlineData("ui", HostRole.Ui)]
     [InlineData("gui", HostRole.Ui)]
     [InlineData("web", HostRole.Ui)]
+    [InlineData("operator", HostRole.Operator)]
+    [InlineData("op", HostRole.Operator)]
     [InlineData("all", HostRole.All)]
     public void ParsesSingleRole(string raw, HostRole expected) => Assert.Equal(expected, HostRoles.Resolve(Cfg(("role", raw))));
+
+    [Fact]
+    public void OperatorIsOptIn_NotPartOfAll() => Assert.False(HostRole.All.HasFlag(HostRole.Operator));
+
+    [Fact]
+    public void ParsesOperatorAlongsideAnotherRole() => Assert.Equal(HostRole.Ui | HostRole.Operator, HostRoles.Resolve(Cfg(("role", "ui,operator"))));
 
     [Fact]
     public void ParsesCommaSeparatedList() => Assert.Equal(HostRole.Api | HostRole.Ui, HostRoles.Resolve(Cfg(("role", "api, ui"))));

--- a/rPDU2MQTT.Tests/UpdateResolverTests.cs
+++ b/rPDU2MQTT.Tests/UpdateResolverTests.cs
@@ -1,0 +1,136 @@
+using rPDU2MQTT.Updates;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>The operator's version math (#210): SemVer parsing/ordering, image-ref parsing, and the
+/// pure update resolver that decides the newest eligible release under a policy.</summary>
+public class UpdateResolverTests
+{
+    // ---- SemVer ----
+
+    [Theory]
+    [InlineData("1.2.3", 1, 2, 3)]
+    [InlineData("v1.2.3", 1, 2, 3)]
+    [InlineData("1.2", 1, 2, 0)]
+    [InlineData("1", 1, 0, 0)]
+    [InlineData("1.2.3+abc1234", 1, 2, 3)]
+    public void SemVer_ParsesReleaseVersions(string tag, int major, int minor, int patch)
+    {
+        Assert.True(SemVer.TryParse(tag, out var v));
+        Assert.Equal((major, minor, patch), (v.Major, v.Minor, v.Patch));
+        Assert.False(v.IsPreRelease);
+    }
+
+    [Theory]
+    [InlineData("stable")]
+    [InlineData("edge")]
+    [InlineData("latest")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("1.2.3.4")]
+    [InlineData("1.x")]
+    public void SemVer_RejectsNonVersions(string? tag) => Assert.False(SemVer.TryParse(tag, out _));
+
+    [Fact]
+    public void SemVer_MarksPreRelease()
+    {
+        Assert.True(SemVer.TryParse("1.2.3-rc.1", out var v));
+        Assert.True(v.IsPreRelease);
+    }
+
+    [Fact]
+    public void SemVer_OrdersCorrectly()
+    {
+        SemVer.TryParse("1.2.3", out var a);
+        SemVer.TryParse("1.10.0", out var b);
+        SemVer.TryParse("2.0.0", out var c);
+        SemVer.TryParse("1.2.3-rc.1", out var pre);
+
+        Assert.True(a!.CompareTo(b!) < 0);            // 1.2.3 < 1.10.0 (numeric, not lexical)
+        Assert.True(b!.CompareTo(c!) < 0);            // 1.10.0 < 2.0.0
+        Assert.True(pre!.CompareTo(a!) < 0);          // 1.2.3-rc.1 < 1.2.3 (pre-release outranked by release)
+    }
+
+    // ---- ImageReference ----
+
+    [Fact]
+    public void ImageReference_ParsesRegistryRepoTag()
+    {
+        Assert.True(ImageReference.TryParse("ghcr.io/xtremeownage/rpdu2mqtt:1.2.3", out var r));
+        Assert.Equal("ghcr.io", r.Registry);
+        Assert.Equal("xtremeownage/rpdu2mqtt", r.Repository);
+        Assert.Equal("1.2.3", r.Tag);
+        Assert.Equal("ghcr.io/xtremeownage/rpdu2mqtt:1.5.0", r.WithTag("1.5.0"));
+    }
+
+    [Fact]
+    public void ImageReference_DefaultsRegistryForBareRepo()
+    {
+        Assert.True(ImageReference.TryParse("library/nginx:1.25", out var r));
+        Assert.Equal(ImageReference.DefaultRegistry, r.Registry);
+        Assert.Equal("library/nginx", r.Repository);
+        Assert.Equal("registry-1.docker.io", r.RegistryHost);
+    }
+
+    [Fact]
+    public void ImageReference_ParsesDigest()
+    {
+        Assert.True(ImageReference.TryParse("ghcr.io/x/y@sha256:abc", out var r));
+        Assert.Equal("sha256:abc", r.Digest);
+        Assert.Null(r.Tag);
+    }
+
+    // ---- UpdateResolver ----
+
+    private static readonly string[] Catalogue =
+        { "1.0.0", "1.1.0", "1.2.0", "1.2.3", "2.0.0", "2.1.0", "stable", "edge", "2.2.0-rc.1" };
+
+    [Fact]
+    public void Resolve_Minor_StaysOnSameMajor()
+    {
+        var check = UpdateResolver.Resolve("1.1.0", Catalogue, UpdatePolicy.Minor);
+        Assert.True(check.UpdateAvailable);
+        Assert.Equal("1.2.3", check.Latest!.ToString());     // newest 1.x, not 2.x
+    }
+
+    [Fact]
+    public void Resolve_Patch_StaysOnSameMinor()
+    {
+        var check = UpdateResolver.Resolve("1.2.0", Catalogue, UpdatePolicy.Patch);
+        Assert.True(check.UpdateAvailable);
+        Assert.Equal("1.2.3", check.Latest!.ToString());     // 1.2.x only
+    }
+
+    [Fact]
+    public void Resolve_Major_TakesNewestRelease()
+    {
+        var check = UpdateResolver.Resolve("1.2.3", Catalogue, UpdatePolicy.Major);
+        Assert.True(check.UpdateAvailable);
+        Assert.Equal("2.1.0", check.Latest!.ToString());     // skips the 2.2.0-rc.1 pre-release
+    }
+
+    [Fact]
+    public void Resolve_ReportsUpToDate_WhenAlreadyNewest()
+    {
+        var check = UpdateResolver.Resolve("2.1.0", Catalogue, UpdatePolicy.Major);
+        Assert.True(check.Applicable);
+        Assert.False(check.UpdateAvailable);
+        Assert.Equal("2.1.0", check.Latest!.ToString());
+    }
+
+    [Fact]
+    public void Resolve_NotApplicable_ForMovingChannelTag()
+    {
+        var check = UpdateResolver.Resolve("stable", Catalogue, UpdatePolicy.Minor);
+        Assert.False(check.Applicable);
+        Assert.False(check.UpdateAvailable);
+    }
+
+    [Fact]
+    public void Resolve_NeverSelectsPreRelease()
+    {
+        var check = UpdateResolver.Resolve("2.1.0", new[] { "2.2.0-rc.1", "2.1.5" }, UpdatePolicy.Minor);
+        Assert.Equal("2.1.5", check.Latest!.ToString());
+    }
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -416,14 +416,29 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         });
 
         // Diagnostics: versions, uptime, runtime, and Kubernetes context for the Diagnostics page.
-        app.MapGet("/api/diagnostics", () =>
+        app.MapGet("/api/diagnostics", async (HttpContext ctx) =>
         {
             var k8s = configSource as KubernetesConfigSource;
+
+            // Operator update report (#210), if the operator has written one to the CR status.
+            object? update = null;
+            if (k8s is not null)
+            {
+                try
+                {
+                    var status = await k8s.ReadStatusAsync(ctx.RequestAborted);
+                    if (status is { } s && s.TryGetProperty("update", out var u))
+                        update = System.Text.Json.JsonSerializer.Deserialize<object>(u.GetRawText());
+                }
+                catch (Exception ex) { Log.Debug($"Diagnostics: could not read operator update status: {ex.Message}"); }
+            }
+
             return Results.Json(new
             {
                 ok = true,
                 version = Version,
                 image = Environment.GetEnvironmentVariable("RPDU2MQTT_IMAGE"),
+                update,
                 dotnet = Environment.Version.ToString(),
                 os = RuntimeInformation.OSDescription,
                 startedUtc = health.StartedUtc,

--- a/rPDU2MQTT.Web/web/schema.fixture.json
+++ b/rPDU2MQTT.Web/web/schema.fixture.json
@@ -1,1952 +1,2020 @@
 [
- {
-  "key": "_README",
-  "label": "fixture",
-  "description": "Real output of ConfigSchema.Build(), used by smoke.mjs so build() renders every section. Regenerate when config sections change: dump JsonSerializer.Serialize(ConfigSchema.Build(), ConfigSchema.Json) to this file. Drift only reduces coverage; it does not cause false failures.",
-  "type": "readme"
- },
- {
-  "key": "MQTT",
-  "label": "MQTT",
-  "description": "MQTT Configuration",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "Credentials",
-    "label": "Credentials",
-    "description": "Optional credentials to connect to MQTT",
-    "type": "object",
-    "required": false,
-    "properties": [
-     {
-      "key": "Username",
-      "label": "Username",
-      "description": "Username to log in as",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Password",
-      "label": "Password",
-      "description": "Password to login with",
-      "type": "password",
-      "required": false
-     }
-    ]
-   },
-   {
-    "key": "ClientID",
-    "label": "ClientID",
-    "description": "The client-id used when connecting to MQTT.",
-    "type": "string",
-    "required": false
-   },
-   {
-    "key": "ParentTopic",
-    "label": "ParentTopic",
-    "description": "The parent topic for MQTT messages.",
-    "type": "string",
-    "required": true,
-    "default": "rPDU2MQTT"
-   },
-   {
-    "key": "Connection",
-    "label": "Connection",
-    "description": "Connection details for MQTT Broker",
-    "type": "object",
-    "required": true,
-    "properties": [
-     {
-      "key": "Scheme",
-      "label": "Connection Scheme",
-      "description": "How to reach the broker: mqtt (plain TCP), mqtts (TLS), ws (WebSocket) or wss (WebSocket over TLS). Leave unset to infer from the port.",
-      "type": "enum",
-      "required": false,
-      "enumValues": [
-       "",
-       "mqtt",
-       "mqtts",
-       "ws",
-       "wss"
-      ]
-     },
-     {
-      "key": "Host",
-      "label": "Host",
-      "description": "Hostname or IP to connect to.",
-      "type": "string",
-      "required": true
-     },
-     {
-      "key": "Port",
-      "label": "Port",
-      "description": "The port to connect to.",
-      "type": "int",
-      "required": false,
-      "min": 0,
-      "max": 65535
-     },
-     {
-      "key": "Timeout",
-      "label": "Connection Timeout",
-      "description": "Default connection timeout.",
-      "type": "int",
-      "required": false,
-      "min": 1,
-      "max": 3600
-     },
-     {
-      "key": "ValidateCertificate",
-      "label": "Validate Certificate",
-      "description": "Enables certificate validation",
-      "type": "bool",
-      "required": false,
-      "default": true
-     }
-    ]
-   },
-   {
-    "key": "KeepAlive",
-    "label": "KeepAlive",
-    "description": "The keepalive interval for the MQTT connection in seconds.",
-    "type": "int",
-    "required": false,
-    "min": 1,
-    "max": 2147483647
-   },
-   {
-    "key": "LastWill",
-    "label": "Last Will / Availability",
-    "description": "Publish a Last-Will message and set an availability topic on entities, so Home Assistant marks them unavailable immediately when the bridge disconnects. When off, entities instead rely on HomeAssistant.SensorExpireAfterSeconds (expire_after) to go unavailable.",
-    "type": "bool",
-    "required": false,
-    "default": true
-   }
-  ]
- },
- {
-  "key": "Pdus",
-  "label": "Pdus",
-  "description": "PDU instances to bridge, keyed by instance name.",
-  "type": "dictionary",
-  "required": false,
-  "valueSchema": {
-   "key": "",
-   "label": "",
-   "type": "object",
-   "required": false,
-   "properties": [
     {
-     "key": "Connection",
-     "label": "Connection",
-     "description": "Connection details for PDU",
-     "type": "object",
-     "required": true,
-     "properties": [
-      {
-       "key": "Host",
-       "label": "Host",
-       "description": "Hostname or IP to connect to.",
-       "type": "string",
-       "required": true
-      },
-      {
-       "key": "Port",
-       "label": "Port",
-       "description": "The port to connect to.",
-       "type": "int",
-       "required": false,
-       "min": 0,
-       "max": 65535
-      },
-      {
-       "key": "Timeout",
-       "label": "Connection Timeout",
-       "description": "Default connection timeout.",
-       "type": "int",
-       "required": false,
-       "min": 1,
-       "max": 3600
-      },
-      {
-       "key": "Scheme",
-       "label": "Connection Scheme",
-       "description": "Connection scheme used",
-       "type": "enum",
-       "required": false,
-       "enumValues": [
-        "",
-        "http",
-        "https"
-       ]
-      },
-      {
-       "key": "ValidateCertificate",
-       "label": "Validate Certificate",
-       "description": "Enables certificate validation",
-       "type": "bool",
-       "required": false,
-       "default": true
-      }
-     ]
+        "key": "_README",
+        "label": "fixture",
+        "description": "Real output of ConfigSchema.Build(), used by smoke.mjs so build() renders every section. Regenerate when config sections change: dump JsonSerializer.Serialize(ConfigSchema.Build(), ConfigSchema.Json) to this file. Drift only reduces coverage; it does not cause false failures.",
+        "type": "readme"
     },
     {
-     "key": "Credentials",
-     "label": "Credentials",
-     "description": "PDU login used for write actions (outlet control). Can also be supplied via RPDU2MQTT_PDU_USERNAME / RPDU2MQTT_PDU_PASSWORD.",
-     "type": "object",
-     "required": false,
-     "properties": [
-      {
-       "key": "Username",
-       "label": "Username",
-       "description": "Username to log in as",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Password",
-       "label": "Password",
-       "description": "Password to login with",
-       "type": "password",
-       "required": false
-      }
-     ]
-    },
-    {
-     "key": "PollInterval",
-     "label": "Poll Interval (seconds)",
-     "description": "How often (seconds) to poll the PDU and publish readings.",
-     "type": "int",
-     "required": false,
-     "default": 5,
-     "min": 1,
-     "max": 2147483647
-    },
-    {
-     "key": "ActionsEnabled",
-     "label": "Enable Write Actions",
-     "description": "Allow the bridge to make changes on the PDU (e.g. toggle outlets). When off, no switches or other write controls are exposed to Home Assistant. Requires PDU credentials.",
-     "type": "bool",
-     "required": false,
-     "default": false
-    },
-    {
-     "key": "RemapModel",
-     "label": "Remap Model column",
-     "description": "Replace each outlet/group's Model (shown in the Home Assistant device info) with contextual text (e.g. parent PDU + name) instead of the PDU's hardware model.",
-     "type": "bool",
-     "required": false,
-     "default": false
-    },
-    {
-     "key": "RemapManufacturer",
-     "label": "Remap Manufacturer column",
-     "description": "Replace each entity's Manufacturer (shown in Home Assistant) with the entity type (Outlet, Group, etc.) instead of the hardware manufacturer.",
-     "type": "bool",
-     "required": false,
-     "default": false
-    }
-   ]
-  },
-  "keyType": "string"
- },
- {
-  "key": "HomeAssistant",
-  "label": "HomeAssistant",
-  "description": "Home Assistant Configuration",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "DiscoveryEnabled",
-    "label": "DiscoveryEnabled",
-    "description": "Indicates whether Home Assistant discovery is enabled.",
-    "type": "bool",
-    "required": false
-   },
-   {
-    "key": "DiscoveryTopic",
-    "label": "DiscoveryTopic",
-    "description": "The discovery topic for Home Assistant.",
-    "type": "string",
-    "required": false
-   },
-   {
-    "key": "DiscoveryInterval",
-    "label": "DiscoveryInterval",
-    "description": "How often (seconds) to republish discovery. 0 = run once at startup until restarted.",
-    "type": "int",
-    "required": false
-   },
-   {
-    "key": "DiscoveryRetain",
-    "label": "DiscoveryRetain",
-    "description": "Whether discovery messages are retained on the broker.",
-    "type": "bool",
-    "required": false
-   },
-   {
-    "key": "SensorExpireAfterSeconds",
-    "label": "SensorExpireAfterSeconds",
-    "description": "expire_after (seconds) applied to sensors; after this long without an update Home Assistant marks them unavailable.",
-    "type": "int",
-    "required": false
-   },
-   {
-    "key": "GroupMemberNameTemplate",
-    "label": "GroupMemberNameTemplate",
-    "description": "Name template for a group's mirrored member switches. Placeholders: {device}, {outlet}, {number}, {group}.",
-    "type": "string",
-    "required": false,
-    "default": "{device} \u2014 Outlet {number} ({outlet})",
-    "templateVars": [
-     "device",
-     "outlet",
-     "number",
-     "group"
-    ]
-   },
-   {
-    "key": "GroupMemberObjectIdTemplate",
-    "label": "GroupMemberObjectIdTemplate",
-    "description": "Stable entity/object_id template for a group's mirrored member switches. Placeholders: {serial}, {number}, {device}, {group}.",
-    "type": "string",
-    "required": false,
-    "default": "{serial}_outlet_{number}",
-    "templateVars": [
-     "serial",
-     "number",
-     "device",
-     "group"
-    ]
-   },
-   {
-    "key": "EnergyDashboard",
-    "label": "EnergyDashboard",
-    "description": "Auto-configure Home Assistant's Energy Dashboard 'devices' (with upstream relationships) from the energy-flow hierarchy, via HA's WebSocket API.",
-    "type": "object",
-    "required": false,
-    "properties": [
-     {
-      "key": "Enabled",
-      "label": "Enabled",
-      "description": "Sync the energy-flow hierarchy into HA's Energy Dashboard via its API. Requires Url + a long-lived access token.",
-      "type": "bool",
-      "required": false,
-      "default": false
-     },
-     {
-      "key": "Url",
-      "label": "Url",
-      "description": "Home Assistant base URL, e.g. http://homeassistant.local:8123 .",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Token",
-      "label": "Token",
-      "description": "Home Assistant long-lived access token (or set RPDU2MQTT_HASS_TOKEN).",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "EnergyMeasurementType",
-      "label": "EnergyMeasurementType",
-      "description": "Measurement type holding each entity's cumulative energy (kWh) \u2014 used to find the Energy Dashboard stat for each tier.",
-      "type": "string",
-      "required": false,
-      "default": "energy"
-     }
-    ]
-   }
-  ]
- },
- {
-  "key": "Overrides",
-  "label": "Overrides",
-  "description": "Overrides",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "PDU",
-    "label": "PDU",
-    "description": "Allows overriding values for the rPDU2MQTT.",
-    "type": "object",
-    "required": false,
-    "properties": [
-     {
-      "key": "ID",
-      "label": "ID",
-      "description": "Overridden ID",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Name",
-      "label": "Name",
-      "description": "Overridden Name",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Enabled",
-      "label": "Enabled",
-      "description": "Is this entity enabled?",
-      "type": "bool",
-      "required": false
-     },
-     {
-      "key": "Make",
-      "label": "Make",
-      "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Model",
-      "label": "Model",
-      "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
-      "type": "string",
-      "required": false
-     }
-    ]
-   },
-   {
-    "key": "Devices",
-    "label": "Devices",
-    "description": "Allows overriding configuration for individual devices.",
-    "type": "dictionary",
-    "required": false,
-    "valueSchema": {
-     "key": "",
-     "label": "",
-     "type": "object",
-     "required": false,
-     "properties": [
-      {
-       "key": "Outlets",
-       "label": "Outlets",
-       "description": "Allows overriding values for individual outlets.",
-       "type": "dictionary",
-       "required": false,
-       "valueSchema": {
-        "key": "",
-        "label": "",
+        "key": "MQTT",
+        "label": "MQTT",
+        "description": "MQTT Configuration",
         "type": "object",
         "required": false,
         "properties": [
-         {
-          "key": "ID",
-          "label": "ID",
-          "description": "Overridden ID",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "Name",
-          "label": "Name",
-          "description": "Overridden Name",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "Enabled",
-          "label": "Enabled",
-          "description": "Is this entity enabled?",
-          "type": "bool",
-          "required": false
-         },
-         {
-          "key": "Make",
-          "label": "Make",
-          "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "Model",
-          "label": "Model",
-          "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
-          "type": "string",
-          "required": false
-         }
+            {
+                "key": "Credentials",
+                "label": "Credentials",
+                "description": "Optional credentials to connect to MQTT",
+                "type": "object",
+                "required": false,
+                "properties": [
+                    {
+                        "key": "Username",
+                        "label": "Username",
+                        "description": "Username to log in as",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Password",
+                        "label": "Password",
+                        "description": "Password to login with",
+                        "type": "password",
+                        "required": false
+                    }
+                ]
+            },
+            {
+                "key": "ClientID",
+                "label": "ClientID",
+                "description": "The client-id used when connecting to MQTT.",
+                "type": "string",
+                "required": false
+            },
+            {
+                "key": "ParentTopic",
+                "label": "ParentTopic",
+                "description": "The parent topic for MQTT messages.",
+                "type": "string",
+                "required": true,
+                "default": "rPDU2MQTT"
+            },
+            {
+                "key": "Connection",
+                "label": "Connection",
+                "description": "Connection details for MQTT Broker",
+                "type": "object",
+                "required": true,
+                "properties": [
+                    {
+                        "key": "Scheme",
+                        "label": "Connection Scheme",
+                        "description": "How to reach the broker: mqtt (plain TCP), mqtts (TLS), ws (WebSocket) or wss (WebSocket over TLS). Leave unset to infer from the port.",
+                        "type": "enum",
+                        "required": false,
+                        "enumValues": [
+                            "",
+                            "mqtt",
+                            "mqtts",
+                            "ws",
+                            "wss"
+                        ]
+                    },
+                    {
+                        "key": "Host",
+                        "label": "Host",
+                        "description": "Hostname or IP to connect to.",
+                        "type": "string",
+                        "required": true
+                    },
+                    {
+                        "key": "Port",
+                        "label": "Port",
+                        "description": "The port to connect to.",
+                        "type": "int",
+                        "required": false,
+                        "min": 0,
+                        "max": 65535
+                    },
+                    {
+                        "key": "Timeout",
+                        "label": "Connection Timeout",
+                        "description": "Default connection timeout.",
+                        "type": "int",
+                        "required": false,
+                        "min": 1,
+                        "max": 3600
+                    },
+                    {
+                        "key": "ValidateCertificate",
+                        "label": "Validate Certificate",
+                        "description": "Enables certificate validation",
+                        "type": "bool",
+                        "required": false,
+                        "default": true
+                    }
+                ]
+            },
+            {
+                "key": "KeepAlive",
+                "label": "KeepAlive",
+                "description": "The keepalive interval for the MQTT connection in seconds.",
+                "type": "int",
+                "required": false,
+                "min": 1,
+                "max": 2147483647
+            },
+            {
+                "key": "LastWill",
+                "label": "Last Will / Availability",
+                "description": "Publish a Last-Will message and set an availability topic on entities, so Home Assistant marks them unavailable immediately when the bridge disconnects. When off, entities instead rely on HomeAssistant.SensorExpireAfterSeconds (expire_after) to go unavailable.",
+                "type": "bool",
+                "required": false,
+                "default": true
+            }
         ]
-       },
-       "keyType": "int"
-      },
-      {
-       "key": "ID",
-       "label": "ID",
-       "description": "Overridden ID",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Name",
-       "label": "Name",
-       "description": "Overridden Name",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Enabled",
-       "label": "Enabled",
-       "description": "Is this entity enabled?",
-       "type": "bool",
-       "required": false
-      },
-      {
-       "key": "Make",
-       "label": "Make",
-       "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Model",
-       "label": "Model",
-       "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
-       "type": "string",
-       "required": false
-      }
-     ]
     },
-    "keyType": "string"
-   },
-   {
-    "key": "Measurements",
-    "label": "Measurements",
-    "description": "Allows overriding individual measurements",
-    "type": "dictionary",
-    "required": false,
-    "valueSchema": {
-     "key": "",
-     "label": "",
-     "type": "object",
-     "required": false,
-     "properties": [
-      {
-       "key": "ID",
-       "label": "ID",
-       "description": "Overridden ID",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Name",
-       "label": "Name",
-       "description": "Overridden Name",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Enabled",
-       "label": "Enabled",
-       "description": "Is this entity enabled?",
-       "type": "bool",
-       "required": false
-      },
-      {
-       "key": "Make",
-       "label": "Make",
-       "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Model",
-       "label": "Model",
-       "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
-       "type": "string",
-       "required": false
-      }
-     ]
+    {
+        "key": "Pdus",
+        "label": "Pdus",
+        "description": "PDU instances to bridge, keyed by instance name.",
+        "type": "dictionary",
+        "required": false,
+        "valueSchema": {
+            "key": "",
+            "label": "",
+            "type": "object",
+            "required": false,
+            "properties": [
+                {
+                    "key": "Connection",
+                    "label": "Connection",
+                    "description": "Connection details for PDU",
+                    "type": "object",
+                    "required": true,
+                    "properties": [
+                        {
+                            "key": "Host",
+                            "label": "Host",
+                            "description": "Hostname or IP to connect to.",
+                            "type": "string",
+                            "required": true
+                        },
+                        {
+                            "key": "Port",
+                            "label": "Port",
+                            "description": "The port to connect to.",
+                            "type": "int",
+                            "required": false,
+                            "min": 0,
+                            "max": 65535
+                        },
+                        {
+                            "key": "Timeout",
+                            "label": "Connection Timeout",
+                            "description": "Default connection timeout.",
+                            "type": "int",
+                            "required": false,
+                            "min": 1,
+                            "max": 3600
+                        },
+                        {
+                            "key": "Scheme",
+                            "label": "Connection Scheme",
+                            "description": "Connection scheme used",
+                            "type": "enum",
+                            "required": false,
+                            "enumValues": [
+                                "",
+                                "http",
+                                "https"
+                            ]
+                        },
+                        {
+                            "key": "ValidateCertificate",
+                            "label": "Validate Certificate",
+                            "description": "Enables certificate validation",
+                            "type": "bool",
+                            "required": false,
+                            "default": true
+                        }
+                    ]
+                },
+                {
+                    "key": "Credentials",
+                    "label": "Credentials",
+                    "description": "PDU login used for write actions (outlet control). Can also be supplied via RPDU2MQTT_PDU_USERNAME / RPDU2MQTT_PDU_PASSWORD.",
+                    "type": "object",
+                    "required": false,
+                    "properties": [
+                        {
+                            "key": "Username",
+                            "label": "Username",
+                            "description": "Username to log in as",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Password",
+                            "label": "Password",
+                            "description": "Password to login with",
+                            "type": "password",
+                            "required": false
+                        }
+                    ]
+                },
+                {
+                    "key": "PollInterval",
+                    "label": "Poll Interval (seconds)",
+                    "description": "How often (seconds) to poll the PDU and publish readings.",
+                    "type": "int",
+                    "required": false,
+                    "default": 5,
+                    "min": 1,
+                    "max": 2147483647
+                },
+                {
+                    "key": "ActionsEnabled",
+                    "label": "Enable Write Actions",
+                    "description": "Allow the bridge to make changes on the PDU (e.g. toggle outlets). When off, no switches or other write controls are exposed to Home Assistant. Requires PDU credentials.",
+                    "type": "bool",
+                    "required": false,
+                    "default": false
+                },
+                {
+                    "key": "RemapModel",
+                    "label": "Remap Model column",
+                    "description": "Replace each outlet/group's Model (shown in the Home Assistant device info) with contextual text (e.g. parent PDU + name) instead of the PDU's hardware model.",
+                    "type": "bool",
+                    "required": false,
+                    "default": false
+                },
+                {
+                    "key": "RemapManufacturer",
+                    "label": "Remap Manufacturer column",
+                    "description": "Replace each entity's Manufacturer (shown in Home Assistant) with the entity type (Outlet, Group, etc.) instead of the hardware manufacturer.",
+                    "type": "bool",
+                    "required": false,
+                    "default": false
+                }
+            ]
+        },
+        "keyType": "string"
     },
-    "keyType": "string"
-   },
-   {
-    "key": "OneviewGroups",
-    "label": "OneviewGroups",
-    "description": "Overrides specific to Oneview groups",
-    "type": "object",
-    "required": false,
-    "properties": [
-     {
-      "key": "Measurements",
-      "label": "Measurements",
-      "description": "Allows overriding individual measurements for groups",
-      "type": "dictionary",
-      "required": false,
-      "valueSchema": {
-       "key": "",
-       "label": "",
-       "type": "object",
-       "required": false,
-       "properties": [
-        {
-         "key": "ID",
-         "label": "ID",
-         "description": "Overridden ID",
-         "type": "string",
-         "required": false
-        },
-        {
-         "key": "Name",
-         "label": "Name",
-         "description": "Overridden Name",
-         "type": "string",
-         "required": false
-        },
-        {
-         "key": "Enabled",
-         "label": "Enabled",
-         "description": "Is this entity enabled?",
-         "type": "bool",
-         "required": false
-        },
-        {
-         "key": "Make",
-         "label": "Make",
-         "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
-         "type": "string",
-         "required": false
-        },
-        {
-         "key": "Model",
-         "label": "Model",
-         "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
-         "type": "string",
-         "required": false
-        }
-       ]
-      },
-      "keyType": "string"
-     },
-     {
-      "key": "Overrides",
-      "label": "Overrides",
-      "description": "Allows overriding group ID, Name, and enabled state.",
-      "type": "dictionary",
-      "required": false,
-      "valueSchema": {
-       "key": "",
-       "label": "",
-       "type": "object",
-       "required": false,
-       "properties": [
-        {
-         "key": "ID",
-         "label": "ID",
-         "description": "Overridden ID",
-         "type": "string",
-         "required": false
-        },
-        {
-         "key": "Name",
-         "label": "Name",
-         "description": "Overridden Name",
-         "type": "string",
-         "required": false
-        },
-        {
-         "key": "Enabled",
-         "label": "Enabled",
-         "description": "Is this entity enabled?",
-         "type": "bool",
-         "required": false
-        },
-        {
-         "key": "Make",
-         "label": "Make",
-         "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
-         "type": "string",
-         "required": false
-        },
-        {
-         "key": "Model",
-         "label": "Model",
-         "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
-         "type": "string",
-         "required": false
-        }
-       ]
-      },
-      "keyType": "string"
-     }
-    ]
-   }
-  ]
- },
- {
-  "key": "Debug",
-  "label": "Debug",
-  "description": "Settings for debugging and diagnostics.",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "PublishMessages",
-    "label": "Publish to MQTT",
-    "description": "Actually publish messages to the broker. Turn off to dry-run the whole pipeline without sending anything.",
-    "type": "bool",
-    "required": false,
-    "default": true
-   },
-   {
-    "key": "PrintDiscovery",
-    "label": "Print Discovery Payloads",
-    "description": "Log the Home Assistant discovery JSON to the console (verbose; for troubleshooting discovery).",
-    "type": "bool",
-    "required": false,
-    "default": false
-   }
-  ]
- },
- {
-  "key": "Prometheus",
-  "label": "Prometheus",
-  "description": "Prometheus metrics exporter",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "Exporter",
-    "label": "Exporter",
-    "description": "Expose a /metrics endpoint for Prometheus to scrape.",
-    "type": "bool",
-    "required": false,
-    "default": false
-   },
-   {
-    "key": "Port",
-    "label": "Port",
-    "description": "Port the /metrics endpoint listens on (Exporter).",
-    "type": "int",
-    "required": false,
-    "default": 9184
-   },
-   {
-    "key": "MetricNameTemplate",
-    "label": "MetricNameTemplate",
-    "description": "Template for Prometheus metric names. Placeholders: {type}, {device}, {source} (a.k.a. {outlet}), {units}. e.g. 'rpdu2mqtt_{type}' -> rpdu2mqtt_realpower; 'pdu_{device}_{type}' -> pdu_rack_pdu_1_realpower. (device/source/units are also emitted as labels.)",
-    "type": "string",
-    "required": false,
-    "default": "rpdu2mqtt_{type}",
-    "templateVars": [
-     "type",
-     "device",
-     "source",
-     "units"
-    ]
-   },
-   {
-    "key": "Labels",
-    "label": "Labels",
-    "description": "Labels attached to every exported metric. Available: device, source, name, number, type, units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set.",
-    "type": "list",
-    "required": false,
-    "valueSchema": {
-     "key": "",
-     "label": "",
-     "type": "string",
-     "required": false
-    }
-   },
-   {
-    "key": "Pushgateway",
-    "label": "Pushgateway",
-    "description": "Push metrics to a Prometheus Pushgateway.",
-    "type": "object",
-    "required": false,
-    "properties": [
-     {
-      "key": "Enabled",
-      "label": "Enabled",
-      "description": "Push metrics to a Pushgateway.",
-      "type": "bool",
-      "required": false,
-      "default": false
-     },
-     {
-      "key": "Url",
-      "label": "Url",
-      "description": "Pushgateway endpoint, e.g. http://pushgateway:9091/metrics.",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Job",
-      "label": "Job",
-      "description": "The 'job' label applied to pushed metrics.",
-      "type": "string",
-      "required": false,
-      "default": "rpdu2mqtt"
-     },
-     {
-      "key": "IntervalSeconds",
-      "label": "IntervalSeconds",
-      "description": "How often to push, in seconds. Falls back to the PDU poll interval when 0.",
-      "type": "int",
-      "required": false,
-      "default": 0
-     }
-    ]
-   }
-  ]
- },
- {
-  "key": "EmonCMS",
-  "label": "EmonCMS",
-  "description": "EmonCMS exporter",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "Enabled",
-    "label": "Enabled",
-    "description": "Push measurements to an EmonCMS server.",
-    "type": "bool",
-    "required": false,
-    "default": false
-   },
-   {
-    "key": "Transport",
-    "label": "Transport",
-    "description": "How to deliver measurements: Http (input/post API) or Mqtt (publish to EmonCMS's MQTT input on the same broker).",
-    "type": "enum",
-    "required": false,
-    "default": "Http",
-    "enumValues": [
-     "Http",
-     "Mqtt"
-    ]
-   },
-   {
-    "key": "Url",
-    "label": "Url",
-    "description": "Base URL of the EmonCMS server, e.g. http://emoncms.example.com. (Http transport.)",
-    "type": "string",
-    "required": false
-   },
-   {
-    "key": "ApiKey",
-    "label": "ApiKey",
-    "description": "EmonCMS write API key (or set RPDU2MQTT_EMONCMS_APIKEY). (Http transport.)",
-    "type": "string",
-    "required": false
-   },
-   {
-    "key": "Node",
-    "label": "Node",
-    "description": "EmonCMS input node name.",
-    "type": "string",
-    "required": false,
-    "default": "rpdu2mqtt"
-   },
-   {
-    "key": "Path",
-    "label": "Path",
-    "description": "API path (relative to Url) that measurements are posted to. (Http transport.)",
-    "type": "string",
-    "required": false,
-    "default": "input/post"
-   },
-   {
-    "key": "InputNameTemplate",
-    "label": "InputNameTemplate",
-    "description": "Template for EmonCMS input keys. Placeholders: {device}, {source} (object-id form), {name} (formatted display name), {number} (outlet number), {type}, {units}. e.g. '{device}_{source}_{type}' -> rack_pdu_1_dell_md1200_realpower. Leave blank to use the full raw identifier.",
-    "type": "string",
-    "required": false,
-    "default": "{device}_{source}_{type}",
-    "templateVars": [
-     "device",
-     "source",
-     "name",
-     "number",
-     "type",
-     "units"
-    ]
-   },
-   {
-    "key": "MqttBaseTopic",
-    "label": "MqttBaseTopic",
-    "description": "Base MQTT topic for EmonCMS's MQTT input (the {base} placeholder of MqttTopicTemplate). (Mqtt transport.)",
-    "type": "string",
-    "required": false,
-    "default": "emon"
-   },
-   {
-    "key": "MqttTopicTemplate",
-    "label": "MqttTopicTemplate",
-    "description": "Template for the EmonCMS MQTT topic each JSON payload is published to. Placeholders: {base} (MqttBaseTopic), {node}, {device} (the PDU's name). Including {device} splits the export so each PDU publishes to its own topic instead of one combined payload, e.g. '{base}/{node}/{device}'. (Mqtt transport.)",
-    "type": "string",
-    "required": false,
-    "default": "{base}/{node}",
-    "templateVars": [
-     "base",
-     "node",
-     "device"
-    ]
-   },
-   {
-    "key": "Feeds",
-    "label": "Feeds",
-    "description": "Automatically create and maintain EmonCMS feeds from the exported inputs. (Http transport; needs a read/write API key.)",
-    "type": "object",
-    "required": false,
-    "properties": [
-     {
-      "key": "AutoConfigure",
-      "label": "AutoConfigure",
-      "description": "Create and maintain EmonCMS feeds from the exported inputs (takes effect without a restart).",
-      "type": "bool",
-      "required": false,
-      "default": false
-     },
-     {
-      "key": "Types",
-      "label": "Types",
-      "description": "The measurement types to build feeds for, each with its own engine, interval and processing.",
-      "type": "list",
-      "required": false,
-      "valueSchema": {
-       "key": "",
-       "label": "",
-       "type": "object",
-       "required": false,
-       "properties": [
-        {
-         "key": "Type",
-         "label": "Type",
-         "description": "The measurement type this applies to (raw PDU type name).",
-         "type": "enum",
-         "required": false,
-         "enumValues": [
-          "",
-          "realpower",
-          "apparentpower",
-          "energy",
-          "current",
-          "voltage",
-          "frequency",
-          "powerfactor"
-         ]
-        },
-        {
-         "key": "Engine",
-         "label": "Engine",
-         "description": "Feed storage engine for this type. Blank inherits Feeds.Engine. PHPFina = fixed-interval, PHPTimeSeries = variable, MySQL = MySQL storage.",
-         "type": "enum",
-         "required": false,
-         "enumValues": [
-          "MySQL",
-          "PHPTimeSeries",
-          "PHPFina",
-          "VirtualFeed"
-         ]
-        },
-        {
-         "key": "IntervalSeconds",
-         "label": "IntervalSeconds",
-         "description": "Sample interval in seconds for this type's feed. Blank inherits Feeds.IntervalSeconds.",
-         "type": "int",
-         "required": false,
-         "min": 1,
-         "max": 86400
-        },
-        {
-         "key": "Daily",
-         "label": "Daily",
-         "description": "Also create a daily kWh/d feed (an extra processlist step: kWh\u2192kWh/d). Typically only for the energy type.",
-         "type": "bool",
-         "required": false,
-         "default": false
-        },
-        {
-         "key": "DailyIntervalSeconds",
-         "label": "DailyIntervalSeconds",
-         "description": "Interval (seconds) for the daily kWh/d feed. Should be a day (86400), not the base interval.",
-         "type": "int",
-         "required": false,
-         "default": 86400,
-         "min": 1,
-         "max": 86400
-        }
-       ]
-      }
-     },
-     {
-      "key": "Engine",
-      "label": "Engine",
-      "description": "Default feed storage engine, for types that don't set their own. PHPFina = fixed-interval time series, PHPTimeSeries = variable interval, MySQL = MySQL storage (no phpfina files).",
-      "type": "enum",
-      "required": false,
-      "default": "PHPFina",
-      "enumValues": [
-       "MySQL",
-       "PHPTimeSeries",
-       "PHPFina",
-       "VirtualFeed"
-      ]
-     },
-     {
-      "key": "IntervalSeconds",
-      "label": "IntervalSeconds",
-      "description": "Default sample interval in seconds for a fixed-interval feed, for types that don't set their own.",
-      "type": "int",
-      "required": false,
-      "default": 10,
-      "min": 1,
-      "max": 86400
-     },
-     {
-      "key": "IdempotentNames",
-      "label": "IdempotentNames",
-      "description": "Name storage feeds idempotently from stable ids (device/source/type) so they DON'T change when a source is renamed. Turn off to name them from the display name instead (renaming a source renames its feed).",
-      "type": "bool",
-      "required": false,
-      "default": true
-     },
-     {
-      "key": "Tag",
-      "label": "Tag",
-      "description": "The EmonCMS tag (group) new feeds are filed under. Blank uses the input node name.",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "StorageNameTemplate",
-      "label": "StorageNameTemplate",
-      "description": "Template for the idempotent storage-feed name. Use only stable placeholders ({device}, {source}, {type}, {number}) so it never changes on a rename. Placeholders: {device}, {source}, {name}, {number}, {type}, {units}.",
-      "type": "string",
-      "required": false,
-      "default": "{device}_{source}_{type}",
-      "templateVars": [
-       "device",
-       "source",
-       "name",
-       "number",
-       "type",
-       "units"
-      ]
-     },
-     {
-      "key": "Virtual",
-      "label": "Virtual",
-      "description": "Optionally create friendly-named virtual feeds that source from the stable storage feeds \u2014 so dashboards get nice names while the underlying feeds stay idempotent.",
-      "type": "object",
-      "required": false,
-      "properties": [
-       {
-        "key": "Enabled",
-        "label": "Enabled",
-        "description": "Create a friendly-named virtual feed for each storage feed, sourced from it (source_feed process).",
-        "type": "bool",
-        "required": false,
-        "default": false
-       },
-       {
-        "key": "NameTemplate",
-        "label": "NameTemplate",
-        "description": "Template for the friendly virtual-feed name. {name} is the source's display name, so these can change freely without touching the stable storage feeds. Placeholders: {device}, {source}, {name}, {number}, {type}, {units}.",
-        "type": "string",
-        "required": false,
-        "default": "{name} {type}",
-        "templateVars": [
-         "device",
-         "source",
-         "name",
-         "number",
-         "type",
-         "units"
-        ]
-       },
-       {
-        "key": "Tag",
-        "label": "Tag",
-        "description": "The EmonCMS tag (group/node) virtual feeds are filed under \u2014 set this to keep the friendly virtual feeds separate from the storage feeds. Blank uses the main Feeds tag.",
-        "type": "string",
-        "required": false
-       }
-      ]
-     },
-     {
-      "key": "Processes",
-      "label": "Processes",
-      "description": "EmonCMS process ids used in the generated processlists. Match these to your EmonCMS (Inputs \u2192 process dropdown).",
-      "type": "object",
-      "required": false,
-      "properties": [
-       {
-        "key": "LogToFeed",
-        "label": "LogToFeed",
-        "description": "Process id_num for 'Log to feed' (EmonCMS stores processlists as id_num:feedid; default 1).",
-        "type": "string",
-        "required": false,
-        "default": "1"
-       },
-       {
-        "key": "KwhToKwhd",
-        "label": "KwhToKwhd",
-        "description": "Process id_num for 'kWh to kWh/d', used for daily energy feeds (default 23).",
-        "type": "string",
-        "required": false,
-        "default": "23"
-       },
-       {
-        "key": "SourceFeed",
-        "label": "SourceFeed",
-        "description": "Process id_num for 'Source feed', used for virtual feeds (default 53).",
-        "type": "string",
-        "required": false,
-        "default": "53"
-       }
-      ]
-     }
-    ]
-   }
-  ]
- },
- {
-  "key": "Logging",
-  "label": "Logging",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "LogFilePath",
-    "label": "LogFilePath",
-    "type": "string",
-    "required": false
-   },
-   {
-    "key": "Console",
-    "label": "Console",
-    "type": "object",
-    "required": false,
-    "properties": [
-     {
-      "key": "Severity",
-      "label": "Severity",
-      "type": "enum",
-      "required": false,
-      "enumValues": [
-       "Verbose",
-       "Debug",
-       "Information",
-       "Warning",
-       "Error",
-       "Fatal"
-      ]
-     },
-     {
-      "key": "Format",
-      "label": "Format",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Enabled",
-      "label": "Enabled",
-      "type": "bool",
-      "required": false
-     }
-    ]
-   },
-   {
-    "key": "File",
-    "label": "File",
-    "type": "object",
-    "required": false,
-    "properties": [
-     {
-      "key": "Path",
-      "label": "Path",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "FileRollover",
-      "label": "FileRollover",
-      "type": "enum",
-      "required": false,
-      "enumValues": [
-       "Infinite",
-       "Year",
-       "Month",
-       "Day",
-       "Hour",
-       "Minute"
-      ]
-     },
-     {
-      "key": "FileRetention",
-      "label": "FileRetention",
-      "type": "int",
-      "required": false
-     },
-     {
-      "key": "Severity",
-      "label": "Severity",
-      "type": "enum",
-      "required": false,
-      "enumValues": [
-       "Verbose",
-       "Debug",
-       "Information",
-       "Warning",
-       "Error",
-       "Fatal"
-      ]
-     },
-     {
-      "key": "Format",
-      "label": "Format",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Enabled",
-      "label": "Enabled",
-      "type": "bool",
-      "required": false
-     }
-    ]
-   },
-   {
-    "key": "Syslog",
-    "label": "Syslog",
-    "type": "object",
-    "required": false,
-    "properties": [
-     {
-      "key": "Host",
-      "label": "Host",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Port",
-      "label": "Port",
-      "type": "int",
-      "required": false
-     },
-     {
-      "key": "Protocol",
-      "label": "Protocol",
-      "type": "enum",
-      "required": false,
-      "enumValues": [
-       "UDP",
-       "TCP"
-      ]
-     },
-     {
-      "key": "AppName",
-      "label": "AppName",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Severity",
-      "label": "Severity",
-      "type": "enum",
-      "required": false,
-      "enumValues": [
-       "Verbose",
-       "Debug",
-       "Information",
-       "Warning",
-       "Error",
-       "Fatal"
-      ]
-     },
-     {
-      "key": "Format",
-      "label": "Format",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "Enabled",
-      "label": "Enabled",
-      "type": "bool",
-      "required": false
-     }
-    ]
-   }
-  ]
- },
- {
-  "key": "Gui",
-  "label": "Gui",
-  "description": "Embedded configuration web GUI",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "Enabled",
-    "label": "Enabled",
-    "description": "Enable the embedded configuration web GUI.",
-    "type": "bool",
-    "required": false,
-    "default": false
-   },
-   {
-    "key": "AuthType",
-    "label": "Authentication",
-    "description": "How users authenticate to the GUI: Basic (username/password), Oidc (SSO), or None (no login).",
-    "type": "enum",
-    "required": false,
-    "default": "Basic",
-    "enumValues": [
-     "Basic",
-     "Oidc",
-     "None"
-    ]
-   },
-   {
-    "key": "Port",
-    "label": "Port",
-    "description": "Port the configuration GUI listens on.",
-    "type": "int",
-    "required": false,
-    "default": 8080
-   },
-   {
-    "key": "Username",
-    "label": "Username",
-    "description": "Username required to access the GUI (HTTP Basic auth).",
-    "type": "string",
-    "required": false
-   },
-   {
-    "key": "Password",
-    "label": "Password",
-    "description": "Password required to access the GUI (HTTP Basic auth). Required unless Oidc is enabled.",
-    "type": "password",
-    "required": false
-   },
-   {
-    "key": "Oidc",
-    "label": "Oidc",
-    "description": "OpenID Connect (SSO) settings (used when AuthType is Oidc).",
-    "type": "object",
-    "required": false,
-    "properties": [
-     {
-      "key": "Authority",
-      "label": "Authority",
-      "description": "OIDC authority / issuer URL (e.g. https://keycloak.example.com/realms/home).",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "ClientId",
-      "label": "ClientId",
-      "description": "OIDC client ID registered with your identity provider.",
-      "type": "string",
-      "required": false
-     },
-     {
-      "key": "ClientSecret",
-      "label": "ClientSecret",
-      "description": "OIDC client secret. Prefer the RPDU2MQTT_OIDC_CLIENT_SECRET env var (or *_FILE secret).",
-      "type": "password",
-      "required": false
-     },
-     {
-      "key": "Scopes",
-      "label": "Scopes",
-      "description": "Space-separated scopes to request.",
-      "type": "string",
-      "required": false,
-      "default": "openid profile email"
-     },
-     {
-      "key": "CallbackPath",
-      "label": "CallbackPath",
-      "description": "Redirect/callback path registered with the identity provider.",
-      "type": "string",
-      "required": false,
-      "default": "/signin-oidc"
-     }
-    ]
-   }
-  ]
- },
- {
-  "key": "Health",
-  "label": "Health",
-  "description": "HTTP health-check endpoints",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "Enabled",
-    "label": "Enabled",
-    "description": "Expose HTTP health-check endpoints: /healthz (liveness) and /readyz (readiness).",
-    "type": "bool",
-    "required": false,
-    "default": true
-   },
-   {
-    "key": "Port",
-    "label": "Port",
-    "description": "Port the health-check endpoints listen on.",
-    "type": "int",
-    "required": false,
-    "default": 8081
-   }
-  ]
- },
- {
-  "key": "Api",
-  "label": "Api",
-  "description": "Read-only REST API + OpenAPI/Scalar docs",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "Enabled",
-    "label": "Enabled",
-    "description": "Expose a read-only REST API (/api/v1/*) with OpenAPI + Scalar docs on its own port. Place it on a trusted network \u2014 it is unauthenticated, like the health endpoints.",
-    "type": "bool",
-    "required": false,
-    "default": false
-   },
-   {
-    "key": "Port",
-    "label": "Port",
-    "description": "Port the REST API + docs listen on.",
-    "type": "int",
-    "required": false,
-    "default": 8082
-   },
-   {
-    "key": "ApiKey",
-    "label": "ApiKey",
-    "description": "Optional API key enabling the write/control endpoints (or set RPDU2MQTT_API_KEY). When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).",
-    "type": "string",
-    "required": false
-   }
-  ]
- },
- {
-  "key": "EnergyFlow",
-  "label": "EnergyFlow",
-  "description": "Virtual upstream nodes (breakers, transfer switches, a \u201cTotal\u201d) and their feeder wiring for the energy-flow hierarchy. Edited visually on the Flow tab.",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "Nodes",
-    "label": "Nodes",
-    "description": "Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.",
-    "type": "list",
-    "required": false,
-    "valueSchema": {
-     "key": "",
-     "label": "",
-     "type": "object",
-     "required": false,
-     "properties": [
-      {
-       "key": "Id",
-       "label": "Id",
-       "description": "Stable unique id used to wire parents/children.",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Label",
-       "label": "Label",
-       "description": "Human-readable label shown in the flow diagram.",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Kind",
-       "label": "Kind",
-       "description": "What this node represents: 'node' (generic), 'panel', 'inverter', 'battery', 'solar', 'grid', or 'load'. Drives styling and the fields the editor offers.",
-       "type": "enum",
-       "required": false,
-       "default": "node",
-       "enumValues": [
-        "",
-        "node",
-        "panel",
-        "inverter",
-        "battery",
-        "solar",
-        "grid",
-        "load"
-       ]
-      },
-      {
-       "key": "Value",
-       "label": "Value",
-       "description": "Optional fixed value for a leaf node. Used only when no live source has reported for it.",
-       "type": "double",
-       "required": false
-      },
-      {
-       "key": "StorageKwh",
-       "label": "StorageKwh",
-       "description": "For a battery node: usable storage capacity in kWh (display metadata; optional).",
-       "type": "double",
-       "required": false
-      },
-      {
-       "key": "Mode",
-       "label": "Mode",
-       "description": "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'static' (a fixed leaf at Value), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins.",
-       "type": "enum",
-       "required": false,
-       "default": "auto",
-       "enumValues": [
-        "",
-        "auto",
-        "static",
-        "residual",
-        "untracked",
-        "none"
-       ]
-      },
-      {
-       "key": "Sources",
-       "label": "Sources",
-       "description": "Live value bindings for this node, one per metric. Each binds a metric to an external source (Type 'mqtt' today). Supersedes Value.",
-       "type": "list",
-       "required": false,
-       "valueSchema": {
-        "key": "",
-        "label": "",
+    {
+        "key": "HomeAssistant",
+        "label": "HomeAssistant",
+        "description": "Home Assistant Configuration",
         "type": "object",
         "required": false,
         "properties": [
-         {
-          "key": "Type",
-          "label": "Type",
-          "description": "Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection).",
-          "type": "enum",
-          "required": false,
-          "default": "mqtt",
-          "enumValues": [
-           "",
-           "mqtt",
-           "modbus"
-          ]
-         },
-         {
-          "key": "Metric",
-          "label": "Metric",
-          "description": "Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.",
-          "type": "enum",
-          "required": false,
-          "default": "realpower",
-          "enumValues": [
-           "",
-           "realpower",
-           "apparentpower",
-           "energy",
-           "current",
-           "voltage",
-           "frequency",
-           "powerfactor"
-          ]
-         },
-         {
-          "key": "Unit",
-          "label": "Unit",
-          "description": "Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, \u2026) on ingest. Blank = already canonical.",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "Topic",
-          "label": "Topic",
-          "description": "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "JsonField",
-          "label": "JsonField",
-          "description": "For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "Scale",
-          "label": "Scale",
-          "description": "Multiplier applied to the received value \u2014 for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.",
-          "type": "double",
-          "required": false,
-          "default": 1
-         },
-         {
-          "key": "StaleAfterSeconds",
-          "label": "StaleAfterSeconds",
-          "description": "Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).",
-          "type": "int",
-          "required": false,
-          "default": 900,
-          "min": 0,
-          "max": 86400
-         },
-         {
-          "key": "Connection",
-          "label": "Connection",
-          "description": "For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from.",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "Register",
-          "label": "Register",
-          "description": "For Type 'modbus': the register address to read (0-based).",
-          "type": "int",
-          "required": false
-         },
-         {
-          "key": "RegisterType",
-          "label": "RegisterType",
-          "description": "For Type 'modbus': which register bank \u2014 'holding' (function 3) or 'input' (function 4).",
-          "type": "enum",
-          "required": false,
-          "default": "holding",
-          "enumValues": [
-           "",
-           "holding",
-           "input"
-          ]
-         },
-         {
-          "key": "DataType",
-          "label": "DataType",
-          "description": "For Type 'modbus': how to decode the register(s) \u2014 uint16, int16, uint32, int32, or float32.",
-          "type": "enum",
-          "required": false,
-          "default": "uint16",
-          "enumValues": [
-           "",
-           "uint16",
-           "int16",
-           "uint32",
-           "int32",
-           "float32"
-          ]
-         },
-         {
-          "key": "WordOrder",
-          "label": "WordOrder",
-          "description": "For Type 'modbus' 32-bit values: word order \u2014 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped).",
-          "type": "enum",
-          "required": false,
-          "default": "big",
-          "enumValues": [
-           "",
-           "big",
-           "little"
-          ]
-         }
+            {
+                "key": "DiscoveryEnabled",
+                "label": "DiscoveryEnabled",
+                "description": "Indicates whether Home Assistant discovery is enabled.",
+                "type": "bool",
+                "required": false
+            },
+            {
+                "key": "DiscoveryTopic",
+                "label": "DiscoveryTopic",
+                "description": "The discovery topic for Home Assistant.",
+                "type": "string",
+                "required": false
+            },
+            {
+                "key": "DiscoveryInterval",
+                "label": "DiscoveryInterval",
+                "description": "How often (seconds) to republish discovery. 0 = run once at startup until restarted.",
+                "type": "int",
+                "required": false
+            },
+            {
+                "key": "DiscoveryRetain",
+                "label": "DiscoveryRetain",
+                "description": "Whether discovery messages are retained on the broker.",
+                "type": "bool",
+                "required": false
+            },
+            {
+                "key": "SensorExpireAfterSeconds",
+                "label": "SensorExpireAfterSeconds",
+                "description": "expire_after (seconds) applied to sensors; after this long without an update Home Assistant marks them unavailable.",
+                "type": "int",
+                "required": false
+            },
+            {
+                "key": "GroupMemberNameTemplate",
+                "label": "GroupMemberNameTemplate",
+                "description": "Name template for a group's mirrored member switches. Placeholders: {device}, {outlet}, {number}, {group}.",
+                "type": "string",
+                "required": false,
+                "default": "{device} — Outlet {number} ({outlet})",
+                "templateVars": [
+                    "device",
+                    "outlet",
+                    "number",
+                    "group"
+                ]
+            },
+            {
+                "key": "GroupMemberObjectIdTemplate",
+                "label": "GroupMemberObjectIdTemplate",
+                "description": "Stable entity/object_id template for a group's mirrored member switches. Placeholders: {serial}, {number}, {device}, {group}.",
+                "type": "string",
+                "required": false,
+                "default": "{serial}_outlet_{number}",
+                "templateVars": [
+                    "serial",
+                    "number",
+                    "device",
+                    "group"
+                ]
+            },
+            {
+                "key": "EnergyDashboard",
+                "label": "EnergyDashboard",
+                "description": "Auto-configure Home Assistant's Energy Dashboard 'devices' (with upstream relationships) from the energy-flow hierarchy, via HA's WebSocket API.",
+                "type": "object",
+                "required": false,
+                "properties": [
+                    {
+                        "key": "Enabled",
+                        "label": "Enabled",
+                        "description": "Sync the energy-flow hierarchy into HA's Energy Dashboard via its API. Requires Url + a long-lived access token.",
+                        "type": "bool",
+                        "required": false,
+                        "default": false
+                    },
+                    {
+                        "key": "Url",
+                        "label": "Url",
+                        "description": "Home Assistant base URL, e.g. http://homeassistant.local:8123 .",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Token",
+                        "label": "Token",
+                        "description": "Home Assistant long-lived access token (or set RPDU2MQTT_HASS_TOKEN).",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "EnergyMeasurementType",
+                        "label": "EnergyMeasurementType",
+                        "description": "Measurement type holding each entity's cumulative energy (kWh) — used to find the Energy Dashboard stat for each tier.",
+                        "type": "string",
+                        "required": false,
+                        "default": "energy"
+                    }
+                ]
+            }
         ]
-       }
-      },
-      {
-       "key": "Mqtt",
-       "label": "Mqtt",
-       "description": "Deprecated: use Sources. Legacy MQTT bindings (implicitly Type 'mqtt'); still honored for back-compat.",
-       "type": "list",
-       "required": false,
-       "valueSchema": {
-        "key": "",
-        "label": "",
+    },
+    {
+        "key": "Overrides",
+        "label": "Overrides",
+        "description": "Overrides",
         "type": "object",
         "required": false,
         "properties": [
-         {
-          "key": "Type",
-          "label": "Type",
-          "description": "Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection).",
-          "type": "enum",
-          "required": false,
-          "default": "mqtt",
-          "enumValues": [
-           "",
-           "mqtt",
-           "modbus"
-          ]
-         },
-         {
-          "key": "Metric",
-          "label": "Metric",
-          "description": "Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.",
-          "type": "enum",
-          "required": false,
-          "default": "realpower",
-          "enumValues": [
-           "",
-           "realpower",
-           "apparentpower",
-           "energy",
-           "current",
-           "voltage",
-           "frequency",
-           "powerfactor"
-          ]
-         },
-         {
-          "key": "Unit",
-          "label": "Unit",
-          "description": "Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, \u2026) on ingest. Blank = already canonical.",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "Topic",
-          "label": "Topic",
-          "description": "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "JsonField",
-          "label": "JsonField",
-          "description": "For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "Scale",
-          "label": "Scale",
-          "description": "Multiplier applied to the received value \u2014 for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.",
-          "type": "double",
-          "required": false,
-          "default": 1
-         },
-         {
-          "key": "StaleAfterSeconds",
-          "label": "StaleAfterSeconds",
-          "description": "Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).",
-          "type": "int",
-          "required": false,
-          "default": 900,
-          "min": 0,
-          "max": 86400
-         },
-         {
-          "key": "Connection",
-          "label": "Connection",
-          "description": "For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from.",
-          "type": "string",
-          "required": false
-         },
-         {
-          "key": "Register",
-          "label": "Register",
-          "description": "For Type 'modbus': the register address to read (0-based).",
-          "type": "int",
-          "required": false
-         },
-         {
-          "key": "RegisterType",
-          "label": "RegisterType",
-          "description": "For Type 'modbus': which register bank \u2014 'holding' (function 3) or 'input' (function 4).",
-          "type": "enum",
-          "required": false,
-          "default": "holding",
-          "enumValues": [
-           "",
-           "holding",
-           "input"
-          ]
-         },
-         {
-          "key": "DataType",
-          "label": "DataType",
-          "description": "For Type 'modbus': how to decode the register(s) \u2014 uint16, int16, uint32, int32, or float32.",
-          "type": "enum",
-          "required": false,
-          "default": "uint16",
-          "enumValues": [
-           "",
-           "uint16",
-           "int16",
-           "uint32",
-           "int32",
-           "float32"
-          ]
-         },
-         {
-          "key": "WordOrder",
-          "label": "WordOrder",
-          "description": "For Type 'modbus' 32-bit values: word order \u2014 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped).",
-          "type": "enum",
-          "required": false,
-          "default": "big",
-          "enumValues": [
-           "",
-           "big",
-           "little"
-          ]
-         }
+            {
+                "key": "PDU",
+                "label": "PDU",
+                "description": "Allows overriding values for the rPDU2MQTT.",
+                "type": "object",
+                "required": false,
+                "properties": [
+                    {
+                        "key": "ID",
+                        "label": "ID",
+                        "description": "Overridden ID",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Name",
+                        "label": "Name",
+                        "description": "Overridden Name",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Enabled",
+                        "label": "Enabled",
+                        "description": "Is this entity enabled?",
+                        "type": "bool",
+                        "required": false
+                    },
+                    {
+                        "key": "Make",
+                        "label": "Make",
+                        "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Model",
+                        "label": "Model",
+                        "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
+                        "type": "string",
+                        "required": false
+                    }
+                ]
+            },
+            {
+                "key": "Devices",
+                "label": "Devices",
+                "description": "Allows overriding configuration for individual devices.",
+                "type": "dictionary",
+                "required": false,
+                "valueSchema": {
+                    "key": "",
+                    "label": "",
+                    "type": "object",
+                    "required": false,
+                    "properties": [
+                        {
+                            "key": "Outlets",
+                            "label": "Outlets",
+                            "description": "Allows overriding values for individual outlets.",
+                            "type": "dictionary",
+                            "required": false,
+                            "valueSchema": {
+                                "key": "",
+                                "label": "",
+                                "type": "object",
+                                "required": false,
+                                "properties": [
+                                    {
+                                        "key": "ID",
+                                        "label": "ID",
+                                        "description": "Overridden ID",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "Name",
+                                        "label": "Name",
+                                        "description": "Overridden Name",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "Enabled",
+                                        "label": "Enabled",
+                                        "description": "Is this entity enabled?",
+                                        "type": "bool",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "Make",
+                                        "label": "Make",
+                                        "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "Model",
+                                        "label": "Model",
+                                        "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
+                                        "type": "string",
+                                        "required": false
+                                    }
+                                ]
+                            },
+                            "keyType": "int"
+                        },
+                        {
+                            "key": "ID",
+                            "label": "ID",
+                            "description": "Overridden ID",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Name",
+                            "label": "Name",
+                            "description": "Overridden Name",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Enabled",
+                            "label": "Enabled",
+                            "description": "Is this entity enabled?",
+                            "type": "bool",
+                            "required": false
+                        },
+                        {
+                            "key": "Make",
+                            "label": "Make",
+                            "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Model",
+                            "label": "Model",
+                            "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
+                            "type": "string",
+                            "required": false
+                        }
+                    ]
+                },
+                "keyType": "string"
+            },
+            {
+                "key": "Measurements",
+                "label": "Measurements",
+                "description": "Allows overriding individual measurements",
+                "type": "dictionary",
+                "required": false,
+                "valueSchema": {
+                    "key": "",
+                    "label": "",
+                    "type": "object",
+                    "required": false,
+                    "properties": [
+                        {
+                            "key": "ID",
+                            "label": "ID",
+                            "description": "Overridden ID",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Name",
+                            "label": "Name",
+                            "description": "Overridden Name",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Enabled",
+                            "label": "Enabled",
+                            "description": "Is this entity enabled?",
+                            "type": "bool",
+                            "required": false
+                        },
+                        {
+                            "key": "Make",
+                            "label": "Make",
+                            "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Model",
+                            "label": "Model",
+                            "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
+                            "type": "string",
+                            "required": false
+                        }
+                    ]
+                },
+                "keyType": "string"
+            },
+            {
+                "key": "OneviewGroups",
+                "label": "OneviewGroups",
+                "description": "Overrides specific to Oneview groups",
+                "type": "object",
+                "required": false,
+                "properties": [
+                    {
+                        "key": "Measurements",
+                        "label": "Measurements",
+                        "description": "Allows overriding individual measurements for groups",
+                        "type": "dictionary",
+                        "required": false,
+                        "valueSchema": {
+                            "key": "",
+                            "label": "",
+                            "type": "object",
+                            "required": false,
+                            "properties": [
+                                {
+                                    "key": "ID",
+                                    "label": "ID",
+                                    "description": "Overridden ID",
+                                    "type": "string",
+                                    "required": false
+                                },
+                                {
+                                    "key": "Name",
+                                    "label": "Name",
+                                    "description": "Overridden Name",
+                                    "type": "string",
+                                    "required": false
+                                },
+                                {
+                                    "key": "Enabled",
+                                    "label": "Enabled",
+                                    "description": "Is this entity enabled?",
+                                    "type": "bool",
+                                    "required": false
+                                },
+                                {
+                                    "key": "Make",
+                                    "label": "Make",
+                                    "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
+                                    "type": "string",
+                                    "required": false
+                                },
+                                {
+                                    "key": "Model",
+                                    "label": "Model",
+                                    "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
+                                    "type": "string",
+                                    "required": false
+                                }
+                            ]
+                        },
+                        "keyType": "string"
+                    },
+                    {
+                        "key": "Overrides",
+                        "label": "Overrides",
+                        "description": "Allows overriding group ID, Name, and enabled state.",
+                        "type": "dictionary",
+                        "required": false,
+                        "valueSchema": {
+                            "key": "",
+                            "label": "",
+                            "type": "object",
+                            "required": false,
+                            "properties": [
+                                {
+                                    "key": "ID",
+                                    "label": "ID",
+                                    "description": "Overridden ID",
+                                    "type": "string",
+                                    "required": false
+                                },
+                                {
+                                    "key": "Name",
+                                    "label": "Name",
+                                    "description": "Overridden Name",
+                                    "type": "string",
+                                    "required": false
+                                },
+                                {
+                                    "key": "Enabled",
+                                    "label": "Enabled",
+                                    "description": "Is this entity enabled?",
+                                    "type": "bool",
+                                    "required": false
+                                },
+                                {
+                                    "key": "Make",
+                                    "label": "Make",
+                                    "description": "Manufacturer shown in Home Assistant (e.g. 'Dell'). Applies to devices, outlets and groups.",
+                                    "type": "string",
+                                    "required": false
+                                },
+                                {
+                                    "key": "Model",
+                                    "label": "Model",
+                                    "description": "Model shown in Home Assistant (e.g. 'PowerEdge R730xd'). Applies to devices, outlets and groups.",
+                                    "type": "string",
+                                    "required": false
+                                }
+                            ]
+                        },
+                        "keyType": "string"
+                    }
+                ]
+            }
         ]
-       }
-      }
-     ]
-    }
-   },
-   {
-    "key": "Links",
-    "label": "Links",
-    "description": "Directed energy-flow links (From feeds To). Allows multiple feeders per node and producer inputs.",
-    "type": "list",
-    "required": false,
-    "valueSchema": {
-     "key": "",
-     "label": "",
-     "type": "object",
-     "required": false,
-     "properties": [
-      {
-       "key": "From",
-       "label": "From",
-       "description": "Source node id \u2014 energy flows out of here.",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "To",
-       "label": "To",
-       "description": "Target node id \u2014 energy flows into here.",
-       "type": "string",
-       "required": false
-      }
-     ]
-    }
-   },
-   {
-    "key": "Parents",
-    "label": "Parents",
-    "description": "Legacy single-feeder map (child id -> parent id). Prefer Links; still honored for back-compat.",
-    "type": "dictionary",
-    "required": false,
-    "valueSchema": {
-     "key": "",
-     "label": "",
-     "type": "string",
-     "required": false
     },
-    "keyType": "string"
-   },
-   {
-    "key": "MqttExport",
-    "label": "MqttExport",
-    "description": "Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.",
-    "type": "bool",
-    "required": false,
-    "default": false
-   },
-   {
-    "key": "MqttTopicTemplate",
-    "label": "MqttTopicTemplate",
-    "description": "Template for each tier's MQTT topic. Placeholders: {parent} (MQTT parent topic), {id}, {label}, {kind}, {metric}, {units}. e.g. '{parent}/energyflow/{id}'.",
-    "type": "string",
-    "required": false,
-    "default": "{parent}/energyflow/{id}",
-    "templateVars": [
-     "parent",
-     "id",
-     "label",
-     "kind",
-     "metric",
-     "units"
-    ]
-   }
-  ]
- },
- {
-  "key": "Modbus",
-  "label": "Modbus",
-  "description": "Modbus TCP connections that energy-flow nodes can be bound to (inverters, meters, PLCs).",
-  "type": "object",
-  "required": false,
-  "properties": [
-   {
-    "key": "Connections",
-    "label": "Connections",
-    "description": "Modbus TCP devices to poll. Add one per device, then reference it from a source binding's Connection.",
-    "type": "list",
-    "required": false,
-    "valueSchema": {
-     "key": "",
-     "label": "",
-     "type": "object",
-     "required": false,
-     "properties": [
-      {
-       "key": "Id",
-       "label": "Id",
-       "description": "Stable id used to reference this connection from a source binding.",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Name",
-       "label": "Name",
-       "description": "Friendly name for the device (shown in the editor).",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Host",
-       "label": "Host",
-       "description": "Hostname or IP address of the Modbus TCP device.",
-       "type": "string",
-       "required": false
-      },
-      {
-       "key": "Port",
-       "label": "Port",
-       "description": "TCP port the device listens on (Modbus default 502).",
-       "type": "int",
-       "required": false,
-       "default": 502
-      },
-      {
-       "key": "UnitId",
-       "label": "UnitId",
-       "description": "Modbus unit / slave id.",
-       "type": "int",
-       "required": false,
-       "default": 1
-      },
-      {
-       "key": "PollIntervalSeconds",
-       "label": "PollIntervalSeconds",
-       "description": "How often to poll this device, in seconds.",
-       "type": "int",
-       "required": false,
-       "default": 10,
-       "min": 1,
-       "max": 86400
-      },
-      {
-       "key": "Enabled",
-       "label": "Enabled",
-       "description": "Poll this device. Turn off to disable it without deleting the connection.",
-       "type": "bool",
-       "required": false,
-       "default": true
-      }
-     ]
+    {
+        "key": "Debug",
+        "label": "Debug",
+        "description": "Settings for debugging and diagnostics.",
+        "type": "object",
+        "required": false,
+        "properties": [
+            {
+                "key": "PublishMessages",
+                "label": "Publish to MQTT",
+                "description": "Actually publish messages to the broker. Turn off to dry-run the whole pipeline without sending anything.",
+                "type": "bool",
+                "required": false,
+                "default": true
+            },
+            {
+                "key": "PrintDiscovery",
+                "label": "Print Discovery Payloads",
+                "description": "Log the Home Assistant discovery JSON to the console (verbose; for troubleshooting discovery).",
+                "type": "bool",
+                "required": false,
+                "default": false
+            }
+        ]
+    },
+    {
+        "key": "Prometheus",
+        "label": "Prometheus",
+        "description": "Prometheus metrics exporter",
+        "type": "object",
+        "required": false,
+        "properties": [
+            {
+                "key": "Exporter",
+                "label": "Exporter",
+                "description": "Expose a /metrics endpoint for Prometheus to scrape.",
+                "type": "bool",
+                "required": false,
+                "default": false
+            },
+            {
+                "key": "Port",
+                "label": "Port",
+                "description": "Port the /metrics endpoint listens on (Exporter).",
+                "type": "int",
+                "required": false,
+                "default": 9184
+            },
+            {
+                "key": "MetricNameTemplate",
+                "label": "MetricNameTemplate",
+                "description": "Template for Prometheus metric names. Placeholders: {type}, {device}, {source} (a.k.a. {outlet}), {units}. e.g. 'rpdu2mqtt_{type}' -> rpdu2mqtt_realpower; 'pdu_{device}_{type}' -> pdu_rack_pdu_1_realpower. (device/source/units are also emitted as labels.)",
+                "type": "string",
+                "required": false,
+                "default": "rpdu2mqtt_{type}",
+                "templateVars": [
+                    "type",
+                    "device",
+                    "source",
+                    "units"
+                ]
+            },
+            {
+                "key": "Labels",
+                "label": "Labels",
+                "description": "Labels attached to every exported metric. Available: device, source, name, number, type, units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set.",
+                "type": "list",
+                "required": false,
+                "valueSchema": {
+                    "key": "",
+                    "label": "",
+                    "type": "string",
+                    "required": false
+                }
+            },
+            {
+                "key": "Pushgateway",
+                "label": "Pushgateway",
+                "description": "Push metrics to a Prometheus Pushgateway.",
+                "type": "object",
+                "required": false,
+                "properties": [
+                    {
+                        "key": "Enabled",
+                        "label": "Enabled",
+                        "description": "Push metrics to a Pushgateway.",
+                        "type": "bool",
+                        "required": false,
+                        "default": false
+                    },
+                    {
+                        "key": "Url",
+                        "label": "Url",
+                        "description": "Pushgateway endpoint, e.g. http://pushgateway:9091/metrics.",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Job",
+                        "label": "Job",
+                        "description": "The 'job' label applied to pushed metrics.",
+                        "type": "string",
+                        "required": false,
+                        "default": "rpdu2mqtt"
+                    },
+                    {
+                        "key": "IntervalSeconds",
+                        "label": "IntervalSeconds",
+                        "description": "How often to push, in seconds. Falls back to the PDU poll interval when 0.",
+                        "type": "int",
+                        "required": false,
+                        "default": 0
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "key": "EmonCMS",
+        "label": "EmonCMS",
+        "description": "EmonCMS exporter",
+        "type": "object",
+        "required": false,
+        "properties": [
+            {
+                "key": "Enabled",
+                "label": "Enabled",
+                "description": "Push measurements to an EmonCMS server.",
+                "type": "bool",
+                "required": false,
+                "default": false
+            },
+            {
+                "key": "Transport",
+                "label": "Transport",
+                "description": "How to deliver measurements: Http (input/post API) or Mqtt (publish to EmonCMS's MQTT input on the same broker).",
+                "type": "enum",
+                "required": false,
+                "default": "Http",
+                "enumValues": [
+                    "Http",
+                    "Mqtt"
+                ]
+            },
+            {
+                "key": "Url",
+                "label": "Url",
+                "description": "Base URL of the EmonCMS server, e.g. http://emoncms.example.com. (Http transport.)",
+                "type": "string",
+                "required": false
+            },
+            {
+                "key": "ApiKey",
+                "label": "ApiKey",
+                "description": "EmonCMS write API key (or set RPDU2MQTT_EMONCMS_APIKEY). (Http transport.)",
+                "type": "string",
+                "required": false
+            },
+            {
+                "key": "Node",
+                "label": "Node",
+                "description": "EmonCMS input node name.",
+                "type": "string",
+                "required": false,
+                "default": "rpdu2mqtt"
+            },
+            {
+                "key": "Path",
+                "label": "Path",
+                "description": "API path (relative to Url) that measurements are posted to. (Http transport.)",
+                "type": "string",
+                "required": false,
+                "default": "input/post"
+            },
+            {
+                "key": "InputNameTemplate",
+                "label": "InputNameTemplate",
+                "description": "Template for EmonCMS input keys. Placeholders: {device}, {source} (object-id form), {name} (formatted display name), {number} (outlet number), {type}, {units}. e.g. '{device}_{source}_{type}' -> rack_pdu_1_dell_md1200_realpower. Leave blank to use the full raw identifier.",
+                "type": "string",
+                "required": false,
+                "default": "{device}_{source}_{type}",
+                "templateVars": [
+                    "device",
+                    "source",
+                    "name",
+                    "number",
+                    "type",
+                    "units"
+                ]
+            },
+            {
+                "key": "MqttBaseTopic",
+                "label": "MqttBaseTopic",
+                "description": "Base MQTT topic for EmonCMS's MQTT input (the {base} placeholder of MqttTopicTemplate). (Mqtt transport.)",
+                "type": "string",
+                "required": false,
+                "default": "emon"
+            },
+            {
+                "key": "MqttTopicTemplate",
+                "label": "MqttTopicTemplate",
+                "description": "Template for the EmonCMS MQTT topic each JSON payload is published to. Placeholders: {base} (MqttBaseTopic), {node}, {device} (the PDU's name). Including {device} splits the export so each PDU publishes to its own topic instead of one combined payload, e.g. '{base}/{node}/{device}'. (Mqtt transport.)",
+                "type": "string",
+                "required": false,
+                "default": "{base}/{node}",
+                "templateVars": [
+                    "base",
+                    "node",
+                    "device"
+                ]
+            },
+            {
+                "key": "Feeds",
+                "label": "Feeds",
+                "description": "Automatically create and maintain EmonCMS feeds from the exported inputs. (Http transport; needs a read/write API key.)",
+                "type": "object",
+                "required": false,
+                "properties": [
+                    {
+                        "key": "AutoConfigure",
+                        "label": "AutoConfigure",
+                        "description": "Create and maintain EmonCMS feeds from the exported inputs (takes effect without a restart).",
+                        "type": "bool",
+                        "required": false,
+                        "default": false
+                    },
+                    {
+                        "key": "Types",
+                        "label": "Types",
+                        "description": "The measurement types to build feeds for, each with its own engine, interval and processing.",
+                        "type": "list",
+                        "required": false,
+                        "valueSchema": {
+                            "key": "",
+                            "label": "",
+                            "type": "object",
+                            "required": false,
+                            "properties": [
+                                {
+                                    "key": "Type",
+                                    "label": "Type",
+                                    "description": "The measurement type this applies to (raw PDU type name).",
+                                    "type": "enum",
+                                    "required": false,
+                                    "enumValues": [
+                                        "",
+                                        "realpower",
+                                        "apparentpower",
+                                        "energy",
+                                        "current",
+                                        "voltage",
+                                        "frequency",
+                                        "powerfactor"
+                                    ]
+                                },
+                                {
+                                    "key": "Engine",
+                                    "label": "Engine",
+                                    "description": "Feed storage engine for this type. Blank inherits Feeds.Engine. PHPFina = fixed-interval, PHPTimeSeries = variable, MySQL = MySQL storage.",
+                                    "type": "enum",
+                                    "required": false,
+                                    "enumValues": [
+                                        "MySQL",
+                                        "PHPTimeSeries",
+                                        "PHPFina",
+                                        "VirtualFeed"
+                                    ]
+                                },
+                                {
+                                    "key": "IntervalSeconds",
+                                    "label": "IntervalSeconds",
+                                    "description": "Sample interval in seconds for this type's feed. Blank inherits Feeds.IntervalSeconds.",
+                                    "type": "int",
+                                    "required": false,
+                                    "min": 1,
+                                    "max": 86400
+                                },
+                                {
+                                    "key": "Daily",
+                                    "label": "Daily",
+                                    "description": "Also create a daily kWh/d feed (an extra processlist step: kWh→kWh/d). Typically only for the energy type.",
+                                    "type": "bool",
+                                    "required": false,
+                                    "default": false
+                                },
+                                {
+                                    "key": "DailyIntervalSeconds",
+                                    "label": "DailyIntervalSeconds",
+                                    "description": "Interval (seconds) for the daily kWh/d feed. Should be a day (86400), not the base interval.",
+                                    "type": "int",
+                                    "required": false,
+                                    "default": 86400,
+                                    "min": 1,
+                                    "max": 86400
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "key": "Engine",
+                        "label": "Engine",
+                        "description": "Default feed storage engine, for types that don't set their own. PHPFina = fixed-interval time series, PHPTimeSeries = variable interval, MySQL = MySQL storage (no phpfina files).",
+                        "type": "enum",
+                        "required": false,
+                        "default": "PHPFina",
+                        "enumValues": [
+                            "MySQL",
+                            "PHPTimeSeries",
+                            "PHPFina",
+                            "VirtualFeed"
+                        ]
+                    },
+                    {
+                        "key": "IntervalSeconds",
+                        "label": "IntervalSeconds",
+                        "description": "Default sample interval in seconds for a fixed-interval feed, for types that don't set their own.",
+                        "type": "int",
+                        "required": false,
+                        "default": 10,
+                        "min": 1,
+                        "max": 86400
+                    },
+                    {
+                        "key": "IdempotentNames",
+                        "label": "IdempotentNames",
+                        "description": "Name storage feeds idempotently from stable ids (device/source/type) so they DON'T change when a source is renamed. Turn off to name them from the display name instead (renaming a source renames its feed).",
+                        "type": "bool",
+                        "required": false,
+                        "default": true
+                    },
+                    {
+                        "key": "Tag",
+                        "label": "Tag",
+                        "description": "The EmonCMS tag (group) new feeds are filed under. Blank uses the input node name.",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "StorageNameTemplate",
+                        "label": "StorageNameTemplate",
+                        "description": "Template for the idempotent storage-feed name. Use only stable placeholders ({device}, {source}, {type}, {number}) so it never changes on a rename. Placeholders: {device}, {source}, {name}, {number}, {type}, {units}.",
+                        "type": "string",
+                        "required": false,
+                        "default": "{device}_{source}_{type}",
+                        "templateVars": [
+                            "device",
+                            "source",
+                            "name",
+                            "number",
+                            "type",
+                            "units"
+                        ]
+                    },
+                    {
+                        "key": "Virtual",
+                        "label": "Virtual",
+                        "description": "Optionally create friendly-named virtual feeds that source from the stable storage feeds — so dashboards get nice names while the underlying feeds stay idempotent.",
+                        "type": "object",
+                        "required": false,
+                        "properties": [
+                            {
+                                "key": "Enabled",
+                                "label": "Enabled",
+                                "description": "Create a friendly-named virtual feed for each storage feed, sourced from it (source_feed process).",
+                                "type": "bool",
+                                "required": false,
+                                "default": false
+                            },
+                            {
+                                "key": "NameTemplate",
+                                "label": "NameTemplate",
+                                "description": "Template for the friendly virtual-feed name. {name} is the source's display name, so these can change freely without touching the stable storage feeds. Placeholders: {device}, {source}, {name}, {number}, {type}, {units}.",
+                                "type": "string",
+                                "required": false,
+                                "default": "{name} {type}",
+                                "templateVars": [
+                                    "device",
+                                    "source",
+                                    "name",
+                                    "number",
+                                    "type",
+                                    "units"
+                                ]
+                            },
+                            {
+                                "key": "Tag",
+                                "label": "Tag",
+                                "description": "The EmonCMS tag (group/node) virtual feeds are filed under — set this to keep the friendly virtual feeds separate from the storage feeds. Blank uses the main Feeds tag.",
+                                "type": "string",
+                                "required": false
+                            }
+                        ]
+                    },
+                    {
+                        "key": "Processes",
+                        "label": "Processes",
+                        "description": "EmonCMS process ids used in the generated processlists. Match these to your EmonCMS (Inputs → process dropdown).",
+                        "type": "object",
+                        "required": false,
+                        "properties": [
+                            {
+                                "key": "LogToFeed",
+                                "label": "LogToFeed",
+                                "description": "Process id_num for 'Log to feed' (EmonCMS stores processlists as id_num:feedid; default 1).",
+                                "type": "string",
+                                "required": false,
+                                "default": "1"
+                            },
+                            {
+                                "key": "KwhToKwhd",
+                                "label": "KwhToKwhd",
+                                "description": "Process id_num for 'kWh to kWh/d', used for daily energy feeds (default 23).",
+                                "type": "string",
+                                "required": false,
+                                "default": "23"
+                            },
+                            {
+                                "key": "SourceFeed",
+                                "label": "SourceFeed",
+                                "description": "Process id_num for 'Source feed', used for virtual feeds (default 53).",
+                                "type": "string",
+                                "required": false,
+                                "default": "53"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "key": "Logging",
+        "label": "Logging",
+        "type": "object",
+        "required": false,
+        "properties": [
+            {
+                "key": "LogFilePath",
+                "label": "LogFilePath",
+                "type": "string",
+                "required": false
+            },
+            {
+                "key": "Console",
+                "label": "Console",
+                "type": "object",
+                "required": false,
+                "properties": [
+                    {
+                        "key": "Severity",
+                        "label": "Severity",
+                        "type": "enum",
+                        "required": false,
+                        "enumValues": [
+                            "Verbose",
+                            "Debug",
+                            "Information",
+                            "Warning",
+                            "Error",
+                            "Fatal"
+                        ]
+                    },
+                    {
+                        "key": "Format",
+                        "label": "Format",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Enabled",
+                        "label": "Enabled",
+                        "type": "bool",
+                        "required": false
+                    }
+                ]
+            },
+            {
+                "key": "File",
+                "label": "File",
+                "type": "object",
+                "required": false,
+                "properties": [
+                    {
+                        "key": "Path",
+                        "label": "Path",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "FileRollover",
+                        "label": "FileRollover",
+                        "type": "enum",
+                        "required": false,
+                        "enumValues": [
+                            "Infinite",
+                            "Year",
+                            "Month",
+                            "Day",
+                            "Hour",
+                            "Minute"
+                        ]
+                    },
+                    {
+                        "key": "FileRetention",
+                        "label": "FileRetention",
+                        "type": "int",
+                        "required": false
+                    },
+                    {
+                        "key": "Severity",
+                        "label": "Severity",
+                        "type": "enum",
+                        "required": false,
+                        "enumValues": [
+                            "Verbose",
+                            "Debug",
+                            "Information",
+                            "Warning",
+                            "Error",
+                            "Fatal"
+                        ]
+                    },
+                    {
+                        "key": "Format",
+                        "label": "Format",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Enabled",
+                        "label": "Enabled",
+                        "type": "bool",
+                        "required": false
+                    }
+                ]
+            },
+            {
+                "key": "Syslog",
+                "label": "Syslog",
+                "type": "object",
+                "required": false,
+                "properties": [
+                    {
+                        "key": "Host",
+                        "label": "Host",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Port",
+                        "label": "Port",
+                        "type": "int",
+                        "required": false
+                    },
+                    {
+                        "key": "Protocol",
+                        "label": "Protocol",
+                        "type": "enum",
+                        "required": false,
+                        "enumValues": [
+                            "UDP",
+                            "TCP"
+                        ]
+                    },
+                    {
+                        "key": "AppName",
+                        "label": "AppName",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Severity",
+                        "label": "Severity",
+                        "type": "enum",
+                        "required": false,
+                        "enumValues": [
+                            "Verbose",
+                            "Debug",
+                            "Information",
+                            "Warning",
+                            "Error",
+                            "Fatal"
+                        ]
+                    },
+                    {
+                        "key": "Format",
+                        "label": "Format",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "Enabled",
+                        "label": "Enabled",
+                        "type": "bool",
+                        "required": false
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "key": "Gui",
+        "label": "Gui",
+        "description": "Embedded configuration web GUI",
+        "type": "object",
+        "required": false,
+        "properties": [
+            {
+                "key": "Enabled",
+                "label": "Enabled",
+                "description": "Enable the embedded configuration web GUI.",
+                "type": "bool",
+                "required": false,
+                "default": false
+            },
+            {
+                "key": "AuthType",
+                "label": "Authentication",
+                "description": "How users authenticate to the GUI: Basic (username/password), Oidc (SSO), or None (no login).",
+                "type": "enum",
+                "required": false,
+                "default": "Basic",
+                "enumValues": [
+                    "Basic",
+                    "Oidc",
+                    "None"
+                ]
+            },
+            {
+                "key": "Port",
+                "label": "Port",
+                "description": "Port the configuration GUI listens on.",
+                "type": "int",
+                "required": false,
+                "default": 8080
+            },
+            {
+                "key": "Username",
+                "label": "Username",
+                "description": "Username required to access the GUI (HTTP Basic auth).",
+                "type": "string",
+                "required": false
+            },
+            {
+                "key": "Password",
+                "label": "Password",
+                "description": "Password required to access the GUI (HTTP Basic auth). Required unless Oidc is enabled.",
+                "type": "password",
+                "required": false
+            },
+            {
+                "key": "Oidc",
+                "label": "Oidc",
+                "description": "OpenID Connect (SSO) settings (used when AuthType is Oidc).",
+                "type": "object",
+                "required": false,
+                "properties": [
+                    {
+                        "key": "Authority",
+                        "label": "Authority",
+                        "description": "OIDC authority / issuer URL (e.g. https://keycloak.example.com/realms/home).",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "ClientId",
+                        "label": "ClientId",
+                        "description": "OIDC client ID registered with your identity provider.",
+                        "type": "string",
+                        "required": false
+                    },
+                    {
+                        "key": "ClientSecret",
+                        "label": "ClientSecret",
+                        "description": "OIDC client secret. Prefer the RPDU2MQTT_OIDC_CLIENT_SECRET env var (or *_FILE secret).",
+                        "type": "password",
+                        "required": false
+                    },
+                    {
+                        "key": "Scopes",
+                        "label": "Scopes",
+                        "description": "Space-separated scopes to request.",
+                        "type": "string",
+                        "required": false,
+                        "default": "openid profile email"
+                    },
+                    {
+                        "key": "CallbackPath",
+                        "label": "CallbackPath",
+                        "description": "Redirect/callback path registered with the identity provider.",
+                        "type": "string",
+                        "required": false,
+                        "default": "/signin-oidc"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "key": "Health",
+        "label": "Health",
+        "description": "HTTP health-check endpoints",
+        "type": "object",
+        "required": false,
+        "properties": [
+            {
+                "key": "Enabled",
+                "label": "Enabled",
+                "description": "Expose HTTP health-check endpoints: /healthz (liveness) and /readyz (readiness).",
+                "type": "bool",
+                "required": false,
+                "default": true
+            },
+            {
+                "key": "Port",
+                "label": "Port",
+                "description": "Port the health-check endpoints listen on.",
+                "type": "int",
+                "required": false,
+                "default": 8081
+            }
+        ]
+    },
+    {
+        "key": "Api",
+        "label": "Api",
+        "description": "Read-only REST API + OpenAPI/Scalar docs",
+        "type": "object",
+        "required": false,
+        "properties": [
+            {
+                "key": "Enabled",
+                "label": "Enabled",
+                "description": "Expose a read-only REST API (/api/v1/*) with OpenAPI + Scalar docs on its own port. Place it on a trusted network — it is unauthenticated, like the health endpoints.",
+                "type": "bool",
+                "required": false,
+                "default": false
+            },
+            {
+                "key": "Port",
+                "label": "Port",
+                "description": "Port the REST API + docs listen on.",
+                "type": "int",
+                "required": false,
+                "default": 8082
+            },
+            {
+                "key": "ApiKey",
+                "label": "ApiKey",
+                "description": "Optional API key enabling the write/control endpoints (or set RPDU2MQTT_API_KEY). When unset, the API is read-only; when set, control requests must send a matching 'X-Api-Key' header. Reads stay open (trusted-network).",
+                "type": "string",
+                "required": false
+            }
+        ]
+    },
+    {
+        "key": "EnergyFlow",
+        "label": "EnergyFlow",
+        "description": "Virtual upstream nodes (breakers, transfer switches, a “Total”) and their feeder wiring for the energy-flow hierarchy. Edited visually on the Flow tab.",
+        "type": "object",
+        "required": false,
+        "properties": [
+            {
+                "key": "Nodes",
+                "label": "Nodes",
+                "description": "Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.",
+                "type": "list",
+                "required": false,
+                "valueSchema": {
+                    "key": "",
+                    "label": "",
+                    "type": "object",
+                    "required": false,
+                    "properties": [
+                        {
+                            "key": "Id",
+                            "label": "Id",
+                            "description": "Stable unique id used to wire parents/children.",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Label",
+                            "label": "Label",
+                            "description": "Human-readable label shown in the flow diagram.",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Kind",
+                            "label": "Kind",
+                            "description": "What this node represents: 'node' (generic), 'panel', 'inverter', 'battery', 'solar', 'grid', or 'load'. Drives styling and the fields the editor offers.",
+                            "type": "enum",
+                            "required": false,
+                            "default": "node",
+                            "enumValues": [
+                                "",
+                                "node",
+                                "panel",
+                                "inverter",
+                                "battery",
+                                "solar",
+                                "grid",
+                                "load"
+                            ]
+                        },
+                        {
+                            "key": "Value",
+                            "label": "Value",
+                            "description": "Optional fixed value for a leaf node. Used only when no live source has reported for it.",
+                            "type": "double",
+                            "required": false
+                        },
+                        {
+                            "key": "StorageKwh",
+                            "label": "StorageKwh",
+                            "description": "For a battery node: usable storage capacity in kWh (display metadata; optional).",
+                            "type": "double",
+                            "required": false
+                        },
+                        {
+                            "key": "Mode",
+                            "label": "Mode",
+                            "description": "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'static' (a fixed leaf at Value), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins.",
+                            "type": "enum",
+                            "required": false,
+                            "default": "auto",
+                            "enumValues": [
+                                "",
+                                "auto",
+                                "static",
+                                "residual",
+                                "untracked",
+                                "none"
+                            ]
+                        },
+                        {
+                            "key": "Sources",
+                            "label": "Sources",
+                            "description": "Live value bindings for this node, one per metric. Each binds a metric to an external source (Type 'mqtt' today). Supersedes Value.",
+                            "type": "list",
+                            "required": false,
+                            "valueSchema": {
+                                "key": "",
+                                "label": "",
+                                "type": "object",
+                                "required": false,
+                                "properties": [
+                                    {
+                                        "key": "Type",
+                                        "label": "Type",
+                                        "description": "Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection).",
+                                        "type": "enum",
+                                        "required": false,
+                                        "default": "mqtt",
+                                        "enumValues": [
+                                            "",
+                                            "mqtt",
+                                            "modbus"
+                                        ]
+                                    },
+                                    {
+                                        "key": "Metric",
+                                        "label": "Metric",
+                                        "description": "Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.",
+                                        "type": "enum",
+                                        "required": false,
+                                        "default": "realpower",
+                                        "enumValues": [
+                                            "",
+                                            "realpower",
+                                            "apparentpower",
+                                            "energy",
+                                            "current",
+                                            "voltage",
+                                            "frequency",
+                                            "powerfactor"
+                                        ]
+                                    },
+                                    {
+                                        "key": "Unit",
+                                        "label": "Unit",
+                                        "description": "Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "Topic",
+                                        "label": "Topic",
+                                        "description": "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "JsonField",
+                                        "label": "JsonField",
+                                        "description": "For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "Scale",
+                                        "label": "Scale",
+                                        "description": "Multiplier applied to the received value — for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.",
+                                        "type": "double",
+                                        "required": false,
+                                        "default": 1
+                                    },
+                                    {
+                                        "key": "StaleAfterSeconds",
+                                        "label": "StaleAfterSeconds",
+                                        "description": "Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).",
+                                        "type": "int",
+                                        "required": false,
+                                        "default": 900,
+                                        "min": 0,
+                                        "max": 86400
+                                    },
+                                    {
+                                        "key": "Connection",
+                                        "label": "Connection",
+                                        "description": "For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from.",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "Register",
+                                        "label": "Register",
+                                        "description": "For Type 'modbus': the register address to read (0-based).",
+                                        "type": "int",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "RegisterType",
+                                        "label": "RegisterType",
+                                        "description": "For Type 'modbus': which register bank — 'holding' (function 3) or 'input' (function 4).",
+                                        "type": "enum",
+                                        "required": false,
+                                        "default": "holding",
+                                        "enumValues": [
+                                            "",
+                                            "holding",
+                                            "input"
+                                        ]
+                                    },
+                                    {
+                                        "key": "DataType",
+                                        "label": "DataType",
+                                        "description": "For Type 'modbus': how to decode the register(s) — uint16, int16, uint32, int32, or float32.",
+                                        "type": "enum",
+                                        "required": false,
+                                        "default": "uint16",
+                                        "enumValues": [
+                                            "",
+                                            "uint16",
+                                            "int16",
+                                            "uint32",
+                                            "int32",
+                                            "float32"
+                                        ]
+                                    },
+                                    {
+                                        "key": "WordOrder",
+                                        "label": "WordOrder",
+                                        "description": "For Type 'modbus' 32-bit values: word order — 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped).",
+                                        "type": "enum",
+                                        "required": false,
+                                        "default": "big",
+                                        "enumValues": [
+                                            "",
+                                            "big",
+                                            "little"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "key": "Mqtt",
+                            "label": "Mqtt",
+                            "description": "Deprecated: use Sources. Legacy MQTT bindings (implicitly Type 'mqtt'); still honored for back-compat.",
+                            "type": "list",
+                            "required": false,
+                            "valueSchema": {
+                                "key": "",
+                                "label": "",
+                                "type": "object",
+                                "required": false,
+                                "properties": [
+                                    {
+                                        "key": "Type",
+                                        "label": "Type",
+                                        "description": "Where this value comes from: 'mqtt' (subscribe to a broker topic) or 'modbus' (read a register from a Modbus TCP connection).",
+                                        "type": "enum",
+                                        "required": false,
+                                        "default": "mqtt",
+                                        "enumValues": [
+                                            "",
+                                            "mqtt",
+                                            "modbus"
+                                        ]
+                                    },
+                                    {
+                                        "key": "Metric",
+                                        "label": "Metric",
+                                        "description": "Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.",
+                                        "type": "enum",
+                                        "required": false,
+                                        "default": "realpower",
+                                        "enumValues": [
+                                            "",
+                                            "realpower",
+                                            "apparentpower",
+                                            "energy",
+                                            "current",
+                                            "voltage",
+                                            "frequency",
+                                            "powerfactor"
+                                        ]
+                                    },
+                                    {
+                                        "key": "Unit",
+                                        "label": "Unit",
+                                        "description": "Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "Topic",
+                                        "label": "Topic",
+                                        "description": "For Type 'mqtt': the topic carrying this value, e.g. 'solar_assistant/inverter_1/pv_power/state'. Subscribed on the configured broker.",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "JsonField",
+                                        "label": "JsonField",
+                                        "description": "For JSON payloads, the field to read (dotted for nesting, e.g. 'battery.power'). Blank = the whole payload is the number.",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "Scale",
+                                        "label": "Scale",
+                                        "description": "Multiplier applied to the received value — for unit conversion, e.g. 0.001 to turn W into kW, or -1 to flip a sign convention.",
+                                        "type": "double",
+                                        "required": false,
+                                        "default": 1
+                                    },
+                                    {
+                                        "key": "StaleAfterSeconds",
+                                        "label": "StaleAfterSeconds",
+                                        "description": "Ignore the last value once it is this old, so a dead publisher stops silently propping up the flow. 0 disables the check (value never expires).",
+                                        "type": "int",
+                                        "required": false,
+                                        "default": 900,
+                                        "min": 0,
+                                        "max": 86400
+                                    },
+                                    {
+                                        "key": "Connection",
+                                        "label": "Connection",
+                                        "description": "For Type 'modbus': the id of the Modbus connection (from the Modbus section) to read from.",
+                                        "type": "string",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "Register",
+                                        "label": "Register",
+                                        "description": "For Type 'modbus': the register address to read (0-based).",
+                                        "type": "int",
+                                        "required": false
+                                    },
+                                    {
+                                        "key": "RegisterType",
+                                        "label": "RegisterType",
+                                        "description": "For Type 'modbus': which register bank — 'holding' (function 3) or 'input' (function 4).",
+                                        "type": "enum",
+                                        "required": false,
+                                        "default": "holding",
+                                        "enumValues": [
+                                            "",
+                                            "holding",
+                                            "input"
+                                        ]
+                                    },
+                                    {
+                                        "key": "DataType",
+                                        "label": "DataType",
+                                        "description": "For Type 'modbus': how to decode the register(s) — uint16, int16, uint32, int32, or float32.",
+                                        "type": "enum",
+                                        "required": false,
+                                        "default": "uint16",
+                                        "enumValues": [
+                                            "",
+                                            "uint16",
+                                            "int16",
+                                            "uint32",
+                                            "int32",
+                                            "float32"
+                                        ]
+                                    },
+                                    {
+                                        "key": "WordOrder",
+                                        "label": "WordOrder",
+                                        "description": "For Type 'modbus' 32-bit values: word order — 'big' (ABCD, high word first) or 'little' (CDAB, word-swapped).",
+                                        "type": "enum",
+                                        "required": false,
+                                        "default": "big",
+                                        "enumValues": [
+                                            "",
+                                            "big",
+                                            "little"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "key": "Links",
+                "label": "Links",
+                "description": "Directed energy-flow links (From feeds To). Allows multiple feeders per node and producer inputs.",
+                "type": "list",
+                "required": false,
+                "valueSchema": {
+                    "key": "",
+                    "label": "",
+                    "type": "object",
+                    "required": false,
+                    "properties": [
+                        {
+                            "key": "From",
+                            "label": "From",
+                            "description": "Source node id — energy flows out of here.",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "To",
+                            "label": "To",
+                            "description": "Target node id — energy flows into here.",
+                            "type": "string",
+                            "required": false
+                        }
+                    ]
+                }
+            },
+            {
+                "key": "Parents",
+                "label": "Parents",
+                "description": "Legacy single-feeder map (child id -> parent id). Prefer Links; still honored for back-compat.",
+                "type": "dictionary",
+                "required": false,
+                "valueSchema": {
+                    "key": "",
+                    "label": "",
+                    "type": "string",
+                    "required": false
+                },
+                "keyType": "string"
+            },
+            {
+                "key": "MqttExport",
+                "label": "MqttExport",
+                "description": "Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.",
+                "type": "bool",
+                "required": false,
+                "default": false
+            },
+            {
+                "key": "MqttTopicTemplate",
+                "label": "MqttTopicTemplate",
+                "description": "Template for each tier's MQTT topic. Placeholders: {parent} (MQTT parent topic), {id}, {label}, {kind}, {metric}, {units}. e.g. '{parent}/energyflow/{id}'.",
+                "type": "string",
+                "required": false,
+                "default": "{parent}/energyflow/{id}",
+                "templateVars": [
+                    "parent",
+                    "id",
+                    "label",
+                    "kind",
+                    "metric",
+                    "units"
+                ]
+            }
+        ]
+    },
+    {
+        "key": "Modbus",
+        "label": "Modbus",
+        "description": "Modbus TCP connections that energy-flow nodes can be bound to (inverters, meters, PLCs).",
+        "type": "object",
+        "required": false,
+        "properties": [
+            {
+                "key": "Connections",
+                "label": "Connections",
+                "description": "Modbus TCP devices to poll. Add one per device, then reference it from a source binding's Connection.",
+                "type": "list",
+                "required": false,
+                "valueSchema": {
+                    "key": "",
+                    "label": "",
+                    "type": "object",
+                    "required": false,
+                    "properties": [
+                        {
+                            "key": "Id",
+                            "label": "Id",
+                            "description": "Stable id used to reference this connection from a source binding.",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Name",
+                            "label": "Name",
+                            "description": "Friendly name for the device (shown in the editor).",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Host",
+                            "label": "Host",
+                            "description": "Hostname or IP address of the Modbus TCP device.",
+                            "type": "string",
+                            "required": false
+                        },
+                        {
+                            "key": "Port",
+                            "label": "Port",
+                            "description": "TCP port the device listens on (Modbus default 502).",
+                            "type": "int",
+                            "required": false,
+                            "default": 502
+                        },
+                        {
+                            "key": "UnitId",
+                            "label": "UnitId",
+                            "description": "Modbus unit / slave id.",
+                            "type": "int",
+                            "required": false,
+                            "default": 1
+                        },
+                        {
+                            "key": "PollIntervalSeconds",
+                            "label": "PollIntervalSeconds",
+                            "description": "How often to poll this device, in seconds.",
+                            "type": "int",
+                            "required": false,
+                            "default": 10,
+                            "min": 1,
+                            "max": 86400
+                        },
+                        {
+                            "key": "Enabled",
+                            "label": "Enabled",
+                            "description": "Poll this device. Turn off to disable it without deleting the connection.",
+                            "type": "bool",
+                            "required": false,
+                            "default": true
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "key": "Operator",
+        "label": "Operator",
+        "description": "Kubernetes operator: let this release manage its own Deployment (registry update checks, optional self-update).",
+        "type": "object",
+        "required": false,
+        "properties": [
+            {
+                "key": "Enabled",
+                "label": "Enabled",
+                "description": "Enable the Kubernetes operator: let this release manage its own Deployment (registry update checks, optional self-update). Requires the Kubernetes config source and the 'operator' role. No effect otherwise.",
+                "type": "bool",
+                "required": false,
+                "default": false
+            },
+            {
+                "key": "CheckForUpdates",
+                "label": "CheckForUpdates",
+                "description": "Periodically check the container registry for a newer image and report it (in the CR status and the GUI Diagnostics page). Read-only — never changes the Deployment on its own.",
+                "type": "bool",
+                "required": false,
+                "default": true
+            },
+            {
+                "key": "CheckIntervalHours",
+                "label": "CheckIntervalHours",
+                "description": "How often to check the registry for updates, in hours.",
+                "type": "int",
+                "required": false,
+                "default": 6
+            },
+            {
+                "key": "Policy",
+                "label": "Policy",
+                "description": "How far an update may move the deployed version: Patch (same major.minor), Minor (same major, no breaking changes), or Major (any newer release).",
+                "type": "enum",
+                "required": false,
+                "default": "Minor",
+                "enumValues": [
+                    "Patch",
+                    "Minor",
+                    "Major"
+                ]
+            },
+            {
+                "key": "AutoUpdate",
+                "label": "AutoUpdate",
+                "description": "Automatically roll the Deployment to the newest eligible release (bounded by Policy). Off by default — checking is safe, but applying an update restarts the workload.",
+                "type": "bool",
+                "required": false,
+                "default": false
+            },
+            {
+                "key": "Registry",
+                "label": "Registry",
+                "description": "Override the registry host to query (e.g. ghcr.io). Defaults to the registry of the currently-deployed image.",
+                "type": "string",
+                "required": false
+            },
+            {
+                "key": "Repository",
+                "label": "Repository",
+                "description": "Override the repository to query (e.g. xtremeownage/rpdu2mqtt). Defaults to the repository of the currently-deployed image.",
+                "type": "string",
+                "required": false
+            }
+        ]
     }
-   }
-  ]
- }
 ]

--- a/rPDU2MQTT.Web/web/src/sections/diagnostics.ts
+++ b/rPDU2MQTT.Web/web/src/sections/diagnostics.ts
@@ -68,6 +68,17 @@ export function addDiagnosticsSection(nav: any, sections: any) {
     info.innerHTML = '';
     info.appendChild(row('App version', b.version));
     if (b.image) info.appendChild(row('Container image', b.image));
+    if (b.update) {
+      // Operator update report (#210). Highlight when a newer release than the deployed one is available.
+      const u = b.update;
+      let txt: string;
+      if (u.available) txt = 'update available → ' + (u.latest || '?') + (u.applied ? ' (auto-updated)' : '') + (u.current ? ' (on ' + u.current + ')' : '');
+      else if (u.current) txt = 'up to date (' + u.current + ')';
+      else txt = u.message || '—';
+      const tr = row('Updates', txt);
+      if (u.available && !u.applied) (tr.lastChild as HTMLElement).style.color = 'var(--warn, #d08700)';
+      info.appendChild(tr);
+    }
     info.appendChild(row('Uptime', b.uptimeSeconds != null ? fmtUptime(b.uptimeSeconds) : null));
     info.appendChild(row('Started (UTC)', b.startedUtc));
     info.appendChild(row('MQTT', (b.mqttConnected ? 'connected' : 'disconnected') + ' — ' + b.mqttHost));

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -406,6 +406,17 @@ function addDiagnosticsSection(nav     , sections     ) {
     info.innerHTML = '';
     info.appendChild(row('App version', b.version));
     if (b.image) info.appendChild(row('Container image', b.image));
+    if (b.update) {
+      // Operator update report (#210). Highlight when a newer release than the deployed one is available.
+      const u = b.update;
+      let txt        ;
+      if (u.available) txt = 'update available → ' + (u.latest || '?') + (u.applied ? ' (auto-updated)' : '') + (u.current ? ' (on ' + u.current + ')' : '');
+      else if (u.current) txt = 'up to date (' + u.current + ')';
+      else txt = u.message || '—';
+      const tr = row('Updates', txt);
+      if (u.available && !u.applied) (tr.lastChild               ).style.color = 'var(--warn, #d08700)';
+      info.appendChild(tr);
+    }
     info.appendChild(row('Uptime', b.uptimeSeconds != null ? fmtUptime(b.uptimeSeconds) : null));
     info.appendChild(row('Started (UTC)', b.startedUtc));
     info.appendChild(row('MQTT', (b.mqttConnected ? 'connected' : 'disconnected') + ' — ' + b.mqttHost));

--- a/rPDU2MQTT/Startup/HostRole.cs
+++ b/rPDU2MQTT/Startup/HostRole.cs
@@ -23,6 +23,7 @@ public static class HostRoles
                 "worker" or "engine" or "data" => HostRole.Worker,
                 "api" => HostRole.Api,
                 "ui" or "gui" or "web" => HostRole.Ui,
+                "operator" or "op" => HostRole.Operator,
                 _ => HostRole.None,
             };
 

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -33,6 +33,7 @@ public static class ServiceConfiguration
         bool worker = roles.HasFlag(HostRole.Worker);
         bool api = roles.HasFlag(HostRole.Api);
         bool ui = roles.HasFlag(HostRole.Ui);
+        bool @operator = roles.HasFlag(HostRole.Operator);
 
         // Bind Configuration + the source it came from (the GUI uses it to save).
         services.AddSingleton(cfg);
@@ -42,7 +43,19 @@ public static class ServiceConfiguration
             services.AddSingleton(k8sSource);
             services.AddHostedService<KubernetesStatusService>();
             services.AddHostedService<KubernetesConfigWatcher>();
+
+            // ---- Operator role: this release manages its own Deployment (#210). ----
+            // Only meaningful with the Kubernetes config source (it patches the CR status + Deployments),
+            // so it's registered here. Self-gates on Operator.Enabled each pass, so toggling it in the GUI
+            // takes effect without a restart.
+            if (@operator)
+            {
+                services.AddSingleton<Services.Operator.IContainerRegistry, Services.Operator.ContainerRegistryClient>();
+                services.AddHostedService<Services.Operator.OperatorService>();
+            }
         }
+        else if (@operator)
+            Log.Warning("The 'operator' role needs the Kubernetes config source (RPDU2MQTT_CONFIG_SOURCE=k8s); it does nothing with a file config. Ignoring.");
 
         // Configure Logging.
         services.ConfigureLogging(cfg);


### PR DESCRIPTION
Addresses #210. Per the issue note, this builds the operator as **its own role/process** (like the worker/api/ui split) whose headline job is **managing which image tag/version is deployed** and **checking for updates**.

## What it does

Run with `--role operator` (chart: `operator.enabled: true`) alongside the Kubernetes config source, and the app manages the Deployment it lives in:

- **Update checks (read-only, default on).** On a timer it reads the deployed image (`RPDU2MQTT_IMAGE`), lists the repo's tags from the registry (OCI/Docker Registry v2, anonymous pull), and resolves the newest eligible release under a policy:
  - `Patch` — newer patch on same `MAJOR.MINOR`
  - `Minor` — newer minor within same `MAJOR` (default, no breaking changes)
  - `Major` — any newer release

  Pre-releases and moving channel tags (`stable`/`edge`) are never selected as a target.
- **Reporting.** Writes `.status.update` (`available`/`current`/`latest`/`policy`/`checkedAt`/…) → visible via `kubectl get rpduconfig` (new **Update** printer column) and on the GUI **Diagnostics** page.
- **Self-update (opt-in, `Operator.AutoUpdate`).** When an eligible newer release exists, rolls the managed Deployment(s) to that tag (strategic-merge patch of the `rpdu2mqtt` container image) — a normal rolling update. Off by default: checking is safe, applying restarts the workload.

## Design notes

- **`HostRole.Operator`** is opt-in — **not** part of `all`, so it doesn't change existing deployments. Only registered with the Kubernetes config source; with a file config it logs a warning and no-ops.
- **The version math is pure and unit-tested** (`SemVer`, `ImageReference`, `UpdateResolver`); the registry/k8s I/O is a thin shell around it.
- **`PatchStatusAsync` switched from a wholesale JSON-Patch replace to a merge patch**, so the operator's status and the worker's connectivity status compose under `.status` instead of clobbering each other (they run in different processes).
- **RBAC unchanged** — the CRD config source's Role already grants `apps/deployments: get,list,patch`, `pods: get,list`, and `rpduconfigs/status: patch`.
- Committed CRD manifests + GUI schema fixture regenerated; `Operator` config live-applied by the config watcher (toggle from the GUI, no restart).

## Enabling (chart)

```yaml
operator: { enabled: true }
kubernetesConfigSource: { enabled: true }
config:
  Operator: { Enabled: true, Policy: Minor, AutoUpdate: false }
```

## Deferred (follow-up)

Reconciling infra objects (Service/Ingress/HTTPRoute) from config toggles — the issue's other angle. It overlaps with Helm's ownership of those resources and needs its own design, so it's noted in `docs/KubernetesCRD.md` and left out here.

## Verification

- `dotnet build` — 0 warnings/errors. `dotnet test` — **269 passed** (+27: semver/resolver/image-ref/host-role), incl. the CRD drift test against the regenerated manifests.
- GUI: `node build.mjs` + `node --check` + `node smoke.mjs` pass; fixture renders the new `Operator` section.
- Helm: `helm lint` clean; renders 1 deployment default, **3 with `split.enabled` (CI invariant held)**, 2 with `operator.enabled` (operator role present), 4 with both.

> Runtime-verifying the in-cluster paths (registry query, CR status patch, Deployment image roll) needs a real cluster — flagging as the maintainer's manual check, consistent with the existing CRD verification constraint in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)