### PR TITLE
fix(gui): show worker-owned health on split API/UI Status boards

### DIFF
--- a/rPDU2MQTT.Core/Core/Heartbeat.cs
+++ b/rPDU2MQTT.Core/Core/Heartbeat.cs
@@ -5,7 +5,7 @@ namespace rPDU2MQTT.Core;
 /// a split deployment — including ones that carry no PDU data (e.g. an <c>api</c> node). Liveness is by
 /// freshness: a process whose last heartbeat is older than <see cref="StaleAfterSeconds"/> is presumed gone.
 /// </summary>
-public sealed record Heartbeat(string Id, string[] Roles, string? Host, DateTime StartedUtc, DateTime TimestampUtc, string? Version)
+public sealed record Heartbeat(string Id, string[] Roles, string? Host, DateTime StartedUtc, DateTime TimestampUtc, string? Version, EmonCmsHealth? EmonCms = null)
 {
     /// <summary>Heartbeats are published this often.</summary>
     public const int IntervalSeconds = 15;
@@ -13,3 +13,10 @@ public sealed record Heartbeat(string Id, string[] Roles, string? Host, DateTime
     /// <summary>A process with no heartbeat in this long is considered gone.</summary>
     public const int StaleAfterSeconds = IntervalSeconds * 3;
 }
+
+/// <summary>
+/// The EmonCMS exporter's last-known health, carried on the worker's <see cref="Heartbeat"/> so a split
+/// API/UI node — which doesn't run the exporter — can still show the true export status on the Status
+/// board instead of a misleading "waiting". Only the process actually exporting sets it.
+/// </summary>
+public sealed record EmonCmsHealth(bool? Ok, DateTime? LastAttemptUtc, DateTime? LastSuccessUtc, string? LastError, int Count);

--- a/rPDU2MQTT.Engine/Services/EmonCmsStatus.cs
+++ b/rPDU2MQTT.Engine/Services/EmonCmsStatus.cs
@@ -37,17 +37,13 @@ public sealed class EmonCmsStatus
         }
     }
 
-    /// <summary>A snapshot for serialization (e.g. the diagnostics endpoint).</summary>
-    public object Snapshot()
+    /// <summary>True once this process has actually tried an export — i.e. it runs the exporter (the worker).</summary>
+    public bool HasAttempted { get { lock (gate) return LastAttemptUtc is not null; } }
+
+    /// <summary>A snapshot for serialization (e.g. the diagnostics endpoint) and for the heartbeat.</summary>
+    public Core.EmonCmsHealth Snapshot()
     {
         lock (gate)
-            return new
-            {
-                ok = LastOk,
-                lastAttemptUtc = LastAttemptUtc,
-                lastSuccessUtc = LastSuccessUtc,
-                lastError = LastError,
-                count = LastCount,
-            };
+            return new Core.EmonCmsHealth(LastOk, LastAttemptUtc, LastSuccessUtc, LastError, LastCount);
     }
 }

--- a/rPDU2MQTT.Engine/Services/HeartbeatService.cs
+++ b/rPDU2MQTT.Engine/Services/HeartbeatService.cs
@@ -24,15 +24,17 @@ public sealed class HeartbeatService : IHostedService
 
     private readonly HiveMQClient mqtt;
     private readonly Config cfg;
+    private readonly EmonCmsStatus emon;
     private readonly Heartbeat self;
     private readonly ConcurrentDictionary<string, Heartbeat> seen = new(StringComparer.OrdinalIgnoreCase);
     private readonly CancellationTokenSource cts = new();
     private Task? pump;
 
-    public HeartbeatService(IHiveMQClient mqtt, Config cfg, HostRole roles)
+    public HeartbeatService(IHiveMQClient mqtt, Config cfg, HostRole roles, EmonCmsStatus emon)
     {
         this.mqtt = (HiveMQClient)mqtt;
         this.cfg = cfg;
+        this.emon = emon;
 
         var roleNames = new[] { HostRole.Worker, HostRole.Api, HostRole.Ui }.Where(r => roles.HasFlag(r)).Select(r => r.ToString().ToLowerInvariant()).ToArray();
         var host = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME") ?? Environment.MachineName;
@@ -68,7 +70,9 @@ public sealed class HeartbeatService : IHostedService
             using var timer = new PeriodicTimer(TimeSpan.FromSeconds(Heartbeat.IntervalSeconds));
             do
             {
-                var beat = self with { TimestampUtc = DateTime.UtcNow };
+                // Only the process actually exporting (the worker) has attempted an export; carry its status
+                // so a split API/UI node can show the true EmonCMS health on the Status board.
+                var beat = self with { TimestampUtc = DateTime.UtcNow, EmonCms = emon.HasAttempted ? emon.Snapshot() : null };
                 seen[beat.Id] = beat;
                 await mqtt.PublishAsync(new MQTT5PublishMessage(TopicFor(beat.Id), QualityOfService.AtLeastOnceDelivery)
                 {

--- a/rPDU2MQTT.Tests/HeartbeatEmonCmsTests.cs
+++ b/rPDU2MQTT.Tests/HeartbeatEmonCmsTests.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Services;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// A split API/UI node shows the worker's EmonCMS export health by reading it off the worker's heartbeat.
+/// These lock the wire contract that carries it across processes.
+/// </summary>
+public class HeartbeatEmonCmsTests
+{
+    private static readonly JsonSerializerOptions Web = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void Heartbeat_RoundTrips_WithEmonCmsHealth()
+    {
+        var health = new EmonCmsHealth(Ok: true, LastAttemptUtc: DateTime.UtcNow, LastSuccessUtc: DateTime.UtcNow, LastError: null, Count: 12);
+        var beat = new Heartbeat("worker-x", new[] { "worker" }, "host", DateTime.UtcNow, DateTime.UtcNow, "1.0.0", health);
+
+        var back = JsonSerializer.Deserialize<Heartbeat>(JsonSerializer.Serialize(beat, Web), Web);
+
+        Assert.NotNull(back!.EmonCms);
+        Assert.True(back.EmonCms!.Ok);
+        Assert.Equal(12, back.EmonCms.Count);
+    }
+
+    [Fact]
+    public void Heartbeat_WithoutEmonCms_DeserializesToNull()
+    {
+        // Older/other-role heartbeats carry no EmonCms; the field must stay optional.
+        var beat = new Heartbeat("ui-x", new[] { "ui" }, "host", DateTime.UtcNow, DateTime.UtcNow, "1.0.0");
+        var back = JsonSerializer.Deserialize<Heartbeat>(JsonSerializer.Serialize(beat, Web), Web);
+        Assert.Null(back!.EmonCms);
+    }
+
+    [Fact]
+    public void EmonCmsStatus_Snapshot_UsesTheFieldNamesTheBoardReads()
+    {
+        var status = new EmonCmsStatus();
+        status.RecordSuccess(5);
+
+        using var doc = JsonSerializer.SerializeToDocument(status.Snapshot(), Web);
+        var root = doc.RootElement;
+
+        // home.ts / diagnostics.ts read these exact keys.
+        Assert.True(root.GetProperty("ok").GetBoolean());
+        Assert.Equal(5, root.GetProperty("count").GetInt32());
+        Assert.True(root.TryGetProperty("lastSuccessUtc", out _));
+        Assert.True(status.HasAttempted);
+    }
+
+    [Fact]
+    public void EmonCmsStatus_HasNotAttempted_BeforeAnyExport() => Assert.False(new EmonCmsStatus().HasAttempted);
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -433,6 +433,22 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 catch (Exception ex) { Log.Debug($"Diagnostics: could not read operator update status: {ex.Message}"); }
             }
 
+            // EmonCMS export health. The exporter runs only on the worker, so on a split API/UI node the
+            // local status has never attempted an export — fall back to the worker's status carried on its
+            // heartbeat, so the Status board shows the true state instead of a misleading "waiting".
+            object? emonStatus = null;
+            if (config.EmonCMS.Enabled)
+            {
+                if (emonCmsStatus.HasAttempted)
+                    emonStatus = emonCmsStatus.Snapshot();
+                else
+                    emonStatus = heartbeats.Processes
+                        .Where(p => p.EmonCms is not null && (DateTime.UtcNow - p.TimestampUtc).TotalSeconds <= Core.Heartbeat.StaleAfterSeconds)
+                        .OrderByDescending(p => p.TimestampUtc)
+                        .Select(p => (object?)p.EmonCms)
+                        .FirstOrDefault() ?? emonCmsStatus.Snapshot();
+            }
+
             return Results.Json(new
             {
                 ok = true,
@@ -486,7 +502,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 pod = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME"),
                 ns = k8s?.Namespace,
                 emoncms = config.EmonCMS.Enabled
-                    ? new { enabled = true, transport = (string?)config.EmonCMS.Transport.ToString().ToLowerInvariant(), status = (object?)emonCmsStatus.Snapshot() }
+                    ? new { enabled = true, transport = (string?)config.EmonCMS.Transport.ToString().ToLowerInvariant(), status = emonStatus }
                     : new { enabled = false, transport = (string?)null, status = (object?)null },
             }, ConfigSchema.Json);
         });

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -87,14 +87,16 @@ public static class ServiceConfiguration
         // Owns the PDU producer(s) — one poller per configured instance; reconciled at runtime when the
         // GUI saves instance changes. Singleton + hosted-service facade so the GUI can trigger reconcile.
         services.AddSingleton<InstanceManager>();
-        // Data production runs in the Worker role; the cache/bus singletons stay registered so the API/GUI
-        // can read them in-process (a single-node 'all' deployment). Splitting these across processes is the
-        // job of the planned message-bus transport.
-        if (worker)
-        {
+        // The snapshot cache must drain the bus on any node that serves data. On a worker it consumes the
+        // local poller; on a split API/UI node it consumes the worker's snapshots that the MqttBusBridge
+        // ingests onto the bus. Without starting it here, a non-worker node's cache never fills and the
+        // Status board shows "PDUs: no data yet / waiting on a worker node" forever even though the worker
+        // is healthy (the consumer only publishes to the bus; nothing drained it).
+        if (worker || api || ui)
             services.AddHostedService(sp => sp.GetRequiredService<Core.SnapshotCache>());
+        // Data production (the PDU pollers) runs only in the Worker role.
+        if (worker)
             services.AddHostedService(sp => sp.GetRequiredService<InstanceManager>());
-        }
 
         // Shared liveness/readiness signals (uptime + last successful poll).
         services.AddSingleton<HealthState>();


### PR DESCRIPTION
## The bug

In a split Kubernetes deployment (separate `worker`/`api`/`ui` processes), the **Status** board is served by whichever node the ingress routes to — usually `ui` or `api`. Two of its cards reflect **worker-only runtime state**, which never reached that node, so they sat amber forever even though the worker was healthy:

- **PDUs** → "No data yet / Waiting on a worker node"
- **EmonCMS** → "Waiting / no export attempted yet"

(Your instinct was right — the worker handles these and wasn't reporting back.)

## Root causes & fixes

**PDUs — the cache never ran on consumer nodes.** `SnapshotCache` is a `BackgroundService` that drains the in-process snapshot bus, but it was only started as a hosted service on the `worker`. On a split `api`/`ui` node the `MqttBusBridge` *does* ingest the worker's snapshots onto the local bus — but nothing drained them, so `snapshots.All` stayed empty and `dataSources` was always empty.
→ Start `SnapshotCache` on any data-serving node (`worker | api | ui`).

**EmonCMS — status was process-local.** The exporter runs only on the worker, and its `EmonCmsStatus` lived only in that process. There was no cross-process channel for it.
→ Carry the exporter's health on the worker's **heartbeat** (new optional `Heartbeat.EmonCms`; only the process that actually exports sets it), and have the diagnostics endpoint fall back to the freshest non-stale worker heartbeat's status when the local node hasn't exported. The board now shows the true EmonCMS state on every node.

The wire shape is unchanged for the GUI (same field names), so no TS/asset changes were needed.

## Verification

- `dotnet build` clean; `dotnet test` **273 passed** (+4 guarding the heartbeat / EmonCmsHealth wire contract).
- Single-node (`all`) behaviour is unchanged — the worker role is present, so both were already starting/populating there.

> The actual split-process behaviour (bus bridge delivery, cross-node heartbeat) needs a real multi-process broker/cluster to exercise, which isn't available here — flagging as the maintainer's manual check, consistent with the repo's existing verification constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)