### PR TITLE
feat(operator): switch channel/version + force update from the Operator page (#210)

### DIFF
--- a/rPDU2MQTT.Core/Core/OperatorCommand.cs
+++ b/rPDU2MQTT.Core/Core/OperatorCommand.cs
@@ -16,6 +16,9 @@ public sealed record OperatorCommand(string Action, DateTime AtUtc, string? Tag 
     /// <summary>Roll the managed Deployment(s) to <see cref="Tag"/> — a channel (stable/edge/dev) or a version.</summary>
     public const string SetTagAction = "set-tag";
 
+    /// <summary>Re-pull the currently-deployed tag now (pins its current digest so it rolls even on IfNotPresent).</summary>
+    public const string RedeployAction = "redeploy";
+
     /// <summary>The (non-retained) bus topic operator commands are published to.</summary>
     public static string TopicFor(string parentTopic) => MQTTHelper.JoinPaths(parentTopic, "_bus", "command", "operator");
 }

--- a/rPDU2MQTT.Core/Core/OperatorCommand.cs
+++ b/rPDU2MQTT.Core/Core/OperatorCommand.cs
@@ -8,10 +8,13 @@ namespace rPDU2MQTT.Core;
 /// from the header — instead of waiting for the next timer tick. The operator subscribes to
 /// <see cref="TopicFor"/> and runs a check as soon as one arrives.
 /// </summary>
-public sealed record OperatorCommand(string Action, DateTime AtUtc)
+public sealed record OperatorCommand(string Action, DateTime AtUtc, string? Tag = null)
 {
     /// <summary>Run an update check immediately.</summary>
     public const string CheckAction = "check";
+
+    /// <summary>Roll the managed Deployment(s) to <see cref="Tag"/> — a channel (stable/edge/dev) or a version.</summary>
+    public const string SetTagAction = "set-tag";
 
     /// <summary>The (non-retained) bus topic operator commands are published to.</summary>
     public static string TopicFor(string parentTopic) => MQTTHelper.JoinPaths(parentTopic, "_bus", "command", "operator");

--- a/rPDU2MQTT.Engine/Services/Operator/ContainerRegistryClient.cs
+++ b/rPDU2MQTT.Engine/Services/Operator/ContainerRegistryClient.cs
@@ -44,10 +44,38 @@ public sealed class ContainerRegistryClient : IContainerRegistry
         return tags;
     }
 
-    private static Task<HttpResponseMessage> SendAsync(string url, string? token, CancellationToken ct)
+    // The manifest media types to ask for when resolving a tag → digest (indexes first for multi-arch).
+    private const string ManifestAccept =
+        "application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json," +
+        "application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json";
+
+    /// <summary>
+    /// Resolve a tag (or reference) to the image digest it currently points at, so a "force update" can pin
+    /// the exact bytes and pull even under <c>imagePullPolicy: IfNotPresent</c>. Null if the registry doesn't
+    /// report one.
+    /// </summary>
+    public async Task<string?> ResolveDigestAsync(string registryHost, string repository, string reference, CancellationToken ct)
+    {
+        var url = $"https://{registryHost}/v2/{repository}/manifests/{reference}";
+        using var response = await SendAsync(url, null, ct, ManifestAccept);
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            var token = await AcquireTokenAsync(response, repository, ct);
+            using var retried = await SendAsync(url, token, ct, ManifestAccept);
+            retried.EnsureSuccessStatusCode();
+            return DigestOf(retried);
+        }
+        response.EnsureSuccessStatusCode();
+        return DigestOf(response);
+    }
+
+    private static string? DigestOf(HttpResponseMessage response)
+        => response.Headers.TryGetValues("Docker-Content-Digest", out var v) ? v.FirstOrDefault() : null;
+
+    private static Task<HttpResponseMessage> SendAsync(string url, string? token, CancellationToken ct, string accept = "application/json")
     {
         var request = new HttpRequestMessage(HttpMethod.Get, url);
-        request.Headers.Accept.ParseAdd("application/json");
+        request.Headers.Accept.ParseAdd(accept);
         if (token is not null)
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         return Http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);

--- a/rPDU2MQTT.Engine/Services/Operator/IContainerRegistry.cs
+++ b/rPDU2MQTT.Engine/Services/Operator/IContainerRegistry.cs
@@ -12,4 +12,10 @@ public interface IContainerRegistry
     /// for public images and pagination followed).
     /// </summary>
     Task<IReadOnlyList<string>> ListTagsAsync(string registryHost, string repository, CancellationToken ct);
+
+    /// <summary>
+    /// Resolve a tag/reference to the image digest it points at, so a "force update" can pin the exact bytes
+    /// and pull even under <c>imagePullPolicy: IfNotPresent</c>. Null if the registry reports none.
+    /// </summary>
+    Task<string?> ResolveDigestAsync(string registryHost, string repository, string reference, CancellationToken ct);
 }

--- a/rPDU2MQTT.Engine/Services/Operator/OperatorService.cs
+++ b/rPDU2MQTT.Engine/Services/Operator/OperatorService.cs
@@ -32,6 +32,7 @@ public sealed class OperatorService : IHostedService, IDisposable
 
     // Container images this app publishes; used to pick the right container(s) to read/patch in a pod spec.
     private const string ContainerName = "rpdu2mqtt";
+    private static readonly System.Text.Json.JsonSerializerOptions Json = new(System.Text.Json.JsonSerializerDefaults.Web);
 
     public OperatorService(KubernetesConfigSource source, Config cfg, IContainerRegistry registry, IHiveMQClient mqtt)
     {
@@ -55,9 +56,23 @@ public sealed class OperatorService : IHostedService, IDisposable
     private void OnMessageReceived(object? sender, OnMessageReceivedEventArgs e)
     {
         if (!string.Equals(e.PublishMessage.Topic, CommandTopic, StringComparison.Ordinal)) return;
-        // Any operator command currently means "check now"; wake the loop (ignore if a wake is already pending).
-        Log.Information("Operator: on-demand update check requested over the bus.");
-        try { checkNow.Release(); } catch (SemaphoreFullException) { /* a check is already pending */ }
+
+        OperatorCommand? cmd;
+        try { cmd = System.Text.Json.JsonSerializer.Deserialize<OperatorCommand>(e.PublishMessage.PayloadAsString ?? "", Json); }
+        catch { return; }
+        if (cmd is null) return;
+
+        if (string.Equals(cmd.Action, OperatorCommand.SetTagAction, StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(cmd.Tag))
+        {
+            Log.Information($"Operator: switch-to-tag '{cmd.Tag}' requested over the bus.");
+            _ = Task.Run(() => SetTagAsync(cmd.Tag!.Trim(), stoppingCts.Token));
+        }
+        else
+        {
+            // "check now": wake the loop (ignore if a wake is already pending).
+            Log.Information("Operator: on-demand update check requested over the bus.");
+            try { checkNow.Release(); } catch (SemaphoreFullException) { /* a check is already pending */ }
+        }
     }
 
     private async Task RunAsync(CancellationToken ct)
@@ -144,6 +159,53 @@ public sealed class OperatorService : IHostedService, IDisposable
                 ? (applied is not null ? $"Auto-updated to {applied}." : $"Update available: {latest}.")
                 : "Up to date.",
         }, ct);
+    }
+
+    /// <summary>
+    /// Roll the managed Deployment(s) to a chosen tag — a channel (<c>stable</c>/<c>edge</c>/<c>dev</c>) or a
+    /// specific version — requested from the GUI. This is the manual counterpart to auto-update.
+    /// </summary>
+    private async Task SetTagAsync(string tag, CancellationToken ct)
+    {
+        var deployedImage = Environment.GetEnvironmentVariable("RPDU2MQTT_IMAGE");
+        if (!ImageReference.TryParse(deployedImage, out var image))
+        {
+            Log.Warning($"Operator: can't switch tag — deployed image unknown (RPDU2MQTT_IMAGE='{deployedImage}').");
+            return;
+        }
+
+        var repository = cfg.Operator.Repository ?? image.Repository;
+        var newImage = image.WithTag(tag);
+
+        // Report the intent before patching: switching may roll this operator's own pod, cutting the run short.
+        await PatchUpdateStatusAsync(new
+        {
+            current = image.Tag,
+            latest = tag,
+            checkedAt = DateTime.UtcNow.ToString("o"),
+            message = $"Switching to {tag}…",
+        }, ct);
+
+        try
+        {
+            var patched = await SetImageAsync(repository, newImage, ct);
+            Log.Warning($"Operator: switched {(patched.Count > 0 ? string.Join(", ", patched) : "no")} deployment(s) to {newImage}.");
+            await PatchUpdateStatusAsync(new
+            {
+                available = false,
+                current = tag,
+                latest = tag,
+                applied = tag,
+                checkedAt = DateTime.UtcNow.ToString("o"),
+                message = $"Switched to {tag}.",
+            }, ct);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Operator: could not switch to {newImage}: {ex.Message}");
+            try { await PatchUpdateStatusAsync(new { current = image.Tag, checkedAt = DateTime.UtcNow.ToString("o"), message = $"Switch to {tag} failed: {ex.Message}" }, ct); }
+            catch { /* best effort */ }
+        }
     }
 
     private string ResolveRegistryHost(ImageReference image)

--- a/rPDU2MQTT.Engine/Services/Operator/OperatorService.cs
+++ b/rPDU2MQTT.Engine/Services/Operator/OperatorService.cs
@@ -67,6 +67,11 @@ public sealed class OperatorService : IHostedService, IDisposable
             Log.Information($"Operator: switch-to-tag '{cmd.Tag}' requested over the bus.");
             _ = Task.Run(() => SetTagAsync(cmd.Tag!.Trim(), stoppingCts.Token));
         }
+        else if (string.Equals(cmd.Action, OperatorCommand.RedeployAction, StringComparison.Ordinal))
+        {
+            Log.Information("Operator: force redeploy requested over the bus.");
+            _ = Task.Run(() => RedeployAsync(stoppingCts.Token));
+        }
         else
         {
             // "check now": wake the loop (ignore if a wake is already pending).
@@ -204,6 +209,43 @@ public sealed class OperatorService : IHostedService, IDisposable
         {
             Log.Error($"Operator: could not switch to {newImage}: {ex.Message}");
             try { await PatchUpdateStatusAsync(new { current = image.Tag, checkedAt = DateTime.UtcNow.ToString("o"), message = $"Switch to {tag} failed: {ex.Message}" }, ct); }
+            catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// Force a re-pull of the currently-deployed tag now: resolve it to its current digest and pin
+    /// <c>repo:tag@digest</c> on the Deployment(s), so it rolls and pulls the new bytes even under
+    /// <c>imagePullPolicy: IfNotPresent</c> (the point of a "force update" on a moving channel like edge/dev).
+    /// </summary>
+    private async Task RedeployAsync(CancellationToken ct)
+    {
+        if (!ImageReference.TryParse(Environment.GetEnvironmentVariable("RPDU2MQTT_IMAGE"), out var image) || string.IsNullOrEmpty(image.Tag))
+        {
+            Log.Warning("Operator: can't force-update — the deployed image has no tag to re-pull.");
+            return;
+        }
+
+        var registryHost = ResolveRegistryHost(image);
+        var repository = cfg.Operator.Repository ?? image.Repository;
+        try
+        {
+            var digest = await registry.ResolveDigestAsync(registryHost, repository, image.Tag, ct);
+            // Keep the tag visible for humans but pin the digest so IfNotPresent still pulls.
+            var newImage = digest is not null ? $"{image.Registry}/{repository}:{image.Tag}@{digest}" : image.WithTag(image.Tag);
+            var patched = await SetImageAsync(repository, newImage, ct);
+            Log.Warning($"Operator: force redeploy — rolled {(patched.Count > 0 ? string.Join(", ", patched) : "no")} deployment(s) to {newImage}.");
+            await PatchUpdateStatusAsync(new
+            {
+                current = image.Tag,
+                checkedAt = DateTime.UtcNow.ToString("o"),
+                message = digest is not null ? $"Redeploying {image.Tag} ({digest[..Math.Min(digest.Length, 19)]}…)." : $"Redeploying {image.Tag}.",
+            }, ct);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Operator: force redeploy failed: {ex.Message}");
+            try { await PatchUpdateStatusAsync(new { current = image.Tag, checkedAt = DateTime.UtcNow.ToString("o"), message = $"Redeploy failed: {ex.Message}" }, ct); }
             catch { /* best effort */ }
         }
     }

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -422,6 +422,50 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             catch (Exception ex) { return Results.Json(new { ok = false, message = $"Could not request a check: {ex.Message}" }, ConfigSchema.Json); }
         });
 
+        // Tags available for the deployed image, so the Operator page can offer a channel/version switch.
+        // The GUI process queries the registry directly (a plain HTTPS call); the switch itself is the operator's job.
+        app.MapGet("/api/operator/tags", async (HttpContext ctx) =>
+        {
+            if (configSource is not KubernetesConfigSource)
+                return Results.Json(new { ok = false, message = "Switching versions needs the Kubernetes config source + the operator role." }, ConfigSchema.Json);
+            if (!Updates.ImageReference.TryParse(Environment.GetEnvironmentVariable("RPDU2MQTT_IMAGE"), out var image))
+                return Results.Json(new { ok = false, message = "The deployed image is unknown (RPDU2MQTT_IMAGE is unset)." }, ConfigSchema.Json);
+            try
+            {
+                var host = image.Registry == Updates.ImageReference.DefaultRegistry ? "registry-1.docker.io" : image.Registry;
+                var tags = await new Services.Operator.ContainerRegistryClient().ListTagsAsync(host, image.Repository, ctx.RequestAborted);
+                // Offer the moving channels that actually exist, then release versions newest-first.
+                var channels = new[] { "stable", "latest", "edge", "dev", "unstable" }.Where(tags.Contains).ToArray();
+                var versions = tags.Where(t => Updates.SemVer.TryParse(t, out _))
+                    .Select(t => { Updates.SemVer.TryParse(t, out var v); return (Tag: t, Ver: v!); })
+                    .Where(x => !x.Ver.IsPreRelease)
+                    .OrderByDescending(x => x.Ver).Select(x => x.Tag).Take(50).ToArray();
+                return Results.Json(new { ok = true, current = image.Tag, registry = image.Registry, repository = image.Repository, channels, versions }, ConfigSchema.Json);
+            }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = $"Could not list tags: {ex.Message}" }, ConfigSchema.Json); }
+        });
+
+        // Switch the deployed image tag (channel or version). The operator rolls the Deployment(s) to it.
+        app.MapPost("/api/operator/set-tag", async (HttpContext ctx) =>
+        {
+            if (configSource is not KubernetesConfigSource)
+                return Results.Json(new { ok = false, message = "Switching versions needs the Kubernetes config source + the operator role." }, ConfigSchema.Json);
+            var tag = ctx.Request.Query["tag"].FirstOrDefault()?.Trim();
+            if (string.IsNullOrWhiteSpace(tag))
+                return Results.Json(new { ok = false, message = "A tag is required." }, ConfigSchema.Json);
+            try
+            {
+                var cmd = new Core.OperatorCommand(Core.OperatorCommand.SetTagAction, DateTime.UtcNow, tag);
+                await ((HiveMQClient)mqtt).PublishAsync(new MQTT5PublishMessage(Core.OperatorCommand.TopicFor(config.MQTT.ParentTopic), QualityOfService.AtLeastOnceDelivery)
+                {
+                    PayloadAsString = System.Text.Json.JsonSerializer.Serialize(cmd, ConfigSchema.Json),
+                    Retain = false,
+                });
+                return Results.Json(new { ok = true, message = $"Switching to '{tag}'. The Deployment will roll — watch the header/Diagnostics for the new version." }, ConfigSchema.Json);
+            }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = $"Could not request the switch: {ex.Message}" }, ConfigSchema.Json); }
+        });
+
         // Configured PDU instances (the per-tab instance selector on Live Data / Control reads this).
         app.MapGet("/api/instances", () =>
         {
@@ -1303,13 +1347,18 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         return reader.ReadToEnd();
     }
 
-    /// <summary>Read the operator's update report from the CR <c>.status.update</c> (#210), or null if none.</summary>
+    /// <summary>
+    /// Read the operator's update report from the CR <c>.status.update</c> (#210), or null if none. Bounded
+    /// by a short timeout so a slow/unreachable API server can never hang the header's /api/status call.
+    /// </summary>
     private static async Task<object?> ReadOperatorUpdateAsync(KubernetesConfigSource? k8s, CancellationToken ct)
     {
         if (k8s is null) return null;
         try
         {
-            var status = await k8s.ReadStatusAsync(ct);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(TimeSpan.FromSeconds(4));
+            var status = await k8s.ReadStatusAsync(cts.Token);
             if (status is { } s && s.TryGetProperty("update", out var u))
                 return System.Text.Json.JsonSerializer.Deserialize<object>(u.GetRawText());
         }

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -466,6 +466,25 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             catch (Exception ex) { return Results.Json(new { ok = false, message = $"Could not request the switch: {ex.Message}" }, ConfigSchema.Json); }
         });
 
+        // Force update: re-pull the currently-deployed tag now (the operator pins its current digest so it
+        // rolls even under IfNotPresent). Useful for moving channels (edge/dev/stable) that changed underneath.
+        app.MapPost("/api/operator/redeploy", async (HttpContext ctx) =>
+        {
+            if (configSource is not KubernetesConfigSource)
+                return Results.Json(new { ok = false, message = "Force update needs the Kubernetes config source + the operator role." }, ConfigSchema.Json);
+            try
+            {
+                var cmd = new Core.OperatorCommand(Core.OperatorCommand.RedeployAction, DateTime.UtcNow);
+                await ((HiveMQClient)mqtt).PublishAsync(new MQTT5PublishMessage(Core.OperatorCommand.TopicFor(config.MQTT.ParentTopic), QualityOfService.AtLeastOnceDelivery)
+                {
+                    PayloadAsString = System.Text.Json.JsonSerializer.Serialize(cmd, ConfigSchema.Json),
+                    Retain = false,
+                });
+                return Results.Json(new { ok = true, message = "Force update requested — re-pulling the current tag and rolling the Deployment." }, ConfigSchema.Json);
+            }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = $"Could not request the update: {ex.Message}" }, ConfigSchema.Json); }
+        });
+
         // Configured PDU instances (the per-tab instance selector on Live Data / Control reads this).
         app.MapGet("/api/instances", () =>
         {

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -1,6 +1,6 @@
 // Schema-driven config form: render scalar/object/dictionary/list nodes, the per-section panels, the
 // nav, and the overall build() that wires every tab.
-import { ensure, el, btn, activate, slug } from './helpers.js';
+import { ensure, el, btn, activate, slug, api, toast } from './helpers.js';
 import { state } from './state.js';
 import { renderOverrides, previewOverridePaths } from './overrides.js';
 import { testMqtt, testPdu, testEmonCms, provisionEmonCmsFeeds, deleteEmonCmsFeeds, rediscoverHa, clearHa, testModbus } from './actions.js';
@@ -219,6 +219,7 @@ function renderConfigSection(node: any, nav: any, sections: any) {
     if (node.key === 'Gui') wireGuiAuth(sec);
     else if (node.key === 'EmonCMS') wireEmonCmsTransport(sec);
     else if (node.key === 'Api') wireApiDocs(sec);
+    else if (node.key === 'Operator') wireOperatorSwitch(sec);
     link.onclick = () => activate(link, sec);
   }
   return link;
@@ -353,6 +354,50 @@ function wireApiDocs(sec: any) {
   enabled?.addEventListener('change', apply);
   apply();
   sec.appendChild(box);
+}
+
+// Operator page: a channel/version switcher — roll the Deployment to stable/edge/dev or a specific release (#210).
+function wireOperatorSwitch(sec: any) {
+  const box = document.createElement('fieldset');
+  const lg = document.createElement('legend'); lg.textContent = 'Deployed version'; box.appendChild(lg);
+  const desc = el('div', { class: 'desc' }); box.appendChild(desc);
+  const row = el('div', { class: 'sec-actions' });
+  const sel = document.createElement('select'); sel.style.width = 'auto';
+  const switchBtn = btn('Switch', 'primary');
+  const status = el('div', { class: 'desc' });
+  row.append(sel, switchBtn); box.append(row, status);
+  sec.appendChild(box);
+
+  const CHANNEL_LABEL: Record<string, string> = {
+    stable: 'stable — newest release', latest: 'latest — newest release', edge: 'edge — main branch (bleeding edge)',
+    dev: 'dev — work-in-progress builds', unstable: 'unstable — work-in-progress builds',
+  };
+
+  api('/api/operator/tags').then(r => {
+    const b = r.body || {};
+    if (!b.ok) { desc.textContent = b.message || 'Version switching is unavailable.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; return; }
+    desc.innerHTML = `Roll the Deployment to a different image tag. Currently deployed: <b>${b.current || '—'}</b>. Switching restarts the workload (a normal rolling update).`;
+    const group = (label: string, tags: string[], fmt: (t: string) => string) => {
+      if (!tags || !tags.length) return;
+      const og = document.createElement('optgroup'); og.label = label;
+      tags.forEach(t => { const o = document.createElement('option'); o.value = t; o.textContent = fmt(t); if (t === b.current) o.selected = true; og.appendChild(o); });
+      sel.appendChild(og);
+    };
+    group('Channels', b.channels || [], (t: string) => CHANNEL_LABEL[t] || t);
+    group('Versions', b.versions || [], (t: string) => t);
+    if (!sel.options.length) { desc.textContent += ' No tags found in the registry.'; switchBtn.disabled = true; }
+
+    switchBtn.onclick = async () => {
+      const tag = sel.value; if (!tag) return;
+      if (tag === b.current) { toast('That tag is already deployed.', false); return; }
+      if (!confirm(`Switch the deployment to "${tag}"? This rolls the workload (all tiers) to that image.`)) return;
+      switchBtn.disabled = true;
+      const res = await api('/api/operator/set-tag?tag=' + encodeURIComponent(tag), { method: 'POST' });
+      switchBtn.disabled = false;
+      toast(res.body?.message || (res.ok ? 'Switch requested.' : 'Switch failed.'), res.ok && res.body?.ok);
+      if (res.ok && res.body?.ok) status.textContent = res.body.message;
+    };
+  }).catch(() => { desc.textContent = 'Could not load available versions.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; });
 }
 
 // Section-specific action buttons (connection tests; Home Assistant discovery actions).

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -364,9 +364,20 @@ function wireOperatorSwitch(sec: any) {
   const row = el('div', { class: 'sec-actions' });
   const sel = document.createElement('select'); sel.style.width = 'auto';
   const switchBtn = btn('Switch', 'primary');
+  const forceBtn = btn('Force update');
+  forceBtn.title = 'Re-pull the current tag now (pins its current digest so it rolls even on IfNotPresent). Use for moving channels like edge/dev that changed underneath.';
   const status = el('div', { class: 'desc' });
-  row.append(sel, switchBtn); box.append(row, status);
+  row.append(sel, switchBtn, forceBtn); box.append(row, status);
   sec.appendChild(box);
+
+  forceBtn.onclick = async () => {
+    if (!confirm('Force a re-pull of the currently-deployed tag and roll the Deployment now?')) return;
+    forceBtn.disabled = true;
+    const res = await api('/api/operator/redeploy', { method: 'POST' });
+    forceBtn.disabled = false;
+    toast(res.body?.message || (res.ok ? 'Force update requested.' : 'Force update failed.'), res.ok && res.body?.ok);
+    if (res.ok && res.body?.ok) status.textContent = res.body.message;
+  };
 
   const CHANNEL_LABEL: Record<string, string> = {
     stable: 'stable — newest release', latest: 'latest — newest release', edge: 'edge — main branch (bleeding edge)',
@@ -375,7 +386,7 @@ function wireOperatorSwitch(sec: any) {
 
   api('/api/operator/tags').then(r => {
     const b = r.body || {};
-    if (!b.ok) { desc.textContent = b.message || 'Version switching is unavailable.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; return; }
+    if (!b.ok) { desc.textContent = b.message || 'Version switching is unavailable.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; forceBtn.style.display = 'none'; return; }
     desc.innerHTML = `Roll the Deployment to a different image tag. Currently deployed: <b>${b.current || '—'}</b>. Switching restarts the workload (a normal rolling update).`;
     const group = (label: string, tags: string[], fmt: (t: string) => string) => {
       if (!tags || !tags.length) return;
@@ -397,7 +408,7 @@ function wireOperatorSwitch(sec: any) {
       toast(res.body?.message || (res.ok ? 'Switch requested.' : 'Switch failed.'), res.ok && res.body?.ok);
       if (res.ok && res.body?.ok) status.textContent = res.body.message;
     };
-  }).catch(() => { desc.textContent = 'Could not load available versions.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; });
+  }).catch(() => { desc.textContent = 'Could not load available versions.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; forceBtn.style.display = 'none'; });
 }
 
 // Section-specific action buttons (connection tests; Home Assistant discovery actions).

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1985,6 +1985,7 @@ function renderConfigSection(node     , nav     , sections     ) {
     if (node.key === 'Gui') wireGuiAuth(sec);
     else if (node.key === 'EmonCMS') wireEmonCmsTransport(sec);
     else if (node.key === 'Api') wireApiDocs(sec);
+    else if (node.key === 'Operator') wireOperatorSwitch(sec);
     link.onclick = () => activate(link, sec);
   }
   return link;
@@ -2119,6 +2120,50 @@ function wireApiDocs(sec     ) {
   enabled?.addEventListener('change', apply);
   apply();
   sec.appendChild(box);
+}
+
+// Operator page: a channel/version switcher — roll the Deployment to stable/edge/dev or a specific release (#210).
+function wireOperatorSwitch(sec     ) {
+  const box = document.createElement('fieldset');
+  const lg = document.createElement('legend'); lg.textContent = 'Deployed version'; box.appendChild(lg);
+  const desc = el('div', { class: 'desc' }); box.appendChild(desc);
+  const row = el('div', { class: 'sec-actions' });
+  const sel = document.createElement('select'); sel.style.width = 'auto';
+  const switchBtn = btn('Switch', 'primary');
+  const status = el('div', { class: 'desc' });
+  row.append(sel, switchBtn); box.append(row, status);
+  sec.appendChild(box);
+
+  const CHANNEL_LABEL                         = {
+    stable: 'stable — newest release', latest: 'latest — newest release', edge: 'edge — main branch (bleeding edge)',
+    dev: 'dev — work-in-progress builds', unstable: 'unstable — work-in-progress builds',
+  };
+
+  api('/api/operator/tags').then(r => {
+    const b = r.body || {};
+    if (!b.ok) { desc.textContent = b.message || 'Version switching is unavailable.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; return; }
+    desc.innerHTML = `Roll the Deployment to a different image tag. Currently deployed: <b>${b.current || '—'}</b>. Switching restarts the workload (a normal rolling update).`;
+    const group = (label        , tags          , fmt                       ) => {
+      if (!tags || !tags.length) return;
+      const og = document.createElement('optgroup'); og.label = label;
+      tags.forEach(t => { const o = document.createElement('option'); o.value = t; o.textContent = fmt(t); if (t === b.current) o.selected = true; og.appendChild(o); });
+      sel.appendChild(og);
+    };
+    group('Channels', b.channels || [], (t        ) => CHANNEL_LABEL[t] || t);
+    group('Versions', b.versions || [], (t        ) => t);
+    if (!sel.options.length) { desc.textContent += ' No tags found in the registry.'; switchBtn.disabled = true; }
+
+    switchBtn.onclick = async () => {
+      const tag = sel.value; if (!tag) return;
+      if (tag === b.current) { toast('That tag is already deployed.', false); return; }
+      if (!confirm(`Switch the deployment to "${tag}"? This rolls the workload (all tiers) to that image.`)) return;
+      switchBtn.disabled = true;
+      const res = await api('/api/operator/set-tag?tag=' + encodeURIComponent(tag), { method: 'POST' });
+      switchBtn.disabled = false;
+      toast(res.body?.message || (res.ok ? 'Switch requested.' : 'Switch failed.'), res.ok && res.body?.ok);
+      if (res.ok && res.body?.ok) status.textContent = res.body.message;
+    };
+  }).catch(() => { desc.textContent = 'Could not load available versions.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; });
 }
 
 // Section-specific action buttons (connection tests; Home Assistant discovery actions).

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2130,9 +2130,20 @@ function wireOperatorSwitch(sec     ) {
   const row = el('div', { class: 'sec-actions' });
   const sel = document.createElement('select'); sel.style.width = 'auto';
   const switchBtn = btn('Switch', 'primary');
+  const forceBtn = btn('Force update');
+  forceBtn.title = 'Re-pull the current tag now (pins its current digest so it rolls even on IfNotPresent). Use for moving channels like edge/dev that changed underneath.';
   const status = el('div', { class: 'desc' });
-  row.append(sel, switchBtn); box.append(row, status);
+  row.append(sel, switchBtn, forceBtn); box.append(row, status);
   sec.appendChild(box);
+
+  forceBtn.onclick = async () => {
+    if (!confirm('Force a re-pull of the currently-deployed tag and roll the Deployment now?')) return;
+    forceBtn.disabled = true;
+    const res = await api('/api/operator/redeploy', { method: 'POST' });
+    forceBtn.disabled = false;
+    toast(res.body?.message || (res.ok ? 'Force update requested.' : 'Force update failed.'), res.ok && res.body?.ok);
+    if (res.ok && res.body?.ok) status.textContent = res.body.message;
+  };
 
   const CHANNEL_LABEL                         = {
     stable: 'stable — newest release', latest: 'latest — newest release', edge: 'edge — main branch (bleeding edge)',
@@ -2141,7 +2152,7 @@ function wireOperatorSwitch(sec     ) {
 
   api('/api/operator/tags').then(r => {
     const b = r.body || {};
-    if (!b.ok) { desc.textContent = b.message || 'Version switching is unavailable.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; return; }
+    if (!b.ok) { desc.textContent = b.message || 'Version switching is unavailable.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; forceBtn.style.display = 'none'; return; }
     desc.innerHTML = `Roll the Deployment to a different image tag. Currently deployed: <b>${b.current || '—'}</b>. Switching restarts the workload (a normal rolling update).`;
     const group = (label        , tags          , fmt                       ) => {
       if (!tags || !tags.length) return;
@@ -2163,7 +2174,7 @@ function wireOperatorSwitch(sec     ) {
       toast(res.body?.message || (res.ok ? 'Switch requested.' : 'Switch failed.'), res.ok && res.body?.ok);
       if (res.ok && res.body?.ok) status.textContent = res.body.message;
     };
-  }).catch(() => { desc.textContent = 'Could not load available versions.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; });
+  }).catch(() => { desc.textContent = 'Could not load available versions.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; forceBtn.style.display = 'none'; });
 }
 
 // Section-specific action buttons (connection tests; Home Assistant discovery actions).


### PR DESCRIPTION
Follow-up to the operator work (#210). The Operator page had update *checks* and a Policy, but no way to actually **choose what's deployed**. Adds that. (The Modbus/framing follow-ups from the same local branch already landed via #221's squash; this PR is only the operator controls.)

## Operator page → "Deployed version" panel

- **Switch** — a dropdown of **Channels** (`stable`/`edge`/`dev` — only the tags that actually exist) and **Versions** (specific releases, newest first), current tag pre-selected. Picking one rolls the Deployment(s) to that tag.
- **Force update** — re-pull the *currently-deployed* tag now, for a moving channel whose pointer moved without the image field changing. Because the chart defaults to `imagePullPolicy: IfNotPresent`, a plain restart wouldn't re-pull — so the operator **resolves the tag to its current digest** and pins `repo:tag@digest` (keeps the channel name visible, forces the pull, and the update-check still reads the tag). Falls back to a plain tag set if the registry returns no digest.

## Wiring

- `OperatorCommand` gains `set-tag` and `redeploy` actions; `OperatorService` applies them by patching the managed Deployment(s) (reusing the auto-update path) and reporting on the CR status.
- `IContainerRegistry.ResolveDigestAsync` (manifest `Docker-Content-Digest`, same anonymous-token flow as tag listing).
- `GET /api/operator/tags` (channels + versions), `POST /api/operator/set-tag`, `POST /api/operator/redeploy` — all Kubernetes-only.
- Also **bounds the `/api/status` operator-status CR read with a 4 s timeout**, fixing a `v?` + red-MQTT header when the API server was slow (the Status page showed both healthy — the header was blanking on a hung read).

## Verification

- `dotnet build` clean; `dotnet test` **285 passed**; GUI `build.mjs` + `--check` + `smoke.mjs` pass.
- The live click→bus→operator→registry→Deployment path needs a real cluster with the operator role — flagging as the maintainer's manual check.

Note: if `AutoUpdate` + a semver Policy are on and you switch to a pinned version, the next check may bump it again — switch to a moving channel or disable AutoUpdate to hold a pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)