### PR TITLE
fix(modbus): one poller per device (worker-only) — stop multi-process contention

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -756,6 +756,13 @@ Each connection has a **`Framing`**:
 If a connection *connects* but every register reads as an error, it's the framing — `auto` handles that for
 you; pin one only if you want to skip the detection.
 
+**One poller per device.** Many RS485-to-Ethernet gateways accept only **one TCP client at a time**, so the
+Modbus poller runs **only in the Worker role** — in a split deployment the API/UI don't poll the device
+themselves (they'd contend with the worker and each other, and reads would time out). The Nodes editor shows
+each binding's value from the shared live cache the worker fills; the **"Test device read"** button opens a
+one-off connection to check a binding before it's saved — use it sparingly if your gateway is single-client,
+since it briefly competes with the worker's poll.
+
 ### Device templates (Nodes tab → "Import device template")
 
 Rather than wire a known device register-by-register, the **Nodes** tab can import a ready-made template:

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -216,48 +216,52 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
         if (value == null) { cell.textContent = err ? 'err' : '—'; cell.style.color = err ? 'var(--bad)' : 'var(--muted)'; cell.title = err || 'no live value yet'; }
         else { const cu = metricMeta(metric)[2]; cell.textContent = `${formatNum(value)} ${cu}`.trim(); cell.style.color = 'var(--good)'; cell.title = ''; }
       };
-      const refresh = async () => {
-        // Modbus: probe the device(s), grouped by connection so each is read once.
-        const modbus = liveCells.filter(lc => (lc.src.Type || 'mqtt') === 'modbus');
-        const conns: any[] = (state.data?.Modbus?.Connections) || [];
-        const byConn = new Map<string, { src: any, cell: any }[]>();
-        modbus.forEach(lc => { const id = lc.src.Connection || ''; (byConn.get(id) || byConn.set(id, []).get(id)!).push(lc); });
-        let probeMsg = '';   // a Modbus error/result to show instead of a bare "updated <time>"
-        for (const [connId, cells] of byConn) {
-          const conn = conns.find(c => c.Id === connId);
-          if (!conn) { cells.forEach(lc => setCell(lc.cell, null, 'pick a connection')); probeMsg = 'Pick a Modbus connection.'; continue; }
-          try {
-            const r = await api('/api/modbus/probe', { method: 'POST', headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ Host: conn.Host, Port: conn.Port, UnitId: conn.UnitId, Framing: conn.Framing, Items: cells.map(lc => lc.src) }) });
-            if (!r.body.ok) { cells.forEach(lc => setCell(lc.cell, null, 'err')); probeMsg = r.body.message || 'probe failed'; continue; }
-            const readings = r.body.readings || [];
-            cells.forEach((lc, i) => setCell(lc.cell, readings[i]?.value ?? null, readings[i]?.error, lc.src.Metric));
-            // Surface the connection result + the first register error inline (not just in the cell tooltip).
-            const firstErr = readings.find((rd: any) => rd?.error)?.error;
-            if (firstErr) probeMsg = (r.body.message || '') + ' — ' + firstErr;
-          } catch (e: any) { cells.forEach(lc => setCell(lc.cell, null, 'err')); probeMsg = String(e?.message || e); }
+      // A Modbus device is a shared serial resource — many gateways accept only one client at a time, and
+      // the worker already polls it. So auto-refresh reads the shared live cache (no device access); only an
+      // explicit "Test device read" opens its own connection, to check a binding before it's saved/polled.
+      const refresh = async (probe = false) => {
+        let probeMsg = '';
+        if (probe) {
+          const modbus = liveCells.filter(lc => (lc.src.Type || 'mqtt') === 'modbus');
+          const conns: any[] = (state.data?.Modbus?.Connections) || [];
+          const byConn = new Map<string, { src: any, cell: any }[]>();
+          modbus.forEach(lc => { const id = lc.src.Connection || ''; (byConn.get(id) || byConn.set(id, []).get(id)!).push(lc); });
+          for (const [connId, cells] of byConn) {
+            const conn = conns.find(c => c.Id === connId);
+            if (!conn) { cells.forEach(lc => setCell(lc.cell, null, 'pick a connection')); probeMsg = 'Pick a Modbus connection.'; continue; }
+            try {
+              const r = await api('/api/modbus/probe', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ Host: conn.Host, Port: conn.Port, UnitId: conn.UnitId, Framing: conn.Framing, Items: cells.map(lc => lc.src) }) });
+              if (!r.body.ok) { cells.forEach(lc => setCell(lc.cell, null, 'err')); probeMsg = r.body.message || 'probe failed'; continue; }
+              const readings = r.body.readings || [];
+              cells.forEach((lc, i) => setCell(lc.cell, readings[i]?.value ?? null, readings[i]?.error, lc.src.Metric));
+              const firstErr = readings.find((rd: any) => rd?.error)?.error;
+              if (firstErr) probeMsg = (r.body.message || '') + ' — ' + firstErr;
+            } catch (e: any) { cells.forEach(lc => setCell(lc.cell, null, 'err')); probeMsg = String(e?.message || e); }
+          }
         }
 
-        // MQTT + future types: whatever the running ingest currently holds in the shared cache.
-        const others = liveCells.filter(lc => (lc.src.Type || 'mqtt') !== 'modbus');
-        if (others.length) {
+        // Every binding not just device-probed reads the shared live cache the running ingests fill.
+        const cached = probe ? liveCells.filter(lc => (lc.src.Type || 'mqtt') !== 'modbus') : liveCells;
+        if (cached.length) {
           try {
             const r = await api('/api/flow/live', { method: 'POST', headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(others.map(lc => ({ Node: node.Id, Metric: lc.src.Metric || 'realpower' }))) });
+              body: JSON.stringify(cached.map(lc => ({ Node: node.Id, Metric: lc.src.Metric || 'realpower' }))) });
             const vals = (r.body && r.body.values) || [];
-            others.forEach((lc, i) => setCell(lc.cell, vals[i]?.value ?? null, undefined, lc.src.Metric));
-          } catch (e: any) { others.forEach(lc => setCell(lc.cell, null, 'err')); }
+            cached.forEach((lc, i) => setCell(lc.cell, vals[i]?.value ?? null, undefined, lc.src.Metric));
+          } catch (e: any) { cached.forEach(lc => setCell(lc.cell, null, 'err')); }
         }
-        // A Modbus error/result wins over the bare timestamp so the failure reason is visible without hovering.
         status.textContent = probeMsg || `updated ${new Date().toLocaleTimeString()}`;
         status.style.color = probeMsg ? 'var(--bad)' : 'var(--muted)';
       };
-      const refreshBtn = btn('Refresh values');
-      refreshBtn.onclick = refresh;
+      const hasModbus = liveCells.some(lc => (lc.src.Type || 'mqtt') === 'modbus');
+      const refreshBtn = btn(hasModbus ? 'Test device read' : 'Refresh values');
+      if (hasModbus) refreshBtn.title = 'Open a one-off connection to the device to test these bindings. Normally the worker polls it and the value shows here automatically — avoid hammering a gateway that allows only one client.';
+      refreshBtn.onclick = () => refresh(true);
       box.appendChild(el('div', { class: 'ld-toolbar', style: { marginTop: '6px' } }, refreshBtn, status));
-      refresh();
+      refresh(false);
       // Self-cleaning: once this editor is replaced/closed its box leaves the DOM and the poll stops.
-      const timer = setInterval(() => { if (!document.body.contains(box)) { clearInterval(timer); return; } refresh(); }, 5000);
+      const timer = setInterval(() => { if (!document.body.contains(box)) { clearInterval(timer); return; } refresh(false); }, 5000);
     }
   }
 

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -994,48 +994,52 @@ function renderNodeEditor(node     , links       , cand                  , reren
         if (value == null) { cell.textContent = err ? 'err' : '—'; cell.style.color = err ? 'var(--bad)' : 'var(--muted)'; cell.title = err || 'no live value yet'; }
         else { const cu = metricMeta(metric)[2]; cell.textContent = `${formatNum(value)} ${cu}`.trim(); cell.style.color = 'var(--good)'; cell.title = ''; }
       };
-      const refresh = async () => {
-        // Modbus: probe the device(s), grouped by connection so each is read once.
-        const modbus = liveCells.filter(lc => (lc.src.Type || 'mqtt') === 'modbus');
-        const conns        = (state.data?.Modbus?.Connections) || [];
-        const byConn = new Map                                   ();
-        modbus.forEach(lc => { const id = lc.src.Connection || ''; (byConn.get(id) || byConn.set(id, []).get(id) ).push(lc); });
-        let probeMsg = '';   // a Modbus error/result to show instead of a bare "updated <time>"
-        for (const [connId, cells] of byConn) {
-          const conn = conns.find(c => c.Id === connId);
-          if (!conn) { cells.forEach(lc => setCell(lc.cell, null, 'pick a connection')); probeMsg = 'Pick a Modbus connection.'; continue; }
-          try {
-            const r = await api('/api/modbus/probe', { method: 'POST', headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ Host: conn.Host, Port: conn.Port, UnitId: conn.UnitId, Framing: conn.Framing, Items: cells.map(lc => lc.src) }) });
-            if (!r.body.ok) { cells.forEach(lc => setCell(lc.cell, null, 'err')); probeMsg = r.body.message || 'probe failed'; continue; }
-            const readings = r.body.readings || [];
-            cells.forEach((lc, i) => setCell(lc.cell, readings[i]?.value ?? null, readings[i]?.error, lc.src.Metric));
-            // Surface the connection result + the first register error inline (not just in the cell tooltip).
-            const firstErr = readings.find((rd     ) => rd?.error)?.error;
-            if (firstErr) probeMsg = (r.body.message || '') + ' — ' + firstErr;
-          } catch (e     ) { cells.forEach(lc => setCell(lc.cell, null, 'err')); probeMsg = String(e?.message || e); }
+      // A Modbus device is a shared serial resource — many gateways accept only one client at a time, and
+      // the worker already polls it. So auto-refresh reads the shared live cache (no device access); only an
+      // explicit "Test device read" opens its own connection, to check a binding before it's saved/polled.
+      const refresh = async (probe = false) => {
+        let probeMsg = '';
+        if (probe) {
+          const modbus = liveCells.filter(lc => (lc.src.Type || 'mqtt') === 'modbus');
+          const conns        = (state.data?.Modbus?.Connections) || [];
+          const byConn = new Map                                   ();
+          modbus.forEach(lc => { const id = lc.src.Connection || ''; (byConn.get(id) || byConn.set(id, []).get(id) ).push(lc); });
+          for (const [connId, cells] of byConn) {
+            const conn = conns.find(c => c.Id === connId);
+            if (!conn) { cells.forEach(lc => setCell(lc.cell, null, 'pick a connection')); probeMsg = 'Pick a Modbus connection.'; continue; }
+            try {
+              const r = await api('/api/modbus/probe', { method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ Host: conn.Host, Port: conn.Port, UnitId: conn.UnitId, Framing: conn.Framing, Items: cells.map(lc => lc.src) }) });
+              if (!r.body.ok) { cells.forEach(lc => setCell(lc.cell, null, 'err')); probeMsg = r.body.message || 'probe failed'; continue; }
+              const readings = r.body.readings || [];
+              cells.forEach((lc, i) => setCell(lc.cell, readings[i]?.value ?? null, readings[i]?.error, lc.src.Metric));
+              const firstErr = readings.find((rd     ) => rd?.error)?.error;
+              if (firstErr) probeMsg = (r.body.message || '') + ' — ' + firstErr;
+            } catch (e     ) { cells.forEach(lc => setCell(lc.cell, null, 'err')); probeMsg = String(e?.message || e); }
+          }
         }
 
-        // MQTT + future types: whatever the running ingest currently holds in the shared cache.
-        const others = liveCells.filter(lc => (lc.src.Type || 'mqtt') !== 'modbus');
-        if (others.length) {
+        // Every binding not just device-probed reads the shared live cache the running ingests fill.
+        const cached = probe ? liveCells.filter(lc => (lc.src.Type || 'mqtt') !== 'modbus') : liveCells;
+        if (cached.length) {
           try {
             const r = await api('/api/flow/live', { method: 'POST', headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(others.map(lc => ({ Node: node.Id, Metric: lc.src.Metric || 'realpower' }))) });
+              body: JSON.stringify(cached.map(lc => ({ Node: node.Id, Metric: lc.src.Metric || 'realpower' }))) });
             const vals = (r.body && r.body.values) || [];
-            others.forEach((lc, i) => setCell(lc.cell, vals[i]?.value ?? null, undefined, lc.src.Metric));
-          } catch (e     ) { others.forEach(lc => setCell(lc.cell, null, 'err')); }
+            cached.forEach((lc, i) => setCell(lc.cell, vals[i]?.value ?? null, undefined, lc.src.Metric));
+          } catch (e     ) { cached.forEach(lc => setCell(lc.cell, null, 'err')); }
         }
-        // A Modbus error/result wins over the bare timestamp so the failure reason is visible without hovering.
         status.textContent = probeMsg || `updated ${new Date().toLocaleTimeString()}`;
         status.style.color = probeMsg ? 'var(--bad)' : 'var(--muted)';
       };
-      const refreshBtn = btn('Refresh values');
-      refreshBtn.onclick = refresh;
+      const hasModbus = liveCells.some(lc => (lc.src.Type || 'mqtt') === 'modbus');
+      const refreshBtn = btn(hasModbus ? 'Test device read' : 'Refresh values');
+      if (hasModbus) refreshBtn.title = 'Open a one-off connection to the device to test these bindings. Normally the worker polls it and the value shows here automatically — avoid hammering a gateway that allows only one client.';
+      refreshBtn.onclick = () => refresh(true);
       box.appendChild(el('div', { class: 'ld-toolbar', style: { marginTop: '6px' } }, refreshBtn, status));
-      refresh();
+      refresh(false);
       // Self-cleaning: once this editor is replaced/closed its box leaves the DOM and the poll stops.
-      const timer = setInterval(() => { if (!document.body.contains(box)) { clearInterval(timer); return; } refresh(); }, 5000);
+      const timer = setInterval(() => { if (!document.body.contains(box)) { clearInterval(timer); return; } refresh(false); }, 5000);
     }
   }
 

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -122,9 +122,14 @@ public static class ServiceConfiguration
         services.AddHostedService(sp => sp.GetRequiredService<Services.EnergyFlowMqttSourceService>());
 
         // Modbus TCP is a second live-value ingest (#129): poll inverters/meters/PLCs into the same seam.
-        // Self-gating too — with no connections/bindings configured it opens no sockets.
+        // Self-gating too — with no connections/bindings configured it opens no sockets. Unlike the MQTT
+        // source (broker fan-out is free), a Modbus device is a shared serial resource: many RS485-to-Ethernet
+        // gateways accept only ONE TCP client at a time, so every process polling it independently causes
+        // contention — the reads time out. So the poller runs only in the Worker role (data production);
+        // the API/UI read the values through the same bus/exports as any other producer.
         services.AddSingleton<Services.EnergyFlowModbusSourceService>();
-        services.AddHostedService(sp => sp.GetRequiredService<Services.EnergyFlowModbusSourceService>());
+        if (worker)
+            services.AddHostedService(sp => sp.GetRequiredService<Services.EnergyFlowModbusSourceService>());
 
         // The graph/exporters see one IFlowValueSource; the composite merges every ingest (MQTT + Modbus).
         services.AddSingleton<Core.Flow.IFlowValueSource>(sp => new Core.Flow.CompositeFlowValueSource(


### PR DESCRIPTION
Your hunch was exactly right. The energy-flow Modbus poller (`EnergyFlowModbusSourceService`) was registered as a hosted service **unconditionally**, so in a split deployment the **worker, api, ui, and operator processes each opened their own connection** to the same device every poll — plus the GUI's "Refresh values" auto-probe every 5s from the ui process.

Many RS485-to-Ethernet gateways (like an EG4 on `:4196`) accept **only one TCP client at a time**, so all but one connection get *connect ok → read times out*. That's the erratic `err` / `Connection timed out` you kept seeing.

## Fix

- **Poll each device from the Worker role only** — data production belongs to the worker, same as the PDU poller. The MQTT flow source stays in every role (broker fan-out is free; no device contention). One process, one connection.
- **Nodes editor** no longer hammers the device: auto-refresh reads the shared live cache (the worker fills it), and the button is now an explicit **"Test device read"** — a one-off probe to check a binding before it's saved. Viewing the editor no longer competes with the worker's poll.

## Trade-off (split deployments)

With the poller worker-only, a split **API/UI** process no longer has Modbus values in its *local* cache, so the Nodes "Current" column there shows a value only after a manual "Test device read" (until cross-process flow-value propagation exists — a reasonable follow-up). The **data pipeline is unaffected**: the worker has the values and exports them to MQTT / Home Assistant / Prometheus as before. A single-node (`all`) deployment is unchanged — the worker is in-process.

## Verification

- `dotnet build` clean; `dotnet test` **285 passed**; GUI `build.mjs` + `--check` + `smoke.mjs` pass.
- The single-client-gateway behaviour needs your actual hardware to confirm end-to-end — but this removes the concurrent connections that were causing the timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)