### PR TITLE
feat(mqtt): published measurements carry when they were read (#205)

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -97,6 +97,13 @@ spec:
                   LastWill:
                     type: boolean
                     description: Publish a Last-Will message and set an availability topic on entities, so Home Assistant marks them unavailable immediately when the bridge disconnects. When off, entities instead rely on HomeAssistant.SensorExpireAfterSeconds (expire_after) to go unavailable.
+                  MessageTimestamp:
+                    type: string
+                    enum:
+                    - None
+                    - UserProperty
+                    - Payload
+                    description: "Carry the time a measurement was read: 'UserProperty' adds an MQTT v5 'timestamp' property and leaves the payload alone (default, safe for every existing consumer), 'Payload' publishes {\"value\": …, \"timestamp\": …} instead of a bare value (Home Assistant discovery adapts automatically), 'None' carries no timestamp."
                 description: MQTT Configuration
               Pdus:
                 type: object

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -97,6 +97,13 @@ spec:
                   LastWill:
                     type: boolean
                     description: Publish a Last-Will message and set an availability topic on entities, so Home Assistant marks them unavailable immediately when the bridge disconnects. When off, entities instead rely on HomeAssistant.SensorExpireAfterSeconds (expire_after) to go unavailable.
+                  MessageTimestamp:
+                    type: string
+                    enum:
+                    - None
+                    - UserProperty
+                    - Payload
+                    description: "Carry the time a measurement was read: 'UserProperty' adds an MQTT v5 'timestamp' property and leaves the payload alone (default, safe for every existing consumer), 'Payload' publishes {\"value\": …, \"timestamp\": …} instead of a bare value (Home Assistant discovery adapts automatically), 'None' carries no timestamp."
                 description: MQTT Configuration
               Pdus:
                 type: object

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -89,6 +89,29 @@ HomeAssistant:
 > Note: `expire_after` only applies to sensors/binary-sensors. Outlet **switches** have no
 > `expire_after` in Home Assistant, so with `LastWill: false` switches will not auto-mark unavailable.
 
+### Message Timestamp (Optional)
+
+Published measurements carry **the time the PDU was read** — not the time we happened to publish — so a
+consumer can tell a fresh reading from a republished one.
+
+```yaml
+Mqtt:
+  MessageTimestamp: UserProperty   # UserProperty (default) | Payload | None
+```
+
+| Mode | What a measurement looks like |
+| --- | --- |
+| `UserProperty` | The payload is unchanged (a bare value); the time rides along as an MQTT v5 `timestamp` user property. Invisible to consumers that don't look for it, so Home Assistant and every existing subscription keep working exactly as before. **Default.** |
+| `Payload` | The payload becomes `{"value": "123.4", "timestamp": "2026-07-21T18:30:15.250Z"}`. Home Assistant discovery adapts automatically (the sensors get `value_template: {{ value_json.value }}`), but anything reading these topics by hand needs updating — which is why it isn't the default. |
+| `None` | No timestamp at all — the behaviour before this option existed. |
+
+The timestamp is ISO-8601 UTC to milliseconds. The value stays a **string** in `Payload` mode, because that's
+how the PDU reports it — re-typing it as a number would turn `0.00` into `0` and lose the device's precision.
+
+> The energy-flow export (`EnergyFlow.MqttExport`) publishes a JSON payload already, so it always includes a
+> `timestamp` field regardless of this setting. For a rolled-up tier it's the **oldest** contributing
+> snapshot's time — a roll-up is only as current as its stalest input.
+
 ### Connection Details (Required)
 Configure the connection to your MQTT broker:
 

--- a/rPDU2MQTT.Core/Core/MessageTimestamps.cs
+++ b/rPDU2MQTT.Core/Core/MessageTimestamps.cs
@@ -1,0 +1,45 @@
+using System.Text.Json;
+using rPDU2MQTT.Models.Config;
+
+namespace rPDU2MQTT.Core;
+
+/// <summary>
+/// Puts the time a measurement was read onto the message that carries it (#205) — as a user property, or in
+/// the payload. Broker-free so the shapes are testable on their own; the publishing services just apply it.
+/// </summary>
+public static class MessageTimestamps
+{
+    /// <summary>The MQTT v5 user-property name, and the JSON field name in <see cref="MessageTimestampMode.Payload"/>.</summary>
+    public const string PropertyName = "timestamp";
+
+    /// <summary>
+    /// ISO-8601, UTC, milliseconds. Sortable, unambiguous, and what every consumer's date parser expects —
+    /// including Home Assistant's <c>as_datetime</c>.
+    /// </summary>
+    public static string Format(DateTime timestampUtc)
+        => timestampUtc.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// The payload for one measurement: the bare value as always, or a small JSON object carrying the value
+    /// and when it was read.
+    /// </summary>
+    public static string Payload(string value, DateTime? timestampUtc, MessageTimestampMode mode)
+    {
+        if (mode != MessageTimestampMode.Payload) return value;
+
+        // The value stays a string: these come off the PDU as text, and re-typing them here would turn
+        // "0.00" into 0 and lose the device's own precision.
+        return JsonSerializer.Serialize(new Dictionary<string, string?>
+        {
+            ["value"] = value,
+            [PropertyName] = Format(timestampUtc ?? DateTime.UtcNow),
+        });
+    }
+
+    /// <summary>
+    /// The Home Assistant value template for a measurement sensor, so discovery keeps matching the payload
+    /// shape this mode publishes.
+    /// </summary>
+    public static string ValueTemplate(MessageTimestampMode mode)
+        => mode == MessageTimestampMode.Payload ? "{{ value_json.value }}" : "{{ value }}";
+}

--- a/rPDU2MQTT.Core/Models/Config/MQTTConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/MQTTConfig.cs
@@ -49,4 +49,14 @@ public class MQTTConfig
     [YamlMember(Alias = "LastWill", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
     [Display(Name = "Last Will / Availability", Description = "Publish a Last-Will message and set an availability topic on entities, so Home Assistant marks them unavailable immediately when the bridge disconnects. When off, entities instead rely on HomeAssistant.SensorExpireAfterSeconds (expire_after) to go unavailable.")]
     public bool LastWill { get; set; } = true;
+
+    /// <summary>
+    /// Whether published measurements carry the time they were read, and how (#205). The timestamp is the
+    /// poll time, so a consumer can tell a fresh reading from a republished one.
+    /// </summary>
+    [DefaultValue(MessageTimestampMode.UserProperty)]
+    [YamlMember(Alias = "MessageTimestamp", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    [Display(Name = "Message Timestamp", Description = "Carry the time a measurement was read: 'UserProperty' adds an MQTT v5 'timestamp' property and leaves the payload alone (default, safe for every existing consumer), 'Payload' publishes {\"value\": …, \"timestamp\": …} instead of a bare value (Home Assistant discovery adapts automatically), 'None' carries no timestamp.")]
+    [AllowedValues("None", "UserProperty", "Payload")]
+    public MessageTimestampMode MessageTimestamp { get; set; } = MessageTimestampMode.UserProperty;
 }

--- a/rPDU2MQTT.Core/Models/Config/MessageTimestampMode.cs
+++ b/rPDU2MQTT.Core/Models/Config/MessageTimestampMode.cs
@@ -1,0 +1,28 @@
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>
+/// How a published measurement carries the moment it was read (#205).
+/// <para>
+/// The timestamp is the <b>PDU's poll time</b>, not the moment we happened to publish — that's the number
+/// worth having, because it's what tells a consumer whether a reading is current or a republished stale one.
+/// </para>
+/// </summary>
+public enum MessageTimestampMode
+{
+    /// <summary>Don't carry one. Exactly what this project did before #205.</summary>
+    None,
+
+    /// <summary>
+    /// An MQTT v5 <c>timestamp</c> user property on every published message. The payload is untouched, so
+    /// every existing consumer — Home Assistant included — keeps working unchanged, and anything that cares
+    /// can read the property. This is the default.
+    /// </summary>
+    UserProperty,
+
+    /// <summary>
+    /// The measurement payload becomes <c>{"value": …, "timestamp": …}</c>. Visible to any consumer, at the
+    /// cost of no longer being a bare number: Home Assistant discovery is adjusted to match automatically,
+    /// but anything reading these topics by hand needs updating, which is why it isn't the default.
+    /// </summary>
+    Payload,
+}

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -32,10 +32,16 @@ public class EnergyFlowMqttExportService : baseMQTTService
 
         // The hierarchy spans every PDU, so build one graph from all fresh sources combined.
         var merged = new PduData();
-        foreach (var snapshot in FreshSnapshots())
-            merged.Devices.AddRange(snapshot.Devices);
+        DateTime? oldest = null;
+        foreach (var snapshot in FreshSnapshotsWithId())
+        {
+            merged.Devices.AddRange(snapshot.Data.Devices);
+            // A tier's roll-up is only as current as its stalest input, so report that rather than flatter it.
+            if (oldest is null || snapshot.TimestampUtc < oldest) oldest = snapshot.TimestampUtc;
+        }
         if (merged.Devices.Count == 0)
             return;
+        DataTimestampUtc = oldest;
 
         // Power defines the hierarchy/topics; energy is the same roll-up over the energy measurement, so
         // each tier gets a total (kWh) it can contribute to the Energy Dashboard.
@@ -68,6 +74,8 @@ public class EnergyFlowMqttExportService : baseMQTTService
                 label = node.Label,
                 kind = node.Kind,
                 parents,
+                // #205: this payload is already JSON, so the read time can just be a field — no mode needed.
+                timestamp = Core.MessageTimestamps.Format(oldest ?? DateTime.UtcNow),
             });
             await PublishString(topic, payload, retain: true, cancellationToken);
 

--- a/rPDU2MQTT.Engine/Services/MQTTPublishingService.cs
+++ b/rPDU2MQTT.Engine/Services/MQTTPublishingService.cs
@@ -16,8 +16,12 @@ public class MQTTPublishingService : basePublishingService
     {
         // Publish every fresh source's data (a stale/absent source is skipped so a PDU outage surfaces
         // via expire_after instead of republishing old values).
-        foreach (var data in FreshSnapshots())
+        foreach (var snapshot in FreshSnapshotsWithId())
         {
+            // #205: everything published from this snapshot is stamped with when the PDU was actually read.
+            DataTimestampUtc = snapshot.TimestampUtc;
+            var data = snapshot.Data;
+
             // Run through each device.
             foreach (var device in data.Devices)
             {

--- a/rPDU2MQTT.Engine/Services/baseTypes/baseDiscoveryService.cs
+++ b/rPDU2MQTT.Engine/Services/baseTypes/baseDiscoveryService.cs
@@ -33,7 +33,9 @@ public abstract class baseDiscoveryService : baseMQTTService
     /// Returns <see langword="null"/> if the measurement cannot be parsed.
     /// </summary>
     public baseEntity? BuildMeasurement(Measurement measurement, DiscoveryDevice Parent)
-        => BuildMeasurement((baseMeasurement)measurement, Parent, "{{ value }}");
+        // #205: the template has to match the payload shape the publisher is using, or Home Assistant reads
+        // the whole JSON document as the state.
+        => BuildMeasurement((baseMeasurement)measurement, Parent, Core.MessageTimestamps.ValueTemplate(cfg.MQTT.MessageTimestamp));
 
     public BinarySensorDiscovery BuildState<T>(T item, DiscoveryDevice Parent) where T : NamedEntity, IEntityWithState
     {

--- a/rPDU2MQTT.Engine/Services/baseTypes/baseMQTTService.cs
+++ b/rPDU2MQTT.Engine/Services/baseTypes/baseMQTTService.cs
@@ -28,6 +28,12 @@ public abstract class baseMQTTService : IHostedService, IDisposable
     /// </summary>
     protected virtual bool LeaderGated => true;
 
+    /// <summary>
+    /// When the data currently being published was read from the device (#205). A publishing loop sets this
+    /// per snapshot; null means "no better answer than now" (e.g. a state echo after a control action).
+    /// </summary>
+    protected DateTime? DataTimestampUtc { get; set; }
+
     protected System.Text.Json.JsonSerializerOptions jsonOptions { get; init; }
 
     protected baseMQTTService(MQTTServiceDependencies dependencies) : this(dependencies, dependencies.Cfg.Primary.PollInterval) { }
@@ -176,6 +182,13 @@ public abstract class baseMQTTService : IHostedService, IDisposable
     {
         if (cfg.Debug.PublishMessages == false)
             return Task.CompletedTask;
+
+        // #205: carry the moment the data was read. As a user property this is invisible to consumers that
+        // don't look for it, so it costs nothing to have on by default — and it's the poll time, not the
+        // publish time, which is what makes a stale republish distinguishable from a fresh reading.
+        if (cfg.MQTT.MessageTimestamp == Models.Config.MessageTimestampMode.UserProperty)
+            msg.UserProperties[Core.MessageTimestamps.PropertyName] =
+                Core.MessageTimestamps.Format(DataTimestampUtc ?? DateTime.UtcNow);
 
         // Disconnects are reported by MqttEventHandler and recovered via auto-reconnect;
         // publish failures surface in tick(). No need to check connectivity per message.

--- a/rPDU2MQTT.Engine/Services/baseTypes/basePublishingService.cs
+++ b/rPDU2MQTT.Engine/Services/baseTypes/basePublishingService.cs
@@ -25,7 +25,9 @@ public abstract class basePublishingService : baseMQTTService
         foreach (var measurement in Measurements)
         {
             var topic = measurement.GetTopicPath();
-            await PublishString(topic, measurement.Value, cancellationToken);
+            // #205: in Payload mode the reading is published as {"value": …, "timestamp": …}; otherwise it
+            // stays the bare value it has always been.
+            await PublishString(topic, Core.MessageTimestamps.Payload(measurement.Value, DataTimestampUtc, cfg.MQTT.MessageTimestamp), cancellationToken);
         }
     }
 

--- a/rPDU2MQTT.Tests/MessageTimestampTests.cs
+++ b/rPDU2MQTT.Tests/MessageTimestampTests.cs
@@ -1,0 +1,78 @@
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Models.Config;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// #205: a published measurement carries the time it was read. The default carries it where nothing can
+/// trip over it (an MQTT v5 user property); Payload mode puts it in the message, and discovery has to move
+/// with it or Home Assistant reads the whole JSON document as the state.
+/// </summary>
+public class MessageTimestampTests
+{
+    private static readonly DateTime Read = new(2026, 7, 21, 18, 30, 15, 250, DateTimeKind.Utc);
+
+    [Fact]
+    public void Default_LeavesThePayloadAlone()
+    {
+        // The whole point of the default: every existing consumer keeps reading a bare value.
+        Assert.Equal("123.4", MessageTimestamps.Payload("123.4", Read, MessageTimestampMode.UserProperty));
+        Assert.Equal("123.4", MessageTimestamps.Payload("123.4", Read, MessageTimestampMode.None));
+        Assert.Equal("{{ value }}", MessageTimestamps.ValueTemplate(MessageTimestampMode.UserProperty));
+        Assert.Equal("{{ value }}", MessageTimestamps.ValueTemplate(MessageTimestampMode.None));
+    }
+
+    [Fact]
+    public void PayloadMode_CarriesValueAndTimestamp_AndDiscoveryFollows()
+    {
+        var payload = MessageTimestamps.Payload("123.4", Read, MessageTimestampMode.Payload);
+
+        using var doc = System.Text.Json.JsonDocument.Parse(payload);
+        Assert.Equal("123.4", doc.RootElement.GetProperty("value").GetString());
+        Assert.Equal("2026-07-21T18:30:15.250Z", doc.RootElement.GetProperty("timestamp").GetString());
+
+        // Home Assistant has to be told where the value moved to.
+        Assert.Equal("{{ value_json.value }}", MessageTimestamps.ValueTemplate(MessageTimestampMode.Payload));
+    }
+
+    [Fact]
+    public void Value_StaysAString_SoDevicePrecisionSurvives()
+    {
+        // "0.00" means the device reported two decimals; re-typing it as a number would throw that away.
+        var payload = MessageTimestamps.Payload("0.00", Read, MessageTimestampMode.Payload);
+        Assert.Contains("\"value\":\"0.00\"", payload);
+    }
+
+    [Fact]
+    public void Timestamp_IsIso8601Utc_ToMilliseconds()
+    {
+        Assert.Equal("2026-07-21T18:30:15.250Z", MessageTimestamps.Format(Read));
+
+        // A local time is normalised rather than published as-is with the wrong meaning.
+        var local = new DateTime(2026, 7, 21, 18, 30, 15, 250, DateTimeKind.Utc).ToLocalTime();
+        Assert.Equal("2026-07-21T18:30:15.250Z", MessageTimestamps.Format(local));
+    }
+
+    [Fact]
+    public void NoReadTime_FallsBackToNow_RatherThanEmpty()
+    {
+        var payload = MessageTimestamps.Payload("1", null, MessageTimestampMode.Payload);
+        using var doc = System.Text.Json.JsonDocument.Parse(payload);
+        var stamp = doc.RootElement.GetProperty("timestamp").GetString();
+
+        Assert.False(string.IsNullOrWhiteSpace(stamp));
+        Assert.True(DateTime.TryParse(stamp, System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsed));
+        Assert.True((DateTime.UtcNow - parsed).Duration() < TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void DefaultMode_IsTheInvisibleOne()
+    {
+        // #205 asked for timestamps; shipping them off by default would not answer the request, and shipping
+        // them in the payload by default would break every consumer that reads a bare value.
+        Assert.Equal(MessageTimestampMode.UserProperty, new Config().MQTT.MessageTimestamp);
+    }
+}


### PR DESCRIPTION
Closes #205.

Every published measurement can now carry **the time the PDU was read** — not the time we happened to publish it. That distinction is the useful part: it's what lets a consumer tell a fresh reading from a republished stale one.

## `Mqtt.MessageTimestamp`

| Mode | What a measurement looks like |
| --- | --- |
| `UserProperty` **(default)** | Payload unchanged (a bare value); the time rides along as an MQTT v5 `timestamp` user property. Invisible to anything that doesn't look for it. |
| `Payload` | `{"value": "123.4", "timestamp": "2026-07-21T18:30:15.250Z"}` |
| `None` | No timestamp — the previous behaviour. |

**Why `UserProperty` is the default:** shipping it off by default wouldn't answer the request; shipping it in the payload by default would break every consumer reading a bare value. A user property delivers the timestamp to anyone who wants it while leaving Home Assistant and every existing subscription byte-for-byte unchanged.

**When `Payload` is on, discovery follows it** — the measurement sensors get `value_template: {{ value_json.value }}`, so HA keeps reading the right field instead of the whole JSON document. That's the failure this would otherwise cause silently.

The value stays a **string** in `Payload` mode: the PDU reports `0.00`, and re-typing it as a number would throw away the precision the device chose.

## Energy-flow export

That payload is already JSON, so it just gains a `timestamp` field regardless of the mode. For a rolled-up tier it's the **oldest** contributing snapshot's time — a roll-up is only as current as its stalest input, and reporting the newest would flatter it.

## Tests + docs

6 new tests (336 total, 0 warnings): the default really does leave the payload alone, `Payload` mode's shape, the discovery template moving with it, string-precision preservation, the ISO-8601-UTC format including a local-time input, and the fallback when no read time is known. CRD manifests regenerated; `docs/Configuration.md` documents all three modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)