### PR TITLE
feat(prometheus): export the friendly names too (#206)

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -382,7 +382,7 @@ spec:
                     type: array
                     items:
                       type: string
-                    description: "Labels attached to every exported metric. Available: device, source, name, number, type, units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set."
+                    description: "Labels attached to every exported metric. Available: device, device_name (the device's display name), source, name (the outlet/entity's display name), number, type, type_name (the measurement said in English, e.g. 'Real Power'), units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set."
                   Pushgateway:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -382,7 +382,7 @@ spec:
                     type: array
                     items:
                       type: string
-                    description: "Labels attached to every exported metric. Available: device, source, name, number, type, units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set."
+                    description: "Labels attached to every exported metric. Available: device, device_name (the device's display name), source, name (the outlet/entity's display name), number, type, type_name (the measurement said in English, e.g. 'Real Power'), units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set."
                   Pushgateway:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -471,6 +471,30 @@ non-alphanumeric characters replaced by `_` (so pick a template that starts with
 default `rpdu2mqtt_{type}` and aggregate/filter by label (the idiomatic approach), or encode them into
 the name if you prefer.
 
+**Friendly names in labels.** The default labels are object-id forms (`device="rack_pdu_1"`,
+`source="outlet_10"`) — stable, but not what the thing is *called*. `Prometheus.Labels` can add the
+human forms alongside them:
+
+```yaml
+Prometheus:
+  Labels: [device, device_name, source, name, type, type_name, units]
+```
+
+| Label | Example | What it is |
+| --- | --- | --- |
+| `device` / `device_name` | `rack_pdu_1` / `Rack PDU 1` | the PDU's id form / its display name |
+| `source` / `name` | `outlet_10` / `Dell MD1200` | the outlet or entity's id form / its display name |
+| `type` / `type_name` | `realpower` / `Real Power` | the measurement type / said in English |
+| `number`, `units`, `instance`, `hierarchy` | `10`, `W`, `rack-b`, `Rack Circuit A` | outlet number, units, PDU instance key, the energy-flow tier feeding it |
+
+> The default set stays `[device, source, units]` on purpose: adding a label changes the identity of every
+> existing time series, which breaks continuity in dashboards that are already recording. Opt in when you
+> want it.
+
+Every gauge's **HELP** text is the measurement said in English with its unit
+(`Real Power (W), measured by rPDU2MQTT.`), so series are readable in Grafana's metric browser without
+adding any labels at all.
+
 You can also rename an individual measurement type via its **Measurements override ID**, which replaces
 `{type}`. For example, with the default template:
 

--- a/rPDU2MQTT.Core/Helpers/MetricsHelper.cs
+++ b/rPDU2MQTT.Core/Helpers/MetricsHelper.cs
@@ -8,7 +8,8 @@ namespace rPDU2MQTT.Helpers;
 /// <summary>A single numeric measurement, flattened for export to Prometheus / EmonCMS / etc.</summary>
 /// <param name="SourceName">The source's formatted display name (vs <paramref name="Source"/>'s object-id form).</param>
 /// <param name="Number">The 1-based outlet number, or null for non-outlet entities (circuits/phase/total).</param>
-public readonly record struct MeasurementReading(string Device, string Source, string Type, double Value, string Units, string Identifier, string Topic, string SourceName, int? Number);
+/// <param name="DeviceName">The device's display name (vs <paramref name="Device"/>'s object-id form) (#206).</param>
+public readonly record struct MeasurementReading(string Device, string Source, string Type, double Value, string Units, string Identifier, string Topic, string SourceName, int? Number, string DeviceName = "");
 
 public static class MetricsHelper
 {
@@ -21,20 +22,49 @@ public static class MetricsHelper
         foreach (var device in data.Devices)
         {
             foreach (var outlet in device.Outlets)
-                foreach (var reading in ToReadings(device.Entity_Name, outlet.Entity_Name, outlet.Entity_DisplayName, outlet.Key + 1, outlet.Measurements))
+                foreach (var reading in ToReadings(device.Entity_Name, device.Entity_DisplayName, outlet.Entity_Name, outlet.Entity_DisplayName, outlet.Key + 1, outlet.Measurements))
                     yield return reading;
 
             foreach (var entity in device.Entity)
-                foreach (var reading in ToReadings(device.Entity_Name, entity.Entity_Name, entity.Entity_DisplayName, null, entity.Measurements))
+                foreach (var reading in ToReadings(device.Entity_Name, device.Entity_DisplayName, entity.Entity_Name, entity.Entity_DisplayName, null, entity.Measurements))
                     yield return reading;
         }
     }
 
-    private static IEnumerable<MeasurementReading> ToReadings(string device, string source, string sourceName, int? number, IEnumerable<Measurement> measurements)
+    private static IEnumerable<MeasurementReading> ToReadings(string device, string deviceName, string source, string sourceName, int? number, IEnumerable<Measurement> measurements)
     {
         foreach (var m in measurements)
             if (double.TryParse(m.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
-                yield return new MeasurementReading(device, source, m.Type, value, m.Units, m.Entity_Identifier, m.GetTopicPath(), sourceName, number);
+                yield return new MeasurementReading(device, source, m.Type, value, m.Units, m.Entity_Identifier, m.GetTopicPath(), sourceName, number, deviceName);
+    }
+
+    /// <summary>
+    /// A measurement type as a human would say it — "Real Power" for <c>realpower</c> (#206). Used for the
+    /// Prometheus gauge's HELP text and the optional <c>type_name</c> label, so a series is readable without
+    /// knowing this project's vocabulary. Unknown types are title-cased rather than dropped.
+    /// </summary>
+    public static string FriendlyTypeName(string? type)
+    {
+        var t = (type ?? "").Trim();
+        if (t.Length == 0) return "";
+
+        return t.ToLowerInvariant() switch
+        {
+            "realpower" => "Real Power",
+            "apparentpower" => "Apparent Power",
+            "powerfactor" => "Power Factor",
+            "energy" => "Energy",
+            "current" => "Current",
+            "voltage" => "Voltage",
+            "frequency" => "Frequency",
+            "temperature" => "Temperature",
+            "humidity" => "Humidity",
+            "accumulatedco2" => "Accumulated CO2",
+            "instantaneousco2" => "Instantaneous CO2",
+            "currentcrestfactor" => "Current Crest Factor",
+            "balance" => "Balance",
+            _ => char.ToUpperInvariant(t[0]) + t[1..],
+        };
     }
 
     /// <summary>

--- a/rPDU2MQTT.Core/Helpers/PrometheusLabels.cs
+++ b/rPDU2MQTT.Core/Helpers/PrometheusLabels.cs
@@ -10,7 +10,7 @@ namespace rPDU2MQTT.Helpers;
 public static class PrometheusLabels
 {
     /// <summary>Label names supported by <c>Prometheus.Labels</c>.</summary>
-    public static readonly string[] Supported = ["device", "source", "name", "number", "type", "units", "instance", "hierarchy"];
+    public static readonly string[] Supported = ["device", "device_name", "source", "name", "number", "type", "type_name", "units", "instance", "hierarchy"];
 
     /// <summary>The configured label names, filtered to the supported set (falls back to the defaults).</summary>
     public static string[] Names(Config config)
@@ -40,10 +40,14 @@ public static class PrometheusLabels
             values[i] = names[i] switch
             {
                 "device" => r.Device,
+                // The friendly forms (#206): what the PDU/outlet is *called*, so a dashboard doesn't have to
+                // decode object-ids. Falls back to the id form when a device has no display name.
+                "device_name" => string.IsNullOrWhiteSpace(r.DeviceName) ? r.Device : r.DeviceName,
                 "source" => r.Source,
                 "name" => r.SourceName ?? r.Source,
                 "number" => r.Number?.ToString() ?? string.Empty,
                 "type" => effectiveType,
+                "type_name" => MetricsHelper.FriendlyTypeName(effectiveType),
                 "units" => r.Units,
                 "instance" => instance,
                 "hierarchy" => hierarchy,

--- a/rPDU2MQTT.Core/Models/Config/PrometheusConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/PrometheusConfig.cs
@@ -36,7 +36,7 @@ public class PrometheusConfig
     /// <c>units</c>, <c>instance</c> (the PDU instance key), <c>hierarchy</c> (the energy-flow tier
     /// feeding this reading). Prometheus requires a consistent label set, so this applies to all metrics.
     /// </summary>
-    [Description("Labels attached to every exported metric. Available: device, source, name, number, type, units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set.")]
+    [Description("Labels attached to every exported metric. Available: device, device_name (the device's display name), source, name (the outlet/entity's display name), number, type, type_name (the measurement said in English, e.g. 'Real Power'), units, instance (PDU instance key), hierarchy (the energy-flow tier feeding it). Changing this changes every metric's label set.")]
     public List<string> Labels { get; set; } = new() { "device", "source", "units" };
 
     [Description("Push metrics to a Prometheus Pushgateway.")]

--- a/rPDU2MQTT.Engine/Services/PrometheusExportService.cs
+++ b/rPDU2MQTT.Engine/Services/PrometheusExportService.cs
@@ -77,7 +77,7 @@ public class PrometheusExportService : baseMQTTService
             {
                 var tier = hierarchy is null ? string.Empty : HierarchyFor(hierarchy, r);
                 var values = PrometheusLabels.Values(labelNames, r, cfg, snapshot.InstanceId, tier);
-                GetGauge(MetricsHelper.PrometheusMetricName(r, cfg), labelNames).WithLabels(values).Set(r.Value);
+                GetGauge(MetricsHelper.PrometheusMetricName(r, cfg), labelNames, r).WithLabels(values).Set(r.Value);
             }
 
         return Task.CompletedTask;
@@ -111,11 +111,22 @@ public class PrometheusExportService : baseMQTTService
     }
 
     // Cached by the resolved metric name (the template may vary the name by device/source/units).
-    private Gauge GetGauge(string name, string[] labelNames)
+    /// <summary>
+    /// The gauge for a metric name, created on first use. Its HELP text is the measurement said in English
+    /// with its unit (#206) — "Real Power (W), measured by rPDU2MQTT" — so a series is readable in Grafana's
+    /// metric browser without knowing this project's vocabulary.
+    /// </summary>
+    private Gauge GetGauge(string name, string[] labelNames, MeasurementReading reading)
     {
         if (!gauges.TryGetValue(name, out var gauge))
         {
-            gauge = Metrics.CreateGauge(name, "rPDU2MQTT measurement", labelNames);
+            var friendly = MetricsHelper.FriendlyTypeName(reading.Type);
+            var units = string.IsNullOrWhiteSpace(reading.Units) ? "" : $" ({reading.Units})";
+            var help = string.IsNullOrWhiteSpace(friendly)
+                ? "Measured by rPDU2MQTT."
+                : $"{friendly}{units}, measured by rPDU2MQTT.";
+
+            gauge = Metrics.CreateGauge(name, help, labelNames);
             gauges[name] = gauge;
         }
         return gauge;

--- a/rPDU2MQTT.Tests/PrometheusFriendlyNameTests.cs
+++ b/rPDU2MQTT.Tests/PrometheusFriendlyNameTests.cs
@@ -1,0 +1,65 @@
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Helpers;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// #206: a scraped series should be readable without knowing this project's vocabulary — the device and
+/// outlet as they're *called*, and the measurement said in English.
+/// </summary>
+public class PrometheusFriendlyNameTests
+{
+    private static MeasurementReading Reading(string device = "rack_pdu", string deviceName = "Rack PDU",
+        string source = "outlet_10", string sourceName = "Dell MD1200", string type = "realpower", string units = "W")
+        => new(device, source, type, 123.4, units, "id", "topic", sourceName, 10, deviceName);
+
+    [Fact]
+    public void FriendlyTypeName_SaysItInEnglish()
+    {
+        Assert.Equal("Real Power", MetricsHelper.FriendlyTypeName("realpower"));
+        Assert.Equal("Apparent Power", MetricsHelper.FriendlyTypeName("apparentpower"));
+        Assert.Equal("Power Factor", MetricsHelper.FriendlyTypeName("powerfactor"));
+        Assert.Equal("Energy", MetricsHelper.FriendlyTypeName("ENERGY"));   // case-insensitive
+
+        // An unknown type is still shown, just title-cased — dropping it would be worse than imperfect.
+        Assert.Equal("Wobbliness", MetricsHelper.FriendlyTypeName("wobbliness"));
+        Assert.Equal("", MetricsHelper.FriendlyTypeName(null));
+    }
+
+    [Fact]
+    public void Friendly_Labels_CarryTheDisplayNames()
+    {
+        var cfg = new Config();
+        cfg.Prometheus.Labels = new() { "device", "device_name", "source", "name", "type", "type_name" };
+
+        var names = PrometheusLabels.Names(cfg);
+        var values = PrometheusLabels.Values(names, Reading(), cfg, "default", "");
+
+        var byName = names.Zip(values).ToDictionary(p => p.First, p => p.Second);
+        Assert.Equal("rack_pdu", byName["device"]);          // the object-id form, unchanged
+        Assert.Equal("Rack PDU", byName["device_name"]);     // ...and what it's actually called
+        Assert.Equal("outlet_10", byName["source"]);
+        Assert.Equal("Dell MD1200", byName["name"]);
+        Assert.Equal("realpower", byName["type"]);
+        Assert.Equal("Real Power", byName["type_name"]);
+    }
+
+    [Fact]
+    public void DeviceName_FallsBackToTheId_WhenThereIsntOne()
+    {
+        var cfg = new Config();
+        cfg.Prometheus.Labels = new() { "device_name" };
+
+        var names = PrometheusLabels.Names(cfg);
+        Assert.Equal("rack_pdu", PrometheusLabels.Values(names, Reading(deviceName: ""), cfg, "default", "").Single());
+    }
+
+    [Fact]
+    public void DefaultLabelSet_IsUnchanged()
+    {
+        // Adding a label to every series by default would change the identity of every existing time series
+        // and break continuity in anyone's dashboards — the friendly ones are opt-in for that reason.
+        Assert.Equal(new[] { "device", "source", "units" }, PrometheusLabels.Names(new Config()));
+    }
+}


### PR DESCRIPTION
Closes #206.

A scraped series was entirely object-id forms — `device="rack_pdu_1"`, `source="outlet_10"`, `type="realpower"`. Stable, but it doesn't tell you what the thing is *called*.

## What's new

| Label | Example | What it is |
| --- | --- | --- |
| `device_name` | `Rack PDU 1` | the PDU's display name (alongside `device`, unchanged) |
| `type_name` | `Real Power` | the measurement said in English (alongside `type`) |
| `name` | `Dell MD1200` | the outlet's display name — already existed, now documented next to the others |

```yaml
Prometheus:
  Labels: [device, device_name, source, name, type, type_name, units]
```

`device_name` falls back to the id form when a device has no display name, so the label is never empty.

## HELP text — this part applies by default

Each gauge's HELP is now the measurement with its unit:

```
# HELP rpdu2mqtt_realpower Real Power (W), measured by rPDU2MQTT.
# TYPE rpdu2mqtt_realpower gauge
```

So the series is readable in Grafana's metric browser without adding a single label. An unrecognised measurement type is title-cased rather than dropped.

## What I deliberately didn't do

**Change the default label set.** Adding a label alters the identity of every existing time series — anything already recording `rpdu2mqtt_realpower{device,source,units}` would see a new series and lose continuity in its dashboards. The friendly labels are opt-in for that reason, and the doc says so where someone will read it.

## Tests + docs

4 new tests (340 total, 0 warnings): the English names including case-insensitivity and the unknown-type fallback, the friendly labels resolving next to the id forms, the empty-display-name fallback, and a guard that the default label set hasn't moved. CRD manifests regenerated; `docs/Configuration.md` gains a labels table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)