### PR TITLE
feat(gui): import a config — merge just the sections you pasted, or replace the lot (#214)

### DIFF
--- a/rPDU2MQTT.Core/ConfigImport.cs
+++ b/rPDU2MQTT.Core/ConfigImport.cs
@@ -1,0 +1,210 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using rPDU2MQTT.Classes;
+using YamlDotNet.RepresentationModel;
+using YamlDotNet.Serialization;
+
+namespace rPDU2MQTT.Core;
+
+/// <summary>How a pasted config is applied to the running one (#214).</summary>
+public enum ConfigImportMode
+{
+    /// <summary>
+    /// Apply only what the paste actually mentions, leaving everything else exactly as it is — so a section
+    /// copied out of a dev instance can be carried to production without dragging the rest of dev with it.
+    /// </summary>
+    Merge,
+
+    /// <summary>
+    /// The paste becomes the whole configuration: anything it doesn't mention goes back to its default.
+    /// Pasting a complete export, in other words.
+    /// </summary>
+    Replace,
+}
+
+/// <summary>What an import would do — returned for review before anything is saved.</summary>
+/// <param name="Config">The resulting configuration.</param>
+/// <param name="Sections">The top-level sections the paste mentioned, in the model's own names.</param>
+/// <param name="Notes">Anything the user should know (a Kubernetes wrapper unwrapped, keys ignored, …).</param>
+public sealed record ConfigImportResult(Config Config, List<string> Sections, List<string> Notes);
+
+/// <summary>
+/// Applies a pasted config fragment to the current one (#214).
+/// <para>
+/// The interesting half is <see cref="ConfigImportMode.Merge"/>: "only what the paste mentions" can't be
+/// answered by deserializing it, because deserializing fills in a default for every key the paste left out —
+/// and those defaults are indistinguishable from deliberate values. So the YAML document is walked
+/// separately to learn which keys are actually <i>present</i>, and that mask decides what gets applied. A
+/// list is treated as one value: half-merging two lists of nodes would produce a topology neither side asked
+/// for.
+/// </para>
+/// </summary>
+public static class ConfigImport
+{
+    private static readonly JsonSerializerOptions Json = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static ConfigImportResult Apply(Config current, string yaml, ConfigImportMode mode)
+    {
+        if (string.IsNullOrWhiteSpace(yaml))
+            throw new ArgumentException("Nothing to import — paste a config.yaml or an RpduConfig manifest.");
+
+        var notes = new List<string>();
+        var root = ParseRoot(yaml, notes);
+        if (root is null || root.Children.Count == 0)
+            throw new ArgumentException("That doesn't look like a configuration — expected YAML with at least one section.");
+
+        // Typed values (defaults included) plus the mask of what the paste actually said.
+        var fragment = Deserialize(yaml, notes);
+        var fragmentJson = JsonSerializer.SerializeToNode(fragment, Json)!.AsObject();
+        var mask = Mask(typeof(Config), root);
+
+        var sections = mask.Keys.OrderBy(s => s, StringComparer.OrdinalIgnoreCase).ToList();
+        if (sections.Count == 0)
+            throw new ArgumentException("None of the keys in that paste match the configuration model.");
+
+        if (mode == ConfigImportMode.Replace)
+            return new ConfigImportResult(fragment, sections, notes);
+
+        var merged = JsonSerializer.SerializeToNode(current, Json)!.AsObject();
+        MergeMasked(merged, fragmentJson, mask);
+
+        var result = JsonSerializer.Deserialize<Config>(merged, Json)
+            ?? throw new InvalidOperationException("The merged configuration could not be rebuilt.");
+        return new ConfigImportResult(result, sections, notes);
+    }
+
+    /// <summary>The document's config mapping — unwrapping a Kubernetes <c>RpduConfig</c> if that's what it is.</summary>
+    private static YamlMappingNode? ParseRoot(string yaml, List<string> notes)
+    {
+        var stream = new YamlStream();
+        using var reader = new StringReader(yaml);
+        stream.Load(reader);
+
+        if (stream.Documents.Count == 0) return null;
+        if (stream.Documents[0].RootNode is not YamlMappingNode root) return null;
+
+        // An exported manifest carries the config under spec:; take it rather than making the user edit it out.
+        if (Child(root, "kind") is YamlScalarNode { Value: "RpduConfig" } && Child(root, "spec") is YamlMappingNode spec)
+        {
+            notes.Add("Read the configuration from the RpduConfig manifest's spec.");
+            return spec;
+        }
+        return root;
+    }
+
+    private static YamlNode? Child(YamlMappingNode map, string key)
+        => map.Children.FirstOrDefault(kv => kv.Key is YamlScalarNode s
+            && string.Equals(s.Value, key, StringComparison.OrdinalIgnoreCase)).Value;
+
+    private static Config Deserialize(string yaml, List<string> notes)
+    {
+        // Unwrap a manifest for the typed pass too, by re-emitting just the spec.
+        var stream = new YamlStream();
+        using (var reader = new StringReader(yaml)) stream.Load(reader);
+        var text = yaml;
+        if (stream.Documents.FirstOrDefault()?.RootNode is YamlMappingNode root
+            && Child(root, "kind") is YamlScalarNode { Value: "RpduConfig" }
+            && Child(root, "spec") is YamlMappingNode spec)
+        {
+            var doc = new YamlDocument(spec);
+            var outStream = new YamlStream(doc);
+            using var writer = new StringWriter();
+            outStream.Save(writer, assignAnchors: false);
+            text = writer.ToString();
+        }
+
+        var deserializer = new DeserializerBuilder()
+            .WithCaseInsensitivePropertyMatching()
+            .IgnoreFields()
+            .IgnoreUnmatchedProperties()   // a paste may carry keys from a newer/older version; say so, don't fail
+            .Build();
+
+        try
+        {
+            using var reader = new StringReader(text);
+            return deserializer.Deserialize<Config>(reader) ?? new Config();
+        }
+        catch (Exception ex)
+        {
+            throw new ArgumentException($"That YAML could not be read as a configuration: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Which properties of <paramref name="type"/> the paste mentions, recursively. The value is a nested
+    /// mask for an object, or null for "take this whole thing" (a scalar, a list, or a dictionary).
+    /// </summary>
+    private static Dictionary<string, Dictionary<string, object?>?> Mask(Type type, YamlMappingNode node)
+    {
+        var mask = new Dictionary<string, Dictionary<string, object?>?>(StringComparer.Ordinal);
+
+        foreach (var (keyNode, valueNode) in node.Children)
+        {
+            if (keyNode is not YamlScalarNode { Value: { } key }) continue;
+            if (MatchProperty(type, key) is not { } property) continue;
+
+            // Recurse only into plain objects: a list is one value, and a dictionary's keys are data
+            // (instance names, override keys), not model properties.
+            // Key the mask by the property's *JSON* name, because that's what the merge below reads —
+            // Config.HASS serializes as "HomeAssistant", and keying by the C# name would silently miss it.
+            var name = JsonName(property);
+            if (valueNode is YamlMappingNode child && IsPlainObject(property.PropertyType))
+                mask[name] = Mask(property.PropertyType, child).ToDictionary(kv => kv.Key, kv => (object?)kv.Value);
+            else
+                mask[name] = null;
+        }
+
+        return mask;
+    }
+
+    /// <summary>Match a YAML key to a property by its YAML alias, its JSON name, or its own name.</summary>
+    private static PropertyInfo? MatchProperty(Type type, string key)
+    {
+        foreach (var p in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!p.CanWrite && !IsPlainObject(p.PropertyType)) continue;
+
+            var alias = p.GetCustomAttribute<YamlMemberAttribute>()?.Alias;
+            var json = p.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name;
+            if (string.Equals(p.Name, key, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(alias, key, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(json, key, StringComparison.OrdinalIgnoreCase))
+                return p;
+        }
+        return null;
+    }
+
+    /// <summary>The name this property serializes to — what the merge and the section list both use.</summary>
+    private static string JsonName(PropertyInfo property)
+        => property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? property.Name;
+
+    private static bool IsPlainObject(Type type)
+        => type.IsClass
+        && type != typeof(string)
+        && !typeof(System.Collections.IEnumerable).IsAssignableFrom(type);
+
+    /// <summary>Copy the masked properties of <paramref name="from"/> onto <paramref name="into"/>.</summary>
+    private static void MergeMasked(JsonObject into, JsonObject from, Dictionary<string, Dictionary<string, object?>?> mask)
+    {
+        foreach (var (name, child) in mask)
+        {
+            if (!from.TryGetPropertyValue(name, out var value)) continue;
+
+            if (child is { Count: > 0 } && value is JsonObject valueObject
+                && into.TryGetPropertyValue(name, out var existing) && existing is JsonObject existingObject)
+            {
+                MergeMasked(existingObject, valueObject, child.ToDictionary(kv => kv.Key, kv => (Dictionary<string, object?>?)kv.Value));
+                continue;
+            }
+
+            into[name] = value?.DeepClone();
+        }
+    }
+}

--- a/rPDU2MQTT.Tests/ConfigImportTests.cs
+++ b/rPDU2MQTT.Tests/ConfigImportTests.cs
@@ -1,0 +1,151 @@
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// #214: paste a section from one instance's export into another. Merge applies only what the paste
+/// mentions; Replace makes the paste the whole configuration.
+/// </summary>
+public class ConfigImportTests
+{
+    private static Config Current()
+    {
+        var cfg = new Config();
+        cfg.MQTT.ParentTopic = "prod";
+        cfg.MQTT.Connection.Host = "prod-broker";
+        cfg.MQTT.KeepAlive = 90;
+        cfg.Prometheus.Exporter = true;
+        cfg.Prometheus.Port = 9999;
+        cfg.EnergyFlow.MqttExport = true;
+        cfg.EnergyFlow.Nodes.Add(new rPDU2MQTT.Models.Config.EnergyFlowNode { Id = "prod-total", Label = "Total" });
+        return cfg;
+    }
+
+    [Fact]
+    public void Merge_AppliesOnlyWhatThePasteMentions()
+    {
+        var result = ConfigImport.Apply(Current(), """
+            EnergyFlow:
+              Nodes:
+                - Id: solar
+                  Label: Solar
+            """, ConfigImportMode.Merge);
+
+        // The pasted section is applied...
+        Assert.Equal("solar", Assert.Single(result.Config.EnergyFlow.Nodes).Id);
+        Assert.Equal(new[] { "EnergyFlow" }, result.Sections);
+
+        // ...and nothing else moved — including the sibling key inside the very section that was touched,
+        // which is the part a naive "deserialize and overwrite" gets wrong (MqttExport would go back to
+        // false, because that's the default the paste never mentioned).
+        Assert.True(result.Config.EnergyFlow.MqttExport);
+        Assert.Equal("prod", result.Config.MQTT.ParentTopic);
+        Assert.Equal("prod-broker", result.Config.MQTT.Connection.Host);
+        Assert.True(result.Config.Prometheus.Exporter);
+        Assert.Equal(9999, result.Config.Prometheus.Port);
+    }
+
+    [Fact]
+    public void Merge_ReachesNestedKeys_WithoutResettingTheirSiblings()
+    {
+        var result = ConfigImport.Apply(Current(), """
+            Mqtt:
+              Connection:
+                Host: dev-broker
+            """, ConfigImportMode.Merge);
+
+        Assert.Equal("dev-broker", result.Config.MQTT.Connection.Host);
+        Assert.Equal("prod", result.Config.MQTT.ParentTopic);   // sibling of Connection
+        Assert.Equal(90, result.Config.MQTT.KeepAlive);         // sibling of Host, one level down
+    }
+
+    [Fact]
+    public void Replace_MakesThePasteTheWholeConfiguration()
+    {
+        var result = ConfigImport.Apply(Current(), """
+            EnergyFlow:
+              Nodes:
+                - Id: solar
+                  Label: Solar
+            """, ConfigImportMode.Replace);
+
+        Assert.Equal("solar", Assert.Single(result.Config.EnergyFlow.Nodes).Id);
+
+        // Everything the paste didn't mention goes back to its default — that's what "full replacement" means.
+        Assert.False(result.Config.EnergyFlow.MqttExport);
+        Assert.Equal("rPDU2MQTT", result.Config.MQTT.ParentTopic);
+        Assert.False(result.Config.Prometheus.Exporter);
+    }
+
+    [Fact]
+    public void A_List_IsOneValue()
+    {
+        var current = Current();
+        current.EnergyFlow.Links.Add(new rPDU2MQTT.Models.Config.EnergyFlowLink { From = "a", To = "b" });
+
+        var result = ConfigImport.Apply(current, """
+            EnergyFlow:
+              Links:
+                - From: solar
+                  To: inverter
+            """, ConfigImportMode.Merge);
+
+        // Half-merging two wiring lists would produce a topology neither side asked for.
+        var link = Assert.Single(result.Config.EnergyFlow.Links);
+        Assert.Equal("solar", link.From);
+
+        // ...and the nodes list, which the paste didn't mention, is untouched.
+        Assert.Equal("prod-total", Assert.Single(result.Config.EnergyFlow.Nodes).Id);
+    }
+
+    [Fact]
+    public void A_KubernetesManifest_IsUnwrapped()
+    {
+        var result = ConfigImport.Apply(Current(), """
+            apiVersion: rpdu2mqtt.xtremeownage.com/v1
+            kind: RpduConfig
+            metadata:
+              name: rpdu2mqtt
+            spec:
+              Mqtt:
+                ParentTopic: from-cluster
+            """, ConfigImportMode.Merge);
+
+        Assert.Equal("from-cluster", result.Config.MQTT.ParentTopic);
+        Assert.Equal(new[] { "MQTT" }, result.Sections);
+        Assert.Contains(result.Notes, n => n.Contains("RpduConfig"));
+
+        // The manifest's own keys aren't config sections and mustn't be reported as ones.
+        Assert.DoesNotContain("kind", result.Sections);
+    }
+
+    [Fact]
+    public void Aliases_And_Casing_AreAccepted()
+    {
+        // The export writes "HomeAssistant"; the model calls the property HASS.
+        var result = ConfigImport.Apply(Current(), """
+            HomeAssistant:
+              DiscoveryEnabled: true
+            prometheus:
+              Port: 1234
+            """, ConfigImportMode.Merge);
+
+        Assert.True(result.Config.HASS.DiscoveryEnabled);
+        Assert.Equal(1234, result.Config.Prometheus.Port);
+        Assert.True(result.Config.Prometheus.Exporter);   // its sibling survived
+        Assert.Equal(new[] { "HomeAssistant", "Prometheus" }, result.Sections);   // reported as the config file names it
+    }
+
+    [Fact]
+    public void Rubbish_IsRefused_WithSomethingToActOn()
+    {
+        Assert.Throws<ArgumentException>(() => ConfigImport.Apply(Current(), "", ConfigImportMode.Merge));
+        Assert.Throws<ArgumentException>(() => ConfigImport.Apply(Current(), "just a string", ConfigImportMode.Merge));
+
+        // Valid YAML, but nothing in it is part of the configuration.
+        var ex = Assert.Throws<ArgumentException>(() => ConfigImport.Apply(Current(), "Nonsense:\n  Foo: 1", ConfigImportMode.Merge));
+        Assert.Contains("match the configuration model", ex.Message);
+    }
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1441,6 +1441,36 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         });
 
         // Render the current form state as YAML (for copy/paste into a ConfigMap, source control, etc.).
+        // Import a pasted config.yaml / RpduConfig — merged into what's on screen, or replacing it whole
+        // (#214). Nothing is saved: the result comes back for the form to load, so it's reviewed (and the
+        // Save button pressed) like any other edit.
+        app.MapPost("/api/config/import", async (HttpContext ctx) =>
+        {
+            try
+            {
+                var req = await System.Text.Json.JsonSerializer.DeserializeAsync<ConfigImportRequest>(
+                    ctx.Request.Body, ProbeJson, ctx.RequestAborted);
+                if (req is null)
+                    return Results.Json(new { ok = false, message = "Nothing to import." }, ConfigSchema.Json);
+
+                var mode = string.Equals(req.Mode, "replace", StringComparison.OrdinalIgnoreCase)
+                    ? Core.ConfigImportMode.Replace
+                    : Core.ConfigImportMode.Merge;
+
+                // Merge against what the form currently holds (which may be unsaved), not against the file.
+                var current = string.IsNullOrWhiteSpace(req.Current) ? config : ConfigSchema.FromJson(req.Current!);
+                var result = Core.ConfigImport.Apply(current, req.Yaml ?? "", mode);
+
+                return Results.Text(
+                    "{\"ok\":true,\"sections\":" + System.Text.Json.JsonSerializer.Serialize(result.Sections)
+                    + ",\"notes\":" + System.Text.Json.JsonSerializer.Serialize(result.Notes)
+                    + ",\"config\":" + ConfigSchema.ToJson(result.Config) + "}",
+                    "application/json");
+            }
+            catch (ArgumentException ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = $"Import failed: {ex.Message}" }, ConfigSchema.Json); }
+        });
+
         app.MapPost("/api/config/yaml", async (HttpContext ctx) =>
         {
             using var reader = new StreamReader(ctx.Request.Body);
@@ -1639,6 +1669,9 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
 
     /// <summary>Body of POST /api/modbus/probe: a device to reach + the register specs to read.</summary>
     private sealed record ModbusProbeRequest(string Host, int Port, int UnitId, string? Framing, int TimeoutMs, List<EnergyFlowSource>? Items);
+
+    /// <summary>Body of POST /api/config/import: the pasted YAML, how to apply it, and the form's current state.</summary>
+    private sealed record ConfigImportRequest(string? Yaml, string? Mode, string? Current);
 
     /// <summary>Body of POST /api/modbus/scan: a device to reach + the block of registers to browse.</summary>
     private sealed record ModbusScanRequest(string Host, int Port, int UnitId, string? Framing, int TimeoutMs, int Start, int Count, string? RegisterType);

--- a/rPDU2MQTT.Web/web/src/sections/export.ts
+++ b/rPDU2MQTT.Web/web/src/sections/export.ts
@@ -1,6 +1,9 @@
-// A synthetic section that exports the current form state as config.yaml or an RpduConfig manifest.
-import { btn, activate, toast, copyText } from '../helpers.js';
+// A synthetic section that exports the current form state as config.yaml or an RpduConfig manifest — and
+// takes one back (#214), merged into what's on screen or replacing it whole.
+import { api, btn, el, activate, toast, copyText } from '../helpers.js';
 import { exportData } from '../overrides.js';
+import { state } from '../state.js';
+import { build } from '../config-form.js';
 
 export function addExportSection(nav: any, sections: any) {
   const link = document.createElement('a'); link.textContent = 'Export'; nav.appendChild(link);
@@ -27,5 +30,70 @@ export function addExportSection(nav: any, sections: any) {
   copy.onclick = async () => { ta.select(); const ok = await copyText(ta.value); toast(ok ? 'Copied to clipboard.' : 'Could not copy — your browser blocked it (the text is selected, so Ctrl+C works).', ok); };
   refresh.onclick = fill;
   fmt.onchange = fill;
+
+  sec.appendChild(buildImport());
+
   link.onclick = () => { activate(link, sec); fill(); };
+}
+
+// The other direction: paste a config (or a section of one) from somewhere else and apply it here.
+function buildImport() {
+  const wrap = el('div', { style: { marginTop: '22px' } });
+  wrap.appendChild(el('h3', { text: 'Import', style: { margin: '4px 0', fontSize: '15px' } }));
+  wrap.appendChild(el('div', {
+    class: 'desc',
+    text: 'Paste a config.yaml or an RpduConfig manifest — a whole one, or just the sections you want. Nothing is saved: the result is loaded into the form for you to review, and you press Save as usual.',
+  }));
+
+  const bar = el('div', { class: 'sec-actions' });
+  const mode = el('select') as HTMLSelectElement;
+  [
+    ['merge', 'Merge — apply only what the paste mentions'],
+    ['replace', 'Replace — the paste becomes the whole config'],
+  ].forEach(([v, t]) => mode.appendChild(el('option', { value: v, text: t })));
+  const apply = btn('Import', 'primary');
+  const status = el('span', { class: 'desc', style: { margin: '0 0 0 8px' } });
+  bar.append(mode, apply, status);
+  wrap.appendChild(bar);
+
+  const input = el('textarea', { class: 'yaml', spellcheck: false, placeholder: 'Paste config.yaml or an RpduConfig manifest here…' }) as HTMLTextAreaElement;
+  wrap.appendChild(input);
+
+  // Replace throws away everything the paste doesn't mention, which is worth saying before it happens.
+  const note = el('div', { class: 'desc' });
+  const describe = () => {
+    note.textContent = mode.value === 'replace'
+      ? 'Replace: any section the paste doesn’t mention goes back to its default — including PDUs, overrides and nodes you have here but not there.'
+      : 'Merge: only the keys present in the paste are applied; everything else keeps its current value. A list (nodes, links, labels) is applied whole rather than half-merged.';
+  };
+  mode.onchange = describe;
+  describe();
+  wrap.appendChild(note);
+
+  apply.onclick = async () => {
+    const yaml = input.value.trim();
+    if (!yaml) { toast('Paste a configuration first.', false); return; }
+
+    status.textContent = 'importing…';
+    const r = await api('/api/config/import', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ Yaml: yaml, Mode: mode.value, Current: JSON.stringify(exportData()) }),
+    });
+
+    if (!r.body?.ok) {
+      status.textContent = '';
+      toast(r.body?.message || 'Import failed.', false);
+      return;
+    }
+
+    // Load it into the form; the user reviews and saves like any other edit.
+    state.data = r.body.config;
+    build();
+    const sections = (r.body.sections || []).join(', ');
+    (r.body.notes || []).forEach((n: string) => toast(n, true));
+    status.textContent = `applied ${sections || 'nothing'}`;
+    toast(`Imported ${sections}. Review the tabs, then Save.`, true);
+  };
+
+  return wrap;
 }

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2090,7 +2090,8 @@ function addNodesSection(nav     , sections     ) {
 }
 
 // ── sections/export.ts ──────────────────────────────────────────
-// A synthetic section that exports the current form state as config.yaml or an RpduConfig manifest.
+// A synthetic section that exports the current form state as config.yaml or an RpduConfig manifest — and
+// takes one back (#214), merged into what's on screen or replacing it whole.
 
 function addExportSection(nav     , sections     ) {
   const link = document.createElement('a'); link.textContent = 'Export'; nav.appendChild(link);
@@ -2117,7 +2118,72 @@ function addExportSection(nav     , sections     ) {
   copy.onclick = async () => { ta.select(); const ok = await copyText(ta.value); toast(ok ? 'Copied to clipboard.' : 'Could not copy — your browser blocked it (the text is selected, so Ctrl+C works).', ok); };
   refresh.onclick = fill;
   fmt.onchange = fill;
+
+  sec.appendChild(buildImport());
+
   link.onclick = () => { activate(link, sec); fill(); };
+}
+
+// The other direction: paste a config (or a section of one) from somewhere else and apply it here.
+function buildImport() {
+  const wrap = el('div', { style: { marginTop: '22px' } });
+  wrap.appendChild(el('h3', { text: 'Import', style: { margin: '4px 0', fontSize: '15px' } }));
+  wrap.appendChild(el('div', {
+    class: 'desc',
+    text: 'Paste a config.yaml or an RpduConfig manifest — a whole one, or just the sections you want. Nothing is saved: the result is loaded into the form for you to review, and you press Save as usual.',
+  }));
+
+  const bar = el('div', { class: 'sec-actions' });
+  const mode = el('select')                     ;
+  [
+    ['merge', 'Merge — apply only what the paste mentions'],
+    ['replace', 'Replace — the paste becomes the whole config'],
+  ].forEach(([v, t]) => mode.appendChild(el('option', { value: v, text: t })));
+  const apply = btn('Import', 'primary');
+  const status = el('span', { class: 'desc', style: { margin: '0 0 0 8px' } });
+  bar.append(mode, apply, status);
+  wrap.appendChild(bar);
+
+  const input = el('textarea', { class: 'yaml', spellcheck: false, placeholder: 'Paste config.yaml or an RpduConfig manifest here…' })                       ;
+  wrap.appendChild(input);
+
+  // Replace throws away everything the paste doesn't mention, which is worth saying before it happens.
+  const note = el('div', { class: 'desc' });
+  const describe = () => {
+    note.textContent = mode.value === 'replace'
+      ? 'Replace: any section the paste doesn’t mention goes back to its default — including PDUs, overrides and nodes you have here but not there.'
+      : 'Merge: only the keys present in the paste are applied; everything else keeps its current value. A list (nodes, links, labels) is applied whole rather than half-merged.';
+  };
+  mode.onchange = describe;
+  describe();
+  wrap.appendChild(note);
+
+  apply.onclick = async () => {
+    const yaml = input.value.trim();
+    if (!yaml) { toast('Paste a configuration first.', false); return; }
+
+    status.textContent = 'importing…';
+    const r = await api('/api/config/import', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ Yaml: yaml, Mode: mode.value, Current: JSON.stringify(exportData()) }),
+    });
+
+    if (!r.body?.ok) {
+      status.textContent = '';
+      toast(r.body?.message || 'Import failed.', false);
+      return;
+    }
+
+    // Load it into the form; the user reviews and saves like any other edit.
+    state.data = r.body.config;
+    build();
+    const sections = (r.body.sections || []).join(', ');
+    (r.body.notes || []).forEach((n        ) => toast(n, true));
+    status.textContent = `applied ${sections || 'nothing'}`;
+    toast(`Imported ${sections}. Review the tabs, then Save.`, true);
+  };
+
+  return wrap;
 }
 
 // ── sections/ha-energy.ts ───────────────────────────────────────


### PR DESCRIPTION
Closes #214.

The GUI could hand you a `config.yaml` or an `RpduConfig` manifest, but not take one back — so moving a section from a dev instance to the cluster meant hand-editing YAML in production.

The **Export** tab now has an **Import** box:

| Mode | What it does |
| --- | --- |
| **Merge** | Applies **only what the paste mentions**; everything else keeps its current value. |
| **Replace** | The paste becomes the whole configuration — anything it doesn't mention goes back to its default. |

## The part that's actually hard

"Only what the paste mentions" can't be answered by deserializing the paste, because deserializing fills in a **default for every key it omits**, and those defaults are indistinguishable from deliberate values. A naive import silently resets siblings — paste an `EnergyFlow.Nodes` list and your `MqttExport: true` quietly becomes `false`.

So the YAML document is walked *separately* to learn which keys are genuinely present, and that mask decides what gets applied, to any depth. There's a test for exactly that failure, and one for a nested case (`Mqtt.Connection.Host` alone leaves both `Mqtt.ParentTopic` and `Mqtt.KeepAlive` untouched).

## Other decisions

- **A list is one value.** Merging two lists of nodes or links would produce a topology neither side asked for, so a pasted list replaces that list wholly. Said plainly in the UI.
- **Replace warns before you click it**, since it discards PDUs/overrides/nodes that exist here but not in the paste.
- **A Kubernetes manifest is unwrapped** from its `spec` automatically, and its own `kind`/`metadata` keys aren't reported as config sections.
- **Aliases and casing are accepted** — the export writes `HomeAssistant`, the model calls the property `HASS`; `prometheus:` works as well as `Prometheus:`.
- **Nothing is saved.** The merged result is loaded into the form, so it's reviewed and saved like any other edit — and it merges against what's *on screen* (possibly unsaved), not against the file on disk.

## Tests

7 new (347 total, 0 warnings): merge applying only the mentioned keys, the nested-sibling case, replace resetting the rest, lists staying whole, manifest unwrapping, alias/casing handling, and rubbish being refused with a message you can act on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)