### PR TITLE
feat(chart): optional scheduled rollout restart (#216)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,20 @@ jobs:
             echo "$out" | grep -q "value: \"$role\"" || { echo "missing RPDU2MQTT_ROLE=$role"; exit 1; }
           done
 
+      - name: helm template (scheduled restart)
+        run: |
+          # Off by default: no CronJob, and no RBAC granted for one.
+          out=$(helm template rpdu2mqtt charts/rpdu2mqtt)
+          echo "$out" | grep -q 'kind: CronJob' && { echo "CronJob should not render by default"; exit 1; }
+
+          out=$(helm template rpdu2mqtt charts/rpdu2mqtt --set autoRestart.enabled=true --set autoRestart.schedule='30 3 * * 0')
+          echo "$out" | grep -q 'kind: CronJob' || { echo "missing CronJob"; exit 1; }
+          echo "$out" | grep -q 'schedule: "30 3 \* \* 0"' || { echo "schedule not applied"; exit 1; }
+          # It must restart by label (this release only), never a bare 'rollout restart deployment'.
+          echo "$out" | grep -q 'app.kubernetes.io/instance=rpdu2mqtt' || { echo "restart must be scoped by label"; exit 1; }
+          # Its own ServiceAccount, not the app's.
+          echo "$out" | grep -q 'name: rpdu2mqtt-restart' || { echo "missing restart ServiceAccount/Role"; exit 1; }
+
       - name: helm template (CRD config source, unmanaged resource)
         run: |
           out=$(helm template rpdu2mqtt charts/rpdu2mqtt \

--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -69,9 +69,20 @@ credentials:
 | `healthProbes.enabled` | `true` | Liveness/readiness probes against the app's health endpoints. |
 | `networkPolicy.enabled` | `false` | Restrict pod access: GUI/API/metrics ingress only from `networkPolicy.guiIngressFrom` / `apiIngressFrom` / `metricsIngressFrom`; health probes always allowed. Optionally restrict egress with `restrictEgress` + `egress`. Requires a NetworkPolicy-enforcing CNI. |
 | `serviceAccount.create` | `true` | Create a ServiceAccount. |
+| `autoRestart.enabled` | `false` | Add a CronJob that rolling-restarts this release's Deployment(s) on a schedule. Also re-pulls the image when the tag is mutable (`stable`/`latest`), so it doubles as an update mechanism. |
+| `autoRestart.schedule` | `"0 4 * * *"` | When to restart (standard cron). |
+| `autoRestart.timeZone` | `""` | IANA zone for the schedule (Kubernetes 1.27+); empty uses the cluster's. |
+| `autoRestart.image.repository` / `.tag` | `bitnami/kubectl` / `1.34` | Image the restart job runs. |
 | `resources`, `nodeSelector`, `tolerations`, `affinity` | `{}` / `[]` | Standard pod scheduling/limits. |
 
 ## Notes
+
+- **Scheduled restarts:** `autoRestart.enabled=true` adds a CronJob that runs
+  `kubectl rollout restart` against the Deployments *this release* renders — matched by label, so it can
+  never wander onto anything else in the namespace. It gets its own ServiceAccount with nothing but
+  `get`/`list`/`patch` on Deployments (a rollout restart is a patch of the pod template's annotations).
+  Missed runs are skipped rather than fired on recovery. With a mutable tag this is also how you get
+  updated images without a `helm upgrade`.
 
 - **GUI in Kubernetes:** by default the config is mounted read-only from a ConfigMap, so the GUI's
   *Save* is disabled — change config by editing values and running `helm upgrade`. To make the GUI

--- a/charts/rpdu2mqtt/templates/cronjob-restart.yaml
+++ b/charts/rpdu2mqtt/templates/cronjob-restart.yaml
@@ -1,0 +1,105 @@
+{{- /*
+  Scheduled rollout restart (#216). Rolling-restarting the Deployment(s) on a schedule also re-pulls the
+  image when the tag is mutable (`stable`, `latest`) — which is the usual reason for wanting it.
+
+  It restarts exactly the Deployments this release renders (all-in-one, or each split tier, plus the
+  operator), found by label rather than by name, so it can't wander onto anything else in the namespace.
+  Its own ServiceAccount is granted only get/list/patch on Deployments — a rollout restart is a patch of
+  the pod template's annotations, nothing more.
+*/}}
+{{- if .Values.autoRestart.enabled }}
+{{- $name := printf "%s-restart" (include "rpdu2mqtt.fullname" .) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "rpdu2mqtt.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "rpdu2mqtt.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "rpdu2mqtt.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "rpdu2mqtt.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.autoRestart.schedule | quote }}
+  {{- with .Values.autoRestart.timeZone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
+  # A restart is only worth doing at its scheduled time: if the cluster was down, skip the missed run
+  # rather than restarting the moment it comes back.
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: {{ .Values.autoRestart.startingDeadlineSeconds }}
+  successfulJobsHistoryLimit: {{ .Values.autoRestart.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.autoRestart.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.autoRestart.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "rpdu2mqtt.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: restart
+        spec:
+          serviceAccountName: {{ $name }}
+          restartPolicy: Never
+          {{- with .Values.autoRestart.image.pullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.autoRestart.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.autoRestart.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+          containers:
+            - name: restart
+              image: "{{ .Values.autoRestart.image.repository }}:{{ .Values.autoRestart.image.tag }}"
+              imagePullPolicy: {{ .Values.autoRestart.image.pullPolicy }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                {{- toYaml .Values.autoRestart.resources | nindent 16 }}
+              command: ["/bin/sh", "-c"]
+              args:
+                - >-
+                  kubectl rollout restart deployment
+                  -n {{ .Release.Namespace }}
+                  -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "rpdu2mqtt.name" . }}
+{{- end }}

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -109,6 +109,35 @@ serviceAccount:
   name: ""
   annotations: {}
 
+# Scheduled rollout restart (#216, Kubernetes only). Adds a CronJob that rolling-restarts this release's
+# Deployment(s) — which also re-pulls the image when the tag is mutable (`stable`, `latest`), so it doubles
+# as an update mechanism. The job restarts only the Deployments this release renders (matched by label) and
+# gets its own ServiceAccount with nothing but get/list/patch on Deployments.
+autoRestart:
+  enabled: false
+  # Standard cron, in the cluster's timezone unless timeZone is set. Default: 04:00 daily.
+  schedule: "0 4 * * *"
+  # IANA name (e.g. "America/Chicago"). Requires Kubernetes 1.27+; leave empty to use the cluster's zone.
+  timeZone: ""
+  # If the cluster was down at the scheduled time, skip the missed run rather than restarting on recovery.
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  backoffLimit: 2
+  image:
+    repository: bitnami/kubectl
+    tag: "1.34"
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      memory: 128Mi
+  nodeSelector: {}
+  tolerations: []
+
 # Store configuration in a Kubernetes RpduConfig custom resource instead of a ConfigMap.
 # When enabled: the chart creates the CR (from `config` above) and grants RBAC to read/write it,
 # the app reads config from the CR (RPDU2MQTT_CONFIG_SOURCE=k8s), and the GUI's Save writes back to


### PR DESCRIPTION
Closes #216.

`autoRestart.enabled=true` adds a CronJob that rolling-restarts this release's Deployment(s) on a schedule:

```yaml
autoRestart:
  enabled: true
  schedule: "0 4 * * *"     # daily at 04:00
  timeZone: "America/Chicago"  # optional, k8s 1.27+
```

Since a rolling restart re-pulls the image when the tag is mutable (`stable`, `latest`), this doubles as the update mechanism the issue mentions.

## Scope, deliberately

- **Restarts only what this release owns.** The job matches Deployments by `app.kubernetes.io/instance` + `name` rather than by name, so it can't wander onto anything else in the namespace, and it covers whatever shape the release has — all-in-one, split tiers, or the operator process.
- **Its own ServiceAccount**, granted `get`/`list`/`patch` on Deployments and nothing else. A rollout restart is a patch of the pod template's annotations; it doesn't need more, and it doesn't reuse the app's account.
- **Missed runs are skipped** (`startingDeadlineSeconds`, `concurrencyPolicy: Forbid`) rather than fired the moment a cluster comes back — a scheduled restart is only worth doing at the hour you picked.
- Runs non-root, read-only root filesystem, all capabilities dropped.

## Verification

CI now templates the chart with the toggle on and asserts: the CronJob renders, the schedule is applied, the restart command is label-scoped, the dedicated ServiceAccount/Role exists — and that **nothing** renders when it's off. `helm lint` + the existing template cases still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)