### PR TITLE
fix(k8s): a restart replaces the pod instead of leaving it Completed (#192)

### DIFF
--- a/charts/rpdu2mqtt/templates/rbac.yaml
+++ b/charts/rpdu2mqtt/templates/rbac.yaml
@@ -12,10 +12,15 @@ rules:
   - apiGroups: ["rpdu2mqtt.xtremeownage.com"]
     resources: ["rpduconfigs/status"]
     verbs: ["get", "patch", "update"]
-  # Lets the GUI Diagnostics page show this pod's logs + recent events.
+  # Lets the GUI Diagnostics page show this pod's logs + recent events, and lets a restart request delete
+  # this pod so Kubernetes replaces it immediately (#192) — stopping the process instead exits 0, shows as
+  # a "Completed" pod, and comes back on the kubelet's backoff. Namespaced; the app only deletes itself.
   - apiGroups: [""]
     resources: ["pods", "pods/log", "events"]
     verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete"]
   # Lets the GUI Diagnostics page roll-restart this release's Deployment(s) (restart a tier / update image).
   - apiGroups: ["apps"]
     resources: ["deployments"]

--- a/rPDU2MQTT.Core/Core/ProcessRestart.cs
+++ b/rPDU2MQTT.Core/Core/ProcessRestart.cs
@@ -1,0 +1,58 @@
+namespace rPDU2MQTT.Core;
+
+/// <summary>
+/// How this process asks to be restarted (#192).
+/// <para>
+/// Stopping the process is the obvious way and the wrong one under Kubernetes: the container exits 0, the
+/// pod is reported <c>Completed</c> — which reads as "this workload finished", not "please run it again" —
+/// and the kubelet restarts it on an exponential backoff that reaches minutes. So where the orchestrator can
+/// replace the pod, ask it to; only fall back to stopping when there's nothing to ask.
+/// </para>
+/// </summary>
+public interface IProcessRestarter
+{
+    /// <summary>
+    /// Restart this process as promptly as the environment allows. Returns a description of what was done,
+    /// for the caller to report; never throws.
+    /// </summary>
+    Task<string> RestartAsync(string reason, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Whether this process is stopping because it asked to be restarted, and the exit code that says so.
+/// <para>
+/// A restart-by-stopping must not exit 0. Exit 0 means "the job is done" — it's what puts a pod in
+/// <c>Completed</c>, and it makes a deliberate restart indistinguishable from a clean finish in any log or
+/// dashboard. <see cref="ExitCode"/> is <c>75</c> (the BSD <c>EX_TEMPFAIL</c>: "temporary failure, retry").
+/// </para>
+/// </summary>
+public static class SelfRestart
+{
+    /// <summary>Exit code used when the process is stopping so that something will start it again.</summary>
+    public const int ExitCode = 75;
+
+    private static int requested;
+
+    /// <summary>Has a restart been requested? Read by the host to pick its exit code.</summary>
+    public static bool Requested => Volatile.Read(ref requested) != 0;
+
+    /// <summary>Why, for the log line that accompanies the exit.</summary>
+    public static string? Reason { get; private set; }
+
+    /// <summary>Mark this process as stopping in order to be restarted.</summary>
+    public static void Mark(string reason)
+    {
+        Reason = reason;
+        Interlocked.Exchange(ref requested, 1);
+    }
+
+    /// <summary>The exit code this process should return: 75 when it wants to come back, 0 otherwise.</summary>
+    public static int ExitCodeFor(bool restartRequested) => restartRequested ? ExitCode : 0;
+
+    /// <summary>Reset — for tests.</summary>
+    internal static void Clear()
+    {
+        Interlocked.Exchange(ref requested, 0);
+        Reason = null;
+    }
+}

--- a/rPDU2MQTT.Engine/Services/DiagnosticService.cs
+++ b/rPDU2MQTT.Engine/Services/DiagnosticService.cs
@@ -65,6 +65,7 @@ public class DiagnosticService : IHostedService
             else if (topic.Equals(restartTopic, StringComparison.OrdinalIgnoreCase))
             {
                 Log.Information("Restart requested via diagnostic action; stopping application.");
+                rPDU2MQTT.Core.SelfRestart.Mark("diagnostic action");   // #192: come back with exit 75, not 0
                 lifetime.StopApplication();
             }
         }

--- a/rPDU2MQTT.Engine/Services/Kubernetes/KubernetesConfigWatcher.cs
+++ b/rPDU2MQTT.Engine/Services/Kubernetes/KubernetesConfigWatcher.cs
@@ -59,6 +59,7 @@ public sealed class KubernetesConfigWatcher : IHostedService, IDisposable
                 if (RequiresRestart(config, reloaded))
                 {
                     Log.Information("RpduConfig spec changed in a way that needs a restart (connection/ports/auth); restarting to apply it.");
+                    rPDU2MQTT.Core.SelfRestart.Mark("config change requiring a restart");   // #192
                     lifetime.StopApplication();
                     return;
                 }

--- a/rPDU2MQTT.Engine/Services/RestartCommandService.cs
+++ b/rPDU2MQTT.Engine/Services/RestartCommandService.cs
@@ -22,14 +22,16 @@ public sealed class RestartCommandService : IHostedService
     private readonly HiveMQClient mqtt;
     private readonly Config cfg;
     private readonly IHostApplicationLifetime lifetime;
+    private readonly rPDU2MQTT.Core.IProcessRestarter? restarter;
     private readonly string[] roles;
     private readonly DateTime startedUtc = DateTime.UtcNow;
 
-    public RestartCommandService(IHiveMQClient mqtt, Config cfg, HostRole roles, IHostApplicationLifetime lifetime)
+    public RestartCommandService(IHiveMQClient mqtt, Config cfg, HostRole roles, IHostApplicationLifetime lifetime, rPDU2MQTT.Core.IProcessRestarter? restarter = null)
     {
         this.mqtt = (HiveMQClient)mqtt;
         this.cfg = cfg;
         this.lifetime = lifetime;
+        this.restarter = restarter;
         this.roles = new[] { HostRole.Worker, HostRole.Api, HostRole.Ui }
             .Where(r => roles.HasFlag(r)).Select(r => r.ToString().ToLowerInvariant()).ToArray();
     }
@@ -63,8 +65,16 @@ public sealed class RestartCommandService : IHostedService
         if (cmd.AtUtc < startedUtc.AddSeconds(-5)) return;
         if (!cmd.MatchesRoles(roles)) return;
 
-        Log.Warning($"Restart requested over the bus (target '{cmd.Target}'); stopping this process [{string.Join('+', roles)}].");
-        // Let any in-flight work / the broker ack settle before the host tears down.
-        _ = Task.Run(async () => { await Task.Delay(500); lifetime.StopApplication(); });
+        // #192: how we come back is the restarter's business — under Kubernetes it replaces the pod rather
+        // than exiting 0, which would show as "Completed" and return on the kubelet's backoff.
+        var why = $"bus request, target '{cmd.Target}' [{string.Join('+', roles)}]";
+        if (restarter is not null)
+            _ = Task.Run(async () => { await Task.Delay(500); await restarter.RestartAsync(why); });
+        else
+        {
+            Log.Warning($"Restart requested over the bus ({why}); stopping this process.");
+            rPDU2MQTT.Core.SelfRestart.Mark(why);
+            _ = Task.Run(async () => { await Task.Delay(500); lifetime.StopApplication(); });
+        }
     }
 }

--- a/rPDU2MQTT.Tests/SelfRestartTests.cs
+++ b/rPDU2MQTT.Tests/SelfRestartTests.cs
@@ -1,0 +1,39 @@
+using rPDU2MQTT.Core;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// #192: a process that stops in order to be restarted must not exit 0. Exit 0 means "the job is done" —
+/// it's what leaves a Kubernetes pod sitting in Completed, and it makes a deliberate restart look identical
+/// to a clean finish in any log or dashboard.
+/// </summary>
+[Collection("SelfRestart")]
+public class SelfRestartTests
+{
+    [Fact]
+    public void CleanShutdown_IsZero_RestartIsNot()
+    {
+        Assert.Equal(0, SelfRestart.ExitCodeFor(restartRequested: false));
+        Assert.Equal(75, SelfRestart.ExitCodeFor(restartRequested: true));
+
+        // 75 is the BSD EX_TEMPFAIL — "temporary failure, retry" — which is exactly the intent.
+        Assert.Equal(75, SelfRestart.ExitCode);
+    }
+
+    [Fact]
+    public void Marking_RecordsTheIntent_AndTheReason()
+    {
+        SelfRestart.Clear();
+        Assert.False(SelfRestart.Requested);
+        Assert.Equal(0, SelfRestart.ExitCodeFor(SelfRestart.Requested));
+
+        SelfRestart.Mark("GUI request");
+
+        Assert.True(SelfRestart.Requested);
+        Assert.Equal("GUI request", SelfRestart.Reason);
+        Assert.Equal(SelfRestart.ExitCode, SelfRestart.ExitCodeFor(SelfRestart.Requested));
+
+        SelfRestart.Clear();
+    }
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -43,6 +43,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     private readonly PduInstanceRegistry registry;
     private readonly InstanceManager instances;
     private readonly EmonCmsStatus emonCmsStatus;
+    private readonly Core.IProcessRestarter? restarter;
     private readonly Core.ISnapshotCache snapshots;
     private readonly Core.HostRole hostRoles;
     private readonly HaEnergyDashboardSync haEnergy;
@@ -52,7 +53,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
 
     private readonly Orleans.IGrainFactory grains;
 
-    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots, Core.HostRole hostRoles, HaEnergyDashboardSync haEnergy, Orleans.IGrainFactory grains, Core.Flow.IFlowValueSource? live = null)
+    public GuiService(Config config, IHiveMQClient mqtt, PDU pdu, DiscoveryCoordinator discovery, IConfigSource configSource, IHostApplicationLifetime lifetime, HealthState health, PduInstanceFactory pduFactory, PduInstanceRegistry registry, InstanceManager instances, EmonCmsStatus emonCmsStatus, Core.ISnapshotCache snapshots, Core.HostRole hostRoles, HaEnergyDashboardSync haEnergy, Orleans.IGrainFactory grains, Core.Flow.IFlowValueSource? live = null, Core.IProcessRestarter? restarter = null)
     {
         this.live = live;
         this.grains = grains;
@@ -67,6 +68,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         this.registry = registry;
         this.instances = instances;
         this.emonCmsStatus = emonCmsStatus;
+        this.restarter = restarter;
         this.snapshots = snapshots;
         this.hostRoles = hostRoles;
         this.haEnergy = haEnergy;
@@ -666,7 +668,14 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
 
             if (target is "" or "local")
             {
+                // #192: the restarter decides how — replacing the pod under Kubernetes, stopping otherwise.
+                if (restarter is not null)
+                {
+                    var message = await restarter.RestartAsync("GUI request");
+                    return Results.Json(new { ok = true, message }, ConfigSchema.Json);
+                }
                 Log.Information("Restart requested via GUI; stopping this process.");
+                Core.SelfRestart.Mark("GUI request");
                 _ = Task.Run(async () => { await Task.Delay(300); lifetime.StopApplication(); });
                 return Results.Json(new { ok = true, message = "Restarting this process…" }, ConfigSchema.Json);
             }

--- a/rPDU2MQTT/Hosting/ProcessRestarters.cs
+++ b/rPDU2MQTT/Hosting/ProcessRestarters.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Startup.ConfigSources;
+
+namespace rPDU2MQTT.Hosting;
+
+/// <summary>
+/// Restart by stopping: the only thing a process can do for itself when nothing is supervising it in a way
+/// we can reach. Marks the intent so the host exits non-zero — see <see cref="SelfRestart"/> for why exit 0
+/// is the wrong answer (#192).
+/// </summary>
+public sealed class StopProcessRestarter : IProcessRestarter
+{
+    private readonly IHostApplicationLifetime lifetime;
+
+    public StopProcessRestarter(IHostApplicationLifetime lifetime) => this.lifetime = lifetime;
+
+    public Task<string> RestartAsync(string reason, CancellationToken cancellationToken = default)
+    {
+        Serilog.Log.Warning("Restart requested ({Reason}); stopping this process so it can be started again.", reason);
+        SelfRestart.Mark(reason);
+
+        // Give the caller's response (and any in-flight publish) a moment to land before the host tears down.
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(400);
+            lifetime.StopApplication();
+        });
+
+        return Task.FromResult("Restarting this process…");
+    }
+}
+
+/// <summary>
+/// Restart under Kubernetes by asking the orchestrator to replace this pod (#192).
+/// <para>
+/// Deleting the pod gets a <i>new</i> one from the ReplicaSet straight away. Stopping the process instead
+/// gets the same pod restarted on the kubelet's exponential backoff — which climbs to five minutes, and
+/// leaves the old pod sitting in <c>Completed</c> looking like it finished on purpose. If the delete is
+/// refused (no RBAC, no pod name), fall back to stopping rather than doing nothing.
+/// </para>
+/// </summary>
+public sealed class KubernetesPodRestarter : IProcessRestarter
+{
+    private readonly KubernetesConfigSource kubernetes;
+    private readonly StopProcessRestarter fallback;
+
+    public KubernetesPodRestarter(KubernetesConfigSource kubernetes, StopProcessRestarter fallback)
+    {
+        this.kubernetes = kubernetes;
+        this.fallback = fallback;
+    }
+
+    public async Task<string> RestartAsync(string reason, CancellationToken cancellationToken = default)
+    {
+        var pod = Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME");
+        if (string.IsNullOrWhiteSpace(pod))
+            return await fallback.RestartAsync(reason, cancellationToken);
+
+        try
+        {
+            Serilog.Log.Warning("Restart requested ({Reason}); deleting pod {Namespace}/{Pod} so it is replaced immediately.",
+                reason, kubernetes.Namespace, pod);
+
+            await kubernetes.Client.CoreV1.DeleteNamespacedPodWithHttpMessagesAsync(pod, kubernetes.Namespace, cancellationToken: cancellationToken);
+            return $"Deleting pod {pod}; Kubernetes will start a replacement.";
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Warning(ex, "Could not delete pod {Pod} (RBAC?); falling back to stopping the process.", pod);
+            return await fallback.RestartAsync(reason, cancellationToken);
+        }
+    }
+}

--- a/rPDU2MQTT/Program.cs
+++ b/rPDU2MQTT/Program.cs
@@ -88,4 +88,13 @@ for (int attempt = 1; ; attempt++)
 
 host.Run();
 
+// #192: exiting 0 says "my work here is done" — which is what puts a Kubernetes pod in Completed and makes
+// a deliberate restart indistinguishable from a clean finish. Say we want to come back.
+if (rPDU2MQTT.Core.SelfRestart.Requested)
+{
+    Log.Information("Exiting with {Code} so this process is started again ({Reason}).",
+        rPDU2MQTT.Core.SelfRestart.ExitCode, rPDU2MQTT.Core.SelfRestart.Reason);
+    return rPDU2MQTT.Core.SelfRestart.ExitCode;
+}
+
 return 0;

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -172,6 +172,18 @@ public static class ServiceConfiguration
         // Who this process is — one identity for everything that reports on its behalf.
         services.AddSingleton<Hosting.ProcessIdentity>();
 
+        // How this process restarts itself (#192). Under Kubernetes, ask the orchestrator to replace the pod:
+        // stopping the process instead exits 0, which shows as a "Completed" pod and comes back on the
+        // kubelet's backoff (minutes). Everywhere else, stopping is all there is — with a non-zero exit code
+        // so "restart me" isn't indistinguishable from "my work here is done".
+        services.AddSingleton<Hosting.StopProcessRestarter>();
+        if (configSource is KubernetesConfigSource)
+            services.AddSingleton<Core.IProcessRestarter>(sp => new Hosting.KubernetesPodRestarter(
+                (KubernetesConfigSource)sp.GetRequiredService<IConfigSource>(),
+                sp.GetRequiredService<Hosting.StopProcessRestarter>()));
+        else
+            services.AddSingleton<Core.IProcessRestarter>(sp => sp.GetRequiredService<Hosting.StopProcessRestarter>());
+
         // v3: each process registers itself with the cluster-wide ProcessRegistryGrain so the GUI can list
         // every role process in a split deployment — replaces the MQTT HeartbeatService beacons.
         if (roles != HostRole.All)


### PR DESCRIPTION
Closes #192.

## What was happening

Every self-restart path stopped the process — the GUI's "restart this process", the bus restart command, the diagnostic action, and the config watcher when a change requires one. Under Kubernetes that means the container **exits 0**, so:

- the pod is reported **`Completed`**, which reads as "this workload finished" rather than "please run it again", and
- the kubelet restarts it on an **exponential backoff** that climbs to five minutes — the delayed start in the screenshot.

## The fix

**Ask the orchestrator instead of exiting.** `IProcessRestarter` decides how a restart happens; under Kubernetes `KubernetesPodRestarter` deletes this pod, so the ReplicaSet creates a *new* one immediately — a fresh pod, no container-restart backoff. If the delete is refused (no RBAC, no `RPDU2MQTT_POD_NAME`) it falls back to stopping rather than silently doing nothing.

**And when stopping is all there is, don't exit 0.** The process now exits **75** — the BSD `EX_TEMPFAIL`, "temporary failure, retry" — so a deliberate restart isn't indistinguishable from a clean finish in logs, dashboards or pod status. Docker/systemd/Kubernetes all still restart it; the difference is that it now *says* what it meant.

## RBAC

The chart's Role gains `pods: delete`, namespaced, with a comment explaining why. The app only ever deletes the pod it is running in — it looks itself up by `RPDU2MQTT_POD_NAME` and deletes nothing else. If you'd rather not grant it, remove the rule: the fallback path still works, just with the old backoff behaviour.

## Tests

2 new (349 total, 0 warnings) covering the exit-code contract and that marking records the intent + reason. The pod-delete path itself needs a live cluster — **that's the maintainer's manual check**: with `autoRestart`/GUI restart under Kubernetes, the pod should disappear and be replaced rather than showing `Completed` with a growing restart delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)