### PR TITLE
fix(mqtt): don't attach timestamps by default — it broke publishing (#205)

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -103,7 +103,7 @@ spec:
                     - None
                     - UserProperty
                     - Payload
-                    description: "Carry the time a measurement was read: 'UserProperty' adds an MQTT v5 'timestamp' property and leaves the payload alone (default, safe for every existing consumer), 'Payload' publishes {\"value\": …, \"timestamp\": …} instead of a bare value (Home Assistant discovery adapts automatically), 'None' carries no timestamp."
+                    description: "Carry the time a measurement was read. 'None' (default) publishes exactly as before. 'UserProperty' adds an MQTT v5 'timestamp' property and leaves the payload alone — verify it against your broker first, since a broker or client that mishandles user properties on PUBLISH can drop the connection. 'Payload' publishes {\"value\": …, \"timestamp\": …} instead of a bare value (Home Assistant discovery adapts automatically)."
                 description: MQTT Configuration
               Pdus:
                 type: object

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -103,7 +103,7 @@ spec:
                     - None
                     - UserProperty
                     - Payload
-                    description: "Carry the time a measurement was read: 'UserProperty' adds an MQTT v5 'timestamp' property and leaves the payload alone (default, safe for every existing consumer), 'Payload' publishes {\"value\": …, \"timestamp\": …} instead of a bare value (Home Assistant discovery adapts automatically), 'None' carries no timestamp."
+                    description: "Carry the time a measurement was read. 'None' (default) publishes exactly as before. 'UserProperty' adds an MQTT v5 'timestamp' property and leaves the payload alone — verify it against your broker first, since a broker or client that mishandles user properties on PUBLISH can drop the connection. 'Payload' publishes {\"value\": …, \"timestamp\": …} instead of a bare value (Home Assistant discovery adapts automatically)."
                 description: MQTT Configuration
               Pdus:
                 type: object

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -96,14 +96,17 @@ consumer can tell a fresh reading from a republished one.
 
 ```yaml
 Mqtt:
-  MessageTimestamp: UserProperty   # UserProperty (default) | Payload | None
+  MessageTimestamp: None   # None (default) | UserProperty | Payload
 ```
+
+> Both non-`None` modes change what goes on the wire, so neither is on by default: turn one on deliberately
+> and watch the next poll land before you walk away from it.
 
 | Mode | What a measurement looks like |
 | --- | --- |
-| `UserProperty` | The payload is unchanged (a bare value); the time rides along as an MQTT v5 `timestamp` user property. Invisible to consumers that don't look for it, so Home Assistant and every existing subscription keep working exactly as before. **Default.** |
+| `UserProperty` | The payload is unchanged (a bare value); the time rides along as an MQTT v5 `timestamp` user property. **Test this against your broker before relying on it** — the payload being unchanged doesn't mean the packet is, and a broker or client that mishandles user properties on PUBLISH can drop the connection, which looks like everything stopping at once. |
 | `Payload` | The payload becomes `{"value": "123.4", "timestamp": "2026-07-21T18:30:15.250Z"}`. Home Assistant discovery adapts automatically (the sensors get `value_template: {{ value_json.value }}`), but anything reading these topics by hand needs updating — which is why it isn't the default. |
-| `None` | No timestamp at all — the behaviour before this option existed. |
+| `None` | No timestamp at all — the behaviour before this option existed. **Default.** |
 
 The timestamp is ISO-8601 UTC to milliseconds. The value stays a **string** in `Payload` mode, because that's
 how the PDU reports it — re-typing it as a number would turn `0.00` into `0` and lose the device's precision.

--- a/rPDU2MQTT.Core/Models/Config/MQTTConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/MQTTConfig.cs
@@ -54,9 +54,9 @@ public class MQTTConfig
     /// Whether published measurements carry the time they were read, and how (#205). The timestamp is the
     /// poll time, so a consumer can tell a fresh reading from a republished one.
     /// </summary>
-    [DefaultValue(MessageTimestampMode.UserProperty)]
+    [DefaultValue(MessageTimestampMode.None)]
     [YamlMember(Alias = "MessageTimestamp", DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
-    [Display(Name = "Message Timestamp", Description = "Carry the time a measurement was read: 'UserProperty' adds an MQTT v5 'timestamp' property and leaves the payload alone (default, safe for every existing consumer), 'Payload' publishes {\"value\": …, \"timestamp\": …} instead of a bare value (Home Assistant discovery adapts automatically), 'None' carries no timestamp.")]
+    [Display(Name = "Message Timestamp", Description = "Carry the time a measurement was read. 'None' (default) publishes exactly as before. 'UserProperty' adds an MQTT v5 'timestamp' property and leaves the payload alone — verify it against your broker first, since a broker or client that mishandles user properties on PUBLISH can drop the connection. 'Payload' publishes {\"value\": …, \"timestamp\": …} instead of a bare value (Home Assistant discovery adapts automatically).")]
     [AllowedValues("None", "UserProperty", "Payload")]
-    public MessageTimestampMode MessageTimestamp { get; set; } = MessageTimestampMode.UserProperty;
+    public MessageTimestampMode MessageTimestamp { get; set; } = MessageTimestampMode.None;
 }

--- a/rPDU2MQTT.Core/Models/Config/MessageTimestampMode.cs
+++ b/rPDU2MQTT.Core/Models/Config/MessageTimestampMode.cs
@@ -9,13 +9,24 @@ namespace rPDU2MQTT.Models.Config;
 /// </summary>
 public enum MessageTimestampMode
 {
-    /// <summary>Don't carry one. Exactly what this project did before #205.</summary>
+    /// <summary>
+    /// Don't carry one — exactly what this project did before #205, and the default.
+    /// <para>
+    /// It defaults here because the other two modes change what goes on the wire, and that can't be
+    /// verified except against your own broker: <see cref="UserProperty"/> shipped as the default once and
+    /// broke publishing outright on a real deployment. Turn one on deliberately, and watch the first poll.
+    /// </para>
+    /// </summary>
     None,
 
     /// <summary>
     /// An MQTT v5 <c>timestamp</c> user property on every published message. The payload is untouched, so
-    /// every existing consumer — Home Assistant included — keeps working unchanged, and anything that cares
-    /// can read the property. This is the default.
+    /// consumers that don't look for it read exactly what they read before.
+    /// <para>
+    /// <b>Verify this against your broker before relying on it.</b> The payload being unchanged does not
+    /// mean the packet is: a broker or client that mishandles user properties on PUBLISH can drop the
+    /// connection, which looks like everything stopping at once. Known to break at least one setup.
+    /// </para>
     /// </summary>
     UserProperty,
 

--- a/rPDU2MQTT.Tests/MessageTimestampTests.cs
+++ b/rPDU2MQTT.Tests/MessageTimestampTests.cs
@@ -69,10 +69,12 @@ public class MessageTimestampTests
     }
 
     [Fact]
-    public void DefaultMode_IsTheInvisibleOne()
+    public void DefaultMode_ChangesNothingOnTheWire()
     {
-        // #205 asked for timestamps; shipping them off by default would not answer the request, and shipping
-        // them in the payload by default would break every consumer that reads a bare value.
-        Assert.Equal(MessageTimestampMode.UserProperty, new Config().MQTT.MessageTimestamp);
+        // This shipped defaulting to UserProperty on the reasoning that a user property is invisible to
+        // consumers that don't read it — which is true of readers and irrelevant to the wire. It broke
+        // publishing outright on a real broker. A mode that changes the packet has to be opted into by
+        // someone who can watch their own broker while they do it.
+        Assert.Equal(MessageTimestampMode.None, new Config().MQTT.MessageTimestamp);
     }
 }


### PR DESCRIPTION
Follow-up to #228, which I got wrong.

`MessageTimestamp` shipped defaulting to `UserProperty`, so **every** published message carried an MQTT v5 `timestamp` user property. On a real deployment that stopped MQTT working outright; setting `MessageTimestamp: None` brought it straight back.

**The default is now `None`** — byte-for-byte the pre-#228 publish path. The feature stays, opt-in, and both non-`None` modes are documented as something to verify against your own broker before relying on.

## What I got wrong

I justified the default as "a user property is invisible to consumers that don't look for it". That's true of *readers* and irrelevant to the *wire*: the property changes the packet, and a broker or client that mishandles user properties on PUBLISH can drop the connection — which presents as everything stopping at once. A change that touches 100% of published messages, which I had no way to test against real infrastructure, should never have been a default. I'd even flagged "live broker can't be verified here" in my own notes and defaulted it on anyway.

## What's still unknown

The **mechanism**. Either HiveMQtt 0.45 mis-encodes user properties on PUBLISH, or the broker rejects them. Telling those apart needs a packet capture or the broker's log, neither of which I can get to. Until someone does, `UserProperty` carries a warning rather than a recommendation.

The test that asserted the old default now asserts the new one, and says why in the comment so it doesn't get "helpfully" flipped back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)