### PR TITLE
chore(deps): keep Microsoft.OpenApi on 2.x — 3.x can't be consumed by ASP.NET Core 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,18 @@ updates:
     labels:
       - "area/dependency"
     open-pull-requests-limit: 10
+    ignore:
+      # Microsoft.OpenApi is pinned here only to lift the 2.0.0 that Microsoft.AspNetCore.OpenApi resolves
+      # to a version with GHSA-v5pm-xwqc-g5wc fixed — it isn't a dependency we use directly (the API project
+      # only calls AddOpenApi/MapOpenApi). The 3.x line is a breaking major that ASP.NET Core 10's OpenApi
+      # package cannot consume: its own source generator assigns IOpenApiMediaType.Example, which is
+      # read-only in 3.x, so the build fails inside generated code we don't own (#227).
+      #
+      # Stay on 2.x until Microsoft.AspNetCore.OpenApi ships a build against 3.x, then drop this and bump
+      # both together. Minor/patch updates are deliberately still allowed, since that's how the security
+      # pin keeps moving.
+      - dependency-name: "Microsoft.OpenApi"
+        update-types: ["version-update:semver-major"]
     groups:
       actions:
         update-types:

--- a/rPDU2MQTT.Api/rPDU2MQTT.Api.csproj
+++ b/rPDU2MQTT.Api/rPDU2MQTT.Api.csproj
@@ -14,7 +14,10 @@
 	<ItemGroup>
 		<PackageReference Include="HiveMQtt" Version="0.45.0" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
-		<!-- Pinned over the 2.0.0 that AspNetCore.OpenApi 10.0.9 resolves: GHSA-v5pm-xwqc-g5wc is fixed in 2.7.5. -->
+		<!-- Pinned over the 2.0.0 that AspNetCore.OpenApi 10.0.9 resolves: GHSA-v5pm-xwqc-g5wc is fixed in 2.7.5.
+		     Stay on the 2.x line: 3.x is a breaking major that AspNetCore.OpenApi 10 cannot consume — its own
+		     source generator assigns IOpenApiMediaType.Example, read-only in 3.x, so the build fails inside
+		     generated code (#227). Dependabot is told to skip the major; revisit when ASP.NET ships against 3.x. -->
 		<PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
 		<PackageReference Include="Scalar.AspNetCore" Version="2.16.11" />
 	</ItemGroup>


### PR DESCRIPTION
Closes #227 (which cannot be merged — see below).

## Why #227 fails

It isn't our code. `Microsoft.AspNetCore.OpenApi` 10.0.9's **own source generator** emits:

```
OpenApiXmlCommentSupport.generated.cs(399,41): error CS0200:
  Property or indexer 'IOpenApiMediaType.Example' cannot be assigned to -- it is read only
```

`Microsoft.OpenApi` 3.x made `IOpenApiMediaType.Example` read-only, and ASP.NET Core 10's OpenAPI package is built against 2.x. The build breaks inside generated code we don't own, and there's no fix on our side short of dropping `Microsoft.AspNetCore.OpenApi` entirely. Nothing in this repo touches `Microsoft.OpenApi` directly — the API project only calls `AddOpenApi()` / `MapOpenApi()`.

## Why the package is pinned at all

Only to lift the **2.0.0** that `AspNetCore.OpenApi` resolves up to a version where **GHSA-v5pm-xwqc-g5wc** is fixed. It's a security floor, not a dependency we chose.

## What this does

Tells Dependabot to skip **major** updates for `Microsoft.OpenApi` — and *only* major, so minor/patch keep flowing, which is exactly how that security floor keeps moving. Otherwise this PR gets raised, fails CI, and gets closed again every week.

Both the dependabot rule and the csproj comment record the reason and the exit condition: drop the ignore and bump both together once `Microsoft.AspNetCore.OpenApi` ships a build against 3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)