### PR TITLE
fix(chart): ship the Orleans membership CRDs — every pod crash-loops without them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,18 @@ jobs:
             echo "$out" | grep -q "value: \"$role\"" || { echo "missing RPDU2MQTT_ROLE=$role"; exit 1; }
           done
 
+      - name: helm template (Orleans membership CRDs)
+        run: |
+          # The silos store membership in these CRDs; without them every pod crash-loops on
+          # "Failure reading all silo entries". They must ship with the chart, not be created at runtime.
+          out=$(helm template rpdu2mqtt charts/rpdu2mqtt --include-crds --set split.enabled=true)
+          for crd in clusterversions.orleans.dot.net silos.orleans.dot.net; do
+            echo "$out" | grep -q "name: $crd" || { echo "chart must ship the $crd CRD"; exit 1; }
+          done
+          # ...and because they ship, nothing needs cluster-scoped write access to CRDs.
+          echo "$out" | grep -q 'customresourcedefinitions' && { echo "app should not be granted CRD permissions"; exit 1; }
+          exit 0
+
       - name: helm template (scheduled restart)
         run: |
           # Off by default: no CronJob, and no RBAC granted for one.

--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -77,6 +77,13 @@ credentials:
 
 ## Notes
 
+- **Orleans membership CRDs:** the chart ships `crds/orleans-membership.yaml`
+  (`clusterversions.orleans.dot.net`, `silos.orleans.dot.net`). The silos store cluster membership in those
+  resources instead of an external database, and without them **every pod crash-loops** on *"Failure reading
+  all silo entries"*. Helm applies `crds/` on **install only, never on upgrade** — so a release that predates
+  them needs a one-off `kubectl apply -f charts/rpdu2mqtt/crds/orleans-membership.yaml`. Argo CD renders with
+  `--include-crds` and applies them on every sync, so it needs nothing extra.
+
 - **Scheduled restarts:** `autoRestart.enabled=true` adds a CronJob that runs
   `kubectl rollout restart` against the Deployments *this release* renders — matched by label, so it can
   never wander onto anything else in the namespace. It gets its own ServiceAccount with nothing but

--- a/charts/rpdu2mqtt/crds/orleans-membership.yaml
+++ b/charts/rpdu2mqtt/crds/orleans-membership.yaml
@@ -1,0 +1,96 @@
+# Orleans Kubernetes clustering membership CRDs.
+#
+# The silos store cluster membership in these two custom resources instead of an external database
+# (Orleans.Clustering.Kubernetes, `silo.UseKubeMembership()`). Without them every silo fails to read
+# membership — "Failure reading all silo entries for cluster id … 404 page not found" from
+# KubeMembershipTable.GetClusterVersion() — and the process exits, so every pod crash-loops.
+#
+# They ship here, in crds/, rather than being created by the app at runtime: they're static, they belong in
+# version control, and creating them at runtime would mean granting the app cluster-scoped write access to
+# CustomResourceDefinitions for the life of the deployment.
+#
+# Copied verbatim from the provider's own definitions
+# (orleans.clustering.kubernetes/<version>/lib/Definitions/{ClusterVersionCRD,SiloEntryCRD}.yaml).
+#
+# NOTE: Helm applies crds/ on install only, never on upgrade. Upgrading a release that predates this file
+# needs them applied once by hand:
+#   kubectl apply -f https://raw.githubusercontent.com/XtremeOwnage/rPDU2MQTT/main/charts/rpdu2mqtt/crds/orleans-membership.yaml
+# Argo CD renders with --include-crds, so it applies them on every sync and needs nothing extra.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterversions.orleans.dot.net
+spec:
+  group: orleans.dot.net
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+            type: object
+            properties:
+                clusterId:
+                    type: string
+                clusterVersion:
+                    type: integer
+  scope: Namespaced
+  names:
+    plural: clusterversions
+    singular: clusterversion
+    kind: OrleansClusterVersion
+    shortNames:
+    - ocv
+    - oc
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: silos.orleans.dot.net
+spec:
+  group: orleans.dot.net
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+            required: [ address, port, generation, hostname, status, siloName ]
+            type: object
+            properties:
+                clusterId:
+                    type: string
+                address:
+                    type: string
+                port:
+                    type: integer
+                generation:
+                    type: integer
+                hostname:
+                    type: string
+                status:
+                    type: string
+                proxyPort:
+                    type: integer
+                siloName:
+                    type: string
+                suspectingSilos:
+                    type: array
+                    items:
+                        type: string
+                suspectingTimes:
+                    type: array
+                    items:
+                        type: string
+                startTime:
+                    type: string
+                iAmAliveTime:
+                    type: string
+  scope: Namespaced
+  names:
+    plural: silos
+    singular: silo
+    kind: OrleansSilo
+    shortNames:
+    - oso
+    - os

--- a/charts/rpdu2mqtt/templates/rbac.yaml
+++ b/charts/rpdu2mqtt/templates/rbac.yaml
@@ -50,7 +50,8 @@ subjects:
 {{- if (include "rpdu2mqtt.clustered" .) }}
 ---
 # v3: Orleans Kubernetes clustering. Split roles are separate silos that form one cluster; membership is
-# stored in orleans.dot.net custom resources (no external DB). Namespaced CRUD on those resources:
+# stored in orleans.dot.net custom resources (no external DB) — the CRDs themselves ship in this chart's
+# crds/ directory, so the app never needs cluster-scoped CRD permissions. Namespaced CRUD on the resources:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -72,34 +73,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "rpdu2mqtt.fullname" . }}-orleans
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "rpdu2mqtt.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
----
-# The provider creates the two CRDs on first start if absent (cluster-scoped). Drop this ClusterRole and
-# pre-install the CRDs if you'd rather not grant CRD creation.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "rpdu2mqtt.fullname" . }}-orleans-crd
-  labels:
-    {{- include "rpdu2mqtt.labels" . | nindent 4 }}
-rules:
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["get", "list", "create"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "rpdu2mqtt.fullname" . }}-orleans-crd
-  labels:
-    {{- include "rpdu2mqtt.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "rpdu2mqtt.fullname" . }}-orleans-crd
 subjects:
   - kind: ServiceAccount
     name: {{ include "rpdu2mqtt.serviceAccountName" . }}


### PR DESCRIPTION
Found on a live cluster: after #225 every pod (worker/api/ui) was crash-looping — 76 restarts in 8 hours, zero grain activations.

```
Failure reading all silo entries for cluster id rpdu2mqtt
HttpOperationException: 'NotFound' … 404 page not found
   at Orleans.Clustering.Kubernetes.KubeMembershipTable.GetClusterVersion()
```

## What was wrong

#225 switched split/scaled deployments onto Kubernetes clustering, where the silos keep membership in `clusterversions.orleans.dot.net` and `silos.orleans.dot.net`. **The chart never shipped those CRDs.** Instead it granted the app a cluster-scoped ClusterRole to create them, with this comment:

> The provider creates the two CRDs on first start if absent

That was never true. `SiloConfiguration` calls `UseKubeMembership()` with no options, and the provider only creates them when explicitly permitted. So the permission was granted, the CRDs were never created, and every silo died on startup — forever.

## The fix

- **`crds/orleans-membership.yaml`** — both CRDs, copied verbatim from the provider's own definitions (`orleans.clustering.kubernetes/…/lib/Definitions/`).
- **The `-orleans-crd` ClusterRole/ClusterRoleBinding is deleted.** With the CRDs shipped, the app has no reason to hold cluster-scoped write access to CustomResourceDefinitions for the life of the deployment. Strictly less privilege than before, and the thing it needed is now in version control where it belongs.
- **CI asserts both halves**: the CRDs render, *and* nothing grants `customresourcedefinitions` — so neither can regress quietly.

## Upgrading an existing release

Helm applies `crds/` **on install only, never on upgrade**, so a release installed before this needs them once by hand:

```
kubectl apply -f charts/rpdu2mqtt/crds/orleans-membership.yaml
```

Argo CD renders with `--include-crds` and applies them on every sync, so GitOps deployments need nothing extra. Both notes are in the chart README and the file's own header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)