### PR TITLE
feat(v3): device grains prefer a worker silo — make the tiering mean something

### DIFF
--- a/charts/rpdu2mqtt/README.md
+++ b/charts/rpdu2mqtt/README.md
@@ -77,6 +77,14 @@ credentials:
 
 ## Notes
 
+- **Where the device work runs (`split.enabled`):** roles decide which *background services* start in each
+  pod — they don't decide where grains live. The grains that hold a device open (the PDU session, a Modbus
+  device) now use a placement strategy that **prefers a silo running the `worker` role**, so in a split
+  deployment that work lands in the worker pod rather than wherever Orleans happened to put it. It's a
+  preference, not a requirement: with no worker silo available it falls back to any silo and logs a warning,
+  because a grain that can't be placed is worse than one placed in the wrong pod. In the default
+  single-Deployment fleet every silo runs every role, so nothing changes.
+
 - **Orleans membership CRDs:** the chart ships `crds/orleans-membership.yaml`
   (`clusterversions.orleans.dot.net`, `silos.orleans.dot.net`). The silos store cluster membership in those
   resources instead of an external database, and without them **every pod crash-loops** on *"Failure reading

--- a/rPDU2MQTT.Grains/Modbus/ModbusGrain.cs
+++ b/rPDU2MQTT.Grains/Modbus/ModbusGrain.cs
@@ -13,6 +13,7 @@ namespace rPDU2MQTT.Grains.Modbus;
 /// scan. Single activation + single-threaded, so the device connection is never contended. Blocking device
 /// I/O runs off the grain turn via <c>Task.Run</c>.
 /// </summary>
+[rPDU2MQTT.Grains.Placement.DevicePlacement]
 public sealed class ModbusGrain : Grain, IModbusGrain
 {
     private readonly ILogger<ModbusGrain> log;

--- a/rPDU2MQTT.Grains/Pdu/PduGrain.cs
+++ b/rPDU2MQTT.Grains/Pdu/PduGrain.cs
@@ -19,6 +19,7 @@ namespace rPDU2MQTT.Grains.Pdu;
 /// which is what let a write reach the wrong device when several PDUs are bridged.
 /// </para>
 /// </summary>
+[rPDU2MQTT.Grains.Placement.DevicePlacement]
 public sealed class PduGrain : Grain, IPduGrain
 {
     private readonly Config config;

--- a/rPDU2MQTT.Grains/Placement/DevicePlacement.cs
+++ b/rPDU2MQTT.Grains/Placement/DevicePlacement.cs
@@ -1,0 +1,64 @@
+using Orleans.Placement;
+using Orleans.Runtime;
+
+namespace rPDU2MQTT.Grains.Placement;
+
+/// <summary>
+/// Place this grain on a silo that runs the <c>worker</c> role, when the deployment has one.
+/// <para>
+/// Splitting the deployment into worker/api/ui Deployments implied that device I/O happens in the worker —
+/// and it didn't. Roles only decide which background services start in each process; every pod is an equal
+/// silo, and Orleans placed grains wherever it liked, so a PDU's HTTP session or a Modbus device's socket
+/// could just as easily live in the pod serving the web GUI. That makes the tiering a label rather than a
+/// boundary, and makes per-role network segmentation actively dangerous.
+/// </para>
+/// <para>
+/// This is a <i>preference</i>, not a requirement: with no worker silo (the default all-in-one fleet, or
+/// every worker down) it falls back to any compatible silo, because a grain that can't be placed is worse
+/// than one placed in the wrong pod. The fallback is logged, so it isn't a silent surprise.
+/// </para>
+/// </summary>
+[Serializable, GenerateSerializer, Immutable, SuppressReferenceTracking]
+public sealed class DevicePlacement : PlacementStrategy
+{
+    public static readonly DevicePlacement Singleton = new();
+
+    /// <summary>The role a silo must advertise (in its silo name) to be preferred.</summary>
+    public const string PreferredRole = "worker";
+
+    /// <summary>
+    /// Silo names carry the role because that's what placement can see: a placement director can ask
+    /// the silo status oracle for a silo's name, and for nothing else about it.
+    /// </summary>
+    public static string SiloName(string role, string suffix) => $"{role}-{suffix}";
+
+    /// <summary>
+    /// Does this silo run the preferred role? An all-in-one silo counts — it runs every role, including
+    /// this one, which is why the single-Deployment default keeps working unchanged.
+    /// </summary>
+    public static bool IsPreferred(string? siloName)
+        => siloName is not null
+        && (siloName.StartsWith(PreferredRole + "-", StringComparison.OrdinalIgnoreCase)
+            || siloName.StartsWith("all-", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The placement rule, as a pure function so it can be tested without a cluster: prefer silos running
+    /// the role; fall back to every candidate when none does. <paramref name="hash"/> spreads different
+    /// grains across the eligible silos while keeping one grain's choice stable for a given silo set.
+    /// </summary>
+    public static SiloAddress? Choose(IReadOnlyList<SiloAddress> candidates, Func<SiloAddress, string?> nameOf, int hash)
+    {
+        if (candidates.Count == 0) return null;
+
+        var preferred = candidates.Where(s => IsPreferred(nameOf(s))).ToList();
+        var pool = preferred.Count > 0 ? preferred : candidates;
+        return pool[(int)((uint)hash % (uint)pool.Count)];
+    }
+}
+
+/// <summary>Marks a grain as doing device I/O — see <see cref="DevicePlacement"/>.</summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class DevicePlacementAttribute : PlacementAttribute
+{
+    public DevicePlacementAttribute() : base(DevicePlacement.Singleton) { }
+}

--- a/rPDU2MQTT.Tests/DevicePlacementTests.cs
+++ b/rPDU2MQTT.Tests/DevicePlacementTests.cs
@@ -1,0 +1,84 @@
+using Orleans.Runtime;
+using rPDU2MQTT.Grains.Placement;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Where a device-owning grain lands. Splitting into worker/api/ui Deployments implied device I/O happens
+/// in the worker; it didn't — roles only gate background services, and Orleans placed grains anywhere, so a
+/// PDU's HTTP session could live in the pod serving the web GUI. This is the rule that makes the label true.
+/// </summary>
+public class DevicePlacementTests
+{
+    private static SiloAddress Silo(int port) => SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, port), 0);
+
+    private static Func<SiloAddress, string?> Names(params (int Port, string? Name)[] names)
+        => silo => names.FirstOrDefault(n => n.Port == silo.Endpoint.Port).Name;
+
+    [Fact]
+    public void Prefers_AWorkerSilo_OverTheOthers()
+    {
+        var ui = Silo(1); var api = Silo(2); var worker = Silo(3);
+        var name = Names((1, "ui-pod-a"), (2, "api-pod-b"), (3, "worker-pod-c"));
+
+        // Whatever the hash, the only worker is the only acceptable answer.
+        for (var hash = 0; hash < 20; hash++)
+            Assert.Equal(worker, DevicePlacement.Choose(new[] { ui, api, worker }, name, hash));
+    }
+
+    [Fact]
+    public void AllInOne_CountsAsAWorker_SoTheDefaultDeploymentIsUnaffected()
+    {
+        // An all-in-one silo runs every role, worker included; a single-Deployment fleet must place normally.
+        var a = Silo(1); var b = Silo(2);
+        var name = Names((1, "all-pod-a"), (2, "all-pod-b"));
+
+        Assert.Contains(DevicePlacement.Choose(new[] { a, b }, name, 0), new[] { a, b });
+        Assert.True(DevicePlacement.IsPreferred("all-pod-a"));
+        Assert.True(DevicePlacement.IsPreferred("worker-pod-a"));
+        Assert.False(DevicePlacement.IsPreferred("ui-pod-a"));
+        Assert.False(DevicePlacement.IsPreferred(null));
+    }
+
+    [Fact]
+    public void NoWorkerAnywhere_FallsBack_RatherThanRefusingToPlace()
+    {
+        // Every worker down, or a deployment that simply has none: a grain placed in the wrong pod beats a
+        // grain that can't be placed at all. The director logs a warning when this happens.
+        var ui = Silo(1); var api = Silo(2);
+        var name = Names((1, "ui-pod-a"), (2, "api-pod-b"));
+
+        var chosen = DevicePlacement.Choose(new[] { ui, api }, name, 7);
+        Assert.Contains(chosen, new[] { ui, api });
+    }
+
+    [Fact]
+    public void SpreadsAcrossWorkers_ButIsStableForOneGrain()
+    {
+        var w1 = Silo(1); var w2 = Silo(2);
+        var name = Names((1, "worker-a"), (2, "worker-b"));
+        var candidates = new[] { w1, w2 };
+
+        // The same grain (same hash) always resolves to the same silo while the silo set is unchanged...
+        Assert.Equal(DevicePlacement.Choose(candidates, name, 42), DevicePlacement.Choose(candidates, name, 42));
+
+        // ...and different grains don't all pile onto one worker.
+        var picks = Enumerable.Range(0, 10).Select(h => DevicePlacement.Choose(candidates, name, h)).Distinct().Count();
+        Assert.Equal(2, picks);
+    }
+
+    [Fact]
+    public void NoSilosAtAll_IsNull_NotAnException()
+    {
+        Assert.Null(DevicePlacement.Choose(System.Array.Empty<SiloAddress>(), _ => "worker-a", 0));
+    }
+
+    [Fact]
+    public void SiloName_CarriesTheRole()
+    {
+        Assert.Equal("worker-rpdu2mqtt-worker-abc123", DevicePlacement.SiloName("worker", "rpdu2mqtt-worker-abc123"));
+        Assert.True(DevicePlacement.IsPreferred(DevicePlacement.SiloName("worker", "pod")));
+        Assert.False(DevicePlacement.IsPreferred(DevicePlacement.SiloName("ui", "pod")));
+    }
+}

--- a/rPDU2MQTT.Tests/GrainTestCluster.cs
+++ b/rPDU2MQTT.Tests/GrainTestCluster.cs
@@ -49,6 +49,9 @@ public static class GrainTestCluster
             silo.Services.AddSingleton<rPDU2MQTT.Core.ISnapshotCache, rPDU2MQTT.Core.SnapshotCache>();
             silo.Services.AddSingleton<rPDU2MQTT.Services.EmonCmsFeedSync>();
             silo.Services.AddSerializer(s => s.AddJsonSerializer(isSupported: IsAbstraction));
+            // Placement is configured exactly as production does it — every silo must register the device
+            // placement director, or a grain that asks for the strategy can't be placed at all.
+            rPDU2MQTT.Startup.SiloConfiguration.ConfigurePlacement(silo);
         }
     }
 

--- a/rPDU2MQTT/Hosting/DevicePlacementDirector.cs
+++ b/rPDU2MQTT/Hosting/DevicePlacementDirector.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+using Orleans.Runtime.Placement;
+using rPDU2MQTT.Grains.Placement;
+
+namespace rPDU2MQTT.Hosting;
+
+/// <summary>
+/// Applies <see cref="DevicePlacement"/>: device-owning grains go to a silo running the worker role when
+/// the deployment has one. Lives in the host rather than next to the strategy because asking a silo's name
+/// needs <see cref="ISiloStatusOracle"/>, which is silo-side runtime — the grains project deliberately
+/// references only the SDK.
+/// </summary>
+public sealed class DevicePlacementDirector : IPlacementDirector
+{
+    private readonly ISiloStatusOracle oracle;
+    private readonly ILogger<DevicePlacementDirector> log;
+
+    public DevicePlacementDirector(ISiloStatusOracle oracle, ILogger<DevicePlacementDirector> log)
+    {
+        this.oracle = oracle;
+        this.log = log;
+    }
+
+    public Task<SiloAddress> OnAddActivation(PlacementStrategy strategy, PlacementTarget target, IPlacementContext context)
+    {
+        var candidates = context.GetCompatibleSilos(target);
+        var chosen = DevicePlacement.Choose(candidates, Name, target.GrainIdentity.GetHashCode())
+            ?? throw new OrleansException($"No compatible silo to place {target.GrainIdentity}.");
+
+        if (!DevicePlacement.IsPreferred(Name(chosen)))
+            log.LogWarning("Placing device grain {Grain} on {Silo} ({Name}) — no silo runs the '{Role}' role, "
+                + "so its device I/O happens there.", target.GrainIdentity, chosen, Name(chosen) ?? "?", DevicePlacement.PreferredRole);
+
+        return Task.FromResult(chosen);
+    }
+
+    private string? Name(SiloAddress silo) => oracle.TryGetSiloName(silo, out var name) ? name : null;
+}

--- a/rPDU2MQTT/Startup/SiloConfiguration.cs
+++ b/rPDU2MQTT/Startup/SiloConfiguration.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Orleans.Clustering.Kubernetes;
+using Orleans.Runtime.Placement;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Serialization;
@@ -16,6 +17,8 @@ public static class SiloConfiguration
 {
     public static void Configure(ISiloBuilder silo)
     {
+        ConfigurePlacement(silo);
+
         silo.Configure<ClusterOptions>(o =>
         {
             o.ClusterId = Environment.GetEnvironmentVariable("RPDU2MQTT_ORLEANS_CLUSTER_ID") ?? "rpdu2mqtt";
@@ -49,6 +52,29 @@ public static class SiloConfiguration
         // Framework-free DTOs that cross grain boundaries: the pipeline contracts, and the PDU snapshot/model
         // (which carry no Orleans attributes) — shipped with JSON so the domain stays serializer-agnostic.
         silo.Services.AddSerializer(s => s.AddJsonSerializer(isSupported: IsGrainDto));
+    }
+
+    /// <summary>
+    /// Silo naming + the device placement director. Extracted because <b>every</b> silo in the cluster must
+    /// register the director: a silo that hasn't can't place a grain that asks for the strategy at all
+    /// ("Could not resolve placement strategy"), so prod and tests configure placement through this one
+    /// method rather than two copies that can drift apart.
+    /// </summary>
+    public static void ConfigurePlacement(ISiloBuilder silo)
+    {
+        // The silo's name carries this process's role, because a placement director can see a silo's name
+        // and nothing else about it. That's what lets device-owning grains land on a worker instead of
+        // wherever Orleans felt like putting them — which, in a split deployment, was frequently the pod
+        // serving the web GUI.
+        var role = (Environment.GetEnvironmentVariable("RPDU2MQTT_ROLE") ?? "all")
+            .Split(new[] { ',', ' ', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault() ?? "all";
+        silo.Configure<SiloOptions>(o => o.SiloName = rPDU2MQTT.Grains.Placement.DevicePlacement.SiloName(
+            role, Environment.GetEnvironmentVariable("RPDU2MQTT_POD_NAME") ?? Environment.MachineName));
+
+        // Device-owning grains (the PDU session, a Modbus device) prefer a worker silo; with none they fall
+        // back to any silo, so the single-Deployment default is unaffected.
+        silo.Services.AddPlacementDirector<rPDU2MQTT.Grains.Placement.DevicePlacement, Hosting.DevicePlacementDirector>();
     }
 
     /// <summary>Types shipped across grains via JSON (no Orleans attributes on the domain).</summary>


### PR DESCRIPTION
`split.enabled` implies the worker pod does the device work. **It doesn't.** Roles only gate which background services start in each process; every pod is an equal silo, and with no placement strategies anywhere, Orleans put grains wherever it liked.

From the live cluster while investigating:

```
worker  #activations: (none)
api     #activations: 0
ui      #activations: 4     ← the grains are here
```

So the PDU's HTTP session and the Modbus device sockets were running in the pod serving the web GUI. The tiering was a label, and any per-role NetworkPolicy built on it — worker gets egress to the PDU VLAN, ui doesn't — would break polling intermittently and inexplicably.

## What this does

- **`DevicePlacement`** prefers a silo whose name says it runs the `worker` role. The role rides in the **silo name** because that's the one thing a placement director can see about another silo (`ISiloStatusOracle.TryGetSiloName`); Orleans 10's built-in metadata filters match against the *calling* silo's metadata, which is affinity, not "put this on a worker".
- Applied to the two grains that actually hold a device open: **`PduGrain`** and **`ModbusGrain`**. Their children don't need it — since #232, outlet and group writes go through the parent PDU grain rather than opening anything themselves.
- **A preference, not a requirement.** With no worker silo — the all-in-one default, or every worker down — it falls back to any compatible silo *and logs a warning*, because a grain that can't be placed is worse than one placed in the wrong pod. An `all-` silo counts as a worker, so single-Deployment fleets are completely unaffected.

## The sharp edge, and why it's shared code

**Every silo in the cluster must register the director.** One that hasn't throws `Could not resolve placement strategy DevicePlacement` and *cannot place the grain at all*. The test cluster hit exactly that on the first run, which is why placement registration is now one method (`SiloConfiguration.ConfigurePlacement`) called by both production and the tests, rather than two copies free to drift.

## Tests

6 new (355 total, 0 warnings): prefers the worker whatever the hash, all-in-one counts as a worker, falls back rather than refusing to place, spreads across multiple workers while staying stable for a single grain, empty candidate set returns null instead of throwing, and the name/role round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)