### PR TITLE
fix(flow): never invent a power value — unknown is reported as unknown

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -727,7 +727,7 @@ spec:
                           - residual
                           - untracked
                           - none
-                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'static' (a fixed leaf at Value), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins."
+                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate children; carries unmet demand only when it is the single path into a node — never splits a load between several unmeasured feeders), 'static' (a fixed leaf at Value), 'residual' (the designated absorber of what its target still needs — this is how you say where unaccounted power comes from), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins."
                         Sources:
                           type: array
                           items:

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -727,7 +727,7 @@ spec:
                           - residual
                           - untracked
                           - none
-                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'static' (a fixed leaf at Value), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins."
+                          description: "How to value this node when it has no direct measurement: 'auto' (aggregate children; carries unmet demand only when it is the single path into a node — never splits a load between several unmeasured feeders), 'static' (a fixed leaf at Value), 'residual' (the designated absorber of what its target still needs — this is how you say where unaccounted power comes from), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins."
                         Sources:
                           type: array
                           items:

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -433,6 +433,30 @@ Logging:
 ```
 
 
+### Accuracy: what the flow will and won't infer
+
+The diagram never states a number nobody supplied. A node's value comes from one of:
+
+1. **A measurement** — a live source bound to it, or a static `Value`.
+2. **Its children**, summed.
+3. **Conservation**, when it is the *single* unmeasured path into a node whose demand is measured. The load
+   is really being drawn and there is exactly one way for it to arrive, so the figure is derived, not guessed.
+
+If none of those apply the node reads **"no data"** on the diagram, publishes nothing to MQTT / Home
+Assistant / EmonCMS, and is reported as `null` by the API — deliberately *not* `0`, because 0 is a claim
+(solar at night really is 0 W) and a fabricated zero recorded into history is worse than a gap.
+
+In particular, **several unmeasured feeders into one node all read "no data"**. If solar, battery and grid
+all feed an inverter and none of them is metered, nothing indicates which supplied the load, so none of them
+is given a share of it. To say where unaccounted power comes from, mark that feeder's `Mode: residual` — the
+designated absorber carries the remainder after every measured feeder has supplied its part.
+
+> Before this rule existed, that case split the load equally between them: three unmeasured sources under a
+> 553 W load each showed 184.3 W, which is indistinguishable on the diagram from a real measurement.
+
+A configured node always appears on the diagram even when it has no value, so a gap in your metering is
+visible as a gap rather than as a missing node.
+
 ## Metric Exporters (Optional)
 
 In addition to MQTT, measurements can be exported to Prometheus and/or EmonCMS. Both are disabled

--- a/rPDU2MQTT.Core/Flow/FlowExport.cs
+++ b/rPDU2MQTT.Core/Flow/FlowExport.cs
@@ -11,18 +11,39 @@ namespace rPDU2MQTT.Core.Flow;
 public static class FlowExport
 {
     /// <summary>
-    /// A node's rolled-up value: the larger of what flows in vs. what flows out (a root only has outflow,
-    /// a leaf only inflow, a balanced tier has equal in/out). Matches the value shown in the GUI.
+    /// A node's rolled-up value, or 0 when the graph could not determine one.
+    /// <para>
+    /// The builder computes this now (see <see cref="FlowNode.Value"/>), so exports agree with the diagram
+    /// instead of re-deriving it. Callers that must distinguish "unknown" from "zero" — anything that
+    /// publishes a reading — should read <see cref="FlowNode.Value"/> and skip nulls; see
+    /// <see cref="TryNodeValue"/>.
+    /// </para>
     /// </summary>
     public static double NodeValue(FlowGraph graph, string id)
+        => TryNodeValue(graph, id, out var value) ? value : 0;
+
+    /// <summary>
+    /// The node's value when the graph actually determined one. False means nothing measures this node and
+    /// nothing downstream determines it — publishing a number for it would be inventing one.
+    /// </summary>
+    public static bool TryNodeValue(FlowGraph graph, string id, out double value)
     {
+        var node = graph.Nodes.FirstOrDefault(n => string.Equals(n.Id, id, StringComparison.OrdinalIgnoreCase));
+        if (node?.Value is { } known) { value = known; return true; }
+
+        // No value on the node: derive it from the links whose flow is known (the larger of in vs. out).
+        // A node the builder marked unknown has only unknown links, so this correctly finds nothing —
+        // while a graph assembled by hand, whose nodes carry no values, still resolves.
         double inflow = 0, outflow = 0;
+        var anyKnown = false;
         foreach (var l in graph.Links)
         {
-            if (string.Equals(l.Target, id, StringComparison.OrdinalIgnoreCase)) inflow += l.Value;
-            if (string.Equals(l.Source, id, StringComparison.OrdinalIgnoreCase)) outflow += l.Value;
+            if (!l.Known) continue;
+            if (string.Equals(l.Target, id, StringComparison.OrdinalIgnoreCase)) { inflow += l.Value; anyKnown = true; }
+            if (string.Equals(l.Source, id, StringComparison.OrdinalIgnoreCase)) { outflow += l.Value; anyKnown = true; }
         }
-        return Math.Max(inflow, outflow);
+        value = anyKnown ? Math.Max(inflow, outflow) : 0;
+        return anyKnown;
     }
 
     /// <summary>The ids of a node's feeders (the sources of links pointing into it) — its upstream parents.</summary>

--- a/rPDU2MQTT.Core/Flow/FlowGraph.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraph.cs
@@ -4,10 +4,24 @@ namespace rPDU2MQTT.Core.Flow;
 /// <param name="Id">Stable unique id (used to wire links).</param>
 /// <param name="Label">Human-readable display name.</param>
 /// <param name="Kind">Node kind: <c>pdu</c>, <c>outlet</c>, <c>circuit</c>, <c>total</c>, … (for styling/grouping).</param>
-public sealed record FlowNode(string Id, string Label, string Kind);
+/// <param name="Value">
+/// The node's power/energy for this graph's metric, or <see langword="null"/> when it is <b>unknown</b>.
+/// <para>
+/// Unknown is deliberately not zero. Zero is a claim — solar at night really is generating 0 W — whereas
+/// unknown means nothing measures this node and nothing downstream determines it. Conflating the two is how
+/// a diagram ends up stating a number nobody supplied, so the distinction is carried in the type.
+/// </para>
+/// </param>
+public sealed record FlowNode(string Id, string Label, string Kind, double? Value = null);
 
 /// <summary>A weighted link between two <see cref="FlowNode"/>s (energy flows Source → Target).</summary>
-public sealed record FlowLink(string Source, string Target, double Value);
+/// <param name="Known">
+/// Is <paramref name="Value"/> actually derived from measurements? False means the topology says this link
+/// exists but nothing determines how much flows along it — typically several unmeasured feeders into one
+/// node, where any split between them would be invented. Such a link carries 0 and must be presented as
+/// "no data", never as zero flow.
+/// </param>
+public sealed record FlowLink(string Source, string Target, double Value, bool Known = true);
 
 /// <summary>
 /// A directed, weighted flow graph (nodes + links) suitable for a Sankey diagram. Today it is derived

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -165,6 +165,49 @@ public static class FlowGraphBuilder
         double DemandShare(string child, HashSet<string> path)
             => Need(child, path) / Math.Max(1, incoming.TryGetValue(child, out var f) ? f.Count : 1);
 
+        // A 'none' node never infers a value, and a 'static' node with no value here (a valued one is
+        // already a leaf above) has nothing to give — both contribute zero rather than absorbing demand.
+        static bool Inert(string m) => m is "none" or "static";
+
+        // Which unmeasured feeders may supply what a node still needs after its measured feeders have
+        // supplied their real figures. This is the line between inference and invention:
+        //
+        //  - An explicit 'residual' feeder was designated for exactly this, so it absorbs the remainder.
+        //  - Otherwise a SINGLE unmeasured feeder conveys it. That isn't a guess: the load downstream is
+        //    really being drawn, and the topology leaves it exactly one path to arrive by.
+        //  - Several unmeasured feeders is a genuine unknown. Nothing says whether the load came from the
+        //    solar, the battery or the grid, so NONE of them carry anything. Dividing it between them —
+        //    which is what this used to do — states a number the user never supplied, on the diagram whose
+        //    whole purpose is to be accurate. Mark one 'residual' to say where the remainder actually goes.
+        List<string> Absorbers(string to)
+        {
+            var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
+            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f))).ToList();
+            var residual = unmeasured.Where(f => Mode(f) == "residual").ToList();
+            if (residual.Count > 0) return residual;
+            return unmeasured.Count == 1 ? unmeasured : new List<string>();
+        }
+
+        // Is the flow along this link determined by measurements at all? False when several unmeasured
+        // feeders compete to supply the same node — the link exists, but its share is unknowable, and it
+        // must be shown as "no data" rather than as zero flow.
+        bool Knowable(string from, string to)
+        {
+            if (leaf.ContainsKey(from)) return true;         // a measured producer supplies a real figure
+            if (Inert(Mode(from))) return true;              // 'none'/'static': deliberately contributes nothing
+
+            var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
+            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f))).ToList();
+
+            // A designated residual is told what it carries, so its own flow is determined. Its unmeasured
+            // siblings are not: "the residual takes the remainder" says nothing about how much solar was
+            // generating, so reporting 0 W for them would be a claim we can't support either.
+            if (unmeasured.Any(f => Mode(f) == "residual")) return Mode(from) == "residual";
+
+            // One unmeasured path is determined by conservation. Several is a real unknown.
+            return unmeasured.Count <= 1;
+        }
+
         // EdgeFlow(from -> to): how much flows along one link.
         //  - A producer (a measured leaf feeding others) supplies its generation, divided across the things
         //    it powers in proportion to their downstream demand (equal split if none draw anything) — so a
@@ -198,38 +241,64 @@ public static class FlowGraphBuilder
                 return totalDemand > 0 ? produced * Need(to, path) / totalDemand : produced / kids.Count;
             }
 
-            // A 'none' node never infers a value, and a 'static' node with no value here (a valued one is
-            // already a leaf above) has nothing to give — both contribute zero rather than absorbing demand.
-            static bool Inert(string m) => m is "none" or "static";
             if (Inert(Mode(from))) return 0;
+
+            var absorbers = Absorbers(to);
+            if (!absorbers.Contains(from, StringComparer.OrdinalIgnoreCase)) return 0;
 
             var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
             var measured = feeders.Where(leaf.ContainsKey).Sum(f => EdgeFlow(f, to, path));
             var remainder = Math.Max(0, Need(to, path) - measured);
-
-            // Unmeasured feeders that may absorb the remainder. If any is 'residual', only those share it;
-            // otherwise the 'auto' feeders split it (back-compat when nothing is measured).
-            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f))).ToList();
-            var residual = unmeasured.Where(f => Mode(f) == "residual").ToList();
-            var absorbers = residual.Count > 0 ? residual : unmeasured;
-            if (absorbers.Count == 0 || !absorbers.Contains(from, StringComparer.OrdinalIgnoreCase)) return 0;
             return remainder / absorbers.Count;
         }
 
-        // Emit one link per edge, valued by the flow it carries.
+        // Emit one link per edge, valued by the flow it carries. A link whose flow is *unknowable* is still
+        // emitted — carrying 0 and flagged — because the wiring is real even when the number isn't, and
+        // silently dropping it hides a node the user deliberately configured.
         var links = new List<FlowLink>();
-        var used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        // Every node the topology wires up, whether or not its link survives the filter below. Deriving the
+        // node set from the surviving links is what made a configured node disappear.
+        var wired = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var (from, kids) in outgoing)
             foreach (var to in kids)
             {
-                var value = EdgeFlow(from, to, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
-                if (value <= 0) continue;
-                links.Add(new FlowLink(from, to, value));
-                used.Add(from); used.Add(to);
+                wired.Add(from); wired.Add(to);
+
+                var known = Knowable(from, to);
+                var value = known ? EdgeFlow(from, to, new HashSet<string>(StringComparer.OrdinalIgnoreCase)) : 0;
+
+                // A known-but-zero link carries nothing and is left off the diagram, as before. An *unknown*
+                // link is kept — it draws as "no data" rather than implying zero flow.
+                if (known && value <= 0) continue;
+
+                links.Add(new FlowLink(from, to, value, known));
             }
 
-        var nodes = used
-            .Select(id => new FlowNode(id, label.TryGetValue(id, out var l) ? l : id, kind.TryGetValue(id, out var k) ? k : "node"))
+        // A node's own value: its measurement if it has one, else what its known links determine (a root
+        // only has outflow, a leaf only inflow). No measurement and no known link means genuinely unknown —
+        // reported as null rather than 0, so nothing downstream can mistake "we don't know" for "it's zero".
+        double? ValueOf(string id)
+        {
+            if (leaf.TryGetValue(id, out var measured)) return measured;
+
+            double inflow = 0, outflow = 0;
+            var anyKnown = false;
+            foreach (var l in links)
+            {
+                if (!l.Known) continue;
+                if (string.Equals(l.Target, id, StringComparison.OrdinalIgnoreCase)) { inflow += l.Value; anyKnown = true; }
+                if (string.Equals(l.Source, id, StringComparison.OrdinalIgnoreCase)) { outflow += l.Value; anyKnown = true; }
+            }
+            return anyKnown ? Math.Max(inflow, outflow) : null;
+        }
+
+        // Every node the user declared, plus every auto (pdu/outlet) node that reported a measurement —
+        // whether or not a value could be determined for it. A configured node that silently disappears is
+        // its own kind of inaccuracy: it reads as "my config is broken" rather than "nothing measures this".
+        var nodes = label.Keys
+            .Where(id => wired.Contains(id) || leaf.ContainsKey(id))
+            .Select(id => new FlowNode(id, label[id], kind.TryGetValue(id, out var k) ? k : "node", ValueOf(id)))
+            .OrderBy(n => n.Id, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         return new FlowGraph(nodes, links, metric, units);

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -93,8 +93,10 @@ public class EnergyFlowNode
     /// <see cref="Value"/> always wins regardless — this only governs nodes the graph would otherwise have
     /// to infer:
     /// <list type="bullet">
-    /// <item><c>auto</c> (default): aggregate children, and as an upstream feeder take a share of what's
-    /// left after measured siblings — the historical behaviour.</item>
+    /// <item><c>auto</c> (default): aggregate children. As an upstream feeder it carries a node's unmet
+    /// demand only when it is the <i>single</i> unmeasured path into that node, where conservation leaves no
+    /// other answer. Several unmeasured feeders into one node is a genuine unknown, and none of them are
+    /// given a value — splitting the load between them would state a figure nobody supplied.</item>
     /// <item><c>static</c>: a fixed leaf valued at <see cref="Value"/> (still superseded by a live source).
     /// This is the mode that gives the fixed value meaning; with no value set it contributes nothing.</item>
     /// <item><c>residual</c>: the designated "untracked" absorber on the <em>feeder</em> side — takes the
@@ -110,7 +112,7 @@ public class EnergyFlowNode
     /// </list>
     /// </summary>
     [DefaultValue("auto")]
-    [Description("How to value this node when it has no direct measurement: 'auto' (aggregate / share the remainder), 'static' (a fixed leaf at Value), 'residual' (absorb untracked remaining demand of what it feeds), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins.")]
+    [Description("How to value this node when it has no direct measurement: 'auto' (aggregate children; carries unmet demand only when it is the single path into a node — never splits a load between several unmeasured feeders), 'static' (a fixed leaf at Value), 'residual' (the designated absorber of what its target still needs — this is how you say where unaccounted power comes from), 'untracked' (show a measured parent's unaccounted consumption), or 'none' (never inferred). A live source always wins.")]
     [AllowedValues("auto", "static", "residual", "untracked", "none")]
     public string Mode { get; set; } = "auto";
 

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -58,8 +58,13 @@ public class EnergyFlowMqttExportService : baseMQTTService
 
         foreach (var node in graph.Nodes)
         {
+            // Nothing determines this tier's power — no measurement, and no single path that conservation
+            // pins down. Publishing it would put a fabricated 0 W into Home Assistant's history, which is
+            // worse than the sensor going unavailable: one is a gap, the other is a lie that gets recorded.
+            if (!FlowExport.TryNodeValue(graph, node.Id, out var power))
+                continue;
+
             var topic = FlowExport.Topic(node, graph, cfg.MQTT.ParentTopic, flow);
-            var power = FlowExport.NodeValue(graph, node.Id);
             var energy = FlowExport.NodeValue(energyGraph, node.Id);   // 0 when this tier has no energy sensor
             var parents = FlowExport.Parents(graph, node.Id);          // the tiers that feed this one
 

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -235,10 +235,11 @@ public class FlowGraphTests
     }
 
     [Fact]
-    public void Build_DiamondPaths_SplitDemandAmongFeeders_NoDoubleCount()
+    public void Build_DiamondPaths_AreUnknown_UntilOnePathIsDesignated()
     {
-        // A panel reachable from the boss both directly AND via a sub-panel (a diamond). The 100W of real
-        // load must not be counted twice: the panel's two feeder links carry 50W each, and the boss totals 100W.
+        // A panel reachable from the boss both directly AND via a sub-panel. The 100W of load is real, but
+        // *how much arrives by each path* is not measured — so neither link may claim a number. This used to
+        // split it 50/50, which reads on the diagram as though someone metered it.
         var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
         var flow = new EnergyFlowConfig
         {
@@ -259,11 +260,49 @@ public class FlowGraphTests
 
         var graph = FlowGraphBuilder.Build(data, flow);
 
-        Assert.Equal(50, graph.Links.Single(l => l.Source == "boss" && l.Target == "panel").Value);
-        Assert.Equal(50, graph.Links.Single(l => l.Source == "sub" && l.Target == "panel").Value);
+        // Both paths into the panel are flagged unknown and carry nothing.
+        Assert.False(graph.Links.Single(l => l.Source == "boss" && l.Target == "panel").Known);
+        Assert.False(graph.Links.Single(l => l.Source == "sub" && l.Target == "panel").Known);
+        Assert.Equal(0, graph.Links.Where(l => l.Target == "panel").Sum(l => l.Value));
+
+        // The real, measured part is untouched: the panel really does supply 100W downstream.
         Assert.Equal(100, graph.Links.Single(l => l.Source == "panel" && l.Target == "pdu:pdu1").Value);
-        // The boss carries the real load once: 50 (direct) + 50 (via sub) = 100, not 200.
-        Assert.Equal(100, graph.Links.Where(l => l.Source == "boss").Sum(l => l.Value));
+        Assert.Equal(100, graph.Nodes.Single(n => n.Id == "panel").Value);
+
+        // ...and the nodes whose value nothing determines say so, rather than showing a plausible figure.
+        Assert.Null(graph.Nodes.Single(n => n.Id == "boss").Value);
+        Assert.Null(graph.Nodes.Single(n => n.Id == "sub").Value);
+    }
+
+    [Fact]
+    public void Build_DiamondPaths_ResolveWhenAPathIsMarkedResidual()
+    {
+        // Saying which path carries the remainder is the supported way to attribute a diamond — an explicit
+        // instruction, so the number is the user's, not ours.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "boss", Label = "Boss" },
+                new EnergyFlowNode { Id = "panel", Label = "Panel" },
+                new EnergyFlowNode { Id = "sub", Label = "Sub", Mode = "residual" },
+            },
+            Links =
+            {
+                new EnergyFlowLink { From = "boss", To = "panel" },
+                new EnergyFlowLink { From = "boss", To = "sub" },
+                new EnergyFlowLink { From = "sub", To = "panel" },
+                new EnergyFlowLink { From = "panel", To = "pdu:pdu1" },
+            },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        // The designated path carries the load; the direct one carries nothing, and both are *determined*.
+        Assert.Equal(100, graph.Links.Single(l => l.Source == "sub" && l.Target == "panel").Value);
+        Assert.True(graph.Links.Single(l => l.Source == "sub" && l.Target == "panel").Known);
+        Assert.DoesNotContain(graph.Links, l => l.Source == "boss" && l.Target == "panel" && l.Value > 0);
     }
 
     [Fact]
@@ -293,7 +332,10 @@ public class FlowGraphTests
 
         Assert.Equal(6000, graph.Links.Single(l => l.Source == "solar").Value); // measured generation shown as-is
         Assert.DoesNotContain(graph.Links, l => l.Source == "grid");            // no fabricated grid draw
-        Assert.DoesNotContain(graph.Nodes, n => n.Id == "grid");
+
+        // The grid node itself stays on the diagram with no value: it is configured, so hiding it reads as
+        // "my wiring is broken" rather than "nothing measures this".
+        Assert.Null(graph.Nodes.Single(n => n.Id == "grid").Value);
     }
 
     [Fact]
@@ -374,7 +416,13 @@ public class FlowGraphTests
         var graph = FlowGraphBuilder.Build(data, flow);
 
         Assert.Equal(100, graph.Links.Single(l => l.Source == "untracked").Value);
-        Assert.DoesNotContain(graph.Links, l => l.Source == "spare");
+
+        // 'spare' supplies nothing — but it is still unmeasured, so it reads as "no data" rather than as a
+        // measured 0 W. Designating a residual says where the remainder went, not what its siblings did.
+        var spare = graph.Links.Single(l => l.Source == "spare");
+        Assert.False(spare.Known);
+        Assert.Equal(0, spare.Value);
+        Assert.Null(graph.Nodes.Single(n => n.Id == "spare").Value);
     }
 
     [Fact]

--- a/rPDU2MQTT.Tests/FlowNoFabricationTests.cs
+++ b/rPDU2MQTT.Tests/FlowNoFabricationTests.cs
@@ -1,0 +1,156 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// The diagram must never state a number nobody supplied.
+/// <para>
+/// The bug these pin: three unmeasured sources (solar, battery, grid) feeding one inverter were each shown
+/// carrying exactly a third of the house load — 184.333 W of 553 W — because the default <c>auto</c> mode
+/// split a node's unmet demand equally between its unmeasured feeders. Nobody configured that split, and on
+/// a diagram whose entire purpose is accurate power data it is indistinguishable from a real measurement.
+/// </para>
+/// </summary>
+public class FlowNoFabricationTests
+{
+    private static Measurement M(string type, string value) => new() { Type = type, Value = value, Units = "W" };
+
+    private static PduData Pdu(string name, params (string Outlet, string Watts)[] outlets)
+    {
+        var device = new Device { Key = name, Entity_Name = name, Entity_DisplayName = name };
+        var i = 0;
+        foreach (var (outlet, watts) in outlets)
+            device.Outlets.Add(new Outlet
+            {
+                Key = i++,
+                Entity_Name = outlet,
+                Entity_DisplayName = outlet,
+                Measurements = { M("realpower", watts) },
+            });
+        return new PduData { Devices = { device } };
+    }
+
+    /// <summary>The reported topology: PV / battery / grid → inverter → main panel → two rack PDUs.</summary>
+    private static EnergyFlowConfig House() => new()
+    {
+        Nodes =
+        {
+            new EnergyFlowNode { Id = "solar", Label = "Solar (PV)", Kind = "solar" },
+            new EnergyFlowNode { Id = "battery", Label = "Battery", Kind = "battery" },
+            new EnergyFlowNode { Id = "grid", Label = "Grid", Kind = "grid" },
+            new EnergyFlowNode { Id = "inverter", Label = "EG4 FlexBoss 21", Kind = "inverter" },
+            new EnergyFlowNode { Id = "main", Label = "Main Panel", Kind = "panel" },
+        },
+        Links =
+        {
+            new EnergyFlowLink { From = "solar", To = "inverter" },
+            new EnergyFlowLink { From = "battery", To = "inverter" },
+            new EnergyFlowLink { From = "grid", To = "inverter" },
+            new EnergyFlowLink { From = "inverter", To = "main" },
+            new EnergyFlowLink { From = "main", To = "pdu:rack1" },
+        },
+    };
+
+    [Fact]
+    public void UnmeasuredSources_AreNotHandedAShareOfTheLoad()
+    {
+        var graph = FlowGraphBuilder.Build(Pdu("rack1", ("Server", "300"), ("NAS", "253")), House());
+
+        // Not one of them may carry a figure: nothing says whether the load came from PV, the battery or
+        // the grid. Previously each was given 553/3 = 184.333 W.
+        foreach (var id in new[] { "solar", "battery", "grid" })
+        {
+            Assert.Null(graph.Nodes.Single(n => n.Id == id).Value);
+            Assert.Equal(0, graph.Links.Where(l => l.Source == id).Sum(l => l.Value));
+            Assert.All(graph.Links.Where(l => l.Source == id), l => Assert.False(l.Known));
+        }
+
+        Assert.DoesNotContain(graph.Links, l => Math.Abs(l.Value - 553d / 3) < 0.01);
+    }
+
+    [Fact]
+    public void TheMeasuredPartOfTheChain_IsStillReported()
+    {
+        var graph = FlowGraphBuilder.Build(Pdu("rack1", ("Server", "300"), ("NAS", "253")), House());
+
+        // Refusing to invent must not throw away what *is* known: the outlets are metered, so everything
+        // their demand determines by conservation — a single path — still carries its real figure.
+        Assert.Equal(553, graph.Nodes.Single(n => n.Id == "main").Value);
+        Assert.Equal(553, graph.Nodes.Single(n => n.Id == "inverter").Value);
+        Assert.Equal(553, graph.Links.Single(l => l.Source == "inverter" && l.Target == "main").Value);
+        Assert.Equal(300, graph.Nodes.Single(n => n.Id == "outlet:rack1:0").Value);
+    }
+
+    [Fact]
+    public void ConfiguredNodes_StayOnTheDiagram_EvenWithNoData()
+    {
+        var graph = FlowGraphBuilder.Build(Pdu("rack1", ("Server", "300")), House());
+
+        // The other half of the complaint: a node set to 'none' vanished entirely, which reads as "my
+        // config is broken" rather than "nothing measures this yet". A wired node is always present.
+        foreach (var id in new[] { "solar", "battery", "grid", "inverter", "main" })
+            Assert.Contains(graph.Nodes, n => n.Id == id);
+    }
+
+    [Fact]
+    public void MarkingAFeederResidual_IsHowYouAskForTheRemainder()
+    {
+        var flow = House();
+        flow.Nodes.Single(n => n.Id == "grid").Mode = "residual";
+
+        var graph = FlowGraphBuilder.Build(Pdu("rack1", ("Server", "300"), ("NAS", "253")), flow);
+
+        // Told explicitly where the unaccounted load comes from, the graph says so — and its siblings still
+        // claim nothing, because the instruction named one absorber.
+        Assert.Equal(553, graph.Nodes.Single(n => n.Id == "grid").Value);
+        Assert.Null(graph.Nodes.Single(n => n.Id == "solar").Value);
+        Assert.Null(graph.Nodes.Single(n => n.Id == "battery").Value);
+    }
+
+    [Fact]
+    public void AMeasuredSource_SuppliesItsRealFigure_AndTheRestStayUnknown()
+    {
+        var flow = House();
+        flow.Nodes.Single(n => n.Id == "solar").Value = 200;   // a bound/static reading
+
+        var graph = FlowGraphBuilder.Build(Pdu("rack1", ("Server", "300"), ("NAS", "253")), flow);
+
+        // Solar reports what it actually generates. The 353 W it doesn't cover is NOT then split between
+        // battery and grid — that would be the same invention in a subtler place.
+        Assert.Equal(200, graph.Nodes.Single(n => n.Id == "solar").Value);
+        Assert.Null(graph.Nodes.Single(n => n.Id == "battery").Value);
+        Assert.Null(graph.Nodes.Single(n => n.Id == "grid").Value);
+    }
+
+    [Fact]
+    public void UnknownIsNotZero_ForAnythingThatPublishes()
+    {
+        var graph = FlowGraphBuilder.Build(Pdu("rack1", ("Server", "300")), House());
+
+        // An exporter must be able to tell "no data" from a real 0 W, or it publishes a fabricated zero to
+        // Home Assistant / Prometheus / EmonCMS and someone's history records it as fact.
+        Assert.False(FlowExport.TryNodeValue(graph, "solar", out _));
+        Assert.True(FlowExport.TryNodeValue(graph, "main", out var main));
+        Assert.Equal(300, main);
+    }
+
+    [Fact]
+    public void ASingleUnmeasuredFeeder_StillConveys_BecauseConservationLeavesNoChoice()
+    {
+        // One path in, a metered load downstream: the power demonstrably arrives that way. This is
+        // inference from measurement, not invention, and it's what keeps ordinary chains working.
+        var flow = new EnergyFlowConfig
+        {
+            Nodes = { new EnergyFlowNode { Id = "main", Label = "Main" } },
+            Links = { new EnergyFlowLink { From = "main", To = "pdu:rack1" } },
+        };
+
+        var graph = FlowGraphBuilder.Build(Pdu("rack1", ("Server", "120")), flow);
+
+        Assert.Equal(120, graph.Nodes.Single(n => n.Id == "main").Value);
+        Assert.True(graph.Links.Single(l => l.Source == "main").Known);
+    }
+}

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -50,9 +50,9 @@ const MODBUS_WORDORDERS = ['big', 'little'];
 // node gets: a node you haven't measured yet should read as nothing, not as an inferred figure.
 const NODE_MODES: [string, string, string][] = [
   ['none', 'None (nothing inferred)', 'Never inferred — contributes nothing unless it has a real value or children, so an unmeasured node simply drops out instead of showing a fabricated figure. The default for a new node.'],
-  ['auto', 'Auto (aggregate / share)', 'Sums its children, and as a feeder takes a share of whatever load measured siblings don’t cover. Sizes the node from what’s left over, so it always shows something.'],
+  ['auto', 'Auto (aggregate)', 'Sums its children. As a feeder it carries a node’s unmet demand only when it is the single path into it — where conservation leaves no other answer. It never splits a load between several unmeasured feeders: that would be inventing a number. Mark one feeder “residual” to say where the remainder actually comes from.'],
   ['static', 'Static (fixed value)', 'A fixed leaf valued at the number you enter (still superseded by a bound live source). Reveals the Fixed value field.'],
-  ['residual', 'Residual (untracked feeder)', 'The designated absorber on the feeder side: carries the demand still needed after every measured feeder has supplied its part.'],
+  ['residual', 'Residual (untracked feeder)', 'The designated absorber on the feeder side: carries the demand still needed after every measured feeder has supplied its part. This is how you tell the diagram where unaccounted power comes from — without it, competing unmeasured feeders all read “no data”.'],
   ['untracked', 'Untracked (child of a measured parent)', 'Place under a parent that has a measured total (a bound source or fixed value): shows the slice of that total its tracked siblings don’t account for. Contributes nothing if the parent has no measured total.'],
 ];
 
@@ -823,8 +823,13 @@ export function addFlowSection(nav: any, sections: any) {
     const incoming: any = {}, outgoing: any = {};
     nodes.forEach((n: any) => { incoming[n.id] = []; outgoing[n.id] = []; });
     links.forEach((l: any) => { (outgoing[l.source] = outgoing[l.source] || []).push(l); (incoming[l.target] = incoming[l.target] || []).push(l); });
-    const sumv = (arr: any[]) => (arr || []).reduce((s, l) => s + l.value, 0);
-    const nodeValue = (id: string) => Math.max(sumv(incoming[id]), sumv(outgoing[id]));
+    // The server decides a node's value and, crucially, whether one is known at all — null means nothing
+    // measures it and nothing downstream determines it. Never substitute 0 for that: 0 is a claim (solar at
+    // night really is 0 W) and showing it for an unmeasured node is exactly the fabrication we removed.
+    const byId: any = {};
+    nodes.forEach((n: any) => { byId[n.id] = n; });
+    const known = (id: string) => byId[id] && byId[id].value != null;
+    const nodeValue = (id: string) => known(id) ? byId[id].value : 0;
 
     // Column index = longest path from a root (a node with no incoming links).
     const colMemo: any = {};
@@ -859,7 +864,13 @@ export function addFlowSection(nav: any, sections: any) {
       if (c === 0) cn.sort((a: any, b: any) => nodeValue(b.id) - nodeValue(a.id));
       else cn.sort((a: any, b: any) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
       let y = padTop;
-      cn.forEach((n: any) => { const h = Math.max(2, nodeValue(n.id) * pxPerUnit); pos[n.id] = { x: colX(c), y, h, outOff: 0, inOff: 0 }; y += h + gap; });
+      // An unknown node gets a fixed placeholder height so it stays visible on the diagram — it's
+      // configured, and hiding it reads as "my wiring is broken" rather than "nothing measures this yet".
+      cn.forEach((n: any) => {
+        const h = known(n.id) ? Math.max(2, nodeValue(n.id) * pxPerUnit) : 10;
+        pos[n.id] = { x: colX(c), y, h, outOff: 0, inOff: 0 };
+        y += h + gap;
+      });
     });
 
     // Fit the viewBox to the tallest column (stacking gaps push it past usableH), so nothing clips.
@@ -871,11 +882,17 @@ export function addFlowSection(nav: any, sections: any) {
     links.sort((a: any, b: any) => pos[a.target].y - pos[b.target].y).forEach((l: any) => {
       const s = pos[l.source], t = pos[l.target];
       if (!s || !t) return;
-      const h = Math.max(1, l.value * pxPerUnit);
+      // An unknown link draws as a hairline: the wiring is real, the quantity isn't known.
+      const unknownLink = l.known === false;
+      const h = unknownLink ? 1.5 : Math.max(1, l.value * pxPerUnit);
       const x1 = s.x + nodeW, x2 = t.x, xc = (x1 + x2) / 2;
       const sTop = s.y + s.outOff, tTop = t.y + t.inOff;
       const color = colors[colMemo[l.source] % colors.length];
-      svg.appendChild(svgEl('path', { d: `M${x1},${sTop} C${xc},${sTop} ${xc},${tTop} ${x2},${tTop} L${x2},${tTop + h} C${xc},${tTop + h} ${xc},${sTop + h} ${x1},${sTop + h} Z`, fill: color, 'fill-opacity': '0.3' }));
+      svg.appendChild(svgEl('path', {
+        d: `M${x1},${sTop} C${xc},${sTop} ${xc},${tTop} ${x2},${tTop} L${x2},${tTop + h} C${xc},${tTop + h} ${xc},${sTop + h} ${x1},${sTop + h} Z`,
+        fill: unknownLink ? 'var(--muted)' : color,
+        'fill-opacity': unknownLink ? '0.25' : '0.3',
+      }));
       s.outOff += h; t.inOff += h;
     });
 
@@ -883,16 +900,35 @@ export function addFlowSection(nav: any, sections: any) {
     // where they cross a ribbon).
     nodes.forEach((n: any) => {
       const p = pos[n.id]; if (!p) return;
-      svg.appendChild(svgEl('rect', { x: p.x, y: p.y, width: nodeW, height: p.h, rx: 2, fill: colors[colMemo[n.id] % colors.length] }));
+      const unknownNode = !known(n.id);
+      svg.appendChild(svgEl('rect', {
+        x: p.x, y: p.y, width: nodeW, height: p.h, rx: 2,
+        fill: unknownNode ? 'var(--muted)' : colors[colMemo[n.id] % colors.length],
+        'fill-opacity': unknownNode ? '0.45' : '1',
+      }));
       const lab = svgEl('text', {
         x: p.x + nodeW + 6, y: p.y + p.h / 2, fill: 'var(--fg)', 'font-size': '11', 'font-weight': n.kind === 'outlet' ? '400' : '600',
         'dominant-baseline': 'middle', 'paint-order': 'stroke', stroke: 'var(--panel2)', 'stroke-width': '3', 'stroke-linejoin': 'round',
       });
-      lab.textContent = `${n.label} · ${formatNum(nodeValue(n.id))} ${units}`;
+      lab.textContent = unknownNode ? `${n.label} · no data` : `${n.label} · ${formatNum(nodeValue(n.id))} ${units}`;
+      if (unknownNode) {
+        lab.setAttribute('fill', 'var(--muted)');
+        lab.setAttribute('font-style', 'italic');
+        const why = svgEl('title');
+        why.textContent = 'Nothing measures this node, and no single path determines it. Bind a live source to it, or mark one of its feeders as "residual" to say where the remainder comes from.';
+        lab.appendChild(why);
+      }
       svg.appendChild(lab);
     });
 
-    count.textContent = `${nodes.length} node(s) · ${links.length} link(s)`;
+    // Surface the unknowns rather than leaving them to be spotted: a node with no data is a gap in the
+    // measurement, and the point of this diagram is knowing which parts of the house are actually covered.
+    const unknownCount = nodes.filter((n: any) => !known(n.id)).length;
+    count.textContent = `${nodes.length} node(s) · ${links.length} link(s)`
+      + (unknownCount ? ` · ${unknownCount} with no data` : '');
+    count.title = unknownCount
+      ? 'Nothing measures these nodes, and no single path determines them. Bind a source, or mark a feeder "residual" to say where the remainder comes from — values are never invented for them.'
+      : '';
     const scroll = el('div', { style: { overflow: 'auto', maxHeight: '74vh', border: '1px solid var(--line)', borderRadius: '6px' } });
     scroll.appendChild(svg); wrap.appendChild(scroll);
     attachZoom(scroll, svg, W, totalH);  // scroll-into-view container is replaced on each draw(), so no leak.

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -907,9 +907,9 @@ const MODBUS_WORDORDERS = ['big', 'little'];
 // node gets: a node you haven't measured yet should read as nothing, not as an inferred figure.
 const NODE_MODES                             = [
   ['none', 'None (nothing inferred)', 'Never inferred — contributes nothing unless it has a real value or children, so an unmeasured node simply drops out instead of showing a fabricated figure. The default for a new node.'],
-  ['auto', 'Auto (aggregate / share)', 'Sums its children, and as a feeder takes a share of whatever load measured siblings don’t cover. Sizes the node from what’s left over, so it always shows something.'],
+  ['auto', 'Auto (aggregate)', 'Sums its children. As a feeder it carries a node’s unmet demand only when it is the single path into it — where conservation leaves no other answer. It never splits a load between several unmeasured feeders: that would be inventing a number. Mark one feeder “residual” to say where the remainder actually comes from.'],
   ['static', 'Static (fixed value)', 'A fixed leaf valued at the number you enter (still superseded by a bound live source). Reveals the Fixed value field.'],
-  ['residual', 'Residual (untracked feeder)', 'The designated absorber on the feeder side: carries the demand still needed after every measured feeder has supplied its part.'],
+  ['residual', 'Residual (untracked feeder)', 'The designated absorber on the feeder side: carries the demand still needed after every measured feeder has supplied its part. This is how you tell the diagram where unaccounted power comes from — without it, competing unmeasured feeders all read “no data”.'],
   ['untracked', 'Untracked (child of a measured parent)', 'Place under a parent that has a measured total (a bound source or fixed value): shows the slice of that total its tracked siblings don’t account for. Contributes nothing if the parent has no measured total.'],
 ];
 
@@ -1680,8 +1680,13 @@ function addFlowSection(nav     , sections     ) {
     const incoming      = {}, outgoing      = {};
     nodes.forEach((n     ) => { incoming[n.id] = []; outgoing[n.id] = []; });
     links.forEach((l     ) => { (outgoing[l.source] = outgoing[l.source] || []).push(l); (incoming[l.target] = incoming[l.target] || []).push(l); });
-    const sumv = (arr       ) => (arr || []).reduce((s, l) => s + l.value, 0);
-    const nodeValue = (id        ) => Math.max(sumv(incoming[id]), sumv(outgoing[id]));
+    // The server decides a node's value and, crucially, whether one is known at all — null means nothing
+    // measures it and nothing downstream determines it. Never substitute 0 for that: 0 is a claim (solar at
+    // night really is 0 W) and showing it for an unmeasured node is exactly the fabrication we removed.
+    const byId      = {};
+    nodes.forEach((n     ) => { byId[n.id] = n; });
+    const known = (id        ) => byId[id] && byId[id].value != null;
+    const nodeValue = (id        ) => known(id) ? byId[id].value : 0;
 
     // Column index = longest path from a root (a node with no incoming links).
     const colMemo      = {};
@@ -1716,7 +1721,13 @@ function addFlowSection(nav     , sections     ) {
       if (c === 0) cn.sort((a     , b     ) => nodeValue(b.id) - nodeValue(a.id));
       else cn.sort((a     , b     ) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
       let y = padTop;
-      cn.forEach((n     ) => { const h = Math.max(2, nodeValue(n.id) * pxPerUnit); pos[n.id] = { x: colX(c), y, h, outOff: 0, inOff: 0 }; y += h + gap; });
+      // An unknown node gets a fixed placeholder height so it stays visible on the diagram — it's
+      // configured, and hiding it reads as "my wiring is broken" rather than "nothing measures this yet".
+      cn.forEach((n     ) => {
+        const h = known(n.id) ? Math.max(2, nodeValue(n.id) * pxPerUnit) : 10;
+        pos[n.id] = { x: colX(c), y, h, outOff: 0, inOff: 0 };
+        y += h + gap;
+      });
     });
 
     // Fit the viewBox to the tallest column (stacking gaps push it past usableH), so nothing clips.
@@ -1728,11 +1739,17 @@ function addFlowSection(nav     , sections     ) {
     links.sort((a     , b     ) => pos[a.target].y - pos[b.target].y).forEach((l     ) => {
       const s = pos[l.source], t = pos[l.target];
       if (!s || !t) return;
-      const h = Math.max(1, l.value * pxPerUnit);
+      // An unknown link draws as a hairline: the wiring is real, the quantity isn't known.
+      const unknownLink = l.known === false;
+      const h = unknownLink ? 1.5 : Math.max(1, l.value * pxPerUnit);
       const x1 = s.x + nodeW, x2 = t.x, xc = (x1 + x2) / 2;
       const sTop = s.y + s.outOff, tTop = t.y + t.inOff;
       const color = colors[colMemo[l.source] % colors.length];
-      svg.appendChild(svgEl('path', { d: `M${x1},${sTop} C${xc},${sTop} ${xc},${tTop} ${x2},${tTop} L${x2},${tTop + h} C${xc},${tTop + h} ${xc},${sTop + h} ${x1},${sTop + h} Z`, fill: color, 'fill-opacity': '0.3' }));
+      svg.appendChild(svgEl('path', {
+        d: `M${x1},${sTop} C${xc},${sTop} ${xc},${tTop} ${x2},${tTop} L${x2},${tTop + h} C${xc},${tTop + h} ${xc},${sTop + h} ${x1},${sTop + h} Z`,
+        fill: unknownLink ? 'var(--muted)' : color,
+        'fill-opacity': unknownLink ? '0.25' : '0.3',
+      }));
       s.outOff += h; t.inOff += h;
     });
 
@@ -1740,16 +1757,35 @@ function addFlowSection(nav     , sections     ) {
     // where they cross a ribbon).
     nodes.forEach((n     ) => {
       const p = pos[n.id]; if (!p) return;
-      svg.appendChild(svgEl('rect', { x: p.x, y: p.y, width: nodeW, height: p.h, rx: 2, fill: colors[colMemo[n.id] % colors.length] }));
+      const unknownNode = !known(n.id);
+      svg.appendChild(svgEl('rect', {
+        x: p.x, y: p.y, width: nodeW, height: p.h, rx: 2,
+        fill: unknownNode ? 'var(--muted)' : colors[colMemo[n.id] % colors.length],
+        'fill-opacity': unknownNode ? '0.45' : '1',
+      }));
       const lab = svgEl('text', {
         x: p.x + nodeW + 6, y: p.y + p.h / 2, fill: 'var(--fg)', 'font-size': '11', 'font-weight': n.kind === 'outlet' ? '400' : '600',
         'dominant-baseline': 'middle', 'paint-order': 'stroke', stroke: 'var(--panel2)', 'stroke-width': '3', 'stroke-linejoin': 'round',
       });
-      lab.textContent = `${n.label} · ${formatNum(nodeValue(n.id))} ${units}`;
+      lab.textContent = unknownNode ? `${n.label} · no data` : `${n.label} · ${formatNum(nodeValue(n.id))} ${units}`;
+      if (unknownNode) {
+        lab.setAttribute('fill', 'var(--muted)');
+        lab.setAttribute('font-style', 'italic');
+        const why = svgEl('title');
+        why.textContent = 'Nothing measures this node, and no single path determines it. Bind a live source to it, or mark one of its feeders as "residual" to say where the remainder comes from.';
+        lab.appendChild(why);
+      }
       svg.appendChild(lab);
     });
 
-    count.textContent = `${nodes.length} node(s) · ${links.length} link(s)`;
+    // Surface the unknowns rather than leaving them to be spotted: a node with no data is a gap in the
+    // measurement, and the point of this diagram is knowing which parts of the house are actually covered.
+    const unknownCount = nodes.filter((n     ) => !known(n.id)).length;
+    count.textContent = `${nodes.length} node(s) · ${links.length} link(s)`
+      + (unknownCount ? ` · ${unknownCount} with no data` : '');
+    count.title = unknownCount
+      ? 'Nothing measures these nodes, and no single path determines them. Bind a source, or mark a feeder "residual" to say where the remainder comes from — values are never invented for them.'
+      : '';
     const scroll = el('div', { style: { overflow: 'auto', maxHeight: '74vh', border: '1px solid var(--line)', borderRadius: '6px' } });
     scroll.appendChild(svg); wrap.appendChild(scroll);
     attachZoom(scroll, svg, W, totalH);  // scroll-into-view container is replaced on each draw(), so no leak.


### PR DESCRIPTION
Reported from a live diagram: three unmeasured sources feeding one inverter each showed **exactly a third of the house load** — 184.333 W of 553 W. Nobody configured that split.

## Cause

The default `auto` mode divided a node's unmet demand equally between its unmeasured feeders:

```csharp
var absorbers = residual.Count > 0 ? residual : unmeasured;   // 'auto' feeders land here
return remainder / absorbers.Count;                            // 553 / 3 = 184.333
```

`auto` is what every node gets when you don't think about it. So solar, battery and grid — none of them metered — were each handed a third of the load, rendered identically to a real measurement.

## The rule now

A node's value is **measured**, **summed from its children**, or **determined by conservation** when it is the *single* unmeasured path into a node whose demand is known (the load is really being drawn; there is exactly one way for it to arrive). Anything else is **unknown**, and says so.

Several unmeasured feeders into one node is a *genuine* unknown — nothing indicates which supplied the load — so **none** of them gets a share. `Mode: residual` is how you say where unaccounted power comes from; that's an instruction, so the number is yours rather than ours.

**Unknown is carried in the type** — `FlowNode.Value` is `double?`, `FlowLink.Known` is a flag — so it can't be quietly flattened. `0` is a *claim* (solar at night really is 0 W); a fabricated zero written into HA history is worse than a gap. The MQTT/HA export now **skips** nodes with no determined value rather than publishing `0`.

## The other half of the report

> if they are set to none — they do not appear on the chart, which is inaccurate

Right, and it was the same class of bug. Nodes were derived from surviving links, so a valueless node vanished — reading as "my config is broken" rather than "nothing measures this". Nodes now come from the **declared topology**: a configured node is always shown, muted, labelled **"no data"**, with a tooltip explaining how to resolve it, and counted in the toolbar (`… · 3 with no data`) so a metering gap is visible *as* a gap.

## What this changes for existing configs

Anything that was showing an invented split now reads "no data" until you bind a source or designate a residual. That is the point — but it will look like values disappeared, so it's worth knowing before upgrading.

A **diamond** (two paths from one source into the same node) is affected too: its 50/50 split was also unmeasured attribution. It now reads "no data" until one path is marked `residual`. Two existing tests asserted the old behaviour and have been rewritten with the reasoning recorded.

## Tests

+8 (363 total, 0 warnings), including a reproduction of the exact reported topology asserting no link anywhere carries 553/3, that the measured part of the chain is still fully reported, that configured nodes stay visible, that a designated residual resolves it, that a measured source doesn't cause its siblings' shares to be invented either, and that exporters can tell unknown from zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)