### PR TITLE
fix(gui): stop the flow diagram's small nodes colliding their labels

### DIFF
--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -857,24 +857,31 @@ export function addFlowSection(nav: any, sections: any) {
     const colX = (c: number) => leftPad + (maxCol > 0 ? c * ((W - leftPad - rightGutter - nodeW) / maxCol) : 0);
 
     const pos: any = {};
+    // Every node's label needs a full text line, whatever its bar height — otherwise a stack of small
+    // "0 W" / "no data" nodes collides its labels into an unreadable smear. So a node occupies a *row* at
+    // least this tall (its bar is centered inside it), while the bar itself stays proportional.
+    const labelRow = 15;
     // Barycenter: a node's preferred y is the value-weighted mean of its (already positioned) feeders.
     const bary = (id: string) => { let w = 0, s = 0; (incoming[id] || []).forEach((l: any) => { const sp = pos[l.source]; if (sp) { s += (sp.y + sp.h / 2) * l.value; w += l.value; } }); return w ? s / w : Infinity; };
+    let bottom = padTop;
     cols.forEach((cn, c) => {
       // Roots stack by size; downstream columns follow their feeder's order (groups children, avoids crossings).
       if (c === 0) cn.sort((a: any, b: any) => nodeValue(b.id) - nodeValue(a.id));
       else cn.sort((a: any, b: any) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
       let y = padTop;
-      // An unknown node gets a fixed placeholder height so it stays visible on the diagram — it's
-      // configured, and hiding it reads as "my wiring is broken" rather than "nothing measures this yet".
       cn.forEach((n: any) => {
-        const h = known(n.id) ? Math.max(2, nodeValue(n.id) * pxPerUnit) : 10;
-        pos[n.id] = { x: colX(c), y, h, outOff: 0, inOff: 0 };
-        y += h + gap;
+        // Bar height is proportional; an unknown or measured-zero node is a thin marker (it has no
+        // magnitude to show) rather than a fixed slab. The row it sits in is what guarantees label spacing.
+        const h = known(n.id) ? Math.max(2, nodeValue(n.id) * pxPerUnit) : 3;
+        const rowH = Math.max(h, labelRow);
+        pos[n.id] = { x: colX(c), y: y + (rowH - h) / 2, h, outOff: 0, inOff: 0 };
+        y += rowH + gap;
       });
+      bottom = Math.max(bottom, y);
     });
 
     // Fit the viewBox to the tallest column (stacking gaps push it past usableH), so nothing clips.
-    const totalH = Math.ceil(Math.max(padTop + usableH, ...nodes.map((n: any) => pos[n.id] ? pos[n.id].y + pos[n.id].h : 0))) + padTop;
+    const totalH = Math.ceil(Math.max(padTop + usableH, bottom)) + padTop;
     const svg = svgEl('svg', { viewBox: `0 0 ${W} ${totalH}`, width: W, height: totalH, style: 'display:block' });
     const colors = ['#49f', '#4f9', '#fa4', '#f49', '#9f4', '#4ff', '#f94', '#a9f'];
 

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1714,24 +1714,31 @@ function addFlowSection(nav     , sections     ) {
     const colX = (c        ) => leftPad + (maxCol > 0 ? c * ((W - leftPad - rightGutter - nodeW) / maxCol) : 0);
 
     const pos      = {};
+    // Every node's label needs a full text line, whatever its bar height — otherwise a stack of small
+    // "0 W" / "no data" nodes collides its labels into an unreadable smear. So a node occupies a *row* at
+    // least this tall (its bar is centered inside it), while the bar itself stays proportional.
+    const labelRow = 15;
     // Barycenter: a node's preferred y is the value-weighted mean of its (already positioned) feeders.
     const bary = (id        ) => { let w = 0, s = 0; (incoming[id] || []).forEach((l     ) => { const sp = pos[l.source]; if (sp) { s += (sp.y + sp.h / 2) * l.value; w += l.value; } }); return w ? s / w : Infinity; };
+    let bottom = padTop;
     cols.forEach((cn, c) => {
       // Roots stack by size; downstream columns follow their feeder's order (groups children, avoids crossings).
       if (c === 0) cn.sort((a     , b     ) => nodeValue(b.id) - nodeValue(a.id));
       else cn.sort((a     , b     ) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
       let y = padTop;
-      // An unknown node gets a fixed placeholder height so it stays visible on the diagram — it's
-      // configured, and hiding it reads as "my wiring is broken" rather than "nothing measures this yet".
       cn.forEach((n     ) => {
-        const h = known(n.id) ? Math.max(2, nodeValue(n.id) * pxPerUnit) : 10;
-        pos[n.id] = { x: colX(c), y, h, outOff: 0, inOff: 0 };
-        y += h + gap;
+        // Bar height is proportional; an unknown or measured-zero node is a thin marker (it has no
+        // magnitude to show) rather than a fixed slab. The row it sits in is what guarantees label spacing.
+        const h = known(n.id) ? Math.max(2, nodeValue(n.id) * pxPerUnit) : 3;
+        const rowH = Math.max(h, labelRow);
+        pos[n.id] = { x: colX(c), y: y + (rowH - h) / 2, h, outOff: 0, inOff: 0 };
+        y += rowH + gap;
       });
+      bottom = Math.max(bottom, y);
     });
 
     // Fit the viewBox to the tallest column (stacking gaps push it past usableH), so nothing clips.
-    const totalH = Math.ceil(Math.max(padTop + usableH, ...nodes.map((n     ) => pos[n.id] ? pos[n.id].y + pos[n.id].h : 0))) + padTop;
+    const totalH = Math.ceil(Math.max(padTop + usableH, bottom)) + padTop;
     const svg = svgEl('svg', { viewBox: `0 0 ${W} ${totalH}`, width: W, height: totalH, style: 'display:block' });
     const colors = ['#49f', '#4f9', '#fa4', '#f49', '#9f4', '#4ff', '#f94', '#a9f'];
 


### PR DESCRIPTION
Follow-up to #239. Now that unmeasured nodes read "no data" instead of a fabricated split, a real hierarchy has several near-zero / no-data nodes stacked at the bottom of a column (solar, battery, MPPTs at night). Each was positioned at its **bar** height — 2–3px — while its label is ~14px, so the labels overlapped into the smear visible in the screenshot.

**Fix:** a node occupies a *row* at least one text-line tall, with its bar centered inside it. Labels always get a full line; a thin value still draws thin; big nodes are unchanged (their bar already exceeds a line). Zero/unknown nodes render as a centered 3px marker rather than a fixed 10px slab, so a stack reads as a tidy list.

GUI-only, rebuilt bundle included; `smoke.mjs` passes.

---

Separately, worth your eye (not fixed here, might be data): in that screenshot **Grid shows 2,001 W** while the tracked load downstream is ~564 W, and **FlexBoss shows 0 W**. If Grid is a real measured reading, that's a ~1,440 W gap between what it supplies and what the hierarchy accounts for — which is legitimate untracked load, but the diagram can't tell you that unless you add an `untracked` child under Grid. If FlexBoss should be carrying the solar/battery contribution, its `0 W` suggests those sources aren't bound yet. Happy to dig in if you want.