### PR TITLE
fix(flow): check the SUBACK on energy-flow MQTT subscribes, and make the ingest observable

### DIFF
--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -35,6 +35,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     // sink — event-driven, no polling bridge. Null in tests / if not wired.
     private readonly ISnapshotSink<MeasurementSnapshot>? sink;
     private long version;
+    private long received;
 
     public EnergyFlowMqttSourceService(MQTTServiceDependencies deps, ISnapshotSink<MeasurementSnapshot>? sink = null)
     {
@@ -50,6 +51,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        Log.Information("Energy-flow MQTT ingest started — reconciling broker subscriptions from EnergyFlow.Nodes.");
         mqtt.OnMessageReceived += OnMessageReceived;
         try
         {
@@ -67,10 +69,21 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     }
 
     /// <summary>Bring the broker subscriptions in line with the current config (added/removed topics).</summary>
+    private long lastDesiredCount = -1;
+
     private async Task Reconcile(CancellationToken ct)
     {
         var desired = BuildBindings(cfg.EnergyFlow.Nodes);
         bindings = desired;
+
+        // Make "did it find any bindings" visible without turning on Debug — the silent failure mode is a
+        // reconcile that quietly finds zero MQTT sources and subscribes to nothing.
+        var bindingCount = desired.Values.Sum(v => v.Count);
+        if (bindingCount != lastDesiredCount)
+        {
+            Log.Information($"Energy-flow MQTT ingest: {bindingCount} binding(s) across {desired.Count} topic(s) from {cfg.EnergyFlow.Nodes.Count} node(s).");
+            lastDesiredCount = bindingCount;
+        }
 
         foreach (var topic in desired.Keys)
         {
@@ -79,8 +92,22 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             {
                 // AtLeastOnce so a value isn't silently dropped; retained messages arrive immediately, which
                 // is what makes a restarted process pick up e.g. Solar Assistant's last reading at once.
-                await mqtt.SubscribeAsync(topic, QualityOfService.AtLeastOnceDelivery);
-                Log.Information($"Energy-flow: subscribed to {topic}.");
+                var result = await mqtt.SubscribeAsync(topic, QualityOfService.AtLeastOnceDelivery);
+
+                // A broker can *deny* a subscription (ACL) and the client reports it in the SUBACK, not as an
+                // exception. Treating that as success is how the ingest dies silently — check it, like the
+                // outlet command handler does, and let a denied topic retry rather than sticking.
+                var granted = result.Subscriptions.All(sub => (int)sub.SubscribeReasonCode <= 2);
+                if (granted)
+                {
+                    Log.Information($"Energy-flow: subscribed to {topic}.");
+                }
+                else
+                {
+                    subscribed.Remove(topic);
+                    var codes = string.Join(", ", result.Subscriptions.Select(sub => sub.SubscribeReasonCode.ToString()));
+                    Log.Error($"Energy-flow: subscription to {topic} was NOT granted ({codes}). The MQTT account likely lacks read permission on this topic — no values will arrive for the nodes bound to it.");
+                }
             }
             catch (Exception ex)
             {
@@ -130,7 +157,11 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             });
 
         if (sink is not null && readings is { Count: > 0 })
+        {
             _ = sink.EmitAsync(new MeasurementSnapshot("mqtt", now, System.Threading.Interlocked.Increment(ref version), readings));
+            if (System.Threading.Interlocked.Increment(ref received) is var n && (n == 1 || n % 100 == 0))
+                Log.Information($"Energy-flow MQTT ingest: received {n} message(s); latest from '{e.PublishMessage.Topic}' → {readings.Count} reading(s).");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Symptom

On the live cluster, the node editor's **Current** column is empty for MQTT-bound nodes, and those nodes read "no data" on the diagram.

## What I confirmed (remotely)

- **`FlowGrain.Ingest` is called 0 times** across all three pods → the energy-flow live cache is empty → both the Current column and the diagram (which read the same cache) show nothing for MQTT/live nodes.
- The config is correct (`eg4-flexboss21-grid` has the `solar_assistant/inverter_1/grid_power/state` binding) and the node grains build from it.
- `INF` logging works, yet the worker logs **no** `Energy-flow: subscribed` line and the string `solar_assistant` appears **0 times** in its log — the ingest simply isn't consuming.

## What this changes

**1. A real bug — unchecked SUBACK.** The outlet-command subscriber checks the subscribe reason code; this one didn't. A broker that *denies* a subscription (ACL) reports it in the SUBACK, not as an exception — so a denied topic was marked subscribed and produced nothing, silently, forever. Now it's checked, logged as an error naming the topic and the reason, and left un-subscribed so it retries.

**2. Observability.** The failure is silent, which is why it took a cluster to find. Added:
- an `Information` line when the ingest **starts**,
- one when the **binding count changes** (`N binding(s) across M topic(s) from K node(s)`),
- a throttled heartbeat when **messages arrive**.

So the next `unstable` deploy will show, in the worker log, exactly which link in the chain is broken: whether the service runs, how many bindings it built, whether the broker grants the subscription, and whether data flows.

## Honesty about scope

This does **not** claim to pin the specific cause on the reported cluster — the account can read the topic via the wildcard topic-browser, so an ACL denial is only one candidate (a lost subscription after an MQTT reconnect is another). It fixes one genuine silent-failure path and turns an unfalsifiable symptom into a clear signal. I'll follow up once the diagnostics land and say what they show.

45 existing energy-flow MQTT tests still pass; no behavior change to the parse/cache path.