### PR TITLE
feat(flow): collapsible node groups on both graphs, with a summed exported total

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -888,6 +888,36 @@ spec:
                           type: string
                           description: Target node id — energy flows into here.
                     description: Directed energy-flow links (From feeds To). Allows multiple feeders per node and producer inputs.
+                  Groups:
+                    type: array
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        Id:
+                          type: string
+                          description: Stable unique id for the group (used in the group's exported topic/metric).
+                        Label:
+                          type: string
+                          description: Human-readable label shown on the flow diagram when the group is collapsed.
+                        Kind:
+                          type: string
+                          enum:
+                          - ''
+                          - node
+                          - panel
+                          - inverter
+                          - battery
+                          - solar
+                          - grid
+                          - load
+                          description: "What the group represents, for diagram styling: 'node', 'panel', 'inverter', 'battery', 'solar', 'grid', or 'load'."
+                        Members:
+                          type: array
+                          items:
+                            type: string
+                          description: The ids of the member nodes this group aggregates.
+                    description: Named groups of nodes shown as one collapsible node on the flow graphs (e.g. three MPPTs as one 'Incoming PV'). Members keep their own links/exports; the group also exports its summed total.
                   Parents:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -888,6 +888,36 @@ spec:
                           type: string
                           description: Target node id — energy flows into here.
                     description: Directed energy-flow links (From feeds To). Allows multiple feeders per node and producer inputs.
+                  Groups:
+                    type: array
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        Id:
+                          type: string
+                          description: Stable unique id for the group (used in the group's exported topic/metric).
+                        Label:
+                          type: string
+                          description: Human-readable label shown on the flow diagram when the group is collapsed.
+                        Kind:
+                          type: string
+                          enum:
+                          - ''
+                          - node
+                          - panel
+                          - inverter
+                          - battery
+                          - solar
+                          - grid
+                          - load
+                          description: "What the group represents, for diagram styling: 'node', 'panel', 'inverter', 'battery', 'solar', 'grid', or 'load'."
+                        Members:
+                          type: array
+                          items:
+                            type: string
+                          description: The ids of the member nodes this group aggregates.
+                    description: Named groups of nodes shown as one collapsible node on the flow graphs (e.g. three MPPTs as one 'Incoming PV'). Members keep their own links/exports; the group also exports its summed total.
                   Parents:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -457,6 +457,14 @@ designated absorber carries the remainder after every measured feeder has suppli
 A configured node always appears on the diagram even when it has no value, so a gap in your metering is
 visible as a gap rather than as a missing node.
 
+**Grouping nodes.** Several nodes can be shown as one collapsible node on both flow graphs — e.g. three MPPTs
+as one "Incoming PV". Add a group on the **Nodes** tab (give it an id, label and members); the flow diagram
+and the node roll-up then show the group as a single node whose value is the **sum of its members**, with a
+toggle above each graph to expand it back to the members. The members are unchanged — they keep their own
+wiring and still export individually — and the group itself also publishes its summed total (`{id}` on the
+MQTT tier topic, its own Home Assistant sensor) when `EnergyFlow.MqttExport` is on. A group is the sum of the
+members that have data, and is itself "no data" when none of them do — never a fabricated zero.
+
 ## Metric Exporters (Optional)
 
 In addition to MQTT, measurements can be exported to Prometheus and/or EmonCMS. Both are disabled

--- a/rPDU2MQTT.Core/Flow/FlowGroups.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGroups.cs
@@ -1,0 +1,41 @@
+using rPDU2MQTT.Models.Config;
+
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>One group's rolled-up value for a metric — the sum of the members that actually have one.</summary>
+/// <param name="Id">The group id (its export key).</param>
+/// <param name="Label">Display label.</param>
+/// <param name="Kind">Node kind, for styling.</param>
+/// <param name="Value">The summed value, or <see langword="null"/> when no member has a known value.</param>
+/// <param name="MemberCount">How many members contributed a known value.</param>
+public sealed record FlowGroupValue(string Id, string Label, string Kind, double? Value, int MemberCount);
+
+/// <summary>
+/// Rolls a node group up to a single value — the sum of its members (#groups).
+/// <para>
+/// The same honesty rule as the rest of the flow applies: a group is the sum of the members that have a
+/// <b>known</b> value, and it is itself unknown (null) when none of them do. It never invents a total for a
+/// group whose members are all "no data", and it never counts an unknown member as zero.
+/// </para>
+/// </summary>
+public static class FlowGroups
+{
+    /// <summary>The group's value for the metric this graph carries, from its members' node values.</summary>
+    public static FlowGroupValue Total(FlowGraph graph, EnergyFlowGroup group)
+    {
+        double sum = 0;
+        var known = 0;
+        foreach (var memberId in group.Members)
+            if (FlowExport.TryNodeValue(graph, memberId, out var v)) { sum += v; known++; }
+
+        var label = string.IsNullOrWhiteSpace(group.Label) ? group.Id : group.Label;
+        var kind = string.IsNullOrWhiteSpace(group.Kind) ? "node" : group.Kind.Trim().ToLowerInvariant();
+        return new FlowGroupValue(group.Id, label, kind, known > 0 ? sum : null, known);
+    }
+
+    /// <summary>Every configured group's rolled-up value for this graph, skipping ids that are blank.</summary>
+    public static IEnumerable<FlowGroupValue> Totals(FlowGraph graph, EnergyFlowConfig flow)
+        => (flow.Groups ?? new())
+            .Where(g => !string.IsNullOrWhiteSpace(g.Id))
+            .Select(g => Total(graph, g));
+}

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -27,6 +27,16 @@ public class EnergyFlowConfig
     public List<EnergyFlowLink> Links { get; set; } = new();
 
     /// <summary>
+    /// Named groups of nodes shown as a single collapsible node on the flow graphs (e.g. three MPPTs shown
+    /// as one "Incoming PV"). Purely presentational for the members — they keep their own links and their own
+    /// exports — but the group itself has a rolled-up total (the sum of its members) that is exported like any
+    /// other tier when <see cref="MqttExport"/> is on. Collapse/expand is a per-viewer UI state; this only
+    /// defines which nodes belong together.
+    /// </summary>
+    [Description("Named groups of nodes shown as one collapsible node on the flow graphs (e.g. three MPPTs as one 'Incoming PV'). Members keep their own links/exports; the group also exports its summed total.")]
+    public List<EnergyFlowGroup> Groups { get; set; } = new();
+
+    /// <summary>
     /// Legacy single-feeder map (child id → parent id), superseded by <see cref="Links"/>. Still honored on
     /// load (each entry behaves like a link parent → child) so older configs keep working.
     /// </summary>
@@ -43,6 +53,28 @@ public class EnergyFlowConfig
     [Description("Template for each tier's MQTT topic. Placeholders: {parent} (MQTT parent topic), {id}, {label}, {kind}, {metric}, {units}. e.g. '{parent}/energyflow/{id}'.")]
     [TemplateVariables("parent", "id", "label", "kind", "metric", "units")]
     public string MqttTopicTemplate { get; set; } = "{parent}/energyflow/{id}";
+}
+
+/// <summary>
+/// A named group of flow nodes, shown as one collapsible node on the graphs and exported as their sum
+/// (#groups). The members are unchanged — they keep their links and export individually; the group is an
+/// overlay plus a rolled-up total.
+/// </summary>
+public class EnergyFlowGroup
+{
+    [Description("Stable unique id for the group (used in the group's exported topic/metric).")]
+    public string Id { get; set; } = "";
+
+    [Description("Human-readable label shown on the flow diagram when the group is collapsed.")]
+    public string Label { get; set; } = "";
+
+    [DefaultValue("node")]
+    [Description("What the group represents, for diagram styling: 'node', 'panel', 'inverter', 'battery', 'solar', 'grid', or 'load'.")]
+    [AllowedValues("node", "panel", "inverter", "battery", "solar", "grid", "load")]
+    public string Kind { get; set; } = "node";
+
+    [Description("The ids of the member nodes this group aggregates.")]
+    public List<string> Members { get; set; } = new();
 }
 
 /// <summary>A directed energy-flow link: energy flows <see cref="From"/> → <see cref="To"/>.</summary>

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -100,5 +100,42 @@ public class EnergyFlowMqttExportService : baseMQTTService
                 await PublishString(configTopic, doc.ToJsonString(), retain: cfg.HASS.DiscoveryRetain, cancellationToken);
             }
         }
+
+        // Node groups (#groups): each group publishes its own summed tier alongside its members, so a
+        // dashboard can chart "Incoming PV" as one series. Skipped when no member has a known value — never a
+        // fabricated zero, the same rule as the nodes.
+        foreach (var g in flow.Groups ?? new())
+        {
+            if (string.IsNullOrWhiteSpace(g.Id)) continue;
+
+            var total = FlowGroups.Total(graph, g);
+            if (total.Value is not { } power) continue;
+
+            var energy = FlowGroups.Total(energyGraph, g).Value ?? 0;
+            var groupNode = new FlowNode(total.Id, total.Label, total.Kind, power);
+            var topic = FlowExport.Topic(groupNode, graph, cfg.MQTT.ParentTopic, flow);
+
+            var payload = JsonSerializer.Serialize(new
+            {
+                id = g.Id,
+                value = power,
+                power,
+                energy,
+                units = graph.Units,
+                energyUnits = energyGraph.Units,
+                label = total.Label,
+                kind = total.Kind,
+                group = true,
+                members = g.Members,
+                timestamp = Core.MessageTimestamps.Format(oldest ?? DateTime.UtcNow),
+            });
+            await PublishString(topic, payload, retain: true, cancellationToken);
+
+            if (!publishDiscovery) continue;
+
+            var configTopic = $"{cfg.HASS.DiscoveryTopic}/device/{FlowExport.DeviceId(g.Id)}/config";
+            var doc = FlowExport.DiscoveryDocument(groupNode, null, topic, energyGraph.Units, graph.Units, availability);
+            await PublishString(configTopic, doc.ToJsonString(), retain: cfg.HASS.DiscoveryRetain, cancellationToken);
+        }
     }
 }

--- a/rPDU2MQTT.Tests/FlowGroupsTests.cs
+++ b/rPDU2MQTT.Tests/FlowGroupsTests.cs
@@ -1,0 +1,99 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// A node group's total is the sum of its members — and, like everything else in the flow, it never invents
+/// one. A group whose members are all "no data" is itself unknown; a known member counts, an unknown one
+/// does not (it is not treated as zero).
+/// </summary>
+public class FlowGroupsTests
+{
+    private static FlowGraph Graph(params FlowNode[] nodes)
+        => new(nodes, System.Array.Empty<FlowLink>(), "realpower", "W");
+
+    private static EnergyFlowGroup Group(params string[] members)
+        => new() { Id = "incoming_pv", Label = "Incoming PV", Kind = "solar", Members = members.ToList() };
+
+    [Fact]
+    public void Total_SumsTheMembersThatHaveAValue()
+    {
+        var graph = Graph(
+            new FlowNode("mppt1", "MPPT 1", "solar", 300),
+            new FlowNode("mppt2", "MPPT 2", "solar", 320),
+            new FlowNode("mppt3", "MPPT 3", "solar", 280));
+
+        var total = FlowGroups.Total(graph, Group("mppt1", "mppt2", "mppt3"));
+
+        Assert.Equal(900, total.Value);
+        Assert.Equal(3, total.MemberCount);
+        Assert.Equal("Incoming PV", total.Label);
+        Assert.Equal("solar", total.Kind);
+    }
+
+    [Fact]
+    public void AnUnknownMember_IsSkipped_NotCountedAsZero()
+    {
+        // MPPT 2 has no data. The group is the sum of the two that do — not (300+0+280) implying MPPT 2 is
+        // off, and not null just because one member is missing.
+        var graph = Graph(
+            new FlowNode("mppt1", "MPPT 1", "solar", 300),
+            new FlowNode("mppt2", "MPPT 2", "solar", null),
+            new FlowNode("mppt3", "MPPT 3", "solar", 280));
+
+        var total = FlowGroups.Total(graph, Group("mppt1", "mppt2", "mppt3"));
+
+        Assert.Equal(580, total.Value);
+        Assert.Equal(2, total.MemberCount);
+    }
+
+    [Fact]
+    public void AllMembersUnknown_MakesTheGroupUnknown_NotZero()
+    {
+        // Solar at night: every MPPT is "no data". The group must be unknown, never a fabricated 0 W that an
+        // exporter would publish into history.
+        var graph = Graph(
+            new FlowNode("mppt1", "MPPT 1", "solar", null),
+            new FlowNode("mppt2", "MPPT 2", "solar", null));
+
+        var total = FlowGroups.Total(graph, Group("mppt1", "mppt2"));
+
+        Assert.Null(total.Value);
+        Assert.Equal(0, total.MemberCount);
+    }
+
+    [Fact]
+    public void AMeasuredZeroMember_Counts_AsZero()
+    {
+        // A member that really measured 0 W is known — the group has a value (it's not unknown), and that
+        // member contributes 0.
+        var graph = Graph(
+            new FlowNode("mppt1", "MPPT 1", "solar", 0),
+            new FlowNode("mppt2", "MPPT 2", "solar", 150));
+
+        var total = FlowGroups.Total(graph, Group("mppt1", "mppt2"));
+
+        Assert.Equal(150, total.Value);
+        Assert.Equal(2, total.MemberCount);
+    }
+
+    [Fact]
+    public void Totals_SkipsBlankIds_AndReadsEveryConfiguredGroup()
+    {
+        var graph = Graph(new FlowNode("a", "A", "node", 10), new FlowNode("b", "B", "node", 20));
+        var flow = new EnergyFlowConfig
+        {
+            Groups =
+            {
+                new EnergyFlowGroup { Id = "g1", Members = { "a", "b" } },
+                new EnergyFlowGroup { Id = "", Members = { "a" } },   // blank id — ignored
+            },
+        };
+
+        var totals = FlowGroups.Totals(graph, flow).ToList();
+        Assert.Single(totals);
+        Assert.Equal(30, totals[0].Value);
+    }
+}

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -677,12 +677,152 @@ async function saveConfig(onSaved: () => void) {
   if (r.ok && r.body.ok) onSaved();
 }
 
+// --- Node groups (#groups): several nodes shown as one collapsible node on both flow graphs. Collapse
+//     state is per-viewer (this session), defaulting to collapsed so a group de-clutters until you open it.
+const collapsedGroups = new Set<string>();
+let groupsInitialized = false;
+
+function flowGroups(): any[] {
+  return (state.data?.EnergyFlow?.Groups || []).filter((g: any) => g && g.Id);
+}
+
+// Start every group collapsed the first time we see it (a group exists to tidy the diagram; opening it is
+// the deliberate act). Newly-added groups also start collapsed.
+function ensureGroupState() {
+  flowGroups().forEach((g: any) => { if (!groupsInitialized || !collapsedGroups.has(g.Id)) collapsedGroups.add(g.Id); });
+  groupsInitialized = true;
+}
+
+// A member's owning group id, only when that group is currently collapsed.
+function collapsedMemberMap(): Record<string, any> {
+  const map: Record<string, any> = {};
+  flowGroups().forEach((g: any) => { if (collapsedGroups.has(g.Id)) (g.Members || []).forEach((m: string) => { map[m] = g; }); });
+  return map;
+}
+
+// Fold a graph's {nodes, links} so each collapsed group becomes a single node (its members' sum), with the
+// members' links re-pointed at the group and duplicates merged. A node/link value of null stays null — a
+// group is only as known as its members (the same never-fabricate rule the server uses).
+function collapseGraph(nodes: any[], links: any[]): { nodes: any[]; links: any[] } {
+  const memberOf = collapsedMemberMap();
+  if (!Object.keys(memberOf).length) return { nodes, links };
+
+  const byId: any = {}; nodes.forEach(n => { byId[n.id] = n; });
+  const groupNode: Record<string, any> = {};
+  flowGroups().forEach((g: any) => {
+    if (!collapsedGroups.has(g.Id)) return;
+    let sum = 0, known = false;
+    (g.Members || []).forEach((m: string) => { const n = byId[m]; if (n && n.value != null) { sum += n.value; known = true; } });
+    groupNode[g.Id] = { id: g.Id, label: g.Label || g.Id, kind: g.Kind || 'node', value: known ? sum : null, group: true };
+  });
+
+  const remap = (id: string) => (memberOf[id] ? memberOf[id].Id : id);
+  // Drop the collapsed members, keep everyone else, add the group nodes (only groups that actually have a
+  // member present in this graph).
+  const present = new Set<string>();
+  const outNodes = nodes.filter(n => !memberOf[n.id]);
+  const merged: Record<string, any> = {};
+  links.forEach(l => {
+    const s = remap(l.source), t = remap(l.target);
+    if (s === t) return;                       // a link fully inside one collapsed group
+    present.add(s); present.add(t);
+    const k = s + ' ' + t;
+    if (!merged[k]) merged[k] = { source: s, target: t, value: 0, known: true };
+    merged[k].value += (l.value || 0);
+    if (l.known === false) merged[k].known = false;
+  });
+  Object.values(groupNode).forEach((gn: any) => { if (present.has(gn.id)) outNodes.push(gn); });
+  return { nodes: outNodes, links: Object.values(merged) };
+}
+
+// The toggle strip above the diagram: one chip per group, click to collapse/expand on both graphs.
+function groupToggles(onToggle: () => void): HTMLElement | null {
+  const groups = flowGroups();
+  if (!groups.length) return null;
+  const row = el('div', { class: 'ld-toolbar', style: { flexWrap: 'wrap', gap: '6px', margin: '0 0 8px' } });
+  row.appendChild(el('span', { class: 'desc', style: { margin: '0' }, text: 'Groups:' }));
+  groups.forEach((g: any) => {
+    const on = collapsedGroups.has(g.Id);
+    const chip = btn(`${on ? '▸' : '▾'} ${g.Label || g.Id}`);
+    chip.title = on ? 'Collapsed — click to expand its members' : 'Expanded — click to collapse into one node';
+    chip.onclick = () => { on ? collapsedGroups.delete(g.Id) : collapsedGroups.add(g.Id); onToggle(); };
+    row.appendChild(chip);
+  });
+  return row;
+}
+
 // The candidate node universe for wiring: the built graph's nodes (pdu/outlet/…) plus the custom defs.
 function flowCandidates(lastGraph: any, customNodes: any[]) {
   const cand = new Map<string, any>();
   (lastGraph?.nodes || []).forEach((n: any) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
   customNodes.forEach((n: any) => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: n.Kind || 'node', custom: true }));
   return cand;
+}
+
+// Group manager (#groups): define named groups of nodes that collapse into one node on the flow graphs and
+// export a summed total. Members keep their own links and exports — a group is an overlay plus a roll-up.
+function renderGroupManager(flow: any, cand: Map<string, any>, rerender: () => void) {
+  const groups = ensure(flow, 'Groups', []);
+  const box = el('div', { style: { margin: '18px 0' } });
+  box.appendChild(el('h3', { text: 'Groups', style: { margin: '4px 0', fontSize: '15px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'Show several nodes as one collapsible node on the flow graphs — e.g. three MPPTs as one “Incoming PV”. Members keep their own wiring and exports; the group also publishes its summed total. Collapse/expand each group from the toggles above either graph.' }));
+
+  const nm = (id: string) => (cand.get(id) || {}).label || id;
+
+  const addBar = el('div', { class: 'ld-toolbar' });
+  const idIn = el('input', { type: 'text', placeholder: 'group id (e.g. incoming_pv)' }) as HTMLInputElement;
+  const labIn = el('input', { type: 'text', placeholder: 'label (e.g. Incoming PV)' }) as HTMLInputElement;
+  const kindSel = el('select', { style: { width: 'auto' } });
+  NODE_KINDS.forEach(([v, label]) => kindSel.appendChild(el('option', { value: v, text: label })));
+  const addBtn = btn('Add group', 'primary');
+  addBtn.onclick = () => {
+    const id = (idIn.value || '').trim();
+    if (!id) { toast('A group id is required.', false); return; }
+    if (groups.some((g: any) => g.Id === id) || cand.has(id)) { toast('That id already exists.', false); return; }
+    const g: any = { Id: id, Label: (labIn.value || '').trim() || id, Members: [] };
+    if (kindSel.value !== 'node') g.Kind = kindSel.value;
+    groups.push(g);
+    rerender();
+  };
+  addBar.append(idIn, labIn, kindSel, addBtn);
+  box.appendChild(addBar);
+
+  if (!groups.length) { box.appendChild(el('div', { class: 'desc', text: 'No groups yet — add one above, then pick its members.' })); return box; }
+
+  groups.forEach((g: any) => {
+    const card = el('div', { style: { border: '1px solid var(--line)', borderRadius: '6px', padding: '10px', margin: '8px 0', background: 'var(--panel2)' } });
+    const head = el('div', { style: { display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' } });
+    const labEdit = el('input', { type: 'text', value: g.Label || g.Id, style: { width: '200px' } }) as HTMLInputElement;
+    labEdit.onchange = () => { g.Label = labEdit.value.trim() || g.Id; };
+    const kindEdit = el('select', { style: { width: 'auto' } });
+    NODE_KINDS.forEach(([v, label]) => kindEdit.appendChild(el('option', { value: v, text: label })));
+    kindEdit.value = g.Kind || 'node';
+    kindEdit.onchange = () => { g.Kind = kindEdit.value === 'node' ? undefined : kindEdit.value; };
+    const del = btn('Delete', 'danger');
+    del.onclick = () => { groups.splice(groups.indexOf(g), 1); toast(`Group ${g.Label || g.Id} deleted.`, true); rerender(); };
+    head.append(el('code', { text: g.Id, style: { color: 'var(--muted)' } }), labEdit, kindEdit, del);
+    card.appendChild(head);
+
+    // Members as removable chips, plus a picker of candidates not already in the group.
+    const memRow = el('div', { style: { display: 'flex', gap: '6px', alignItems: 'center', flexWrap: 'wrap', margin: '8px 0 0' } });
+    memRow.appendChild(el('span', { class: 'desc', style: { margin: '0', minWidth: '64px' }, text: 'Members' }));
+    (g.Members || []).forEach((m: string) => {
+      const chip = el('span', { style: { display: 'inline-flex', gap: '5px', alignItems: 'center', background: 'var(--panel)', border: '1px solid var(--line)', borderRadius: '10px', padding: '1px 8px', fontSize: '12px' } });
+      const x = el('span', { text: '✕', style: { cursor: 'pointer', color: 'var(--bad)' } });
+      x.onclick = () => { g.Members.splice(g.Members.indexOf(m), 1); rerender(); };
+      chip.append(nm(m), x); memRow.appendChild(chip);
+    });
+    const sel = el('select', { style: { width: 'auto' } }) as HTMLSelectElement;
+    sel.appendChild(el('option', { value: '', text: '+ add member…' }));
+    [...cand.keys()].filter(id => id !== g.Id && !(g.Members || []).includes(id)).sort((a, b) => nm(a).localeCompare(nm(b)))
+      .forEach(id => sel.appendChild(el('option', { value: id, text: nm(id) })));
+    sel.onchange = () => { if (sel.value) { ensure(g, 'Members', []).push(sel.value); rerender(); } };
+    memRow.appendChild(sel);
+    card.appendChild(memRow);
+    box.appendChild(card);
+  });
+
+  return box;
 }
 
 // Virtual-node manager (#129): the dedicated node-configuration surface (its own Nodes tab). Each row is a
@@ -780,6 +920,9 @@ export function addFlowSection(nav: any, sections: any) {
   const ed: any = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
   let lastGraph: any = null;
 
+  // Collapsing/expanding a group must move both graphs together (they share the collapse state).
+  const redrawBoth = () => { if (lastGraph) draw(lastGraph); renderTree(); };
+
   // The distributed node-grain roll-up (v3): each configured node's value computed by its own grain
   // (measured leaves report their source, aggregates sum their children, residuals the remainder).
   const renderTree = async () => {
@@ -798,25 +941,62 @@ export function addFlowSection(nav: any, sections: any) {
       dd.textContent = 'No node values yet — add energy-flow nodes and feed a source; the grains roll them up here.';
       treePanel.appendChild(dd); return;
     }
+
+    ensureGroupState();
+    const toggles = groupToggles(redrawBoth);
+    if (toggles) treePanel.appendChild(toggles);
+
     const t = document.createElement('table'); t.className = 'ld';
     const hr = document.createElement('tr'); ['Node', 'Rolled-up values'].forEach(x => { const th = document.createElement('th'); th.textContent = x; hr.appendChild(th); });
     const thead = document.createElement('thead'); thead.appendChild(hr); t.appendChild(thead);
     const tb = document.createElement('tbody');
-    nodes.forEach((n: any) => {
+
+    const metricsText = (metrics: any[]) => (metrics || []).map((m: any) => m.metric + ': ' + formatNum(m.value)).join(', ');
+    const byNode: any = {}; nodes.forEach((n: any) => { byNode[n.node] = n; });
+
+    const row = (label: string, metrics: any[], opts?: { indent?: boolean; head?: boolean }) => {
       const tr = document.createElement('tr');
-      const c1 = document.createElement('td'); c1.textContent = n.node;
+      const c1 = document.createElement('td'); c1.textContent = label;
+      if (opts?.indent) c1.style.paddingLeft = '24px';
+      if (opts?.head) c1.style.fontWeight = '600';
       const c2 = document.createElement('td'); c2.style.cssText = 'color:var(--muted);font-size:12px;';
-      c2.textContent = (n.metrics || []).map((m: any) => m.metric + ': ' + formatNum(m.value)).join(', ');
+      c2.textContent = metricsText(metrics);
       tr.appendChild(c1); tr.appendChild(c2); tb.appendChild(tr);
+    };
+
+    // Sum a group's members per metric — only members that actually have a value, so a group is never a
+    // fabricated total (matches the diagram and the server export).
+    const groupMetrics = (g: any) => {
+      const sums: Record<string, number> = {};
+      (g.Members || []).forEach((m: string) => (byNode[m]?.metrics || []).forEach((mm: any) => { sums[mm.metric] = (sums[mm.metric] || 0) + mm.value; }));
+      return Object.entries(sums).map(([metric, value]) => ({ metric, value }));
+    };
+
+    // Members are shown under their group (summed when collapsed, listed when expanded), never twice.
+    const allMembers = new Set<string>();
+    flowGroups().forEach((g: any) => (g.Members || []).forEach((m: string) => allMembers.add(m)));
+
+    nodes.forEach((n: any) => { if (!allMembers.has(n.node)) row(n.node, n.metrics); });
+
+    flowGroups().forEach((g: any) => {
+      row((g.Label || g.Id) + '  (group)', groupMetrics(g), { head: true });
+      if (!collapsedGroups.has(g.Id))
+        (g.Members || []).forEach((m: string) => { if (byNode[m]) row(byNode[m].node, byNode[m].metrics, { indent: true }); });
     });
+
     t.appendChild(tb); treePanel.appendChild(t);
   };
 
   // Layered Sankey: columns = longest path from a root (energy flows left->right, parent->child).
   const draw = (graph: any) => {
     wrap.innerHTML = '';
-    const links = (graph.links || []).slice();
-    const nodes = graph.nodes || [];
+    ensureGroupState();
+    // Fold collapsed groups into single nodes before laying out; the toggle strip re-draws on change.
+    const folded = collapseGraph((graph.nodes || []).slice(), (graph.links || []).slice());
+    const toggles = groupToggles(redrawBoth);
+    if (toggles) wrap.appendChild(toggles);
+    const links = folded.links;
+    const nodes = folded.nodes;
     if (!links.length) { wrap.innerHTML = '<div class="desc" style="color:var(--muted)">No measured power flow to display. Define an EnergyFlow hierarchy, or check that outlets report power.</div>'; count.textContent = ''; return; }
 
     const units = graph.units || '';
@@ -1263,6 +1443,7 @@ export function addNodesSection(nav: any, sections: any) {
 
     const cand = flowCandidates(lastGraph, customNodes);
     ed.appendChild(renderNodeManager(flow, customNodes, links, cand, editing, (close?: boolean) => { if (close) editing.id = null; render(); }));
+    ed.appendChild(renderGroupManager(flow, cand, render));
   };
 
   const load = async () => {

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1534,12 +1534,152 @@ async function saveConfig(onSaved            ) {
   if (r.ok && r.body.ok) onSaved();
 }
 
+// --- Node groups (#groups): several nodes shown as one collapsible node on both flow graphs. Collapse
+//     state is per-viewer (this session), defaulting to collapsed so a group de-clutters until you open it.
+const collapsedGroups = new Set        ();
+let groupsInitialized = false;
+
+function flowGroups()        {
+  return (state.data?.EnergyFlow?.Groups || []).filter((g     ) => g && g.Id);
+}
+
+// Start every group collapsed the first time we see it (a group exists to tidy the diagram; opening it is
+// the deliberate act). Newly-added groups also start collapsed.
+function ensureGroupState() {
+  flowGroups().forEach((g     ) => { if (!groupsInitialized || !collapsedGroups.has(g.Id)) collapsedGroups.add(g.Id); });
+  groupsInitialized = true;
+}
+
+// A member's owning group id, only when that group is currently collapsed.
+function collapsedMemberMap()                      {
+  const map                      = {};
+  flowGroups().forEach((g     ) => { if (collapsedGroups.has(g.Id)) (g.Members || []).forEach((m        ) => { map[m] = g; }); });
+  return map;
+}
+
+// Fold a graph's {nodes, links} so each collapsed group becomes a single node (its members' sum), with the
+// members' links re-pointed at the group and duplicates merged. A node/link value of null stays null — a
+// group is only as known as its members (the same never-fabricate rule the server uses).
+function collapseGraph(nodes       , links       )                                 {
+  const memberOf = collapsedMemberMap();
+  if (!Object.keys(memberOf).length) return { nodes, links };
+
+  const byId      = {}; nodes.forEach(n => { byId[n.id] = n; });
+  const groupNode                      = {};
+  flowGroups().forEach((g     ) => {
+    if (!collapsedGroups.has(g.Id)) return;
+    let sum = 0, known = false;
+    (g.Members || []).forEach((m        ) => { const n = byId[m]; if (n && n.value != null) { sum += n.value; known = true; } });
+    groupNode[g.Id] = { id: g.Id, label: g.Label || g.Id, kind: g.Kind || 'node', value: known ? sum : null, group: true };
+  });
+
+  const remap = (id        ) => (memberOf[id] ? memberOf[id].Id : id);
+  // Drop the collapsed members, keep everyone else, add the group nodes (only groups that actually have a
+  // member present in this graph).
+  const present = new Set        ();
+  const outNodes = nodes.filter(n => !memberOf[n.id]);
+  const merged                      = {};
+  links.forEach(l => {
+    const s = remap(l.source), t = remap(l.target);
+    if (s === t) return;                       // a link fully inside one collapsed group
+    present.add(s); present.add(t);
+    const k = s + ' ' + t;
+    if (!merged[k]) merged[k] = { source: s, target: t, value: 0, known: true };
+    merged[k].value += (l.value || 0);
+    if (l.known === false) merged[k].known = false;
+  });
+  Object.values(groupNode).forEach((gn     ) => { if (present.has(gn.id)) outNodes.push(gn); });
+  return { nodes: outNodes, links: Object.values(merged) };
+}
+
+// The toggle strip above the diagram: one chip per group, click to collapse/expand on both graphs.
+function groupToggles(onToggle            )                     {
+  const groups = flowGroups();
+  if (!groups.length) return null;
+  const row = el('div', { class: 'ld-toolbar', style: { flexWrap: 'wrap', gap: '6px', margin: '0 0 8px' } });
+  row.appendChild(el('span', { class: 'desc', style: { margin: '0' }, text: 'Groups:' }));
+  groups.forEach((g     ) => {
+    const on = collapsedGroups.has(g.Id);
+    const chip = btn(`${on ? '▸' : '▾'} ${g.Label || g.Id}`);
+    chip.title = on ? 'Collapsed — click to expand its members' : 'Expanded — click to collapse into one node';
+    chip.onclick = () => { on ? collapsedGroups.delete(g.Id) : collapsedGroups.add(g.Id); onToggle(); };
+    row.appendChild(chip);
+  });
+  return row;
+}
+
 // The candidate node universe for wiring: the built graph's nodes (pdu/outlet/…) plus the custom defs.
 function flowCandidates(lastGraph     , customNodes       ) {
   const cand = new Map             ();
   (lastGraph?.nodes || []).forEach((n     ) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
   customNodes.forEach((n     ) => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: n.Kind || 'node', custom: true }));
   return cand;
+}
+
+// Group manager (#groups): define named groups of nodes that collapse into one node on the flow graphs and
+// export a summed total. Members keep their own links and exports — a group is an overlay plus a roll-up.
+function renderGroupManager(flow     , cand                  , rerender            ) {
+  const groups = ensure(flow, 'Groups', []);
+  const box = el('div', { style: { margin: '18px 0' } });
+  box.appendChild(el('h3', { text: 'Groups', style: { margin: '4px 0', fontSize: '15px' } }));
+  box.appendChild(el('div', { class: 'desc', text: 'Show several nodes as one collapsible node on the flow graphs — e.g. three MPPTs as one “Incoming PV”. Members keep their own wiring and exports; the group also publishes its summed total. Collapse/expand each group from the toggles above either graph.' }));
+
+  const nm = (id        ) => (cand.get(id) || {}).label || id;
+
+  const addBar = el('div', { class: 'ld-toolbar' });
+  const idIn = el('input', { type: 'text', placeholder: 'group id (e.g. incoming_pv)' })                    ;
+  const labIn = el('input', { type: 'text', placeholder: 'label (e.g. Incoming PV)' })                    ;
+  const kindSel = el('select', { style: { width: 'auto' } });
+  NODE_KINDS.forEach(([v, label]) => kindSel.appendChild(el('option', { value: v, text: label })));
+  const addBtn = btn('Add group', 'primary');
+  addBtn.onclick = () => {
+    const id = (idIn.value || '').trim();
+    if (!id) { toast('A group id is required.', false); return; }
+    if (groups.some((g     ) => g.Id === id) || cand.has(id)) { toast('That id already exists.', false); return; }
+    const g      = { Id: id, Label: (labIn.value || '').trim() || id, Members: [] };
+    if (kindSel.value !== 'node') g.Kind = kindSel.value;
+    groups.push(g);
+    rerender();
+  };
+  addBar.append(idIn, labIn, kindSel, addBtn);
+  box.appendChild(addBar);
+
+  if (!groups.length) { box.appendChild(el('div', { class: 'desc', text: 'No groups yet — add one above, then pick its members.' })); return box; }
+
+  groups.forEach((g     ) => {
+    const card = el('div', { style: { border: '1px solid var(--line)', borderRadius: '6px', padding: '10px', margin: '8px 0', background: 'var(--panel2)' } });
+    const head = el('div', { style: { display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' } });
+    const labEdit = el('input', { type: 'text', value: g.Label || g.Id, style: { width: '200px' } })                    ;
+    labEdit.onchange = () => { g.Label = labEdit.value.trim() || g.Id; };
+    const kindEdit = el('select', { style: { width: 'auto' } });
+    NODE_KINDS.forEach(([v, label]) => kindEdit.appendChild(el('option', { value: v, text: label })));
+    kindEdit.value = g.Kind || 'node';
+    kindEdit.onchange = () => { g.Kind = kindEdit.value === 'node' ? undefined : kindEdit.value; };
+    const del = btn('Delete', 'danger');
+    del.onclick = () => { groups.splice(groups.indexOf(g), 1); toast(`Group ${g.Label || g.Id} deleted.`, true); rerender(); };
+    head.append(el('code', { text: g.Id, style: { color: 'var(--muted)' } }), labEdit, kindEdit, del);
+    card.appendChild(head);
+
+    // Members as removable chips, plus a picker of candidates not already in the group.
+    const memRow = el('div', { style: { display: 'flex', gap: '6px', alignItems: 'center', flexWrap: 'wrap', margin: '8px 0 0' } });
+    memRow.appendChild(el('span', { class: 'desc', style: { margin: '0', minWidth: '64px' }, text: 'Members' }));
+    (g.Members || []).forEach((m        ) => {
+      const chip = el('span', { style: { display: 'inline-flex', gap: '5px', alignItems: 'center', background: 'var(--panel)', border: '1px solid var(--line)', borderRadius: '10px', padding: '1px 8px', fontSize: '12px' } });
+      const x = el('span', { text: '✕', style: { cursor: 'pointer', color: 'var(--bad)' } });
+      x.onclick = () => { g.Members.splice(g.Members.indexOf(m), 1); rerender(); };
+      chip.append(nm(m), x); memRow.appendChild(chip);
+    });
+    const sel = el('select', { style: { width: 'auto' } })                     ;
+    sel.appendChild(el('option', { value: '', text: '+ add member…' }));
+    [...cand.keys()].filter(id => id !== g.Id && !(g.Members || []).includes(id)).sort((a, b) => nm(a).localeCompare(nm(b)))
+      .forEach(id => sel.appendChild(el('option', { value: id, text: nm(id) })));
+    sel.onchange = () => { if (sel.value) { ensure(g, 'Members', []).push(sel.value); rerender(); } };
+    memRow.appendChild(sel);
+    card.appendChild(memRow);
+    box.appendChild(card);
+  });
+
+  return box;
 }
 
 // Virtual-node manager (#129): the dedicated node-configuration surface (its own Nodes tab). Each row is a
@@ -1637,6 +1777,9 @@ function addFlowSection(nav     , sections     ) {
   const ed      = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
   let lastGraph      = null;
 
+  // Collapsing/expanding a group must move both graphs together (they share the collapse state).
+  const redrawBoth = () => { if (lastGraph) draw(lastGraph); renderTree(); };
+
   // The distributed node-grain roll-up (v3): each configured node's value computed by its own grain
   // (measured leaves report their source, aggregates sum their children, residuals the remainder).
   const renderTree = async () => {
@@ -1655,25 +1798,62 @@ function addFlowSection(nav     , sections     ) {
       dd.textContent = 'No node values yet — add energy-flow nodes and feed a source; the grains roll them up here.';
       treePanel.appendChild(dd); return;
     }
+
+    ensureGroupState();
+    const toggles = groupToggles(redrawBoth);
+    if (toggles) treePanel.appendChild(toggles);
+
     const t = document.createElement('table'); t.className = 'ld';
     const hr = document.createElement('tr'); ['Node', 'Rolled-up values'].forEach(x => { const th = document.createElement('th'); th.textContent = x; hr.appendChild(th); });
     const thead = document.createElement('thead'); thead.appendChild(hr); t.appendChild(thead);
     const tb = document.createElement('tbody');
-    nodes.forEach((n     ) => {
+
+    const metricsText = (metrics       ) => (metrics || []).map((m     ) => m.metric + ': ' + formatNum(m.value)).join(', ');
+    const byNode      = {}; nodes.forEach((n     ) => { byNode[n.node] = n; });
+
+    const row = (label        , metrics       , opts                                       ) => {
       const tr = document.createElement('tr');
-      const c1 = document.createElement('td'); c1.textContent = n.node;
+      const c1 = document.createElement('td'); c1.textContent = label;
+      if (opts?.indent) c1.style.paddingLeft = '24px';
+      if (opts?.head) c1.style.fontWeight = '600';
       const c2 = document.createElement('td'); c2.style.cssText = 'color:var(--muted);font-size:12px;';
-      c2.textContent = (n.metrics || []).map((m     ) => m.metric + ': ' + formatNum(m.value)).join(', ');
+      c2.textContent = metricsText(metrics);
       tr.appendChild(c1); tr.appendChild(c2); tb.appendChild(tr);
+    };
+
+    // Sum a group's members per metric — only members that actually have a value, so a group is never a
+    // fabricated total (matches the diagram and the server export).
+    const groupMetrics = (g     ) => {
+      const sums                         = {};
+      (g.Members || []).forEach((m        ) => (byNode[m]?.metrics || []).forEach((mm     ) => { sums[mm.metric] = (sums[mm.metric] || 0) + mm.value; }));
+      return Object.entries(sums).map(([metric, value]) => ({ metric, value }));
+    };
+
+    // Members are shown under their group (summed when collapsed, listed when expanded), never twice.
+    const allMembers = new Set        ();
+    flowGroups().forEach((g     ) => (g.Members || []).forEach((m        ) => allMembers.add(m)));
+
+    nodes.forEach((n     ) => { if (!allMembers.has(n.node)) row(n.node, n.metrics); });
+
+    flowGroups().forEach((g     ) => {
+      row((g.Label || g.Id) + '  (group)', groupMetrics(g), { head: true });
+      if (!collapsedGroups.has(g.Id))
+        (g.Members || []).forEach((m        ) => { if (byNode[m]) row(byNode[m].node, byNode[m].metrics, { indent: true }); });
     });
+
     t.appendChild(tb); treePanel.appendChild(t);
   };
 
   // Layered Sankey: columns = longest path from a root (energy flows left->right, parent->child).
   const draw = (graph     ) => {
     wrap.innerHTML = '';
-    const links = (graph.links || []).slice();
-    const nodes = graph.nodes || [];
+    ensureGroupState();
+    // Fold collapsed groups into single nodes before laying out; the toggle strip re-draws on change.
+    const folded = collapseGraph((graph.nodes || []).slice(), (graph.links || []).slice());
+    const toggles = groupToggles(redrawBoth);
+    if (toggles) wrap.appendChild(toggles);
+    const links = folded.links;
+    const nodes = folded.nodes;
     if (!links.length) { wrap.innerHTML = '<div class="desc" style="color:var(--muted)">No measured power flow to display. Define an EnergyFlow hierarchy, or check that outlets report power.</div>'; count.textContent = ''; return; }
 
     const units = graph.units || '';
@@ -2120,6 +2300,7 @@ function addNodesSection(nav     , sections     ) {
 
     const cand = flowCandidates(lastGraph, customNodes);
     ed.appendChild(renderNodeManager(flow, customNodes, links, cand, editing, (close          ) => { if (close) editing.id = null; render(); }));
+    ed.appendChild(renderGroupManager(flow, cand, render));
   };
 
   const load = async () => {


### PR DESCRIPTION
Requested: show several nodes as one — e.g. three MPPTs as **"Incoming PV"** — on **both** the Sankey diagram and the node-grain roll-up.

## Design

A group is an **overlay + a roll-up**, not a change to the flow DAG or the node grains:

```yaml
EnergyFlow:
  Groups:
    - Id: incoming_pv
      Label: Incoming PV
      Kind: solar
      Members: [MPPT_1, MPPT_2, MPPT_3]
```

- **Both graphs fold** a collapsed group into a single node whose value is the **sum of its members**, re-pointing the members' links at the group and merging duplicates. A toggle above either graph expands it back to the members; the two graphs **share** the collapse state, so they move together.
- The group **also publishes its summed total** as its own tier (MQTT topic + a Home Assistant sensor) when `EnergyFlow.MqttExport` is on. Members are untouched — same links, same individual exports.
- **Managed on the Nodes tab**: create a group, pick its members from a dropdown, edit or delete.

Collapse is client-side over config the browser already has, so there's **no API change** — the group definitions live in `state.data.EnergyFlow.Groups`.

## The honesty rule, carried through

Every place that sums a group — `FlowGroups.Total` (export), the Sankey fold, the roll-up — obeys the same rule as the rest of the flow: a group is the sum of the members that actually **have** a value, and is itself **"no data"** when none do. An unknown member is skipped, never counted as zero; an all-unknown group is `null`, never a fabricated `0` an exporter would write into history.

## Tests

5 new (371 total, 0 warnings): sum of members, an unknown member skipped (not zeroed), all-unknown → null, a measured-zero member counts, blank group ids ignored. CRD regenerated; GUI smoke passes; docs updated.

Since it's config-only, it reaches your `unstable` deploy and shows up on the Flow/Nodes tabs with no schema change.