### PR TITLE
feat(gui): a "Check now" button in the Operator section that reports the result

### DIFF
--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -219,7 +219,7 @@ function renderConfigSection(node: any, nav: any, sections: any) {
     if (node.key === 'Gui') wireGuiAuth(sec);
     else if (node.key === 'EmonCMS') wireEmonCmsTransport(sec);
     else if (node.key === 'Api') wireApiDocs(sec);
-    else if (node.key === 'Operator') wireOperatorSwitch(sec);
+    else if (node.key === 'Operator') { wireOperatorCheck(sec); wireOperatorSwitch(sec); }
     link.onclick = () => activate(link, sec);
   }
   return link;
@@ -354,6 +354,45 @@ function wireApiDocs(sec: any) {
   enabled?.addEventListener('change', apply);
   apply();
   sec.appendChild(box);
+}
+
+// Operator page: an on-demand update check. Asks the operator to query the registry now and says plainly
+// whether a newer eligible version (bounded by Policy) is available — read-only, never touches the Deployment.
+function wireOperatorCheck(sec: any) {
+  const box = document.createElement('fieldset');
+  const lg = document.createElement('legend'); lg.textContent = 'Update check'; box.appendChild(lg);
+  box.appendChild(el('div', { class: 'desc', text: 'Check the registry now and report whether a newer eligible version (bounded by Policy) is available. Read-only — this never changes the Deployment.' }));
+  const row = el('div', { class: 'sec-actions' });
+  const check = btn('Check now', 'primary');
+  const result = el('div', { class: 'desc', style: { margin: '4px 0 0', fontSize: '13px' } });
+  row.append(check); box.append(row, result);
+  sec.appendChild(box);
+
+  const show = (u: any) => {
+    // Available / up-to-date / no-info — colour-coded so the answer reads at a glance.
+    if (u?.available) {
+      result.style.color = 'var(--warn, #fa4)';
+      let s = `↑ Update available: ${u.latest || '?'}` + (u.current ? ` (currently ${u.current})` : '');
+      if (u.applied) s += ` — auto-update rolled to ${u.applied}`;
+      result.textContent = s;
+    } else if (u?.current) {
+      result.style.color = 'var(--good)';
+      result.textContent = `✓ Up to date — ${u.current} is the newest ${u.policy ? u.policy.toLowerCase() + '-eligible ' : ''}release`;
+    } else {
+      result.style.color = 'var(--muted)';
+      result.textContent = u?.message || 'No update information returned.';
+    }
+    if (u?.checkedAt) result.textContent += ` · checked ${new Date(u.checkedAt).toLocaleTimeString()}`;
+  };
+
+  check.onclick = async () => {
+    check.disabled = true;
+    result.style.color = 'var(--muted)'; result.textContent = 'Checking the registry…';
+    const r = await api('/api/operator/check', { method: 'POST' });
+    check.disabled = false;
+    if (!r.body?.ok) { result.style.color = 'var(--bad)'; result.textContent = r.body?.message || 'Check failed.'; return; }
+    show(r.body.update);
+  };
 }
 
 // Operator page: a channel/version switcher — roll the Deployment to stable/edge/dev or a specific release (#210).

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2739,7 +2739,7 @@ function renderConfigSection(node     , nav     , sections     ) {
     if (node.key === 'Gui') wireGuiAuth(sec);
     else if (node.key === 'EmonCMS') wireEmonCmsTransport(sec);
     else if (node.key === 'Api') wireApiDocs(sec);
-    else if (node.key === 'Operator') wireOperatorSwitch(sec);
+    else if (node.key === 'Operator') { wireOperatorCheck(sec); wireOperatorSwitch(sec); }
     link.onclick = () => activate(link, sec);
   }
   return link;
@@ -2874,6 +2874,45 @@ function wireApiDocs(sec     ) {
   enabled?.addEventListener('change', apply);
   apply();
   sec.appendChild(box);
+}
+
+// Operator page: an on-demand update check. Asks the operator to query the registry now and says plainly
+// whether a newer eligible version (bounded by Policy) is available — read-only, never touches the Deployment.
+function wireOperatorCheck(sec     ) {
+  const box = document.createElement('fieldset');
+  const lg = document.createElement('legend'); lg.textContent = 'Update check'; box.appendChild(lg);
+  box.appendChild(el('div', { class: 'desc', text: 'Check the registry now and report whether a newer eligible version (bounded by Policy) is available. Read-only — this never changes the Deployment.' }));
+  const row = el('div', { class: 'sec-actions' });
+  const check = btn('Check now', 'primary');
+  const result = el('div', { class: 'desc', style: { margin: '4px 0 0', fontSize: '13px' } });
+  row.append(check); box.append(row, result);
+  sec.appendChild(box);
+
+  const show = (u     ) => {
+    // Available / up-to-date / no-info — colour-coded so the answer reads at a glance.
+    if (u?.available) {
+      result.style.color = 'var(--warn, #fa4)';
+      let s = `↑ Update available: ${u.latest || '?'}` + (u.current ? ` (currently ${u.current})` : '');
+      if (u.applied) s += ` — auto-update rolled to ${u.applied}`;
+      result.textContent = s;
+    } else if (u?.current) {
+      result.style.color = 'var(--good)';
+      result.textContent = `✓ Up to date — ${u.current} is the newest ${u.policy ? u.policy.toLowerCase() + '-eligible ' : ''}release`;
+    } else {
+      result.style.color = 'var(--muted)';
+      result.textContent = u?.message || 'No update information returned.';
+    }
+    if (u?.checkedAt) result.textContent += ` · checked ${new Date(u.checkedAt).toLocaleTimeString()}`;
+  };
+
+  check.onclick = async () => {
+    check.disabled = true;
+    result.style.color = 'var(--muted)'; result.textContent = 'Checking the registry…';
+    const r = await api('/api/operator/check', { method: 'POST' });
+    check.disabled = false;
+    if (!r.body?.ok) { result.style.color = 'var(--bad)'; result.textContent = r.body?.message || 'Check failed.'; return; }
+    show(r.body.update);
+  };
 }
 
 // Operator page: a channel/version switcher — roll the Deployment to stable/edge/dev or a specific release (#210).


### PR DESCRIPTION
Requested: a Check-now button in the Operator section, "especially if it gave confirmation a newer version is available."

The registry check already existed (`/api/operator/check` → `IOperatorGrain.CheckNow`, read-only), but only behind the header chip. The Operator config section now has an **Update check** fieldset:

- **Check now** queries the registry immediately and reports, colour-coded:
  - amber — `↑ Update available: <latest> (currently <current>)`, noting an auto-update roll if one occurred,
  - green — `✓ Up to date — <current> is the newest <policy>-eligible release`,
  - muted — the operator's own message (e.g. "only with the Kubernetes config source"),
  - with the check time appended.

Read-only — it never changes the Deployment (that's still Switch / Force update below it). GUI-only, no API or config change; smoke passes.