### PR TITLE
fix(gui): topic browser survives a wildcard-denying broker; groups made discoverable

### DIFF
--- a/rPDU2MQTT.Grains.Abstractions/Discovery/ITopicIndexGrain.cs
+++ b/rPDU2MQTT.Grains.Abstractions/Discovery/ITopicIndexGrain.cs
@@ -21,6 +21,16 @@ public sealed record TopicIndexState
 
     /// <summary>The cap — the index stops growing here rather than following a chatty broker forever.</summary>
     [Id(2)] public int Capacity { get; init; }
+
+    /// <summary>The topic filter currently being browsed (e.g. <c>#</c> or <c>solar_assistant/#</c>).</summary>
+    [Id(3)] public string Filter { get; init; } = "#";
+
+    /// <summary>
+    /// Did the broker grant the subscription? <c>null</c> = not answered yet, <c>true</c> = granted,
+    /// <c>false</c> = denied (an ACL that forbids the wildcard — the usual reason a browse stays empty on an
+    /// otherwise-working broker).
+    /// </summary>
+    [Id(4)] public bool? Granted { get; init; }
 }
 
 /// <summary>
@@ -28,19 +38,27 @@ public sealed record TopicIndexState
 /// <para>
 /// It exists <b>only while someone is looking</b>. A reader calls <see cref="Renew"/> while the editor is
 /// open, which leases the index for a short window; the process holding the broker connection polls
-/// <see cref="Wanted"/> and subscribes only during that lease, unsubscribing when it lapses. The grain drops
-/// everything it holds and deactivates once the lease expires, and it is capped while it lives — so
-/// browsing costs a subscription for as long as you browse, and nothing at all afterwards. That is the whole
-/// design constraint: no permanent background indexer quietly accumulating every topic on the broker.
+/// <see cref="Wanted"/> / <see cref="DesiredFilter"/> and subscribes only during that lease, unsubscribing
+/// when it lapses. So browsing costs a subscription for as long as you browse, and nothing at all afterwards.
 /// </para>
 /// </summary>
 public interface ITopicIndexGrain : IGrainWithIntegerKey
 {
-    /// <summary>Ask for (and keep) a live index. Called by a reader while it's browsing.</summary>
-    Task<TopicIndexState> Renew();
+    /// <summary>
+    /// Ask for (and keep) a live index of the given topic filter. <paramref name="filter"/> defaults to
+    /// <c>#</c> (everything); narrow it (e.g. <c>solar_assistant/#</c>) when a broker's ACL forbids the bare
+    /// wildcard. Changing the filter re-subscribes and clears what was held for the old one.
+    /// </summary>
+    Task<TopicIndexState> Renew(string? filter);
 
     /// <summary>Is anyone still browsing? Polled by the process that owns the broker connection.</summary>
     Task<bool> Wanted();
+
+    /// <summary>The filter to subscribe to right now, or empty when nobody is browsing.</summary>
+    Task<string> DesiredFilter();
+
+    /// <summary>The subscriber reports whether the broker granted the subscription (SUBACK), so a denied ACL is visible rather than a silent empty list.</summary>
+    Task ReportSubscription(bool granted);
 
     /// <summary>Record what the broker was seen carrying. An empty batch still counts as "I'm listening".</summary>
     Task Observe(List<TopicSample> samples);

--- a/rPDU2MQTT.Grains/Discovery/TopicIndexGrain.cs
+++ b/rPDU2MQTT.Grains/Discovery/TopicIndexGrain.cs
@@ -5,10 +5,9 @@ namespace rPDU2MQTT.Grains.Discovery;
 /// <summary>
 /// The browsable topic index (singleton, key 0) — see <see cref="ITopicIndexGrain"/> for why it's leased.
 /// <para>
-/// Two bounds keep it from becoming the thing it must not be. In <b>time</b>: the index lives on a lease that
-/// readers renew, and when the lease lapses it drops everything and deactivates, so nothing survives the page
-/// being closed. In <b>size</b>: it holds at most <see cref="Capacity"/> topics and evicts the least recently
-/// seen, so even a firehose broker can't grow it without limit while someone is browsing.
+/// Two bounds keep it from becoming a standing background indexer. In <b>time</b>: the index lives on a lease
+/// that readers renew, and when the lease lapses it drops everything and deactivates. In <b>size</b>: it
+/// holds at most <see cref="Capacity"/> topics and evicts the least recently seen.
 /// </para>
 /// </summary>
 public sealed class TopicIndexGrain : Grain, ITopicIndexGrain
@@ -28,10 +27,22 @@ public sealed class TopicIndexGrain : Grain, ITopicIndexGrain
 
     private DateTime leaseUntilUtc = DateTime.MinValue;
     private DateTime lastObservedUtc = DateTime.MinValue;
+    private string filter = "#";
+    private bool? granted;
     private IGrainTimer? timer;
 
-    public Task<TopicIndexState> Renew()
+    public Task<TopicIndexState> Renew(string? filter)
     {
+        // A blank filter means "just renew, keep browsing what I'm browsing" (the detail lookups do this),
+        // so it never resets a narrowed filter back to '#'. A non-blank, different filter re-subscribes.
+        if (!string.IsNullOrWhiteSpace(filter) && filter!.Trim() != this.filter)
+        {
+            this.filter = filter.Trim();
+            topics.Clear();
+            granted = null;
+            lastObservedUtc = DateTime.MinValue;
+        }
+
         leaseUntilUtc = DateTime.UtcNow + Lease;
         // KeepAlive so the lease can actually expire on its own — that expiry is what frees everything.
         timer ??= this.RegisterGrainTimer(TickAsync, new GrainTimerCreationOptions(Tick, Tick) { KeepAlive = true });
@@ -39,6 +50,14 @@ public sealed class TopicIndexGrain : Grain, ITopicIndexGrain
     }
 
     public Task<bool> Wanted() => Task.FromResult(DateTime.UtcNow < leaseUntilUtc);
+
+    public Task<string> DesiredFilter() => Task.FromResult(DateTime.UtcNow < leaseUntilUtc ? filter : "");
+
+    public Task ReportSubscription(bool granted)
+    {
+        this.granted = granted;
+        return Task.CompletedTask;
+    }
 
     public Task Observe(List<TopicSample> samples)
     {
@@ -80,6 +99,8 @@ public sealed class TopicIndexGrain : Grain, ITopicIndexGrain
         Listening = DateTime.UtcNow - lastObservedUtc < ListeningWindow,
         Topics = topics.Count,
         Capacity = Capacity,
+        Filter = filter,
+        Granted = granted,
     };
 
     /// <summary>Hold the newest <see cref="Capacity"/> topics; the rest are someone else's traffic.</summary>
@@ -97,6 +118,8 @@ public sealed class TopicIndexGrain : Grain, ITopicIndexGrain
 
         // Nobody is browsing any more: let go of everything and stop existing.
         topics.Clear();
+        granted = null;
+        lastObservedUtc = DateTime.MinValue;
         timer?.Dispose();
         timer = null;
         DeactivateOnIdle();

--- a/rPDU2MQTT.Tests/TopicIndexTests.cs
+++ b/rPDU2MQTT.Tests/TopicIndexTests.cs
@@ -117,7 +117,7 @@ public class TopicIndexGrainTests
         {
             var index = cluster.GrainFactory.GetGrain<ITopicIndexGrain>(0);
 
-            var state = await index.Renew();
+            var state = await index.Renew(null);
             Assert.False(state.Listening);        // nothing has reported yet
             Assert.True(await index.Wanted());    // ...but the subscriber is now asked to
 
@@ -128,7 +128,7 @@ public class TopicIndexGrainTests
                 Sample("tele/plug/SENSOR", """{"ENERGY":{"Power":12}}"""),
             });
 
-            Assert.True((await index.Renew()).Listening);
+            Assert.True((await index.Renew(null)).Listening);
 
             var solar = await index.Search("pv_power", 10);
             Assert.Equal("solar_assistant/inverter_1/pv_power/state", Assert.Single(solar).Topic);
@@ -150,14 +150,74 @@ public class TopicIndexGrainTests
         try
         {
             var index = cluster.GrainFactory.GetGrain<ITopicIndexGrain>(0);
-            await index.Renew();
+            await index.Renew(null);
 
             var flood = new List<TopicSample>();
             for (var i = 0; i < 2500; i++) flood.Add(Sample($"noisy/{i}/state", i.ToString()));
             await index.Observe(flood);
 
-            var state = await index.Renew();
+            var state = await index.Renew(null);
             Assert.Equal(state.Capacity, state.Topics);   // held at the cap, not at 2500
+        }
+        finally { await cluster.StopAllSilosAsync(); }
+    }
+
+    [Fact]
+    public async Task Filter_DefaultsToWildcard_Narrows_AndBlankKeepsIt()
+    {
+        var cluster = await GrainTestCluster.StartAsync();
+        try
+        {
+            var index = cluster.GrainFactory.GetGrain<ITopicIndexGrain>(0);
+
+            // Default is the bare wildcard, and that's what the subscriber is told to subscribe to.
+            Assert.Equal("#", (await index.Renew(null)).Filter);
+            Assert.Equal("#", await index.DesiredFilter());
+
+            // Narrowing to a prefix re-subscribes and drops what was held for the old filter.
+            await index.Observe(new List<TopicSample> { Sample("anything/1", "x") });
+            var narrowed = await index.Renew("solar_assistant/#");
+            Assert.Equal("solar_assistant/#", narrowed.Filter);
+            Assert.Equal(0, narrowed.Topics);   // cleared on the filter change
+            Assert.Equal("solar_assistant/#", await index.DesiredFilter());
+
+            // A blank renew keeps the current filter (the detail lookups renew this way; they must not reset it).
+            Assert.Equal("solar_assistant/#", (await index.Renew(null)).Filter);
+            Assert.Equal("solar_assistant/#", (await index.Renew("  ")).Filter);
+        }
+        finally { await cluster.StopAllSilosAsync(); }
+    }
+
+    [Fact]
+    public async Task DeniedSubscription_IsVisible_AsGrantedFalse()
+    {
+        var cluster = await GrainTestCluster.StartAsync();
+        try
+        {
+            var index = cluster.GrainFactory.GetGrain<ITopicIndexGrain>(0);
+            await index.Renew(null);
+
+            // Before the subscriber reports, grant is unknown (null) — not a silent "false".
+            Assert.Null((await index.Renew(null)).Granted);
+
+            // The subscriber reports the SUBACK outcome; a denial surfaces so the browser can explain it.
+            await index.ReportSubscription(false);
+            Assert.False((await index.Renew(null)).Granted);
+
+            await index.ReportSubscription(true);
+            Assert.True((await index.Renew(null)).Granted);
+        }
+        finally { await cluster.StopAllSilosAsync(); }
+    }
+
+    [Fact]
+    public async Task NobodyBrowsing_HasNoDesiredFilter()
+    {
+        var cluster = await GrainTestCluster.StartAsync();
+        try
+        {
+            // Un-leased: the subscriber must be told to subscribe to nothing.
+            Assert.Equal("", await cluster.GrainFactory.GetGrain<ITopicIndexGrain>(0).DesiredFilter());
         }
         finally { await cluster.StopAllSilosAsync(); }
     }

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -830,7 +830,9 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             try
             {
                 var index = grains.GetGrain<Grains.Abstractions.Discovery.ITopicIndexGrain>(0);
-                var state = await index.Renew();
+                // The filter to browse (default '#'); a restricted broker can narrow it, e.g. 'solar_assistant/#'.
+                var filter = ctx.Request.Query["filter"].FirstOrDefault();
+                var state = await index.Renew(filter);
                 var q = ctx.Request.Query["q"].FirstOrDefault();
                 var limit = int.TryParse(ctx.Request.Query["limit"].FirstOrDefault(), out var n) ? n : 50;
 
@@ -850,9 +852,10 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                     };
                 }).ToArray();
 
-                // "listening" tells the editor whether anything is feeding the index yet, so it can say
-                // "waiting for the broker" instead of looking broken on the first keystroke.
-                return Results.Json(new { ok = true, listening = state.Listening, indexed = state.Topics, capacity = state.Capacity, topics }, ConfigSchema.Json);
+                // "listening" tells the editor whether anything is feeding the index yet; "granted" tells it
+                // whether the broker actually allowed the subscription, so a denied ACL reads as a clear
+                // message instead of a mysteriously empty list.
+                return Results.Json(new { ok = true, listening = state.Listening, indexed = state.Topics, capacity = state.Capacity, filter = state.Filter, granted = state.Granted, topics }, ConfigSchema.Json);
             }
             catch (Exception ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
         });
@@ -865,7 +868,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             {
                 var topic = ctx.Request.Query["topic"].FirstOrDefault() ?? "";
                 var index = grains.GetGrain<Grains.Abstractions.Discovery.ITopicIndexGrain>(0);
-                await index.Renew();
+                await index.Renew(null);   // keep the current browse filter alive; we only want one topic's detail
                 var sample = await index.Get(topic);
                 if (sample is null)
                     return Results.Json(new { ok = false, message = "Nothing has been seen on that topic yet." }, ConfigSchema.Json);

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -85,8 +85,9 @@ function overlay(title: string): { body: any, close: () => void } {
   return { body, close };
 }
 
-async function fetchTopics(q: string, limit = 50): Promise<any> {
-  const r = await api(`/api/mqtt/topics?q=${encodeURIComponent(q || '')}&limit=${limit}`);
+async function fetchTopics(q: string, limit = 50, filter?: string): Promise<any> {
+  const f = filter ? `&filter=${encodeURIComponent(filter)}` : '';
+  const r = await api(`/api/mqtt/topics?q=${encodeURIComponent(q || '')}&limit=${limit}${f}`);
   return (r.body && r.body.ok) ? r.body : { topics: [], listening: false, indexed: 0 };
 }
 
@@ -156,8 +157,17 @@ function openTopicPicker(current: string, onPick: (topic: string) => void) {
   const { body, close } = overlay('Browse broker topics');
   body.appendChild(el('div', { class: 'desc', text: 'Live topics seen on the broker while this window is open. Nothing is indexed in the background — the subscription starts when you browse and stops when you stop.' }));
 
+  // Which broker filter to subscribe to. Default '#' (everything); a broker whose ACL forbids the bare
+  // wildcard can narrow it, e.g. 'solar_assistant/#', and still browse under that prefix.
+  const filterBar = el('div', { class: 'ld-toolbar' });
+  const filterIn = el('input', { type: 'text', value: '#', placeholder: '# (everything)', style: { width: '220px' } }) as HTMLInputElement;
+  filterIn.title = 'The topic filter to subscribe to while browsing. If the broker denies “#”, narrow it (e.g. solar_assistant/#).';
+  const applyFilter = btn('Browse this');
+  filterBar.append(el('span', { class: 'desc', style: { margin: '0' }, text: 'Subscribe to:' }), filterIn, applyFilter);
+  body.appendChild(filterBar);
+
   const bar = el('div', { class: 'ld-toolbar' });
-  const search = el('input', { type: 'search', value: current || '', placeholder: 'filter topics…', style: { width: '320px' } }) as HTMLInputElement;
+  const search = el('input', { type: 'search', value: current || '', placeholder: 'filter the shown topics…', style: { width: '320px' } }) as HTMLInputElement;
   const status = el('span', { class: 'desc', style: { margin: '0 0 0 8px' } });
   bar.append(search, status);
   body.appendChild(bar);
@@ -171,11 +181,18 @@ function openTopicPicker(current: string, onPick: (topic: string) => void) {
   body.appendChild(tbl);
 
   const load = async () => {
-    const b = await fetchTopics(search.value.trim(), 100);
+    const b = await fetchTopics(search.value.trim(), 100, filterIn.value.trim() || '#');
     tbody.innerHTML = '';
+    if (b.granted === false) {
+      // The broker refused the subscription — say so plainly instead of a mysterious empty list.
+      status.style.color = 'var(--bad)';
+      status.textContent = `The broker denied the subscription to “${b.filter || filterIn.value.trim()}”. Your MQTT account lacks read permission on it — grant it, or narrow the filter above to a prefix you can read (e.g. solar_assistant/#).`;
+      return;
+    }
+    status.style.color = 'var(--muted)';
     status.textContent = b.listening
-      ? `${(b.topics || []).length} shown · ${b.indexed}/${b.capacity} indexed`
-      : 'waiting for the broker subscription to come up…';
+      ? `${(b.topics || []).length} shown · ${b.indexed}/${b.capacity} indexed · subscribed to “${b.filter || '#'}”`
+      : `waiting for the broker subscription to “${b.filter || filterIn.value.trim()}” to come up…`;
     (b.topics || []).forEach((t: any) => {
       const tr = el('tr');
       tr.appendChild(el('td', {}, el('code', { text: t.topic })));
@@ -190,6 +207,8 @@ function openTopicPicker(current: string, onPick: (topic: string) => void) {
 
   let timer: any = null;
   search.oninput = () => { clearTimeout(timer); timer = setTimeout(load, 250); };
+  applyFilter.onclick = () => load();
+  filterIn.onkeydown = (e: any) => { if (e.key === 'Enter') load(); };
   load();
   // Keep the index's lease alive (and the list fresh) for as long as the window is open.
   const poll = setInterval(() => { if (!document.body.contains(tbl)) { clearInterval(poll); return; } load(); }, 5000);
@@ -1442,8 +1461,10 @@ export function addNodesSection(nav: any, sections: any) {
     };
 
     const cand = flowCandidates(lastGraph, customNodes);
-    ed.appendChild(renderNodeManager(flow, customNodes, links, cand, editing, (close?: boolean) => { if (close) editing.id = null; render(); }));
+    // Groups first: the node manager appends the (tall) per-node editor beneath its table when one is open,
+    // which would otherwise bury the Groups section off the bottom of the page.
     ed.appendChild(renderGroupManager(flow, cand, render));
+    ed.appendChild(renderNodeManager(flow, customNodes, links, cand, editing, (close?: boolean) => { if (close) editing.id = null; render(); }));
   };
 
   const load = async () => {

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -942,8 +942,9 @@ function overlay(title        )                                   {
   return { body, close };
 }
 
-async function fetchTopics(q        , limit = 50)               {
-  const r = await api(`/api/mqtt/topics?q=${encodeURIComponent(q || '')}&limit=${limit}`);
+async function fetchTopics(q        , limit = 50, filter         )               {
+  const f = filter ? `&filter=${encodeURIComponent(filter)}` : '';
+  const r = await api(`/api/mqtt/topics?q=${encodeURIComponent(q || '')}&limit=${limit}${f}`);
   return (r.body && r.body.ok) ? r.body : { topics: [], listening: false, indexed: 0 };
 }
 
@@ -1013,8 +1014,17 @@ function openTopicPicker(current        , onPick                         ) {
   const { body, close } = overlay('Browse broker topics');
   body.appendChild(el('div', { class: 'desc', text: 'Live topics seen on the broker while this window is open. Nothing is indexed in the background — the subscription starts when you browse and stops when you stop.' }));
 
+  // Which broker filter to subscribe to. Default '#' (everything); a broker whose ACL forbids the bare
+  // wildcard can narrow it, e.g. 'solar_assistant/#', and still browse under that prefix.
+  const filterBar = el('div', { class: 'ld-toolbar' });
+  const filterIn = el('input', { type: 'text', value: '#', placeholder: '# (everything)', style: { width: '220px' } })                    ;
+  filterIn.title = 'The topic filter to subscribe to while browsing. If the broker denies “#”, narrow it (e.g. solar_assistant/#).';
+  const applyFilter = btn('Browse this');
+  filterBar.append(el('span', { class: 'desc', style: { margin: '0' }, text: 'Subscribe to:' }), filterIn, applyFilter);
+  body.appendChild(filterBar);
+
   const bar = el('div', { class: 'ld-toolbar' });
-  const search = el('input', { type: 'search', value: current || '', placeholder: 'filter topics…', style: { width: '320px' } })                    ;
+  const search = el('input', { type: 'search', value: current || '', placeholder: 'filter the shown topics…', style: { width: '320px' } })                    ;
   const status = el('span', { class: 'desc', style: { margin: '0 0 0 8px' } });
   bar.append(search, status);
   body.appendChild(bar);
@@ -1028,11 +1038,18 @@ function openTopicPicker(current        , onPick                         ) {
   body.appendChild(tbl);
 
   const load = async () => {
-    const b = await fetchTopics(search.value.trim(), 100);
+    const b = await fetchTopics(search.value.trim(), 100, filterIn.value.trim() || '#');
     tbody.innerHTML = '';
+    if (b.granted === false) {
+      // The broker refused the subscription — say so plainly instead of a mysterious empty list.
+      status.style.color = 'var(--bad)';
+      status.textContent = `The broker denied the subscription to “${b.filter || filterIn.value.trim()}”. Your MQTT account lacks read permission on it — grant it, or narrow the filter above to a prefix you can read (e.g. solar_assistant/#).`;
+      return;
+    }
+    status.style.color = 'var(--muted)';
     status.textContent = b.listening
-      ? `${(b.topics || []).length} shown · ${b.indexed}/${b.capacity} indexed`
-      : 'waiting for the broker subscription to come up…';
+      ? `${(b.topics || []).length} shown · ${b.indexed}/${b.capacity} indexed · subscribed to “${b.filter || '#'}”`
+      : `waiting for the broker subscription to “${b.filter || filterIn.value.trim()}” to come up…`;
     (b.topics || []).forEach((t     ) => {
       const tr = el('tr');
       tr.appendChild(el('td', {}, el('code', { text: t.topic })));
@@ -1047,6 +1064,8 @@ function openTopicPicker(current        , onPick                         ) {
 
   let timer      = null;
   search.oninput = () => { clearTimeout(timer); timer = setTimeout(load, 250); };
+  applyFilter.onclick = () => load();
+  filterIn.onkeydown = (e     ) => { if (e.key === 'Enter') load(); };
   load();
   // Keep the index's lease alive (and the list fresh) for as long as the window is open.
   const poll = setInterval(() => { if (!document.body.contains(tbl)) { clearInterval(poll); return; } load(); }, 5000);
@@ -2299,8 +2318,10 @@ function addNodesSection(nav     , sections     ) {
     };
 
     const cand = flowCandidates(lastGraph, customNodes);
-    ed.appendChild(renderNodeManager(flow, customNodes, links, cand, editing, (close          ) => { if (close) editing.id = null; render(); }));
+    // Groups first: the node manager appends the (tall) per-node editor beneath its table when one is open,
+    // which would otherwise bury the Groups section off the bottom of the page.
     ed.appendChild(renderGroupManager(flow, cand, render));
+    ed.appendChild(renderNodeManager(flow, customNodes, links, cand, editing, (close          ) => { if (close) editing.id = null; render(); }));
   };
 
   const load = async () => {

--- a/rPDU2MQTT/Hosting/MqttTopicIndexService.cs
+++ b/rPDU2MQTT/Hosting/MqttTopicIndexService.cs
@@ -31,7 +31,7 @@ public sealed class MqttTopicIndexService : BackgroundService
     private readonly HiveMQClient mqtt;
     private readonly IGrainFactory grains;
     private readonly ConcurrentDictionary<string, TopicSample> buffer = new(StringComparer.Ordinal);
-    private bool subscribed;
+    private string? subscribedFilter;   // the filter currently subscribed on the broker, or null
 
     public MqttTopicIndexService(MQTTServiceDependencies deps, IGrainFactory grains)
     {
@@ -52,18 +52,26 @@ public sealed class MqttTopicIndexService : BackgroundService
         }
         while (await SafeWait(timer, stoppingToken));
 
-        if (subscribed) await StopListening();
+        if (subscribedFilter is not null) await StopListening();
     }
 
     private async Task PumpAsync()
     {
         var index = grains.GetGrain<ITopicIndexGrain>(0);
-        var wanted = await index.Wanted();
+        var wanted = await index.DesiredFilter();   // the filter to browse, or "" when nobody is browsing
 
-        if (wanted && !subscribed) await StartListening();
-        else if (!wanted && subscribed) await StopListening();
-
-        if (!subscribed) return;
+        // Re-subscribe when the wanted filter changes (the user narrowed it, e.g. to solar_assistant/#).
+        if (string.IsNullOrEmpty(wanted))
+        {
+            if (subscribedFilter is not null) await StopListening();
+            return;
+        }
+        if (subscribedFilter != wanted)
+        {
+            if (subscribedFilter is not null) await StopListening();
+            await StartListening(wanted, index);
+        }
+        if (subscribedFilter is null) return;
 
         // Hand over what we've seen (an empty batch still says "the subscription is open").
         var batch = buffer.Keys.Take(MaxBuffered).ToList();
@@ -74,30 +82,41 @@ public sealed class MqttTopicIndexService : BackgroundService
         await index.Observe(samples);
     }
 
-    private async Task StartListening()
+    private async Task StartListening(string filter, ITopicIndexGrain index)
     {
         try
         {
             mqtt.OnMessageReceived += OnMessageReceived;
-            await mqtt.SubscribeAsync("#", QualityOfService.AtMostOnceDelivery);
-            subscribed = true;
-            Serilog.Log.Information("Topic index: subscribed to # while the Nodes editor is browsing.");
+            var result = await mqtt.SubscribeAsync(filter, QualityOfService.AtMostOnceDelivery);
+            subscribedFilter = filter;
+
+            // A broker can *deny* the subscription (an ACL that forbids the wildcard) and report it in the
+            // SUBACK, not as an exception. Unchecked, that's a silently-empty browser on a working broker.
+            var granted = result.Subscriptions.All(sub => (int)sub.SubscribeReasonCode <= 2);
+            await index.ReportSubscription(granted);
+            if (granted)
+                Serilog.Log.Information($"Topic index: subscribed to '{filter}' while the Nodes editor is browsing.");
+            else
+                Serilog.Log.Warning($"Topic index: the broker DENIED the subscription to '{filter}' — the MQTT account likely lacks read permission on it. The topic browser will stay empty; grant it, or browse a narrower prefix.");
         }
         catch (Exception ex)
         {
             mqtt.OnMessageReceived -= OnMessageReceived;
-            Serilog.Log.Warning($"Topic index: could not subscribe: {ex.Message}");
+            subscribedFilter = null;
+            Serilog.Log.Warning($"Topic index: could not subscribe to '{filter}': {ex.Message}");
         }
     }
 
     private async Task StopListening()
     {
-        subscribed = false;
+        var filter = subscribedFilter;
+        subscribedFilter = null;
         mqtt.OnMessageReceived -= OnMessageReceived;
         buffer.Clear();
+        if (filter is null) return;
         try
         {
-            await mqtt.UnsubscribeAsync("#");
+            await mqtt.UnsubscribeAsync(filter);
             Serilog.Log.Information("Topic index: nobody is browsing; unsubscribed.");
         }
         catch (Exception ex) { Serilog.Log.Debug($"Topic index: unsubscribe failed: {ex.Message}"); }


### PR DESCRIPTION
Two things from using the deployed build.

## Topic browser showed `0/2000 indexed`

The UI pod **did** subscribe to `#` (log confirms) but indexed nothing — and the code never checked the SUBACK. A broker whose ACL forbids the bare `#` wildcard (while still allowing the specific energy-flow topics, which work fine) failed **silently**. Your external viewer showing live data confirmed the broker has it; rPDU's `#` just wasn't granted.

- **SUBACK is checked** now and the grant/deny state flows to the index grain. The browser shows *"The broker denied the subscription to `#` … grant it, or narrow the filter above to a prefix you can read (e.g. `solar_assistant/#`)"* instead of a blank list.
- **The browse filter is configurable** (default `#`). A restricted broker can subscribe to a prefix it *can* read. There's now a "Subscribe to:" box in the browser. Changing it re-subscribes and clears the old topics; a blank renew keeps the current filter (the per-topic detail lookups renew that way and must not reset it).

## "Not seeing where the groupings are configured"

The Groups manager was appended **below** the node table — which puts it under the tall per-node editor whenever one is open, i.e. off the bottom of the page. It now renders **above** the node manager, so it's the first thing on the Nodes tab.

## Tests

+4 grain tests (374 total, 0 warnings): filter default/narrow/blank-keeps-current, a denial surfaces as `Granted = false` (and is `null` until reported, never a silent false), and no desired filter when nobody is browsing. GUI smoke passes.