### PR TITLE
chore(operator): structured report severity; dedup/tidy the check path

### DIFF
--- a/rPDU2MQTT.Grains.Abstractions/Operator/IOperatorGrain.cs
+++ b/rPDU2MQTT.Grains.Abstractions/Operator/IOperatorGrain.cs
@@ -1,6 +1,24 @@
 namespace rPDU2MQTT.Grains.Abstractions.Operator;
 
 /// <summary>
+/// How a report should read at a glance. The grain knows its state exactly when it writes the message, so it
+/// says so here rather than leaving the GUI to guess a colour by keyword-matching the prose (which drifts the
+/// moment a message is reworded). <see cref="Info"/> is first so a blank/initial report is neutral, not falsely
+/// green. Serialized as its name via <c>JsonStringEnumConverter</c>, e.g. <c>"updateAvailable"</c>.
+/// </summary>
+public enum OperatorSeverity
+{
+    /// <summary>Neutral — checking, disabled, or couldn't determine (muted).</summary>
+    Info,
+    /// <summary>Running the latest eligible build (good).</summary>
+    Ok,
+    /// <summary>A newer build is available, or one was just applied (attention).</summary>
+    UpdateAvailable,
+    /// <summary>The check itself failed (muted/error).</summary>
+    Error,
+}
+
+/// <summary>
 /// The operator's update report — held in the grain and returned to callers, replacing the round-trip
 /// through the CR <c>status</c> the GUI used to poll. Property names are the camelCase the GUI already reads.
 /// </summary>
@@ -15,6 +33,7 @@ public sealed record OperatorReport
     [Id(5)] public string? Applied { get; init; }
     [Id(6)] public string? CheckedAt { get; init; }
     [Id(7)] public string? Message { get; init; }
+    [Id(8)] public OperatorSeverity Severity { get; init; }
 }
 
 /// <summary>

--- a/rPDU2MQTT.Grains/Operator/OperatorGrain.cs
+++ b/rPDU2MQTT.Grains/Operator/OperatorGrain.cs
@@ -45,16 +45,20 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
 
     public async Task<OperatorReport> CheckNow(bool force)
     {
-        if (source is null) return report = report with { Message = "Operator needs the Kubernetes config source." };
+        if (source is null) return report = report with { Message = "Operator needs the Kubernetes config source.", Severity = OperatorSeverity.Info };
         if (!cfg.Operator.Enabled || !cfg.Operator.CheckForUpdates)
-            return report = report with { Message = "Update checks are disabled (Operator.Enabled / CheckForUpdates)." };
+            return report = report with { Message = "Update checks are disabled (Operator.Enabled / CheckForUpdates).", Severity = OperatorSeverity.Info };
 
         var interval = TimeSpan.FromHours(Math.Max(1, cfg.Operator.CheckIntervalHours));
         if (!force && DateTime.UtcNow - lastCheckUtc < interval) return report;   // throttle unless forced
         lastCheckUtc = DateTime.UtcNow;
 
         try { await CheckOnceAsync(CancellationToken.None); }
-        catch (Exception ex) { log.LogWarning("Operator: check failed: {Msg}", ex.Message); }
+        catch (Exception ex)
+        {
+            log.LogWarning("Operator: check failed: {Msg}", ex.Message);
+            report = report with { CheckedAt = NowIso(), Message = $"Update check failed: {ex.Message}", Severity = OperatorSeverity.Error };
+        }
         return report;
     }
 
@@ -69,7 +73,7 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
         try
         {
             var patched = await SetImageAsync(repository, newImage, newImage, CancellationToken.None);
-            await Report(report with { Available = false, Current = tag, Latest = tag, Applied = tag, CheckedAt = NowIso(), Message = $"Switched to {tag}." });
+            await Report(report with { Available = false, Current = tag, Latest = tag, Applied = tag, CheckedAt = NowIso(), Message = $"Switched to {tag}.", Severity = OperatorSeverity.Ok });
             return $"Switching to {tag}: rolled {(patched.Count > 0 ? string.Join(", ", patched) : "no")} deployment(s).";
         }
         catch (Exception ex) { return $"Switch to {tag} failed: {ex.Message}"; }
@@ -85,10 +89,10 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
         try
         {
             var digest = await registry.ResolveDigestAsync(registryHost, repository, image.Tag, CancellationToken.None);
-            var newImage = digest is not null ? $"{image.Registry}/{repository}:{image.Tag}@{digest}" : image.WithTag(image.Tag);
+            var newImage = digest is not null ? Pinned(image, repository, digest) : image.WithTag(image.Tag);
             // Container image may carry the @digest to force the re-pull; RPDU2MQTT_IMAGE stays the clean tag.
             var patched = await SetImageAsync(repository, newImage, image.WithTag(image.Tag), CancellationToken.None);
-            await Report(report with { Current = image.Tag, CheckedAt = NowIso(), Message = $"Redeploying {image.Tag}." });
+            await Report(report with { Current = image.Tag, CheckedAt = NowIso(), Message = $"Redeploying {image.Tag}.", Severity = OperatorSeverity.Ok });
             return $"Force update: rolled {(patched.Count > 0 ? string.Join(", ", patched) : "no")} deployment(s) to {newImage}.";
         }
         catch (Exception ex) { return $"Redeploy failed: {ex.Message}"; }
@@ -100,7 +104,7 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
     {
         if (!ImageReference.TryParse(Environment.GetEnvironmentVariable("RPDU2MQTT_IMAGE"), out var image))
         {
-            await Report(report with { CheckedAt = NowIso(), Message = "Deployed image is unknown (RPDU2MQTT_IMAGE)." });
+            await Report(report with { CheckedAt = NowIso(), Message = "Deployed image is unknown (RPDU2MQTT_IMAGE).", Severity = OperatorSeverity.Info });
             return;
         }
 
@@ -111,28 +115,36 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
 
         if (!check.Applicable)
         {
+            if (string.IsNullOrEmpty(image.Tag))
+            {
+                await Report(report with { CheckedAt = NowIso(), Message = "The deployed image has no tag to track.", Severity = OperatorSeverity.Info });
+                return;
+            }
+
             // A moving channel (unstable/edge/latest/stable) has no version to compare — but its digest moves
             // as new builds publish. Compare what the tag points to in the registry now against the digest
             // this process is actually running, so "Check now" can say a newer build is waiting instead of a
-            // misleading "up to date".
-            var registryDigest = await registry.ResolveDigestAsync(registryHost, repository, image.Tag, ct);
-            var runningDigest = await RunningDigestAsync(ct);
-            var newer = registryDigest is not null && runningDigest is not null && !DigestsEqual(registryDigest, runningDigest);
+            // misleading "up to date". The two reads hit different services (registry vs the k8s API) and don't
+            // depend on each other, so run them together.
+            var digestTask = registry.ResolveDigestAsync(registryHost, repository, image.Tag, ct);
+            var runningTask = RunningDigestAsync(ct);
+            var registryDigest = await digestTask;
+            var runningDigest = await runningTask;
+            var newer = registryDigest is not null && runningDigest is not null && !ImageDigest.Equal(registryDigest, runningDigest);
 
-            string message = registryDigest is null
-                ? $"Tracking the moving '{image.Tag}' channel — couldn't read its digest from the registry."
+            var (message, severity) = registryDigest is null
+                ? ($"Tracking the moving '{image.Tag}' channel — couldn't read its digest from the registry.", OperatorSeverity.Info)
                 : runningDigest is null
-                    ? $"Tracking the moving '{image.Tag}' channel — couldn't determine the running digest to compare."
+                    ? ($"Tracking the moving '{image.Tag}' channel — couldn't determine the running digest to compare.", OperatorSeverity.Info)
                     : newer
-                        ? $"A newer '{image.Tag}' build is available — use Force update to pull it."
-                        : $"Running the latest '{image.Tag}' build.";
+                        ? ($"A newer '{image.Tag}' build is available — use Force update to pull it.", OperatorSeverity.UpdateAvailable)
+                        : ($"Running the latest '{image.Tag}' build.", OperatorSeverity.Ok);
 
             var appliedChannel = (string?)null;
             if (newer && cfg.Operator.AutoUpdate)
             {
                 // AutoUpdate on a channel means "keep pulling its latest build": re-pull, pinning the digest.
-                var pinned = $"{image.Registry}/{repository}:{image.Tag}@{registryDigest}";
-                if ((await SetImageAsync(repository, pinned, image.WithTag(image.Tag), ct)).Count > 0)
+                if ((await SetImageAsync(repository, Pinned(image, repository, registryDigest!), image.WithTag(image.Tag), ct)).Count > 0)
                 {
                     appliedChannel = image.Tag;
                     message = $"A newer '{image.Tag}' build was available — auto-updated (rolling now).";
@@ -149,6 +161,7 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
                 Applied = appliedChannel,
                 CheckedAt = NowIso(),
                 Message = message,
+                Severity = severity,
             });
             return;
         }
@@ -172,8 +185,14 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
             Applied = applied,
             CheckedAt = NowIso(),
             Message = check.UpdateAvailable ? (applied is not null ? $"Auto-updated to {applied}." : $"Update available: {latest}.") : "Up to date.",
+            Severity = check.UpdateAvailable ? OperatorSeverity.UpdateAvailable : OperatorSeverity.Ok,
         });
     }
+
+    /// <summary>A digest-pinned <c>registry/repo:tag@sha256:…</c> pull reference — honours the operator's
+    /// repository override, so it can't use <see cref="ImageReference.ToString"/>.</summary>
+    private static string Pinned(ImageReference image, string repository, string digest)
+        => $"{image.Registry}/{repository}:{image.Tag}@{digest}";
 
     private string ResolveRegistryHost(ImageReference image)
     {
@@ -199,8 +218,6 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
         }
         catch (Exception ex) { log.LogDebug("Operator: could not read running digest: {Msg}", ex.Message); return null; }
     }
-
-    private static bool DigestsEqual(string a, string b) => ImageDigest.Equal(a, b);
 
     /// <summary>Store the report in-grain and mirror it to the CR status for kubectl visibility.</summary>
     private async Task Report(OperatorReport r)

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -369,14 +369,14 @@ function wireOperatorCheck(sec: any) {
   sec.appendChild(box);
 
   const show = (u: any) => {
-    // The operator's message is authoritative and correct for both releases and moving channels
-    // (e.g. "A newer 'unstable' build is available" vs "Running the latest 'unstable' build"), so drive the
-    // display from it rather than re-deriving — the old re-derivation called 'unstable' a "release".
+    // The operator reports both the message and a Severity, so the colour comes straight from that severity —
+    // no re-deriving from wording (the old code called 'unstable' a "release", then keyword-sniffed the prose).
+    // Fall back to `available` only for a legacy report that predates the severity field.
     const msg = u?.message || (u?.available ? 'Update available.' : 'Up to date.');
-    const iffy = /couldn.?t|couldn't|unknown|failed|error|disabled|needs|not a release/i.test(msg);
-    if (u?.available) { result.style.color = 'var(--warn, #fa4)'; result.textContent = '↑ ' + msg; }
-    else if (iffy) { result.style.color = 'var(--muted)'; result.textContent = msg; }
-    else { result.style.color = 'var(--good)'; result.textContent = '✓ ' + msg; }
+    const sev = u?.severity ?? (u?.available ? 'UpdateAvailable' : 'Ok');
+    if (sev === 'UpdateAvailable') { result.style.color = 'var(--warn, #fa4)'; result.textContent = '↑ ' + msg; }
+    else if (sev === 'Ok') { result.style.color = 'var(--good)'; result.textContent = '✓ ' + msg; }
+    else { result.style.color = 'var(--muted)'; result.textContent = msg; }   // Info / Error
     if (u?.checkedAt) result.textContent += ` · checked ${new Date(u.checkedAt).toLocaleTimeString()}`;
   };
 

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2910,14 +2910,14 @@ function wireOperatorCheck(sec     ) {
   sec.appendChild(box);
 
   const show = (u     ) => {
-    // The operator's message is authoritative and correct for both releases and moving channels
-    // (e.g. "A newer 'unstable' build is available" vs "Running the latest 'unstable' build"), so drive the
-    // display from it rather than re-deriving — the old re-derivation called 'unstable' a "release".
+    // The operator reports both the message and a Severity, so the colour comes straight from that severity —
+    // no re-deriving from wording (the old code called 'unstable' a "release", then keyword-sniffed the prose).
+    // Fall back to `available` only for a legacy report that predates the severity field.
     const msg = u?.message || (u?.available ? 'Update available.' : 'Up to date.');
-    const iffy = /couldn.?t|couldn't|unknown|failed|error|disabled|needs|not a release/i.test(msg);
-    if (u?.available) { result.style.color = 'var(--warn, #fa4)'; result.textContent = '↑ ' + msg; }
-    else if (iffy) { result.style.color = 'var(--muted)'; result.textContent = msg; }
-    else { result.style.color = 'var(--good)'; result.textContent = '✓ ' + msg; }
+    const sev = u?.severity ?? (u?.available ? 'UpdateAvailable' : 'Ok');
+    if (sev === 'UpdateAvailable') { result.style.color = 'var(--warn, #fa4)'; result.textContent = '↑ ' + msg; }
+    else if (sev === 'Ok') { result.style.color = 'var(--good)'; result.textContent = '✓ ' + msg; }
+    else { result.style.color = 'var(--muted)'; result.textContent = msg; }   // Info / Error
     if (u?.checkedAt) result.textContent += ` · checked ${new Date(u.checkedAt).toLocaleTimeString()}`;
   };
 


### PR DESCRIPTION
Cleanup pass (via `/simplify`) over the "Check now" moving-tag work (#246). No behaviour change intended.

## Altitude — structured severity, not prose-sniffing
`OperatorReport` gains a `Severity` enum (`Info` / `Ok` / `UpdateAvailable` / `Error`), set authoritatively wherever a report is built. The GUI colours the result from that severity instead of running a regex over the human message (`/couldn.?t|unknown|failed|.../`). Rewording or localising a message can no longer silently change its colour — the exact class of fragility behind the earlier "unstable is the newest release" bug. Serializes as a string via the existing `JsonStringEnumConverter`; the GUI keeps an `available`-based fallback for any legacy report without the field.

## Efficiency
The registry-digest read and the running-pod-digest read hit different services (registry vs the k8s API) and don't depend on each other, so they now start together rather than one-after-the-other.

## Reuse
The digest-pinned `registry/repo:tag@digest` reference — previously interpolated in both `Redeploy` and the new moving-channel branch — is now a single `Pinned()` helper (honours the operator's repository override, so it can't use `ImageReference.ToString`).

## Simplify
- Dropped the single-use `DigestsEqual` pass-through; callers use `ImageDigest.Equal` directly.
- Removed the redundant `couldn't` regex alternative (`couldn.?t` already matched it) — now moot since the GUI no longer regexes at all.

## Also
Fixed a pre-existing `CS8604` (nullable `image.Tag` into `ResolveDigestAsync`) by guarding a tagless image before the channel check.

## Verification
Clean build (0 warnings), 380 tests pass, GUI build + smoke OK.

### Deliberately skipped (noted, not fixed)
- Factoring the "read own pod" boilerplate into a shared `KubernetesConfigSource` helper — the two other call sites extract different fields and live outside this diff.
- Caching the running digest / reading the pod once per auto-update pass — real but negligible (the path is gated by a manual button + an hourly timer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)