### PR TITLE
feat(ha): roll solar/battery/grid into HA's Energy Dashboard sources

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -753,6 +753,13 @@ spec:
                                 - frequency
                                 - powerfactor
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.'
+                              Direction:
+                                type: string
+                                enum:
+                                - ''
+                                - out
+                                - in
+                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production; the supply direction) or 'in' (battery charge, grid export). Lets a battery/grid node bind both directions."
                               Unit:
                                 type: string
                                 description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.
@@ -826,6 +833,13 @@ spec:
                                 - frequency
                                 - powerfactor
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.'
+                              Direction:
+                                type: string
+                                enum:
+                                - ''
+                                - out
+                                - in
+                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production; the supply direction) or 'in' (battery charge, grid export). Lets a battery/grid node bind both directions."
                               Unit:
                                 type: string
                                 description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -753,6 +753,13 @@ spec:
                                 - frequency
                                 - powerfactor
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.'
+                              Direction:
+                                type: string
+                                enum:
+                                - ''
+                                - out
+                                - in
+                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production; the supply direction) or 'in' (battery charge, grid export). Lets a battery/grid node bind both directions."
                               Unit:
                                 type: string
                                 description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.
@@ -826,6 +833,13 @@ spec:
                                 - frequency
                                 - powerfactor
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, or powerfactor.'
+                              Direction:
+                                type: string
+                                enum:
+                                - ''
+                                - out
+                                - in
+                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production; the supply direction) or 'in' (battery charge, grid export). Lets a battery/grid node bind both directions."
                               Unit:
                                 type: string
                                 description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.

--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace rPDU2MQTT.Core.Flow;
@@ -11,6 +12,15 @@ public sealed record HaDeviceConsumption(
     string stat_consumption,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? included_in_stat,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? name);
+
+/// <summary>The direction of a node's energy stat, relative to the node — see <see cref="Models.Config.EnergyFlowSource.Direction"/>.</summary>
+public enum EnergyDirection
+{
+    /// <summary>Energy leaving the node toward the home: battery discharge, grid import, solar production.</summary>
+    Out,
+    /// <summary>Energy flowing back into the node from the home: battery charge, grid export.</summary>
+    In,
+}
 
 /// <summary>
 /// Maps an energy-flow hierarchy onto Home Assistant's Energy-Dashboard device list (#128): one entry per
@@ -31,6 +41,67 @@ public static class EnergyDashboardSync
             entries.Add(new HaDeviceConsumption(stat, NearestAncestorStat(graph, node.Id, statFor), node.Label));
         }
         return entries;
+    }
+
+    /// <summary>
+    /// The kind-tagged flow nodes (<c>solar</c> / <c>battery</c> / <c>grid</c>) mapped onto Home Assistant's
+    /// Energy-Dashboard <c>energy_sources</c> — the grid/solar/battery buckets, as opposed to the "individual
+    /// devices" list <see cref="BuildDeviceConsumption"/> fills. This is the roll-up that makes HA's dashboard
+    /// actually reflect the system, not just tally sub-loads (#energy-rollup).
+    /// <para>
+    /// <paramref name="statFor"/> resolves a node's energy stat in a direction: <c>Out</c> is the supply
+    /// sensor (discharge/import/production) every tier already has; <c>In</c> is the return sensor
+    /// (charge/export). It returns null when no such stat exists in HA — and a source is emitted only from the
+    /// stats that actually resolve, so nothing here invents a statistic HA doesn't have. A battery needs both
+    /// directions to be representable (HA requires <c>stat_energy_from</c> and <c>stat_energy_to</c>); a grid
+    /// appears with whichever flow directions resolve.
+    /// </para>
+    /// </summary>
+    public static List<JsonObject> BuildEnergySources(FlowGraph graph, Func<string, EnergyDirection, string?> statFor)
+    {
+        var sources = new List<JsonObject>();
+        foreach (var node in graph.Nodes)
+        {
+            var outStat = statFor(node.Id, EnergyDirection.Out);
+            var inStat = statFor(node.Id, EnergyDirection.In);
+            switch (node.Kind?.ToLowerInvariant())
+            {
+                case "solar" when !string.IsNullOrEmpty(outStat):
+                    sources.Add(new JsonObject { ["type"] = "solar", ["stat_energy_from"] = outStat });
+                    break;
+
+                // HA's battery source needs both a from (discharge) and a to (charge) stat; without the pair
+                // it can't be expressed, so we skip it rather than emit a half-source HA will reject.
+                case "battery" when !string.IsNullOrEmpty(outStat) && !string.IsNullOrEmpty(inStat):
+                    sources.Add(new JsonObject { ["type"] = "battery", ["stat_energy_from"] = outStat, ["stat_energy_to"] = inStat });
+                    break;
+
+                case "grid" when !string.IsNullOrEmpty(outStat) || !string.IsNullOrEmpty(inStat):
+                    var grid = new JsonObject { ["type"] = "grid", ["cost_adjustment_day"] = 0.0 };
+                    if (!string.IsNullOrEmpty(outStat))
+                        grid["flow_from"] = new JsonArray(new JsonObject { ["stat_energy_from"] = outStat });
+                    if (!string.IsNullOrEmpty(inStat))
+                        grid["flow_to"] = new JsonArray(new JsonObject { ["stat_energy_to"] = inStat });
+                    sources.Add(grid);
+                    break;
+            }
+        }
+        return sources;
+    }
+
+    /// <summary>Every energy stat entity_id referenced by an <c>energy_sources</c> entry (ours or HA's) — used
+    /// to tell our entries apart from the user's own when merging, without matching on <c>type</c>.</summary>
+    public static IEnumerable<string> StatsOf(JsonObject source)
+    {
+        if ((string?)source["stat_energy_from"] is { Length: > 0 } from) yield return from;
+        if ((string?)source["stat_energy_to"] is { Length: > 0 } to) yield return to;
+        foreach (var key in new[] { "flow_from", "flow_to" })
+            foreach (var flow in source[key]?.AsArray() ?? new JsonArray())
+                if (flow is JsonObject f)
+                {
+                    if ((string?)f["stat_energy_from"] is { Length: > 0 } ff) yield return ff;
+                    if ((string?)f["stat_energy_to"] is { Length: > 0 } ft) yield return ft;
+                }
     }
 
     // Walk up the primary-feeder chain to the first ancestor that has an energy stat (skipping tiers that

--- a/rPDU2MQTT.Core/Flow/FlowExport.cs
+++ b/rPDU2MQTT.Core/Flow/FlowExport.cs
@@ -76,8 +76,15 @@ public static class FlowExport
     /// <summary>The Home Assistant device identifier for a tier ("energyflow_&lt;key&gt;").</summary>
     public static string DeviceId(string nodeId) => "energyflow_" + NodeKey(nodeId);
 
-    /// <summary>The HA unique_id / entity object_id of a tier's energy sensor ("energyflow_&lt;key&gt;_energy").</summary>
+    /// <summary>The HA unique_id / entity object_id of a tier's energy sensor ("energyflow_&lt;key&gt;_energy").
+    /// This is the <c>out</c> (supply) direction — discharge/import/production — the sensor every tier already
+    /// carries.</summary>
     public static string EnergyUniqueId(string nodeId) => DeviceId(nodeId) + "_energy";
+
+    /// <summary>The HA unique_id of a tier's <c>in</c>-direction energy sensor ("energyflow_&lt;key&gt;_energy_in")
+    /// — battery charge / grid export. Distinct from <see cref="EnergyUniqueId"/> so both directions can map to
+    /// Home Assistant's battery/grid split.</summary>
+    public static string EnergyInUniqueId(string nodeId) => DeviceId(nodeId) + "_energy_in";
 
     /// <summary>
     /// Flow node id -> the unique_id of the native PDU-discovery energy sensor it already has (#177): PDU

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -188,6 +188,25 @@ public class EnergyFlowSource
     public string Metric { get; set; } = "realpower";
 
     /// <summary>
+    /// Which way energy flows for this source, so a bidirectional role (battery, grid) can bind both
+    /// directions on the same node (#energy-rollup). Framed relative to the node itself:
+    /// <list type="bullet">
+    /// <item><c>out</c> (default): energy leaving this node toward the home — battery <em>discharge</em>,
+    /// grid <em>import</em>, solar <em>production</em>. This is the supply direction and the only one older
+    /// single-direction configs ever meant.</item>
+    /// <item><c>in</c>: energy flowing back into this node from the home — battery <em>charge</em>,
+    /// grid <em>export</em>.</item>
+    /// </list>
+    /// Home Assistant's Energy Dashboard uses exactly this split: a battery's <c>out</c> becomes
+    /// <c>stat_energy_from</c> and its <c>in</c> becomes <c>stat_energy_to</c>; a grid's <c>out</c> is
+    /// <c>flow_from</c> (consumption) and its <c>in</c> is <c>flow_to</c> (return).
+    /// </summary>
+    [DefaultValue("out")]
+    [Description("Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production; the supply direction) or 'in' (battery charge, grid export). Lets a battery/grid node bind both directions.")]
+    [AllowedValues("out", "in")]
+    public string Direction { get; set; } = "out";
+
+    /// <summary>
     /// The unit the source publishes this value in (e.g. <c>kW</c>, <c>Wh</c>). The reading is converted to
     /// the metric's canonical unit (W, kWh, V, …) on ingest so every export stays consistent. Blank assumes
     /// the value is already canonical. See <see cref="rPDU2MQTT.Core.Flow.FlowUnits"/>.

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -54,6 +54,28 @@ public sealed class HaEnergyDashboardSync
         return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver);
     }
 
+    /// <summary>
+    /// The Energy-Dashboard <c>energy_sources</c> (grid/solar/battery buckets) the kind-tagged flow nodes map
+    /// to — the roll-up on top of the individual-device list. Directions resolve through HA's authoritative
+    /// unique_id → entity_id map (Out = the native/energyflow supply sensor; In = the energyflow return
+    /// sensor), so a bucket only appears once its stat actually exists in HA.
+    /// </summary>
+    public List<JsonObject> BuildEnergySources(IReadOnlyDictionary<string, string> entityByUniqueId)
+    {
+        var merged = new PduData();
+        foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
+        if (merged.Devices.Count == 0) return new();
+
+        var energyType = string.IsNullOrWhiteSpace(config.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : config.HASS.EnergyDashboard.EnergyMeasurementType;
+        var native = FlowExport.NativeEnergyUniqueIds(merged, energyType);
+        var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric, live);
+
+        string? Resolve(string uid) => entityByUniqueId.TryGetValue(uid, out var e) ? e : null;
+        return EnergyDashboardSync.BuildEnergySources(graph, (id, dir) => dir == Core.Flow.EnergyDirection.Out
+            ? Resolve(native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id))
+            : Resolve(FlowExport.EnergyInUniqueId(id)));
+    }
+
     /// <summary>Merge our hierarchy devices into HA's energy prefs (preserving the user's own). Returns the count synced.</summary>
     public async Task<int> SyncAsync(string url, string token, CancellationToken ct)
     {
@@ -80,11 +102,25 @@ public sealed class HaEnergyDashboardSync
             keep.Add(JsonSerializer.SerializeToNode(d, Json)!);
         prefs["device_consumption"] = keep;
 
+        // Roll the grid/solar/battery buckets into energy_sources too, preserving any the user set up
+        // themselves — an entry is "ours" only when it references a stat we produced (matched by entity_id,
+        // not by type), so a hand-added second grid/solar survives.
+        var sources = BuildEnergySources(entityByUniqueId);
+        var ourStats = sources.SelectMany(EnergyDashboardSync.StatsOf).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var keepSources = new JsonArray();
+        foreach (var existing in prefs["energy_sources"]?.AsArray() ?? new JsonArray())
+            if (existing is JsonObject o && !EnergyDashboardSync.StatsOf(o).Any(ourStats.Contains))
+                keepSources.Add(o.DeepClone());
+        foreach (var src in sources)
+            keepSources.Add(src.DeepClone());
+        prefs["energy_sources"] = keepSources;
+
         await SavePrefs(call, prefs);
         return devices.Count;
     }
 
-    /// <summary>Remove every device from HA's Energy-Dashboard device list. Returns how many were cleared.</summary>
+    /// <summary>Remove every device from HA's Energy-Dashboard device list, and the grid/solar/battery sources
+    /// we added (but not the user's own). Returns how many devices were cleared.</summary>
     public async Task<int> ClearAsync(string url, string token, CancellationToken ct)
     {
         using var ws = await ConnectAuth(url, token, ct);
@@ -94,6 +130,20 @@ public sealed class HaEnergyDashboardSync
             ?? throw new Exception("Could not read HA energy preferences.");
         var cleared = prefs["device_consumption"]?.AsArray()?.Count ?? 0;
         prefs["device_consumption"] = new JsonArray();
+
+        // Strip only the energy_sources whose stats we produced — a user's hand-configured grid/solar stays.
+        var registry = (await call("config/entity_registry/list", null))?["result"]?.AsArray() ?? new JsonArray();
+        var entityByUniqueId = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in registry)
+            if ((string?)e?["unique_id"] is { Length: > 0 } uid && (string?)e?["entity_id"] is { Length: > 0 } eid)
+                entityByUniqueId[uid] = eid;
+
+        var ourStats = BuildEnergySources(entityByUniqueId).SelectMany(EnergyDashboardSync.StatsOf).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var keepSources = new JsonArray();
+        foreach (var existing in prefs["energy_sources"]?.AsArray() ?? new JsonArray())
+            if (existing is JsonObject o && !EnergyDashboardSync.StatsOf(o).Any(ourStats.Contains))
+                keepSources.Add(o.DeepClone());
+        prefs["energy_sources"] = keepSources;
 
         await SavePrefs(call, prefs);
         return cleared;

--- a/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
+++ b/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Mapping the kind-tagged flow nodes onto Home Assistant's Energy-Dashboard <c>energy_sources</c>
+/// (grid/solar/battery), including the Out/In direction split and the "never emit a stat HA doesn't have"
+/// rule (#energy-rollup).
+/// </summary>
+public class EnergyDashboardSourcesTests
+{
+    private static FlowGraph Graph(params FlowNode[] nodes) =>
+        new(nodes, System.Array.Empty<FlowLink>(), "realpower", "W");
+
+    // A resolver over a fixed (id, direction) -> entity_id table; anything absent is "no stat in HA".
+    private static System.Func<string, EnergyDirection, string?> Stats(params (string id, EnergyDirection dir, string entity)[] rows) =>
+        (id, dir) => rows.FirstOrDefault(r => r.id == id && r.dir == dir).entity;
+
+    [Fact]
+    public void Solar_MapsProductionToStatEnergyFrom()
+    {
+        var sources = EnergyDashboardSync.BuildEnergySources(
+            Graph(new FlowNode("pv", "Solar", "solar")),
+            Stats(("pv", EnergyDirection.Out, "sensor.solar_energy")));
+
+        var s = Assert.Single(sources);
+        Assert.Equal("solar", (string?)s["type"]);
+        Assert.Equal("sensor.solar_energy", (string?)s["stat_energy_from"]);
+    }
+
+    [Fact]
+    public void Battery_NeedsBothDirections_ElseSkipped()
+    {
+        var node = new FlowNode("batt", "Battery", "battery");
+
+        // Both directions -> a battery source with from (discharge) + to (charge).
+        var both = EnergyDashboardSync.BuildEnergySources(Graph(node),
+            Stats(("batt", EnergyDirection.Out, "sensor.batt_discharge"),
+                  ("batt", EnergyDirection.In, "sensor.batt_charge")));
+        var b = Assert.Single(both);
+        Assert.Equal("battery", (string?)b["type"]);
+        Assert.Equal("sensor.batt_discharge", (string?)b["stat_energy_from"]);
+        Assert.Equal("sensor.batt_charge", (string?)b["stat_energy_to"]);
+
+        // Only discharge known -> HA can't express a one-sided battery, so nothing is emitted.
+        Assert.Empty(EnergyDashboardSync.BuildEnergySources(Graph(node),
+            Stats(("batt", EnergyDirection.Out, "sensor.batt_discharge"))));
+    }
+
+    [Fact]
+    public void Grid_EmitsWhicheverFlowsResolve()
+    {
+        var node = new FlowNode("grid", "Grid", "grid");
+
+        // Import only -> flow_from present, flow_to omitted (not null — HA rejects nulls).
+        var importOnly = Assert.Single(EnergyDashboardSync.BuildEnergySources(Graph(node),
+            Stats(("grid", EnergyDirection.Out, "sensor.grid_import"))));
+        Assert.Equal("grid", (string?)importOnly["type"]);
+        Assert.Equal("sensor.grid_import", (string?)importOnly["flow_from"]!.AsArray()[0]!["stat_energy_from"]);
+        Assert.False(importOnly.ContainsKey("flow_to"));
+
+        // Both -> flow_from (import) + flow_to (export).
+        var both = Assert.Single(EnergyDashboardSync.BuildEnergySources(Graph(node),
+            Stats(("grid", EnergyDirection.Out, "sensor.grid_import"),
+                  ("grid", EnergyDirection.In, "sensor.grid_export"))));
+        Assert.Equal("sensor.grid_import", (string?)both["flow_from"]!.AsArray()[0]!["stat_energy_from"]);
+        Assert.Equal("sensor.grid_export", (string?)both["flow_to"]!.AsArray()[0]!["stat_energy_to"]);
+    }
+
+    [Fact]
+    public void NonRoleAndUnresolvedNodes_ProduceNothing()
+    {
+        var sources = EnergyDashboardSync.BuildEnergySources(
+            Graph(new FlowNode("pdu", "A PDU", "pdu"),                  // not a role kind
+                  new FlowNode("pv", "Solar", "solar")),               // role, but no stat resolves
+            Stats());   // empty table
+        Assert.Empty(sources);
+    }
+
+    [Fact]
+    public void StatsOf_ExtractsEveryReferencedEntity()
+    {
+        var grid = Assert.Single(EnergyDashboardSync.BuildEnergySources(
+            Graph(new FlowNode("grid", "Grid", "grid")),
+            Stats(("grid", EnergyDirection.Out, "sensor.import"),
+                  ("grid", EnergyDirection.In, "sensor.export"))));
+
+        Assert.Equal(new[] { "sensor.import", "sensor.export" },
+            EnergyDashboardSync.StatsOf(grid).OrderBy(x => x).Reverse().ToArray());
+    }
+}


### PR DESCRIPTION
First slice of the "simplify for Home Assistant" work. Chosen direction: **HA energy rollup first**, **per-source in/out** model.

## The gap this closes
The Energy Dashboard sync only filled HA's **"individual devices"** list (`device_consumption`). The dashboard's actual **grid / solar / battery** buckets (`energy_sources`) — the whole point of the Energy Dashboard — stayed empty, even though flow nodes are already tagged `solar` / `battery` / `grid`. This maps the tagged nodes onto those buckets.

## Mapping
| Node kind | HA source | Directions |
|-----------|-----------|------------|
| `solar`   | solar     | `stat_energy_from` = production (out) |
| `battery` | battery   | `stat_energy_from` = discharge (out), `stat_energy_to` = charge (in) |
| `grid`    | grid      | `flow_from` = import (out), `flow_to` = export (in) |

## The in/out model (as chosen)
`EnergyFlowSource` gains a `Direction`:
- **`out`** (default) — energy leaving the node toward the home: battery **discharge**, grid **import**, solar **production**. This is the supply direction every older single-direction config already meant, so nothing changes for existing setups.
- **`in`** — energy flowing back into the node: battery **charge**, grid **export**.

So a battery/grid node binds *both* directions on one node — no more hand-modelling the reverse leg.

## Accuracy & safety (the non-negotiables)
- Every stat resolves through HA's authoritative `unique_id → entity_id` map. A bucket appears **only once its statistic actually exists in HA** — nothing here invents a statistic. (A battery needs *both* stats to be representable, so it shows up when both exist.)
- The merge **preserves the user's own** `energy_sources`, matched by the entity_ids we produce (not by `type`), so a hand-configured second grid/solar survives a sync.
- **Clear** removes only *our* sources, never the user's.

## What lights up now vs. next
- **Now:** solar production and grid import resolve immediately from the energyflow/native energy sensors that already exist.
- **Next slice (PR2):** publish the directional `_energy_in` sensors (battery charge / grid export) from the export service so those directions light up too — the `In` resolver already looks for them. Then the guided "Energy System" editor and the visual tab.

## Verification
- Pure mapper `EnergyDashboardSync.BuildEnergySources` unit-tested (solar, battery both/one-missing, grid import-only/both, non-role/unresolved, `StatsOf` extraction).
- 385 tests pass, GUI build + smoke OK, CRDs regenerated for the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)