### PR TITLE
feat(flow): publish battery-charge / grid-export energy (HA in-direction stats)

### DIFF
--- a/rPDU2MQTT.Core/Flow/FlowExport.cs
+++ b/rPDU2MQTT.Core/Flow/FlowExport.cs
@@ -118,7 +118,7 @@ public static class FlowExport
     /// these makes the whole hierarchy — not just leaf outlets — visible to HA and linkable in the dashboard.
     /// </summary>
     public static JsonObject DiscoveryDocument(FlowNode node, string? primaryParentId, string stateTopic,
-        string energyUnits, string powerUnits, string? availabilityTopic)
+        string energyUnits, string powerUnits, string? availabilityTopic, bool includeEnergyIn = false)
     {
         var id = DeviceId(node.Id);
         var device = new JsonObject
@@ -155,6 +155,12 @@ public static class FlowExport
                 [$"{id}_power"] = Sensor($"{id}_power", "Power", "power", "measurement", string.IsNullOrWhiteSpace(powerUnits) ? "W" : powerUnits, "{{ value_json.power }}"),
             },
         };
+        // A bidirectional node (battery/grid) also carries its in-direction energy — charge / export — as a
+        // second total_increasing sensor, which is what lets HA's Energy Dashboard show battery charge and
+        // grid return. Its unique_id matches EnergyInUniqueId so the dashboard sync can resolve it.
+        if (includeEnergyIn)
+            doc["components"]!.AsObject()[$"{id}_energy_in"] =
+                Sensor($"{id}_energy_in", "Energy In", "energy", "total_increasing", string.IsNullOrWhiteSpace(energyUnits) ? "kWh" : energyUnits, "{{ value_json.energy_in }}");
         if (!string.IsNullOrEmpty(availabilityTopic))
             doc["availability_topic"] = availabilityTopic;
         return doc;

--- a/rPDU2MQTT.Core/Flow/FlowMetricKey.cs
+++ b/rPDU2MQTT.Core/Flow/FlowMetricKey.cs
@@ -1,0 +1,24 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// The cache/metric key a flow reading is stored under, given its <see cref="Models.Config.EnergyFlowSource.Direction"/>.
+/// <para>
+/// A node's <c>out</c> reading (discharge/import/production) is the supply value the whole flow roll-up reads
+/// for <c>(node, metric)</c>, so it keeps the bare metric. An <c>in</c> reading (battery charge, grid export)
+/// is a distinct quantity that must not overwrite it, so it is stored under a suffixed key — invisible to the
+/// main graph, retrievable by the exporter that publishes the battery-charge / grid-export sensors (#energy-rollup).
+/// </para>
+/// </summary>
+public static class FlowMetricKey
+{
+    /// <summary>Suffix marking an in-direction reading. Chosen so it can't collide with a real metric name.</summary>
+    public const string InSuffix = "#in";
+
+    /// <summary>The storage key for <paramref name="metric"/> in the given direction ("in" / "out").</summary>
+    public static string For(string metric, string? direction)
+        => string.Equals(direction, "in", System.StringComparison.OrdinalIgnoreCase) ? metric + InSuffix : metric;
+
+    /// <summary>The storage key for <paramref name="metric"/> in the given <see cref="EnergyDirection"/>.</summary>
+    public static string For(string metric, EnergyDirection direction)
+        => direction == EnergyDirection.In ? metric + InSuffix : metric;
+}

--- a/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
@@ -54,7 +54,7 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         var bindings = BuildBindings(cfg.EnergyFlow.Nodes);
 
         // Prune readings no longer produced by any current modbus binding (a removed/retyped source).
-        var live = bindings.Values.SelectMany(v => v).Select(b => (b.NodeId, b.Source.Metric)).ToHashSet();
+        var live = bindings.Values.SelectMany(v => v).Select(b => (b.NodeId, FlowMetricKey.For(b.Source.Metric, b.Source.Direction))).ToHashSet();
         foreach (var key in latest.Keys.Where(k => !live.Contains((k.Node, k.Metric))).ToList())
             latest.Remove(key.Node, key.Metric);
 
@@ -82,7 +82,7 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         var framing = resolvedFraming.TryGetValue(conn.Id, out var cached) ? cached : conn.Framing;
 
         ReadBatch(conn.Host, conn.Port, conn.UnitId, framing, conn.TimeoutMs, forConn.Select(f => f.Source).ToList(),
-            onValue: (src, value) => latest.Set(nodeOf[src], src.Metric, value, src.StaleAfterSeconds, nowUtc),
+            onValue: (src, value) => latest.Set(nodeOf[src], FlowMetricKey.For(src.Metric, src.Direction), value, src.StaleAfterSeconds, nowUtc),
             onError: (src, msg) => Log.Debug($"Energy-flow Modbus: node '{nodeOf[src]}' register {src.Register} on {conn.Id} — {msg}"),
             onResolved: f => resolvedFraming[conn.Id] = f);
     }

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -56,6 +56,15 @@ public class EnergyFlowMqttExportService : baseMQTTService
         // hierarchy tiers (panels/circuits/grid/etc.) get an energyflow discovery device.
         var native = FlowExport.NativeEnergyUniqueIds(merged, energyMetric);
 
+        // Nodes that declare an in-direction (charge/export) energy source get a second energy sensor, fed
+        // from the direction-qualified cache key. This is what lights up HA's battery-charge / grid-export.
+        var energyInNodes = flow.Nodes
+            .Where(n => n.AllSources().Any(s =>
+                string.Equals(s.Metric, energyMetric, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(s.Direction, "in", StringComparison.OrdinalIgnoreCase)))
+            .Select(n => n.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         foreach (var node in graph.Nodes)
         {
             // Nothing determines this tier's power — no measurement, and no single path that conservation
@@ -68,12 +77,18 @@ public class EnergyFlowMqttExportService : baseMQTTService
             var energy = FlowExport.NodeValue(energyGraph, node.Id);   // 0 when this tier has no energy sensor
             var parents = FlowExport.Parents(graph, node.Id);          // the tiers that feed this one
 
+            // The in-direction (charge/export) energy, when this node declares one and a fresh value exists —
+            // null otherwise, so HA's energy_in sensor reads unavailable rather than a fabricated 0.
+            double? energyIn = energyInNodes.Contains(node.Id) && live is not null
+                && live.TryGetValue(node.Id, FlowMetricKey.For(energyMetric, "in"), out var ein) ? ein : null;
+
             var payload = JsonSerializer.Serialize(new
             {
                 id = node.Id,
                 value = power,       // retained for #164 back-compat (== power)
                 power,
                 energy,
+                energy_in = energyIn,
                 units = graph.Units,
                 energyUnits = energyGraph.Units,
                 label = node.Label,
@@ -96,7 +111,7 @@ public class EnergyFlowMqttExportService : baseMQTTService
             }
             else
             {
-                var doc = FlowExport.DiscoveryDocument(node, parents.FirstOrDefault(), topic, energyGraph.Units, graph.Units, availability);
+                var doc = FlowExport.DiscoveryDocument(node, parents.FirstOrDefault(), topic, energyGraph.Units, graph.Units, availability, includeEnergyIn: energyInNodes.Contains(node.Id));
                 await PublishString(configTopic, doc.ToJsonString(), retain: cfg.HASS.DiscoveryRetain, cancellationToken);
             }
         }

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -138,7 +138,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
         {
             if (topic == removedTopic) continue;
             foreach (var (nodeId, src) in list)
-                if (nodeId == key.Node && string.Equals(src.Metric, key.Metric, StringComparison.OrdinalIgnoreCase))
+                if (nodeId == key.Node && string.Equals(FlowMetricKey.For(src.Metric, src.Direction), key.Metric, StringComparison.OrdinalIgnoreCase))
                     return false;
         }
         return true;
@@ -210,8 +210,12 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             // Normalise to the metric's canonical unit (kW -> W, Wh -> kWh, …) so the roll-up and exports are
             // consistent, then apply the manual Scale (sign flips / oddball adjustments) on top.
             var value = raw * FlowUnits.ToCanonicalFactor(src.Metric, src.Unit) * src.Scale;
-            cache.Set(nodeId, src.Metric, value, src.StaleAfterSeconds, nowUtc);
-            onReading?.Invoke(nodeId, src.Metric, value, src.StaleAfterSeconds);
+            // An 'in' (charge/export) reading is stored under a direction-qualified key so it doesn't overwrite
+            // the 'out' supply value the roll-up reads — and, being a non-metric key, is skipped by the grain
+            // measurement sink below (Metrics.TryParse fails), keeping charge/export out of the power flow.
+            var key = FlowMetricKey.For(src.Metric, src.Direction);
+            cache.Set(nodeId, key, value, src.StaleAfterSeconds, nowUtc);
+            onReading?.Invoke(nodeId, key, value, src.StaleAfterSeconds);
         }
     }
 

--- a/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
+++ b/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
@@ -197,6 +197,37 @@ public class EnergyFlowMqttSourceTests
         Assert.Equal(812.5, v);
     }
 
+    [Fact]
+    public void Apply_KeepsInAndOutDirectionsSeparate()
+    {
+        // A battery binds discharge (out, default) and charge (in) on the same node/metric. Before the
+        // direction key they collided on (node, "energy") and one silently overwrote the other.
+        var nodes = new[]
+        {
+            NodeWith("battery",
+                new EnergyFlowSource { Topic = "sa/discharge", Metric = "energy" },                      // out (default)
+                new EnergyFlowSource { Topic = "sa/charge", Metric = "energy", Direction = "in" }),
+        };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+        var cache = new FlowValueCache();
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/discharge", "12.5", DateTime.UtcNow);
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/charge", "4.0", DateTime.UtcNow);
+
+        Assert.True(cache.TryGetValue("battery", "energy", out var discharge));     // the supply value the roll-up reads
+        Assert.Equal(12.5, discharge);
+        Assert.True(cache.TryGetValue("battery", FlowMetricKey.For("energy", "in"), out var charge));
+        Assert.Equal(4.0, charge);
+    }
+
+    [Theory]
+    [InlineData("energy", "out", "energy")]
+    [InlineData("energy", "in", "energy#in")]
+    [InlineData("energy", null, "energy")]        // default is out
+    [InlineData("energy", "IN", "energy#in")]     // case-insensitive
+    public void FlowMetricKey_SuffixesOnlyTheInDirection(string metric, string? direction, string expected)
+        => Assert.Equal(expected, FlowMetricKey.For(metric, direction));
+
     [Theory]
     [InlineData("realpower", "kW", 1000)]        // 1 kW -> 1000 W
     [InlineData("energy", "Wh", 0.001)]          // 1 Wh -> 0.001 kWh

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -674,6 +674,24 @@ public class FlowGraphTests
         var root = FlowExport.DiscoveryDocument(new FlowNode("grid_power", "Grid", "node"), null, "t", "kWh", "W", null);
         Assert.Null(root["device"]!["via_device"]);
         Assert.Null(root["availability_topic"]);
+
+        // No energy_in sensor unless the node is bidirectional.
+        Assert.False(doc["components"]!.AsObject().ContainsKey("energyflow_outlet_rack_pdu_10_energy_in"));
+    }
+
+    [Fact]
+    public void FlowExport_DiscoveryDocument_AddsEnergyInSensor_ForABidirectionalNode()
+    {
+        // A battery/grid node exposes its in-direction (charge/export) energy as a second total_increasing
+        // sensor, whose unique_id matches EnergyInUniqueId so the dashboard sync can resolve it to stat_energy_to.
+        var doc = FlowExport.DiscoveryDocument(new FlowNode("battery", "Battery", "battery"),
+            null, "rpdu2mqtt/energyflow/battery", "kWh", "W", null, includeEnergyIn: true);
+
+        var energyIn = doc["components"]!["energyflow_battery_energy_in"]!;
+        Assert.Equal(FlowExport.EnergyInUniqueId("battery"), (string?)energyIn["unique_id"]);
+        Assert.Equal("energy", (string?)energyIn["device_class"]);
+        Assert.Equal("total_increasing", (string?)energyIn["state_class"]);
+        Assert.Equal("{{ value_json.energy_in }}", (string?)energyIn["value_template"]);
     }
 
     [Fact]


### PR DESCRIPTION
Slice B of the "simplify for Home Assistant" energy work — the follow-up #248's `In` resolver was already waiting for.

## The problem #248 left open
#248 maps the grid/solar/battery buckets, but battery **charge** and grid **export** (`stat_energy_to` / `flow_to`) had no statistic to point at. Worse, the ingest keyed every reading by `(node, metric)`, so a battery's charge and discharge energy both landed on `(battery, "energy")` — **one silently overwrote the other**.

## Fix: a direction-qualified cache key
An in-direction reading is stored under `FlowMetricKey` — `energy` stays `energy` (the supply/out value), the in side becomes `energy#in`:

- The **out** value the whole flow roll-up reads is untouched — diagram and existing exports don't change.
- The **in** value survives alongside it. Being a non-metric key, it's skipped by the grain measurement sink (`Metrics.TryParse` fails), so **charge/export stay out of the power flow** — they're a separate quantity, not a fabricated reverse leg on the Sankey.
- The exporter reads it and publishes an `energy_in` payload field plus a second `total_increasing` HA sensor `energyflow_<id>_energy_in` for any node that declares an in-direction `energy` source. Its unique_id is exactly what #248 resolves to `stat_energy_to` / `flow_to`.

Both the **MQTT and Modbus** ingests store and prune under the directional key.

## Accuracy
Absent or stale in-value → the `energy_in` field is `null` and HA's sensor reads **unavailable**, never a fabricated `0`. Same rule as the rest of the flow.

## End-to-end, now complete
`charge/discharge source (Direction in/out)` → ingest keeps them separate → exporter publishes `energyflow_<id>_energy` + `_energy_in` → HA creates both sensors → #248's sync maps battery `from`/`to` and grid `flow_from`/`flow_to`. **Battery and grid now fully populate HA's Energy Dashboard.**

## Verification
- Ingest keeps in/out separate (regression test for the collision); `FlowMetricKey` suffix rules; discovery emits the `_energy_in` sensor only for a bidirectional node with the resolvable unique_id.
- 391 tests pass. No config-model change (Direction shipped in #248), so no CRD churn.

Roadmap: next is **C** — the guided "Energy System" editor + the visual overview tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)