### PR TITLE
fix(flow): a mid-chain node reading 0 W no longer detaches the graph below it

### DIFF
--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -120,12 +120,19 @@ public static class FlowGraphBuilder
         // Custom directed links (From feeds To) plus legacy Parents (parent feeds child) — only when both
         // endpoints are known nodes. A node may gather several feeders (multi-parent) and a producer is
         // simply a link pointing into what it powers (e.g. solar → inverter).
+        // Track which edges the user wired by hand: unlike the auto PDU → outlet links, these must stay on
+        // the diagram even when their computed flow is zero, so the topology someone deliberately drew (e.g.
+        // Solar → inverter → GridBoss) always renders as a connected chain — a mid-chain node that happens to
+        // read 0 W must not silently detach everything downstream of it.
+        var wiredEdges = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        static string EdgeKey(string from, string to) => from + "␟" + to;
         foreach (var l in flow.Links)
             if (!string.IsNullOrEmpty(l.From) && !string.IsNullOrEmpty(l.To) && label.ContainsKey(l.From) && label.ContainsKey(l.To))
-                AddEdgeSafe(l.From, l.To);
+                if (AddEdgeSafe(l.From, l.To)) wiredEdges.Add(EdgeKey(l.From, l.To));
         foreach (var (child, parent) in flow.Parents)
             if (!string.IsNullOrEmpty(child) && !string.IsNullOrEmpty(parent) && label.ContainsKey(child) && label.ContainsKey(parent))
-                AddEdgeSafe(parent, child);
+                if (AddEdgeSafe(parent, child)) wiredEdges.Add(EdgeKey(parent, child));
+        bool Wired(string from, string to) => wiredEdges.Contains(EdgeKey(from, to));
 
         // Which feeders point into each node — used to split a node's demand across them (so a node
         // reachable by several paths isn't counted multiple times) and, crucially, to let measured feeders
@@ -267,9 +274,15 @@ public static class FlowGraphBuilder
                 var known = Knowable(from, to);
                 var value = known ? EdgeFlow(from, to, new HashSet<string>(StringComparer.OrdinalIgnoreCase)) : 0;
 
-                // A known-but-zero link carries nothing and is left off the diagram, as before. An *unknown*
-                // link is kept — it draws as "no data" rather than implying zero flow.
-                if (known && value <= 0) continue;
+                // A known-but-zero link is normally left off the diagram (an idle outlet, or a pure source
+                // generating nothing — solar at night correctly drops out). But when the zero sits on a link
+                // the user wired *out of a node that itself has incoming flow*, dropping it would detach the
+                // whole chain below a mid-chain node that happens to read 0 W (e.g. an inverter whose "load"
+                // register is 0 while its PV feeds straight through to the grid). Keep those, so the wired
+                // topology always renders — the zero just draws as a hairline — while a zero-producing source
+                // still drops as before.
+                var passThroughZero = Wired(from, to) && incoming.TryGetValue(from, out var upstream) && upstream.Count > 0;
+                if (known && value <= 0 && !passThroughZero) continue;
 
                 links.Add(new FlowLink(from, to, value, known));
             }

--- a/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
+++ b/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
@@ -458,6 +458,35 @@ public class EnergyFlowMqttSourceTests
     }
 
     [Fact]
+    public void Build_MidChainNodeReadingZero_KeepsTheWiredLink_SoDownstreamStaysConnected()
+    {
+        // A real setup: Solar (PV) → inverter → GridBoss, a live source bound to each. The inverter's "load
+        // output" register reads 0 (its PV feeds straight through to the grid), which used to zero the
+        // inverter→gridboss link and drop it — detaching GridBoss into a root and breaking the wired chain.
+        var data = OnePdu(Outlet(0, "Load", "realpower", "100"));
+        var flow = new EnergyFlowConfig();
+        flow.Nodes.Add(new EnergyFlowNode { Id = "solar", Label = "Solar" });
+        flow.Nodes.Add(new EnergyFlowNode { Id = "inverter", Label = "Inverter" });
+        flow.Nodes.Add(new EnergyFlowNode { Id = "gridboss", Label = "GridBoss" });
+        flow.Links.Add(new EnergyFlowLink { From = "solar", To = "inverter" });
+        flow.Links.Add(new EnergyFlowLink { From = "inverter", To = "gridboss" });
+        flow.Links.Add(new EnergyFlowLink { From = "gridboss", To = "outlet:pdu1:0" });
+
+        var live = new FakeLive().Set("solar", "realpower", 4916).Set("inverter", "realpower", 0).Set("gridboss", "realpower", 3322);
+        var graph = FlowGraphBuilder.Build(data, flow, "realpower", live);
+
+        // The wired inverter→gridboss link survives (a hairline 0), so GridBoss keeps its feeder and the chain
+        // renders solar → inverter → gridboss instead of GridBoss floating off as a root.
+        var link = Assert.Single(graph.Links, l => l.Source == "inverter" && l.Target == "gridboss");
+        Assert.Equal(0, link.Value);
+        Assert.True(link.Known);
+        // Contrast: a *pure* zero-producing source (no inflow) still drops — solar reading 0 has no link.
+        var night = FlowGraphBuilder.Build(data, flow, "realpower",
+            new FakeLive().Set("solar", "realpower", 0).Set("inverter", "realpower", 0).Set("gridboss", "realpower", 3322));
+        Assert.DoesNotContain(night.Links, l => l.Source == "solar");
+    }
+
+    [Fact]
     public void Build_WithoutALiveSourceIsUnchanged()
     {
         var data = OnePdu(Outlet(0, "Load", "realpower", "100"));


### PR DESCRIPTION
## What you saw
You wired **MPPT → Solar → FlexBoss → GridBoss**, but the Sankey showed **GridBoss as a detached root** feeding the panel, with Solar dead-ending — the chain wasn't reflected.

## Why
The builder drops known-**zero** links, which is correct for a pure source (solar at night generates nothing and should drop out). But your FlexBoss inverter has a live source bound to it that reads **0 W** — its "load output" register is 0 because the PV feeds straight through to the grid. So `FlexBoss → GridBoss` computed to 0, got dropped, and **GridBoss detached into a root**. Every mid-chain node reading 0 broke the chain there.

## Fix
A zero link is now **kept when it was wired by hand AND its source node itself has an incoming feeder** — i.e. a genuine pass-through, not a pure source. So:
- `Solar → inverter → GridBoss` stays connected (the inverter has inflow, so its 0-out link is kept as a hairline and GridBoss keeps its feeder).
- `Solar (at night, 0 W)` with no inflow still drops exactly as before.

The accuracy rules are untouched — every existing no-fabrication test passes, plus a new test for this exact chain. 393 tests green. Backend-only, no CRD/GUI change.

## Also worth doing on your side
The flow *values* will still look lopsided because a 0-reading register is bound to the inverter (4.9 kW flows in, 0 flows out). For the cleanest series chart, either leave the pass-through nodes (inverter/GridBoss) **unmeasured** so the upstream flow carries through them, or bind them to a register that reflects throughput rather than local load. Either way, the topology now renders connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)