### PR TITLE
fix(gui,api): raise Kestrel header limit so a fat cookie jar doesn't 431

### DIFF
--- a/rPDU2MQTT.Api/ApiService.cs
+++ b/rPDU2MQTT.Api/ApiService.cs
@@ -49,6 +49,8 @@ public sealed class ApiService : IHostedService, IAsyncDisposable
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = Array.Empty<string>() });
         builder.Logging.ClearProviders();
         builder.WebHost.UseUrls($"http://*:{cfg.Api.Port}");
+        // Match the GUI: don't 431 on a large cookie jar carried across sibling subdomains (default is 32 KB).
+        builder.WebHost.ConfigureKestrel(k => k.Limits.MaxRequestHeadersTotalSize = 64 * 1024);
         builder.Services.AddOpenApi();
 
         app = builder.Build();

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -127,6 +127,10 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = Array.Empty<string>() });
         builder.Logging.ClearProviders();
         builder.WebHost.UseUrls($"http://*:{gui.Port}");
+        // Kestrel's default 32 KB request-header cap returns 431 once cookies pile up — OIDC session/nonce
+        // cookies, plus anything set across sibling *.<domain> subdomains that all get sent here. Give it room
+        // so a browser carrying a fat cookie jar can still reach the GUI.
+        builder.WebHost.ConfigureKestrel(k => k.Limits.MaxRequestHeadersTotalSize = 64 * 1024);
 
         if (UseOidc)
             ConfigureOidc(builder, gui.Oidc);


### PR DESCRIPTION
## The 431 you hit
The GUI at `pdu.kube.xtremeownage.com` returned **431 Request Header Fields Too Large**. I traced the routing: the GUI is served by the app's own **Kestrel** host (with OIDC), fronted by **Cilium's Gateway API** (`main-gateway` in the `cilium` namespace) — no nginx, so proxy-buffer annotations don't apply.

Kestrel's default request-header cap is **32 KB**. A browser carrying OIDC session/nonce cookies *plus* everything set across your sibling `*.kube.xtremeownage.com` subdomains easily exceeds that, and Kestrel rejects the request before the page loads. Kestrel (32 KB) trips **before** Envoy (60 KB), so the app is the bottleneck.

## Fix
Raise `MaxRequestHeadersTotalSize` to **64 KB** on both the GUI and API Kestrel hosts. That's above the gateway's own 60 KB ceiling, so the app is no longer the limiting factor. Ships in the image → deploys via your normal GitOps sync, no cluster change.

## If it somehow persists after deploy
Then headers exceed even 60 KB and it's the **gateway** (Cilium/Envoy) rejecting them — that's a `max_request_headers_kb` tune on `main-gateway`, cluster-side. But 32 KB is far and away the likeliest culprit, and clearing cookies for the domain is the instant workaround in the meantime.

393 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)