### PR TITLE
fix(gui): clicking a group node on the flow map now expands it

### DIFF
--- a/rPDU2MQTT.Web/web/src/helpers.ts
+++ b/rPDU2MQTT.Web/web/src/helpers.ts
@@ -105,16 +105,24 @@ export function attachZoom(scroll: any, svg: any, baseW: number, baseH: number, 
   const cleanups = [() => scroll.removeEventListener('wheel', onWheel)];
 
   if (pan) {
-    let dragging = false, sx = 0, sy = 0, sl = 0, st = 0;
+    // `armed` on press, but only actually pan once the pointer passes a small threshold. Without that, a plain
+    // click nudged the scroll by a pixel, moved the target out from under the cursor, and the browser dropped
+    // the click — so clickable nodes (expand a group) never fired.
+    let armed = false, panning = false, sx = 0, sy = 0, sl = 0, st = 0;
     scroll.style.cursor = 'grab';
     const onDown = (e: any) => {
       if (e.button !== 0) return;
-      dragging = true; sx = e.clientX; sy = e.clientY; sl = scroll.scrollLeft; st = scroll.scrollTop;
-      scroll.style.cursor = 'grabbing';
+      armed = true; panning = false; sx = e.clientX; sy = e.clientY; sl = scroll.scrollLeft; st = scroll.scrollTop;
     };
     // Track on window so a drag that runs past the container edge keeps panning until release.
-    const onMove = (e: any) => { if (!dragging) return; scroll.scrollLeft = sl - (e.clientX - sx); scroll.scrollTop = st - (e.clientY - sy); };
-    const onUp = () => { if (!dragging) return; dragging = false; scroll.style.cursor = 'grab'; };
+    const onMove = (e: any) => {
+      if (!armed) return;
+      const dx = e.clientX - sx, dy = e.clientY - sy;
+      if (!panning && Math.hypot(dx, dy) < 4) return;   // still within click tolerance — leave the click alone
+      panning = true; scroll.style.cursor = 'grabbing';
+      scroll.scrollLeft = sl - dx; scroll.scrollTop = st - dy;
+    };
+    const onUp = () => { if (!armed) return; armed = false; if (panning) { panning = false; scroll.style.cursor = 'grab'; } };
     scroll.addEventListener('pointerdown', onDown);
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1150,10 +1150,12 @@ export function addFlowSection(nav: any, sections: any) {
       s.outOff += h; t.inOff += h;
     });
 
-    // Each member node -> its group, so a group reads like a node: click the collapsed group node to expand
-    // it, or click any of its expanded members to fold it back — the toggles above stay as an alternative.
+    // A group reads like a node: click the group node to toggle it, or click any expanded member to fold it
+    // back — the toggles above stay as an alternative. memberGroup maps a member to its group; groupById maps
+    // a group's id (including an anchor group, whose id is a real node) so the anchor toggles either way.
     const memberGroup: Record<string, any> = {};
-    flowGroups().forEach((g: any) => (g.Members || []).forEach((m: string) => { memberGroup[m] = g; }));
+    const groupById: Record<string, any> = {};
+    flowGroups().forEach((g: any) => { groupById[g.Id] = g; (g.Members || []).forEach((m: string) => { memberGroup[m] = g; }); });
 
     // Nodes + labels (to the right of each node, vertically centered; a bg halo keeps them legible
     // where they cross a ribbon).
@@ -1180,14 +1182,16 @@ export function addFlowSection(nav: any, sections: any) {
       }
       svg.appendChild(lab);
 
-      // Group node (collapsed) or a member of one (expanded): make the node itself the expand/collapse control.
-      const grp = n.group ? n : memberGroup[n.id];
+      // Group node (collapsed), an anchor node (expanded), or a member: make the node the expand/collapse control.
+      const grp = n.group ? n : (memberGroup[n.id] || groupById[n.id]);
       if (grp) {
         const gid = n.group ? n.id : grp.Id;
         const toggle = () => { collapsedGroups.has(gid) ? collapsedGroups.delete(gid) : collapsedGroups.add(gid); redrawBoth(); };
         [rect, lab].forEach(elm => { elm.style.cursor = 'pointer'; elm.addEventListener('click', toggle); });
         const hint = svgEl('title');
-        hint.textContent = n.group ? `“${n.label}” groups ${(grp.Members || []).length} node(s) — click to expand` : `In group “${grp.Label || grp.Id}” — click to collapse`;
+        hint.textContent = n.group ? `“${n.label}” groups ${(grp.Members || []).length} node(s) — click to expand`
+          : grp.Id === n.id ? `Group of ${(grp.Members || []).length} node(s) — click to collapse`
+          : `In group “${grp.Label || grp.Id}” — click to collapse`;
         rect.appendChild(hint);
         if (n.group) lab.textContent = '▸ ' + lab.textContent;   // an affordance that this node opens up
       }

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -111,16 +111,24 @@ function attachZoom(scroll     , svg     , baseW        , baseH        , pan = f
   const cleanups = [() => scroll.removeEventListener('wheel', onWheel)];
 
   if (pan) {
-    let dragging = false, sx = 0, sy = 0, sl = 0, st = 0;
+    // `armed` on press, but only actually pan once the pointer passes a small threshold. Without that, a plain
+    // click nudged the scroll by a pixel, moved the target out from under the cursor, and the browser dropped
+    // the click — so clickable nodes (expand a group) never fired.
+    let armed = false, panning = false, sx = 0, sy = 0, sl = 0, st = 0;
     scroll.style.cursor = 'grab';
     const onDown = (e     ) => {
       if (e.button !== 0) return;
-      dragging = true; sx = e.clientX; sy = e.clientY; sl = scroll.scrollLeft; st = scroll.scrollTop;
-      scroll.style.cursor = 'grabbing';
+      armed = true; panning = false; sx = e.clientX; sy = e.clientY; sl = scroll.scrollLeft; st = scroll.scrollTop;
     };
     // Track on window so a drag that runs past the container edge keeps panning until release.
-    const onMove = (e     ) => { if (!dragging) return; scroll.scrollLeft = sl - (e.clientX - sx); scroll.scrollTop = st - (e.clientY - sy); };
-    const onUp = () => { if (!dragging) return; dragging = false; scroll.style.cursor = 'grab'; };
+    const onMove = (e     ) => {
+      if (!armed) return;
+      const dx = e.clientX - sx, dy = e.clientY - sy;
+      if (!panning && Math.hypot(dx, dy) < 4) return;   // still within click tolerance — leave the click alone
+      panning = true; scroll.style.cursor = 'grabbing';
+      scroll.scrollLeft = sl - dx; scroll.scrollTop = st - dy;
+    };
+    const onUp = () => { if (!armed) return; armed = false; if (panning) { panning = false; scroll.style.cursor = 'grab'; } };
     scroll.addEventListener('pointerdown', onDown);
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
@@ -2032,10 +2040,12 @@ function addFlowSection(nav     , sections     ) {
       s.outOff += h; t.inOff += h;
     });
 
-    // Each member node -> its group, so a group reads like a node: click the collapsed group node to expand
-    // it, or click any of its expanded members to fold it back — the toggles above stay as an alternative.
+    // A group reads like a node: click the group node to toggle it, or click any expanded member to fold it
+    // back — the toggles above stay as an alternative. memberGroup maps a member to its group; groupById maps
+    // a group's id (including an anchor group, whose id is a real node) so the anchor toggles either way.
     const memberGroup                      = {};
-    flowGroups().forEach((g     ) => (g.Members || []).forEach((m        ) => { memberGroup[m] = g; }));
+    const groupById                      = {};
+    flowGroups().forEach((g     ) => { groupById[g.Id] = g; (g.Members || []).forEach((m        ) => { memberGroup[m] = g; }); });
 
     // Nodes + labels (to the right of each node, vertically centered; a bg halo keeps them legible
     // where they cross a ribbon).
@@ -2062,14 +2072,16 @@ function addFlowSection(nav     , sections     ) {
       }
       svg.appendChild(lab);
 
-      // Group node (collapsed) or a member of one (expanded): make the node itself the expand/collapse control.
-      const grp = n.group ? n : memberGroup[n.id];
+      // Group node (collapsed), an anchor node (expanded), or a member: make the node the expand/collapse control.
+      const grp = n.group ? n : (memberGroup[n.id] || groupById[n.id]);
       if (grp) {
         const gid = n.group ? n.id : grp.Id;
         const toggle = () => { collapsedGroups.has(gid) ? collapsedGroups.delete(gid) : collapsedGroups.add(gid); redrawBoth(); };
         [rect, lab].forEach(elm => { elm.style.cursor = 'pointer'; elm.addEventListener('click', toggle); });
         const hint = svgEl('title');
-        hint.textContent = n.group ? `“${n.label}” groups ${(grp.Members || []).length} node(s) — click to expand` : `In group “${grp.Label || grp.Id}” — click to collapse`;
+        hint.textContent = n.group ? `“${n.label}” groups ${(grp.Members || []).length} node(s) — click to expand`
+          : grp.Id === n.id ? `Group of ${(grp.Members || []).length} node(s) — click to collapse`
+          : `In group “${grp.Label || grp.Id}” — click to collapse`;
         rect.appendChild(hint);
         if (n.group) lab.textContent = '▸ ' + lab.textContent;   // an affordance that this node opens up
       }


### PR DESCRIPTION
## The bug
Clicking the collapsed **▸ Solar (PV)** group node did nothing.

Cause: the Sankey's drag-to-pan (added in #254) engaged on *any* pointer-down with no movement threshold. So a plain click nudged the scroll by a pixel, which shifted the SVG (and the label you clicked) out from under the cursor — and the browser then suppressed the `click` event. The editor's pan already had a threshold, which is why its node clicks worked and the Sankey's didn't.

## Fix
- Pan now engages only past a **~4px threshold** (same as the editor). A click that doesn't move the pointer no longer scrolls, so the `click` fires and the group expands/collapses.
- Bonus: a group's **anchor node** is now clickable to toggle whether it's collapsed *or* expanded (previously you could only collapse by clicking a member). So "click Solar PV to open/close its MPPTs" works from the node itself both ways.

GUI build + smoke pass. No backend change.

_(For context, the "Solar (PV) · 0 W" in your screenshot is correct data — the whole PV/inverter/battery side is reading 0 there while Grid→GridBoss carries 7 kW, i.e. no sun. Once it's producing, the collapsed group will show Solar PV's own figure.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)