### PR TITLE
feat(ha): keep grid/solar/battery/inverter out of the Energy Dashboard device list

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -207,6 +207,11 @@ spec:
                       EnergyMeasurementType:
                         type: string
                         description: Measurement type holding each entity's cumulative energy (kWh) — used to find the Energy Dashboard stat for each tier.
+                      ExcludeDeviceKinds:
+                        type: array
+                        items:
+                          type: string
+                        description: "Node kinds to leave OUT of the Energy Dashboard's individual-devices list (they're sources/storage/pass-through, shown as the dashboard's grid/solar/battery sources instead). Default: grid, solar, battery, inverter. Empty list = export every tier."
                     description: Auto-configure Home Assistant's Energy Dashboard 'devices' (with upstream relationships) from the energy-flow hierarchy, via HA's WebSocket API.
                 description: Home Assistant Configuration
               Overrides:

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -207,6 +207,11 @@ spec:
                       EnergyMeasurementType:
                         type: string
                         description: Measurement type holding each entity's cumulative energy (kWh) — used to find the Energy Dashboard stat for each tier.
+                      ExcludeDeviceKinds:
+                        type: array
+                        items:
+                          type: string
+                        description: "Node kinds to leave OUT of the Energy Dashboard's individual-devices list (they're sources/storage/pass-through, shown as the dashboard's grid/solar/battery sources instead). Default: grid, solar, battery, inverter. Empty list = export every tier."
                     description: Auto-configure Home Assistant's Energy Dashboard 'devices' (with upstream relationships) from the energy-flow hierarchy, via HA's WebSocket API.
                 description: Home Assistant Configuration
               Overrides:

--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -30,15 +30,23 @@ public enum EnergyDirection
 /// </summary>
 public static class EnergyDashboardSync
 {
-    public static List<HaDeviceConsumption> BuildDeviceConsumption(FlowGraph graph, Func<string, string?> statFor)
+    public static List<HaDeviceConsumption> BuildDeviceConsumption(FlowGraph graph, Func<string, string?> statFor,
+        IReadOnlyCollection<string>? excludeKinds = null)
     {
+        var excluded = excludeKinds is { Count: > 0 }
+            ? new HashSet<string>(excludeKinds, StringComparer.OrdinalIgnoreCase)
+            : null;
         var entries = new List<HaDeviceConsumption>();
         foreach (var node in graph.Nodes)
         {
+            // Sources/storage/pass-through (grid, solar, battery, inverter) aren't "device consumption" — they
+            // clutter the list and double-count against the dashboard's own grid/solar/battery buckets.
+            if (excluded is not null && excluded.Contains(node.Kind ?? "node"))
+                continue;
             var stat = statFor(node.Id);
             if (string.IsNullOrEmpty(stat))
                 continue;   // no energy sensor for this tier -> can't be an Energy-Dashboard device
-            entries.Add(new HaDeviceConsumption(stat, NearestAncestorStat(graph, node.Id, statFor), node.Label));
+            entries.Add(new HaDeviceConsumption(stat, NearestAncestorStat(graph, node.Id, statFor, excluded), node.Label));
         }
         return entries;
     }
@@ -104,10 +112,12 @@ public static class EnergyDashboardSync
                 }
     }
 
-    // Walk up the primary-feeder chain to the first ancestor that has an energy stat (skipping tiers that
-    // don't), so the upstream link stays valid even when an intermediate tier has no energy sensor.
-    private static string? NearestAncestorStat(FlowGraph graph, string id, Func<string, string?> statFor)
+    // Walk up the primary-feeder chain to the first ancestor that has an energy stat AND is itself a device
+    // (not an excluded source/storage tier), so a device's included_in_stat never points at a tier we left out
+    // of the list — and the link still spans intermediate tiers that have no sensor.
+    private static string? NearestAncestorStat(FlowGraph graph, string id, Func<string, string?> statFor, ISet<string>? excluded = null)
     {
+        var kindOf = graph.Nodes.ToDictionary(n => n.Id, n => n.Kind ?? "node", StringComparer.OrdinalIgnoreCase);
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { id };
         var current = id;
         while (true)
@@ -118,8 +128,9 @@ public static class EnergyDashboardSync
             var parent = parents[0];        // HA upstream is single-parent: follow the primary feeder
             if (!seen.Add(parent))
                 return null;                // cycle guard
+            var isExcluded = excluded is not null && excluded.Contains(kindOf.TryGetValue(parent, out var k) ? k : "node");
             var stat = statFor(parent);
-            if (!string.IsNullOrEmpty(stat))
+            if (!string.IsNullOrEmpty(stat) && !isExcluded)
                 return stat;
             current = parent;
         }

--- a/rPDU2MQTT.Core/Models/Config/HomeAssistantConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/HomeAssistantConfig.cs
@@ -84,4 +84,13 @@ public class HomeAssistantEnergyDashboardConfig
     [DefaultValue("energy")]
     [Description("Measurement type holding each entity's cumulative energy (kWh) — used to find the Energy Dashboard stat for each tier.")]
     public string EnergyMeasurementType { get; set; } = "energy";
+
+    /// <summary>
+    /// Node kinds kept OUT of the Energy Dashboard's "individual devices" list (#energy-rollup). Sources and
+    /// storage — grid, solar, battery — belong in the dashboard's own grid/solar/battery buckets (synced
+    /// separately), and an inverter is a pass-through, not a consumer; listing them as devices double-counts
+    /// and clutters. Defaults to those roles; set to an empty list to export every tier as a device.
+    /// </summary>
+    [Description("Node kinds to leave OUT of the Energy Dashboard's individual-devices list (they're sources/storage/pass-through, shown as the dashboard's grid/solar/battery sources instead). Default: grid, solar, battery, inverter. Empty list = export every tier.")]
+    public List<string> ExcludeDeviceKinds { get; set; } = new() { "grid", "solar", "battery", "inverter" };
 }

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -36,7 +36,9 @@ public sealed class HaEnergyDashboardSync
     /// tiers whose sensor isn't in HA are skipped and their children link to the nearest ancestor that is —
     /// giving HA the full Grid → Panel → Circuit → PDU → outlet chain.
     /// </summary>
-    public List<HaDeviceConsumption> BuildDevices(IReadOnlyDictionary<string, string> entityByUniqueId)
+    /// <param name="excludeKinds">Node kinds to leave out; pass null to build the full set of tiers we manage
+    /// (used by the sync to retire devices we exported before an exclusion was added).</param>
+    public List<HaDeviceConsumption> BuildDevices(IReadOnlyDictionary<string, string> entityByUniqueId, IReadOnlyCollection<string>? excludeKinds)
     {
         var merged = new PduData();
         foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
@@ -51,7 +53,7 @@ public sealed class HaEnergyDashboardSync
             var uid = native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id);
             return entityByUniqueId.TryGetValue(uid, out var e) ? e : null;
         };
-        return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver);
+        return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver, excludeKinds);
     }
 
     /// <summary>
@@ -89,14 +91,18 @@ public sealed class HaEnergyDashboardSync
             if ((string?)e?["unique_id"] is { Length: > 0 } uid && (string?)e?["entity_id"] is { Length: > 0 } eid)
                 entityByUniqueId[uid] = eid;
 
-        var devices = BuildDevices(entityByUniqueId);
+        var devices = BuildDevices(entityByUniqueId, config.HASS.EnergyDashboard.ExcludeDeviceKinds);
         var prefs = (await call("energy/get_prefs", null))?["result"]?.AsObject()
             ?? throw new Exception("Could not read HA energy preferences.");
 
-        var ours = devices.Select(d => d.stat_consumption).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        // "Managed" is every tier we *could* export (no exclusion). Dropping all of it before re-adding the
+        // kept devices means a tier we exported before an exclusion was configured (a grid/battery/inverter)
+        // is retired on the next sync, not left orphaned — while the user's own devices (never in this set)
+        // stay put.
+        var managed = BuildDevices(entityByUniqueId, null).Select(d => d.stat_consumption).ToHashSet(StringComparer.OrdinalIgnoreCase);
         var keep = new JsonArray();
         foreach (var existingDevice in prefs["device_consumption"]?.AsArray() ?? new JsonArray())
-            if (existingDevice is JsonObject o && !ours.Contains((string?)o["stat_consumption"] ?? ""))
+            if (existingDevice is JsonObject o && !managed.Contains((string?)o["stat_consumption"] ?? ""))
                 keep.Add(o.DeepClone());
         foreach (var d in devices)
             keep.Add(JsonSerializer.SerializeToNode(d, Json)!);

--- a/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
+++ b/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
@@ -80,6 +80,42 @@ public class EnergyDashboardSourcesTests
     }
 
     [Fact]
+    public void DeviceConsumption_ExcludesSourceAndStorageKinds()
+    {
+        // grid/solar/battery/inverter belong in the dashboard's own buckets, not the individual-devices list.
+        var graph = Graph(
+            new FlowNode("grid", "Grid", "grid"),
+            new FlowNode("batt", "Battery", "battery"),
+            new FlowNode("inv", "Inverter", "inverter"),
+            new FlowNode("rack", "Rack PDU", "pdu"),
+            new FlowNode("srv", "Server", "outlet"));
+        string? stat(string id) => "sensor." + id + "_energy";   // everything has an energy stat
+
+        var all = EnergyDashboardSync.BuildDeviceConsumption(graph, stat);
+        Assert.Equal(5, all.Count);   // no exclusion -> every tier
+
+        var filtered = EnergyDashboardSync.BuildDeviceConsumption(graph, stat, new[] { "grid", "solar", "battery", "inverter" });
+        Assert.Equal(new[] { "sensor.rack_energy", "sensor.srv_energy" },
+            filtered.Select(d => d.stat_consumption).OrderBy(x => x).ToArray());
+    }
+
+    [Fact]
+    public void DeviceConsumption_IncludedInStat_SkipsAnExcludedAncestor()
+    {
+        // A server behind an excluded inverter should link upstream to the next *kept* ancestor, not the
+        // inverter (which is no longer a device) — else included_in_stat dangles.
+        var graph = new FlowGraph(
+            new[] { new FlowNode("panel", "Panel", "panel"), new FlowNode("inv", "Inverter", "inverter"), new FlowNode("srv", "Server", "outlet") },
+            new[] { new FlowLink("panel", "inv", 100), new FlowLink("inv", "srv", 100) },
+            "realpower", "W");
+        string? stat(string id) => "sensor." + id + "_energy";
+
+        var srv = Assert.Single(EnergyDashboardSync.BuildDeviceConsumption(graph, stat, new[] { "inverter" }),
+            d => d.stat_consumption == "sensor.srv_energy");
+        Assert.Equal("sensor.panel_energy", srv.included_in_stat);   // skipped the inverter, linked to the panel
+    }
+
+    [Fact]
     public void StatsOf_ExtractsEveryReferencedEntity()
     {
         var grid = Assert.Single(EnergyDashboardSync.BuildEnergySources(


### PR DESCRIPTION
Your Energy Dashboard's **individual devices** list was polluted with the inverter, battery, grid, and grid-boss — and grid/solar/battery double-counted against the source buckets from #248. Those aren't "device consumption."

## Fix
New setting **`HomeAssistant.EnergyDashboard.ExcludeDeviceKinds`** (default **grid, solar, battery, inverter**) drops those node kinds from the individual-devices export:
- **grid / solar / battery** → represented as the dashboard's own grid/solar/battery **sources** (#248), not as devices.
- **inverter** → a pass-through, not a load.
- Everything else (PDUs, outlets, panels, circuits, the real loads) still exports as devices.

`included_in_stat` also skips an excluded ancestor now, so a server behind the inverter links upstream to the next *kept* tier (e.g. the panel) instead of a node that's no longer in the list.

## Cleans up existing dashboards
The sync now retires tiers it exported *before* this exclusion existed: it drops every tier it **could** manage, then re-adds only the kept ones. So on your next **Sync**, the stale **Grid / Battery / EG4 FlexBoss 21** device entries disappear — while your own hand-added devices (never in that set) stay. Set the list to empty to go back to exporting every tier.

## Verify
- Pure mapper tested: exclusion filters the right kinds; the ancestor walk skips an excluded inverter.
- 395 tests pass, CRD regenerated. The setting is editable in the GUI's HomeAssistant section.

After deploy: open the **HA Energy Mapping** page and hit **Sync** — the device list should collapse to just your real loads, with Grid/Solar/Battery living in the source buckets above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)