### PR TITLE
fix(ha): only register Energy-Dashboard entries the bridge can give kWh for

### DIFF
--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -48,8 +48,13 @@ public sealed class HaEnergyDashboardSync
         var native = FlowExport.NativeEnergyUniqueIds(merged, energyType);
 
         var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric, live);
+        var energyGraph = FlowGraphBuilder.Build(merged, config.EnergyFlow, energyType, live);
         Func<string, string?> resolver = id =>
         {
+            // Only register a tier the bridge can actually give an energy (kWh) figure for. A node with no
+            // energy behind it (power-only outlets, an unmeasured tier) would resolve to an entity HA then
+            // marks "unavailable" — clutter, not data. Same never-fabricate rule as the diagram.
+            if (!FlowExport.TryNodeValue(energyGraph, id, out _)) return null;
             var uid = native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id);
             return entityByUniqueId.TryGetValue(uid, out var e) ? e : null;
         };
@@ -71,10 +76,15 @@ public sealed class HaEnergyDashboardSync
         var energyType = string.IsNullOrWhiteSpace(config.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : config.HASS.EnergyDashboard.EnergyMeasurementType;
         var native = FlowExport.NativeEnergyUniqueIds(merged, energyType);
         var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric, live);
+        var energyGraph = FlowGraphBuilder.Build(merged, config.EnergyFlow, energyType, live);
 
         string? Resolve(string uid) => entityByUniqueId.TryGetValue(uid, out var e) ? e : null;
         return EnergyDashboardSync.BuildEnergySources(graph, (id, dir) => dir == Core.Flow.EnergyDirection.Out
-            ? Resolve(native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id))
+            // Out (production/discharge/import): only when the bridge knows this node's energy, else HA gets an
+            // unavailable stat and the whole grid/solar/battery bucket reads broken.
+            ? (FlowExport.TryNodeValue(energyGraph, id, out _)
+                ? Resolve(native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id))
+                : null)
             : Resolve(FlowExport.EnergyInUniqueId(id)));
     }
 


### PR DESCRIPTION
Explains both symptoms in your screenshots — the empty grid/solar/battery sections and the sea of ⚠️ "unavailable" devices.

## Root cause
HA's Energy Dashboard is **energy (kWh)** based. The sync registered a tier whenever its HA entity *resolved* — even if the bridge had **no kWh figure** for it (a power-only outlet, an unmeasured tier). HA then marks that entity **unavailable**, which is exactly the ⚠️ you're seeing on most devices, and why the source buckets don't light up.

## Fix
Both the device and the grid/solar/battery resolvers now gate on the **energy graph**: a tier is registered only when `TryNodeValue` finds a *known* energy value for it. Power-only outlets and unmeasured tiers drop out instead of becoming unavailable stats.

395 tests pass. Backend-only, no schema/GUI change.

## …but part of this is on the data/HA side, not code
After you deploy + **Sync**, expect:
- Devices that **do** report cumulative energy (kWh) → listed and, after HA gathers statistics (**the banner's "up to 2 hours"**), available.
- Devices that only report **power (W)** → no longer listed (we can't give HA energy for them). If you want per-outlet energy for those, HA's **Riemann-sum integration** turns a W sensor into a kWh one you can then map.
- **Grid/Solar/Battery sources** populate only when their **kWh** is bound (Nodes tab → the node's `energy` metric). **Battery needs both** a charge *and* discharge energy source, or HA can't form the battery bucket.

### Quick diagnostics in HA
1. **Developer Tools → States**: find the `sensor.energyflow_*` / native energy entities — do they have a real kWh value and `state_class: total_increasing`? If `unavailable`, the bridge isn't publishing that energy.
2. **Settings → Devices → Entities → Statistics**: confirm the entity has long-term statistics (energy dashboard only accepts those).
3. If sources are still empty right after sync, give it the 2-hour window, then re-check.

If after all that specific entities are still unavailable, it's an MQTT/publish issue for *those* energy sensors — tell me which and I'll trace the publish path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)