### PR TITLE
feat(diag): surface Modbus source health (why solar/battery/grid read null)

### DIFF
--- a/rPDU2MQTT.Grains.Abstractions/Modbus/IModbusGrain.cs
+++ b/rPDU2MQTT.Grains.Abstractions/Modbus/IModbusGrain.cs
@@ -17,6 +17,22 @@ public sealed record ModbusBinding
     [Id(8)] public int StaleAfterSeconds { get; init; } = 900;
 }
 
+/// <summary>
+/// A Modbus device's poll health, so the GUI can show whether a source (e.g. an inverter) is actually being
+/// read — the gap that made "everything's green but no data" impossible to diagnose. All times are UTC.
+/// </summary>
+[GenerateSerializer]
+public sealed record ModbusHealth
+{
+    [Id(0)] public string Key { get; init; } = "";        // host|port|unitId
+    [Id(1)] public int Bindings { get; init; }
+    [Id(2)] public DateTime? LastAttemptUtc { get; init; }
+    [Id(3)] public DateTime? LastOkUtc { get; init; }      // last poll that mapped ≥1 value
+    [Id(4)] public int LastValueCount { get; init; }       // values read on the last OK poll
+    [Id(5)] public string? LastError { get; init; }        // socket/read failure summary, or null when healthy
+    [Id(6)] public int PollIntervalSeconds { get; init; }
+}
+
 /// <summary>A device's whole configuration, pushed to the grain by the reconciler (host/port/unitId are the key).</summary>
 [GenerateSerializer]
 public sealed record ModbusDeviceConfig
@@ -42,6 +58,9 @@ public interface IModbusGrain : IGrainWithStringKey
 
     /// <summary>The most recent successful reading set from this device, or null if none yet.</summary>
     Task<MeasurementSnapshot?> Latest();
+
+    /// <summary>This device's poll health (last attempt/success, value count, last error) for the GUI.</summary>
+    Task<ModbusHealth> Health();
 
     /// <summary>The grain key for a device address.</summary>
     static string KeyFor(string host, int port, int unitId) => $"{host}|{port}|{unitId}";

--- a/rPDU2MQTT.Grains/Modbus/ModbusGrain.cs
+++ b/rPDU2MQTT.Grains/Modbus/ModbusGrain.cs
@@ -26,6 +26,10 @@ public sealed class ModbusGrain : Grain, IModbusGrain
     private MeasurementSnapshot? latest;
     private long version;
     private DateTime lastConfiguredUtc;
+    // Poll health, surfaced via Health() so the GUI can show whether the device is actually being read.
+    private DateTime? lastAttemptUtc, lastOkUtc;
+    private int lastValueCount;
+    private string? lastError;
 
     public ModbusGrain(ILogger<ModbusGrain> log) => this.log = log;
 
@@ -38,6 +42,17 @@ public sealed class ModbusGrain : Grain, IModbusGrain
     }
 
     public Task<MeasurementSnapshot?> Latest() => Task.FromResult(latest);
+
+    public Task<ModbusHealth> Health() => Task.FromResult(new ModbusHealth
+    {
+        Key = key,
+        Bindings = config?.Bindings.Count ?? 0,
+        LastAttemptUtc = lastAttemptUtc,
+        LastOkUtc = lastOkUtc,
+        LastValueCount = lastValueCount,
+        LastError = lastError,
+        PollIntervalSeconds = config?.PollIntervalSeconds ?? 0,
+    });
 
     public Task Configure(ModbusDeviceConfig cfg)
     {
@@ -68,6 +83,7 @@ public sealed class ModbusGrain : Grain, IModbusGrain
         }
 
         if (config.Bindings.Count == 0) return;
+        lastAttemptUtc = DateTime.UtcNow;
 
         var sources = config.Bindings.Select(b => new EnergyFlowSource
         {
@@ -88,6 +104,7 @@ public sealed class ModbusGrain : Grain, IModbusGrain
         // Couldn't even open the socket — the gateway/device is unreachable at host:port.
         if (!ok)
         {
+            lastError = message;
             log.LogWarning("Modbus {Key}: {Msg}", key, message);
             return;
         }
@@ -113,9 +130,18 @@ public sealed class ModbusGrain : Grain, IModbusGrain
             log.LogWarning("Modbus {Key} ({Msg}): {Fail}/{Total} register(s) failed — {Details}",
                 key, message, failures.Count, readings.Count, string.Join("; ", failures));
 
-        if (mapped.Count == 0) return;
+        if (mapped.Count == 0)
+        {
+            // Socket opened but every register read failed — the device answered but gave us nothing usable.
+            lastError = failures.Count > 0 ? $"{failures.Count} register(s) failed: {failures[0]}" : "no values read";
+            return;
+        }
 
         log.LogInformation("Modbus {Key}: read {Count} value(s) ({Msg}).", key, mapped.Count, message);
+        lastOkUtc = DateTime.UtcNow;
+        lastValueCount = mapped.Count;
+        // A partial read still counts as reachable, but keep the failure note so the GUI can show "3 of 5 read".
+        lastError = failures.Count > 0 ? $"{failures.Count} of {readings.Count} register(s) failed" : null;
         latest = new MeasurementSnapshot(key, DateTimeOffset.UtcNow, ++version, mapped);
         await GrainFactory.GetGrain<IFlowGrain>(0).Ingest(latest);
     }

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -543,12 +543,35 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                         .FirstOrDefault() ?? emonCmsStatus.Snapshot();
             }
 
+            // Modbus source health: for each configured connection, ask its device grain whether it's actually
+            // being read — so "everything's green but no inverter data" is diagnosable, instead of the failure
+            // living only in a log line while solar/battery/grid quietly read null.
+            var modbus = new List<object>();
+            foreach (var conn in config.Modbus.Connections)
+            {
+                if (!conn.Enabled || string.IsNullOrWhiteSpace(conn.Host)) continue;
+                try
+                {
+                    var h = await grains.GetGrain<Grains.Abstractions.Modbus.IModbusGrain>(
+                        Grains.Abstractions.Modbus.IModbusGrain.KeyFor(conn.Host, conn.Port, conn.UnitId)).Health();
+                    long? okAge = h.LastOkUtc is { } okAt ? (long)Math.Max(0, (DateTime.UtcNow - okAt).TotalSeconds) : null;
+                    var stale = h.LastOkUtc is null || (h.PollIntervalSeconds > 0 && okAge > Math.Max(30, h.PollIntervalSeconds * 3));
+                    modbus.Add(new
+                    {
+                        id = conn.Id, name = conn.Name ?? conn.Id, host = $"{conn.Host}:{conn.Port}", unitId = conn.UnitId,
+                        bindings = h.Bindings, values = h.LastValueCount, lastOkAgeSeconds = okAge, error = h.LastError, stale,
+                    });
+                }
+                catch { /* device grain unreachable from here — leave it off rather than guess */ }
+            }
+
             return Results.Json(new
             {
                 ok = true,
                 version = Version,
                 image = Environment.GetEnvironmentVariable("RPDU2MQTT_IMAGE"),
                 update,
+                modbus,
                 dotnet = Environment.Version.ToString(),
                 os = RuntimeInformation.OSDescription,
                 startedUtc = health.StartedUtc,

--- a/rPDU2MQTT.Web/web/src/sections/diagnostics.ts
+++ b/rPDU2MQTT.Web/web/src/sections/diagnostics.ts
@@ -95,6 +95,15 @@ export function addDiagnosticsSection(nav: any, sections: any) {
     const ds = b.dataSources || [];
     if (!ds.length) comp.appendChild(compLine('', 'PDU data — none yet' + (roles.length && !roles.includes('worker') ? ' (waiting on a worker)' : '')));
     else ds.forEach((s: any) => comp.appendChild(compLine(s.stale ? 'bad' : 'good', 'PDU data · ' + s.instance + ' — ' + (s.stale ? 'stale, ' : '') + 'updated ' + s.ageSeconds + 's ago')));
+    // Modbus sources (inverters/meters). This is where "everything's green but no solar/battery/grid data"
+    // gets diagnosed — a device that isn't answering shows red here instead of only in a log line.
+    (b.modbus || []).forEach((m: any) => {
+      const label = 'Modbus · ' + (m.name || m.id) + ' (' + (m.host || '?') + ')';
+      if (m.stale)
+        comp.appendChild(compLine('bad', label + ' — ' + (m.lastOkAgeSeconds == null ? 'no successful read yet' : 'stale, last read ' + m.lastOkAgeSeconds + 's ago') + (m.error ? ' · ' + m.error : '')));
+      else
+        comp.appendChild(compLine('good', label + ' — reading ' + m.values + ' value(s), ' + (m.lastOkAgeSeconds ?? 0) + 's ago' + (m.error ? ' · ' + m.error : '')));
+    });
     // Other role processes seen on the bus (split deployments only).
     (b.processes || []).forEach((p: any) => comp.appendChild(compLine(p.stale ? 'bad' : 'good', 'Process · ' + ((p.roles || []).join('+') || '?') + ' @ ' + (p.host || '?') + ' — ' + (p.stale ? 'last seen ' : 'alive, ') + p.ageSeconds + 's ago')));
   };

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -504,6 +504,15 @@ function addDiagnosticsSection(nav     , sections     ) {
     const ds = b.dataSources || [];
     if (!ds.length) comp.appendChild(compLine('', 'PDU data — none yet' + (roles.length && !roles.includes('worker') ? ' (waiting on a worker)' : '')));
     else ds.forEach((s     ) => comp.appendChild(compLine(s.stale ? 'bad' : 'good', 'PDU data · ' + s.instance + ' — ' + (s.stale ? 'stale, ' : '') + 'updated ' + s.ageSeconds + 's ago')));
+    // Modbus sources (inverters/meters). This is where "everything's green but no solar/battery/grid data"
+    // gets diagnosed — a device that isn't answering shows red here instead of only in a log line.
+    (b.modbus || []).forEach((m     ) => {
+      const label = 'Modbus · ' + (m.name || m.id) + ' (' + (m.host || '?') + ')';
+      if (m.stale)
+        comp.appendChild(compLine('bad', label + ' — ' + (m.lastOkAgeSeconds == null ? 'no successful read yet' : 'stale, last read ' + m.lastOkAgeSeconds + 's ago') + (m.error ? ' · ' + m.error : '')));
+      else
+        comp.appendChild(compLine('good', label + ' — reading ' + m.values + ' value(s), ' + (m.lastOkAgeSeconds ?? 0) + 's ago' + (m.error ? ' · ' + m.error : '')));
+    });
     // Other role processes seen on the bus (split deployments only).
     (b.processes || []).forEach((p     ) => comp.appendChild(compLine(p.stale ? 'bad' : 'good', 'Process · ' + ((p.roles || []).join('+') || '?') + ' @ ' + (p.host || '?') + ' — ' + (p.stale ? 'last seen ' : 'alive, ') + p.ageSeconds + 's ago')));
   };


### PR DESCRIPTION
Explains your screenshots: Status all green, grains active, PDU/MQTT/EmonCMS healthy — yet the Energy Overview shows **Solar / Battery / Grid = "NO READING YET"**.

## What's actually happening
All three of those come from your **EG4 FlexBoss over Modbus**. When that device stops answering — an inverter idling overnight, a gateway dropping its single TCP client, or register reads failing — `ModbusGrain` only wrote a **log warning**. It pushed no fresh values, so the flow grain's solar/battery/grid went stale → null → "NO READING YET". And there was **no Modbus card anywhere**, so everything else looked green and the real culprit was invisible.

## Fix: make Modbus health visible
- `ModbusGrain` now tracks poll health — last attempt, last **successful** read, value count, and the last error (socket unreachable / N registers failed).
- The **Diagnostics → Components** panel now shows a line per Modbus connection:
  - 🟢 `Modbus · EG4 FlexBoss (10.x.x.x:502) — reading 12 value(s), 4s ago`
  - 🔴 `Modbus · EG4 FlexBoss (…) — stale, last read 900s ago · could not connect` / `no successful read yet`

So "green everywhere but no inverter data" now points straight at the device that isn't answering.

## What to check after deploy
Open **Diagnostics** — if the FlexBoss line is **red/stale**, that's your answer: the inverter/gateway isn't responding (very likely if it idles at "lights out"), so there's genuinely nothing to show — the GUI is being honest, not broken. If it's **green** but the Energy tiles are still null, tell me and I'll trace the grain→UI mirror.

395 tests pass, GUI smoke OK. No schema/CRD change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)