### PR TITLE
fix(flow): don't lock a source out of ingest after it restarts (version reset)

### DIFF
--- a/rPDU2MQTT.Grains/Flow/FlowGrain.cs
+++ b/rPDU2MQTT.Grains/Flow/FlowGrain.cs
@@ -23,8 +23,15 @@ public sealed class FlowGrain : Grain, IFlowGrain
     /// <summary>Raw leaf readings as ingested, with their staleness — the per-process sync reads these.</summary>
     private readonly FlowValueCache raw = new();
 
-    /// <summary>Last seen snapshot version per source, so a duplicate/out-of-order snapshot is ignored.</summary>
-    private readonly Dictionary<string, long> sourceVersions = new(StringComparer.Ordinal);
+    /// <summary>
+    /// Last accepted (version, time) per source, so a duplicate/out-of-order snapshot is ignored. The version
+    /// dedupes rapid in-order snapshots, but a source process's counter <b>resets to 0 when it restarts</b> —
+    /// and this grain is a singleton that can outlive that process, so a version-only guard would then reject
+    /// every post-restart snapshot forever, silently freezing that source (its node grains keep heartbeating
+    /// their last value, so the freeze is invisible in the roll-up). The wall-clock time never goes backwards
+    /// across a restart, so a snapshot that's newer by time is accepted even when its version looks stale.
+    /// </summary>
+    private readonly Dictionary<string, (long Version, DateTimeOffset At)> sourceSeen = new(StringComparer.Ordinal);
 
     /// <summary>The projection: each node's current value per metric, as its grain last published it.</summary>
     private readonly Dictionary<string, Dictionary<Metric, double>> nodes = new(StringComparer.OrdinalIgnoreCase);
@@ -37,13 +44,18 @@ public sealed class FlowGrain : Grain, IFlowGrain
 
     public async Task Ingest(MeasurementSnapshot measurements)
     {
-        // Order-tolerant per source: an older/duplicate version is ignored.
-        if (sourceVersions.TryGetValue(measurements.SourceId, out var seen) && measurements.Version <= seen)
+        // Order-tolerant per source: ignore a snapshot only when it's stale by BOTH version and wall-clock
+        // time. A post-restart snapshot has a reset (low) version but a newer timestamp, so it's accepted —
+        // otherwise a source that restarted would be locked out until its counter climbed back past the old
+        // high, which for a fast-ticking source can be a very long time (or never).
+        if (sourceSeen.TryGetValue(measurements.SourceId, out var seen)
+            && measurements.Version <= seen.Version && measurements.TimestampUtc <= seen.At)
         {
-            log.LogTrace("Flow ingest from {Source}: version {Version} <= {Seen}, ignored.", measurements.SourceId, measurements.Version, seen);
+            log.LogTrace("Flow ingest from {Source}: v{Version}@{At} not newer than v{SeenV}@{SeenAt}, ignored.",
+                measurements.SourceId, measurements.Version, measurements.TimestampUtc, seen.Version, seen.At);
             return;
         }
-        sourceVersions[measurements.SourceId] = measurements.Version;
+        sourceSeen[measurements.SourceId] = (measurements.Version, measurements.TimestampUtc);
 
         var now = DateTime.UtcNow;
         foreach (var r in measurements.Readings)

--- a/rPDU2MQTT.Tests/FlowGrainTests.cs
+++ b/rPDU2MQTT.Tests/FlowGrainTests.cs
@@ -39,10 +39,32 @@ public class FlowGrainTests
         try
         {
             var flow = cluster.GrainFactory.GetGrain<IFlowGrain>(0);
-            await flow.Ingest(new MeasurementSnapshot("s", DateTimeOffset.UtcNow, 5, new[] { new MeasurementReading("n", Metric.RealPower, 500, 900) }));
-            await flow.Ingest(new MeasurementSnapshot("s", DateTimeOffset.UtcNow, 3, new[] { new MeasurementReading("n", Metric.RealPower, 999, 900) })); // older, ignored
+            var t = DateTimeOffset.UtcNow;
+            await flow.Ingest(new MeasurementSnapshot("s", t, 5, new[] { new MeasurementReading("n", Metric.RealPower, 500, 900) }));
+            // Out-of-order within one source: a lower version created earlier (so an earlier timestamp) is ignored.
+            await flow.Ingest(new MeasurementSnapshot("s", t.AddSeconds(-1), 3, new[] { new MeasurementReading("n", Metric.RealPower, 999, 900) }));
 
             Assert.Equal(500, await flow.NodeValue("n", Metric.RealPower));
+        }
+        finally { await cluster.StopAllSilosAsync(); }
+    }
+
+    [Fact]
+    public async Task FlowGrain_AcceptsPostRestartSnapshot_WhenVersionResetButTimeAdvanced()
+    {
+        // A source process restarts: its version counter drops back to a low number, but wall-clock time has
+        // moved on. The grain (a singleton that outlived the source) must NOT reject the fresh data — the bug
+        // that silently froze MQTT after a rollout while the roll-up kept showing the last value.
+        var cluster = await GrainTestCluster.StartAsync();
+        try
+        {
+            var flow = cluster.GrainFactory.GetGrain<IFlowGrain>(0);
+            var t = DateTimeOffset.UtcNow;
+            await flow.Ingest(new MeasurementSnapshot("mqtt", t, 5000, new[] { new MeasurementReading("grid", Metric.RealPower, 500, 900) }));
+            await flow.Ingest(new MeasurementSnapshot("mqtt", t.AddSeconds(5), 1, new[] { new MeasurementReading("grid", Metric.RealPower, 2058, 900) })); // restart
+
+            Assert.Equal(2058, await flow.NodeValue("grid", Metric.RealPower));
+            Assert.Equal(2058, Assert.Single(await flow.RawValues(), r => r.NodeId == "grid").Value);
         }
         finally { await cluster.StopAllSilosAsync(); }
     }


### PR DESCRIPTION
This is the "SOMETHING is not working" bug — and your diagnostic screenshots nailed it.

## Evidence
- **Node-grain roll-up (correct):** `grid: RealPower 2058`, `gridboss: 2058`, `main_panel: 2058`.
- **Flow diagram / Energy Overview (wrong):** `Grid · no data`, `GridBoss · 0 W`, `Main Panel · 544 W` (just the PDU sum).
- **Modbus** nodes (`EG4 FlexBoss 21 · 0 W`) *do* show on the diagram; **MQTT** nodes (grid, from Solar Assistant) don't.

## Root cause
`FlowGrain.Ingest` deduped per source by a **monotonic version**: ignore any `version <= last seen`. But a source process's counter **resets to 0 when it restarts**, and `FlowGrain` is a singleton that can outlive that process. So after your rollout ("up 26m"), every post-restart MQTT snapshot (versions 1, 2, 3…) was `<=` the remembered high-water mark and **silently dropped**.

Why it looked half-working: the node grains keep heart-beating their last value, so the **roll-up stayed at 2058**, while the **raw mirror** — which the Sankey, Energy Overview, and exporters read — expired to "no data". Modbus kept flowing because its grain's version stayed continuous; MQTT froze because its worker had restarted.

## Fix
`Ingest` now tracks `(version, timestampUtc)` per source and ignores a snapshot only when it's stale by **both**. Wall-clock time never goes backwards across a restart, so a reset-version snapshot with a newer timestamp is accepted; a genuinely out-of-order snapshot (lower version *and* earlier timestamp) is still ignored. Regression test added; 396 pass.

**After deploy:** the flow diagram and Energy Overview should immediately match the roll-up (grid 2058, etc.). No re-sync or restart dance needed — it self-heals on the next MQTT message.

---
**Separately, on your battery-wiring note:** that one's your topology, not a bug — in the editor the **Battery → Solar (PV)** link should be **Battery → EG4 FlexBoss 21**. Click the ✕ on the Battery→Solar link, then drag Battery's ● port onto the EG4 FlexBoss node. (Grid looks like it feeds the inverter correctly; only Battery is routed through Solar PV.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)