### PR TITLE
fix(gui): lay hierarchy nodes next to what they feed (no more tier-skipping lines)

### DIFF
--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1287,13 +1287,26 @@ export function addFlowSection(nav: any, sections: any) {
       seen.delete(id); return colMemo[id] = c;
     };
     [...cand.keys()].forEach(id => col(id));
+    // Pull each node as far RIGHT as its nearest child allows (longest-path left-justifies every root, which
+    // leaves a feeder that skips a tier — Battery → inverter, past Solar — trailing a long line across the
+    // columns above it). A sink keeps its column; everyone else sits one step left of its earliest child, so
+    // it lands right next to what it powers. Processed children-first (descending depth); every edge still
+    // points strictly rightward because a node ends up strictly left of all its children.
+    const colX: any = {};
+    [...cand.keys()].sort((a, b) => colMemo[b] - colMemo[a]).forEach(id => {
+      const outs = outgoing[id] || [];
+      colX[id] = outs.length ? Math.max(0, Math.min(...outs.map((e: any) => colX[e.to])) - 1) : colMemo[id];
+    });
+    // Never leave an empty left margin if every node pulled off column 0.
+    const minC = Math.min(...([...cand.keys()].map(id => colX[id]) as number[]));
+    if (minC > 0) [...cand.keys()].forEach(id => { colX[id] -= minC; });
     // Would adding from→to create a loop? (can `to` already reach `from`?)
     const reaches = (a: string, b: string) => { const stack = [a], seen = new Set(); while (stack.length) { const x = stack.pop()!; if (x === b) return true; if (seen.has(x)) continue; seen.add(x); (outgoing[x] || []).forEach((e: any) => stack.push(e.to)); } return false; };
 
     // Layout: stack each column top-to-bottom; order downstream columns by feeder barycenter.
     const padX = 22, padY = 18, rowGap = 16, step = NW + 96;
     const cols: any[] = [];
-    [...cand.keys()].forEach(id => { const c = col(id); (cols[c] = cols[c] || []).push(id); });
+    [...cand.keys()].forEach(id => { const c = colX[id]; (cols[c] = cols[c] || []).push(id); });
     const pos: any = {};
     const bary = (id: string) => { const ins = incoming[id] || []; if (!ins.length) return 1e9; let s = 0, w = 0; ins.forEach((e: any) => { const p = pos[e.from]; if (p) { s += p.y + NH / 2; w++; } }); return w ? s / w : 1e9; };
     cols.forEach((ids, c) => {

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2186,13 +2186,26 @@ function addFlowSection(nav     , sections     ) {
       seen.delete(id); return colMemo[id] = c;
     };
     [...cand.keys()].forEach(id => col(id));
+    // Pull each node as far RIGHT as its nearest child allows (longest-path left-justifies every root, which
+    // leaves a feeder that skips a tier — Battery → inverter, past Solar — trailing a long line across the
+    // columns above it). A sink keeps its column; everyone else sits one step left of its earliest child, so
+    // it lands right next to what it powers. Processed children-first (descending depth); every edge still
+    // points strictly rightward because a node ends up strictly left of all its children.
+    const colX      = {};
+    [...cand.keys()].sort((a, b) => colMemo[b] - colMemo[a]).forEach(id => {
+      const outs = outgoing[id] || [];
+      colX[id] = outs.length ? Math.max(0, Math.min(...outs.map((e     ) => colX[e.to])) - 1) : colMemo[id];
+    });
+    // Never leave an empty left margin if every node pulled off column 0.
+    const minC = Math.min(...([...cand.keys()].map(id => colX[id])            ));
+    if (minC > 0) [...cand.keys()].forEach(id => { colX[id] -= minC; });
     // Would adding from→to create a loop? (can `to` already reach `from`?)
     const reaches = (a        , b        ) => { const stack = [a], seen = new Set(); while (stack.length) { const x = stack.pop() ; if (x === b) return true; if (seen.has(x)) continue; seen.add(x); (outgoing[x] || []).forEach((e     ) => stack.push(e.to)); } return false; };
 
     // Layout: stack each column top-to-bottom; order downstream columns by feeder barycenter.
     const padX = 22, padY = 18, rowGap = 16, step = NW + 96;
     const cols        = [];
-    [...cand.keys()].forEach(id => { const c = col(id); (cols[c] = cols[c] || []).push(id); });
+    [...cand.keys()].forEach(id => { const c = colX[id]; (cols[c] = cols[c] || []).push(id); });
     const pos      = {};
     const bary = (id        ) => { const ins = incoming[id] || []; if (!ins.length) return 1e9; let s = 0, w = 0; ins.forEach((e     ) => { const p = pos[e.from]; if (p) { s += p.y + NH / 2; w++; } }); return w ? s / w : 1e9; };
     cols.forEach((ids, c) => {


### PR DESCRIPTION
Your layout complaint, not the wiring — Battery→FlexBoss is correct, it just *looked* dumb.

## Why
The editor columns nodes by **longest-path-from-root**, which left-justifies every root. So a feeder that skips a tier — **Battery → inverter, past Solar PV** — sat in column 0 while the inverter was two columns over, dragging a long connector across the nodes in between.

## Fix
Each node is now **pulled as far right as its nearest child allows** (one step left of its earliest child). So Battery and Grid land in the column **right before EG4 FlexBoss 21**, alongside Solar PV — short, clean connectors, no crossing.

- Sinks keep their column, so the overall depth (and the outlet column) is unchanged.
- Every edge still points strictly rightward (a node ends up strictly left of *all* its children).
- Columns are normalised so there's never an empty left margin.

GUI build + smoke pass. No backend change — pure layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)