### PR TITLE
fix(ha): actually retire excluded/stale devices from the Energy Dashboard

### DIFF
--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -62,6 +62,30 @@ public sealed class HaEnergyDashboardSync
     }
 
     /// <summary>
+    /// Every energy entity_id any flow tier maps to right now — ignoring the energy-known gate and the kind
+    /// exclusion. This is the full set the sync "owns" and may remove: dropping it before re-adding the kept
+    /// devices is what retires a tier once it's excluded (grid/battery/inverter) or once it stops being a
+    /// device, without ever touching an entity the user added themselves.
+    /// </summary>
+    private HashSet<string> ManagedStats(IReadOnlyDictionary<string, string> entityByUniqueId)
+    {
+        var stats = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var merged = new PduData();
+        foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
+        if (merged.Devices.Count == 0) return stats;
+
+        var energyType = string.IsNullOrWhiteSpace(config.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : config.HASS.EnergyDashboard.EnergyMeasurementType;
+        var native = FlowExport.NativeEnergyUniqueIds(merged, energyType);
+        var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric, live);
+        foreach (var node in graph.Nodes)
+        {
+            var uid = native.TryGetValue(node.Id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(node.Id);
+            if (entityByUniqueId.TryGetValue(uid, out var e)) stats.Add(e);
+        }
+        return stats;
+    }
+
+    /// <summary>
     /// The Energy-Dashboard <c>energy_sources</c> (grid/solar/battery buckets) the kind-tagged flow nodes map
     /// to — the roll-up on top of the individual-device list. Directions resolve through HA's authoritative
     /// unique_id → entity_id map (Out = the native/energyflow supply sensor; In = the energyflow return
@@ -105,11 +129,12 @@ public sealed class HaEnergyDashboardSync
         var prefs = (await call("energy/get_prefs", null))?["result"]?.AsObject()
             ?? throw new Exception("Could not read HA energy preferences.");
 
-        // "Managed" is every tier we *could* export (no exclusion). Dropping all of it before re-adding the
-        // kept devices means a tier we exported before an exclusion was configured (a grid/battery/inverter)
-        // is retired on the next sync, not left orphaned — while the user's own devices (never in this set)
-        // stay put.
-        var managed = BuildDevices(entityByUniqueId, null).Select(d => d.stat_consumption).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        // "Managed" is every energy entity any flow tier maps to — no kind exclusion AND no energy gate.
+        // Dropping all of it before re-adding the kept devices retires a tier we exported before it was
+        // excluded (grid/battery/inverter) OR before it lost a live value, instead of orphaning it. The gate
+        // must NOT apply here: a grid tier that's momentarily energy-unknown would otherwise fall through the
+        // gap — not in `managed` so never removed, not in `devices` so never re-added — and linger forever.
+        var managed = ManagedStats(entityByUniqueId);
         var keep = new JsonArray();
         foreach (var existingDevice in prefs["device_consumption"]?.AsArray() ?? new JsonArray())
             if (existingDevice is JsonObject o && !managed.Contains((string?)o["stat_consumption"] ?? ""))


### PR DESCRIPTION
The grid/battery/inverter that #261 was supposed to remove kept lingering — a bug from stacking #261 and #262.

## Root cause
The sync retires a device by dropping every entity in a **"managed"** set, then re-adding the kept ones. But #262's **energy-known gate** had leaked into that set: `managed` was `BuildDevices(…, null)`, which only includes tiers with a **live kWh value**. So a grid/battery/inverter tier that was momentarily energy-unknown fell into a gap:
- not in `managed` → never removed
- excluded by kind → never re-added

…and lingered forever.

## Fix
`managed` is now `ManagedStats()` — every energy entity any flow tier resolves to, with **no energy gate and no kind exclusion**. An excluded (or now value-less) tier is always caught and removed; a user's own device (never one of our resolved entities) is never touched.

396 tests pass. Backend only.

---

## The bigger picture on your three screenshots
These stack, and two of them trace back to a bug you haven't deployed the fix for yet:

1. **grid/battery/inverter still listed** → this PR (#268). Deploy + **Sync** and they clear.
2. **Upstream device blank** and **3. Grid/Solar/Battery source sections empty** → both need the flow to actually be carrying kWh. Your running build is `feat-gui-warn-nodes-without-energy` (~#263) — it does **not** include **#265**, the version-reset fix that unfroze MQTT after your rollout. Until #265 is deployed, grid/panels read null-energy, so:
   - the source buckets can't resolve (empty), and
   - a device's upstream can't link to a parent that isn't itself a live device.

**So: sync your GitOps to pick up #265–#268, then hit "Sync" on the HA Energy Mapping page.** After that: grid/battery/inverter gone from devices, the source buckets populated (grid/solar/battery have energy bindings), and upstream links filled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)