### PR TITLE
fix(ha): populate grid/solar/battery sources on entity existence, not live value

### DIFF
--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -100,15 +100,16 @@ public sealed class HaEnergyDashboardSync
         var energyType = string.IsNullOrWhiteSpace(config.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : config.HASS.EnergyDashboard.EnergyMeasurementType;
         var native = FlowExport.NativeEnergyUniqueIds(merged, energyType);
         var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric, live);
-        var energyGraph = FlowGraphBuilder.Build(merged, config.EnergyFlow, energyType, live);
 
+        // The three role buckets resolve purely on whether the energy ENTITY exists in HA — no live-value gate.
+        // That sensor is published from the node's discovery (off its power reading), so it exists even when the
+        // kWh value is momentarily absent; gating on the value here made grid/solar/battery vanish whenever the
+        // source ticked slowly. A bucket the user explicitly configured is worth showing when its sensor exists;
+        // HA handles availability. (The dozens of individual devices keep their gate — that's where unavailable
+        // clutter actually matters.)
         string? Resolve(string uid) => entityByUniqueId.TryGetValue(uid, out var e) ? e : null;
         return EnergyDashboardSync.BuildEnergySources(graph, (id, dir) => dir == Core.Flow.EnergyDirection.Out
-            // Out (production/discharge/import): only when the bridge knows this node's energy, else HA gets an
-            // unavailable stat and the whole grid/solar/battery bucket reads broken.
-            ? (FlowExport.TryNodeValue(energyGraph, id, out _)
-                ? Resolve(native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id))
-                : null)
+            ? Resolve(native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id))
             : Resolve(FlowExport.EnergyInUniqueId(id)));
     }
 


### PR DESCRIPTION
Last piece — the **Electricity grid / Solar panels / Home battery storage** buckets staying empty after your clear+resync.

## Why
Those three role buckets were gated on a **live kWh value** being known (the #262 gate). But the node's energy sensor is published from its **discovery** — off the *power* reading — so `sensor.energyflow_grid_energy` etc. exist in HA even when the kWh value is momentarily absent (a slow-ticking or briefly-quiet source). The gate then returned null for a bucket whose sensor was sitting right there → empty buckets.

## Fix
The buckets now resolve purely on whether the **energy entity exists** in HA; HA handles availability. A bucket you explicitly configured (tagged the node, bound its energy) is worth surfacing when its sensor exists. The individual-device rows keep the gate — that's where "unavailable" clutter actually matters.

396 tests pass. Backend only.

## After deploy + Sync
- **Grid** → should populate (it has an energy binding and its sensor exists).
- **Solar** → populates **if** the solar node has an `energy` source bound. In your roll-up earlier, `eg4-flexboss21-solar` showed only `RealPower` — no energy metric. Bind a solar **production energy (kWh)** source on the Nodes tab and it'll fill in.
- **Battery** → HA needs **both** a charge and a discharge energy stat. Bind battery `energy` with **Direction: Discharge (out)** *and* a second with **Direction: Charge (in)**; the `⚠` on the Nodes tab flags any node missing energy.

So grid should light up on the next sync; solar/battery depend on those energy bindings existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)