### PR TITLE
feat(flow): 'split' a single ± source into out/in; hide direction where it's moot

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -765,7 +765,8 @@ spec:
                                 - ''
                                 - out
                                 - in
-                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production; the supply direction) or 'in' (battery charge, grid export). Lets a battery/grid node bind both directions."
+                                - split
+                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production), 'in' (battery charge, grid export), or 'split' — one signed value fanned into both directions, positive as out and the magnitude of negative as in (for a single ± power/current topic or register). Only meaningful for directional metrics (realpower, apparentpower, current, energy); ignored for voltage/frequency/powerfactor/soc."
                               Unit:
                                 type: string
                                 description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.
@@ -846,7 +847,8 @@ spec:
                                 - ''
                                 - out
                                 - in
-                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production; the supply direction) or 'in' (battery charge, grid export). Lets a battery/grid node bind both directions."
+                                - split
+                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production), 'in' (battery charge, grid export), or 'split' — one signed value fanned into both directions, positive as out and the magnitude of negative as in (for a single ± power/current topic or register). Only meaningful for directional metrics (realpower, apparentpower, current, energy); ignored for voltage/frequency/powerfactor/soc."
                               Unit:
                                 type: string
                                 description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -765,7 +765,8 @@ spec:
                                 - ''
                                 - out
                                 - in
-                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production; the supply direction) or 'in' (battery charge, grid export). Lets a battery/grid node bind both directions."
+                                - split
+                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production), 'in' (battery charge, grid export), or 'split' — one signed value fanned into both directions, positive as out and the magnitude of negative as in (for a single ± power/current topic or register). Only meaningful for directional metrics (realpower, apparentpower, current, energy); ignored for voltage/frequency/powerfactor/soc."
                               Unit:
                                 type: string
                                 description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.
@@ -846,7 +847,8 @@ spec:
                                 - ''
                                 - out
                                 - in
-                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production; the supply direction) or 'in' (battery charge, grid export). Lets a battery/grid node bind both directions."
+                                - split
+                                description: "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production), 'in' (battery charge, grid export), or 'split' — one signed value fanned into both directions, positive as out and the magnitude of negative as in (for a single ± power/current topic or register). Only meaningful for directional metrics (realpower, apparentpower, current, energy); ignored for voltage/frequency/powerfactor/soc."
                               Unit:
                                 type: string
                                 description: Unit the source publishes in (e.g. kW, Wh, mV). Converted to the metric's canonical unit (W, kWh, V, …) on ingest. Blank = already canonical.

--- a/rPDU2MQTT.Core/Flow/FlowMetricKey.cs
+++ b/rPDU2MQTT.Core/Flow/FlowMetricKey.cs
@@ -21,4 +21,22 @@ public static class FlowMetricKey
     /// <summary>The storage key for <paramref name="metric"/> in the given <see cref="EnergyDirection"/>.</summary>
     public static string For(string metric, EnergyDirection direction)
         => direction == EnergyDirection.In ? metric + InSuffix : metric;
+
+    /// <summary>True for the <c>split</c> direction — one signed source fanned into both out and in.</summary>
+    public static bool IsSplit(string? direction) => string.Equals(direction, "split", System.StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The cache key(s) and value(s) a reading produces. Normally one — the metric under its direction. But a
+    /// <c>split</c> source carries a single signed number (a battery/grid power that swings ±) and fans into
+    /// both directions: the positive part is the out (discharge/import) reading, the magnitude of the negative
+    /// part is the in (charge/export) reading. So one topic/register drives both without needing two feeds.
+    /// </summary>
+    public static IEnumerable<(string Key, double Value)> Fan(string metric, string? direction, double value)
+        => IsSplit(direction)
+            ? new[] { (metric, System.Math.Max(0, value)), (metric + InSuffix, System.Math.Max(0, -value)) }
+            : new[] { (For(metric, direction), value) };
+
+    /// <summary>The cache key(s) a source writes, without values — for staleness/binding bookkeeping.</summary>
+    public static IEnumerable<string> Keys(string metric, string? direction)
+        => IsSplit(direction) ? new[] { metric, metric + InSuffix } : new[] { For(metric, direction) };
 }

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -202,8 +202,8 @@ public class EnergyFlowSource
     /// <c>flow_from</c> (consumption) and its <c>in</c> is <c>flow_to</c> (return).
     /// </summary>
     [DefaultValue("out")]
-    [Description("Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production; the supply direction) or 'in' (battery charge, grid export). Lets a battery/grid node bind both directions.")]
-    [AllowedValues("out", "in")]
+    [Description("Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production), 'in' (battery charge, grid export), or 'split' — one signed value fanned into both directions, positive as out and the magnitude of negative as in (for a single ± power/current topic or register). Only meaningful for directional metrics (realpower, apparentpower, current, energy); ignored for voltage/frequency/powerfactor/soc.")]
+    [AllowedValues("out", "in", "split")]
     public string Direction { get; set; } = "out";
 
     /// <summary>

--- a/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
@@ -54,7 +54,8 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         var bindings = BuildBindings(cfg.EnergyFlow.Nodes);
 
         // Prune readings no longer produced by any current modbus binding (a removed/retyped source).
-        var live = bindings.Values.SelectMany(v => v).Select(b => (b.NodeId, FlowMetricKey.For(b.Source.Metric, b.Source.Direction))).ToHashSet();
+        var live = bindings.Values.SelectMany(v => v)
+            .SelectMany(b => FlowMetricKey.Keys(b.Source.Metric, b.Source.Direction).Select(k => (b.NodeId, Key: k))).ToHashSet();
         foreach (var key in latest.Keys.Where(k => !live.Contains((k.Node, k.Metric))).ToList())
             latest.Remove(key.Node, key.Metric);
 
@@ -82,7 +83,7 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         var framing = resolvedFraming.TryGetValue(conn.Id, out var cached) ? cached : conn.Framing;
 
         ReadBatch(conn.Host, conn.Port, conn.UnitId, framing, conn.TimeoutMs, forConn.Select(f => f.Source).ToList(),
-            onValue: (src, value) => latest.Set(nodeOf[src], FlowMetricKey.For(src.Metric, src.Direction), value, src.StaleAfterSeconds, nowUtc),
+            onValue: (src, value) => { foreach (var (key, v) in FlowMetricKey.Fan(src.Metric, src.Direction, value)) latest.Set(nodeOf[src], key, v, src.StaleAfterSeconds, nowUtc); },
             onError: (src, msg) => Log.Debug($"Energy-flow Modbus: node '{nodeOf[src]}' register {src.Register} on {conn.Id} — {msg}"),
             onResolved: f => resolvedFraming[conn.Id] = f);
     }

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -138,7 +138,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
         {
             if (topic == removedTopic) continue;
             foreach (var (nodeId, src) in list)
-                if (nodeId == key.Node && string.Equals(FlowMetricKey.For(src.Metric, src.Direction), key.Metric, StringComparison.OrdinalIgnoreCase))
+                if (nodeId == key.Node && FlowMetricKey.Keys(src.Metric, src.Direction).Any(k => string.Equals(k, key.Metric, StringComparison.OrdinalIgnoreCase)))
                     return false;
         }
         return true;
@@ -210,12 +210,15 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             // Normalise to the metric's canonical unit (kW -> W, Wh -> kWh, …) so the roll-up and exports are
             // consistent, then apply the manual Scale (sign flips / oddball adjustments) on top.
             var value = raw * FlowUnits.ToCanonicalFactor(src.Metric, src.Unit) * src.Scale;
-            // An 'in' (charge/export) reading is stored under a direction-qualified key so it doesn't overwrite
-            // the 'out' supply value the roll-up reads — and, being a non-metric key, is skipped by the grain
-            // measurement sink below (Metrics.TryParse fails), keeping charge/export out of the power flow.
-            var key = FlowMetricKey.For(src.Metric, src.Direction);
-            cache.Set(nodeId, key, value, src.StaleAfterSeconds, nowUtc);
-            onReading?.Invoke(nodeId, key, value, src.StaleAfterSeconds);
+            // Fan the reading into its direction(s): normally one key, but a 'split' source (a single signed
+            // value) writes both the out (positive part) and in (negative magnitude) keys. The 'in' key is
+            // direction-qualified so it doesn't overwrite the out supply value, and — being a non-metric key —
+            // is skipped by the grain sink below (Metrics.TryParse fails), keeping charge/export out of the flow.
+            foreach (var (key, v) in FlowMetricKey.Fan(src.Metric, src.Direction, value))
+            {
+                cache.Set(nodeId, key, v, src.StaleAfterSeconds, nowUtc);
+                onReading?.Invoke(nodeId, key, v, src.StaleAfterSeconds);
+            }
         }
     }
 

--- a/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
+++ b/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
@@ -228,6 +228,33 @@ public class EnergyFlowMqttSourceTests
     public void FlowMetricKey_SuffixesOnlyTheInDirection(string metric, string? direction, string expected)
         => Assert.Equal(expected, FlowMetricKey.For(metric, direction));
 
+    [Fact]
+    public void Apply_SplitDirection_FansOneSignedValueIntoBothOutAndIn()
+    {
+        // A single battery-power topic swings ±: positive = discharging (out), negative = charging (in). One
+        // 'split' binding drives both, so the user needn't invent two topics they don't have.
+        var nodes = new[] { NodeWith("battery", new EnergyFlowSource { Topic = "sa/batt_power", Metric = "realpower", Direction = "split" }) };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+        var cache = new FlowValueCache();
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/batt_power", "1500", DateTime.UtcNow);   // discharging
+        Assert.True(cache.TryGetValue("battery", "realpower", out var outV) && outV == 1500);
+        Assert.True(cache.TryGetValue("battery", FlowMetricKey.For("realpower", "in"), out var inV) && inV == 0);
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/batt_power", "-800", DateTime.UtcNow);   // charging
+        Assert.True(cache.TryGetValue("battery", "realpower", out outV) && outV == 0);
+        Assert.True(cache.TryGetValue("battery", FlowMetricKey.For("realpower", "in"), out inV) && inV == 800);
+    }
+
+    [Fact]
+    public void FlowMetricKey_Fan_SplitsSignedValue_ElsePassesThrough()
+    {
+        Assert.Equal(new[] { ("p", 5.0), ("p#in", 0.0) }, FlowMetricKey.Fan("p", "split", 5).ToArray());
+        Assert.Equal(new[] { ("p", 0.0), ("p#in", 3.0) }, FlowMetricKey.Fan("p", "split", -3).ToArray());
+        Assert.Equal(new[] { ("p", -3.0) }, FlowMetricKey.Fan("p", "out", -3).ToArray());   // no split: as-is
+        Assert.Equal(new[] { ("p#in", 4.0) }, FlowMetricKey.Fan("p", "in", 4).ToArray());
+    }
+
     [Theory]
     [InlineData("realpower", "kW", 1000)]        // 1 kW -> 1000 W
     [InlineData("energy", "Wh", 0.001)]          // 1 Wh -> 0.001 kWh

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -41,7 +41,12 @@ const kindMeta = (kind?: string) => NODE_KINDS.find(k => k[0] === (kind || 'node
 const SOURCE_TYPES: [string, string][] = [['mqtt', 'MQTT topic'], ['modbus', 'Modbus TCP']];
 
 // Metrics whose sign carries direction, so inverting one is meaningful (export vs import, charge vs discharge).
+// These are also the ones a single ± value can be *split* into out/in — an instantaneous quantity, unlike a
+// cumulative energy counter (which needs separate in/out totals, so it gets out/in but not split).
 const SIGNED_METRICS = ['realpower', 'apparentpower', 'current'];
+// Metrics where an in/out direction means anything at all. Voltage, frequency, power factor and state of
+// charge don't have a direction, so the Direction control is hidden for them entirely.
+const DIRECTIONAL_METRICS = [...SIGNED_METRICS, 'energy'];
 
 // Why a "Current" cell can sit empty — the thing every new binding trips over.
 const LIVE_HINT = 'Live value from the running ingest. It appears when the source next reports: an MQTT binding when the publisher sends, a Modbus one on the worker’s next poll — and a new or edited binding is not read at all until you Save. Nothing here is missing because the page needs reloading.';
@@ -407,16 +412,16 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
   // reads) vs 'in' (charge/export, exported as the energy_in sensor HA's dashboard picks up). Other kinds only
   // ever flow one way, so the column stays hidden for them. Labels are role-specific so the choice reads plainly.
   const bidirectional = (node.Kind === 'battery' || node.Kind === 'grid');
-  const dirLabels: Record<string, string> = node.Kind === 'battery' ? { out: 'Discharge (out)', in: 'Charge (in)' }
-    : node.Kind === 'grid' ? { out: 'Import (out)', in: 'Export (in)' }
-    : { out: 'Out', in: 'In' };
+  const dirLabels: Record<string, string> = node.Kind === 'battery' ? { out: 'Discharge (out)', in: 'Charge (in)', split: 'Split ± (dis/charge)' }
+    : node.Kind === 'grid' ? { out: 'Import (out)', in: 'Export (in)', split: 'Split ± (import/export)' }
+    : { out: 'Out', in: 'In', split: 'Split ±' };
 
   const sources: any[] = ensure(node, 'Sources', []);
   if (sources.length) {
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
     const colHint: any = {
-      Direction: 'Which way energy flows for this source. The out direction (discharge/import) is the supply value; the in direction (charge/export) is published as a second energy sensor so Home Assistant’s Energy Dashboard can show it.',
+      Direction: 'Which way energy flows for this source. Out (discharge/import) is the supply value; In (charge/export) is a second sensor for HA’s Energy Dashboard. Split takes one ± value and fans it into both — positive as out, negative as in — for a single signed power/current topic. Hidden for metrics with no direction (voltage, frequency, power factor, state of charge).',
       Invert: 'Flip the sign of a power or current reading — for a source that publishes export/discharge as positive when your hierarchy wants it negative (or vice versa).',
       Current: LIVE_HINT,
     };
@@ -448,13 +453,22 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
       metricSel.onchange = () => { src.Metric = metricSel.value; src.Unit = undefined; rerender(); };
       tr.appendChild(el('td', {}, metricSel));
 
-      // Direction (battery/grid only): bind discharge/import as 'out' and charge/export as 'in' on the same node.
+      // Direction (battery/grid only, and only for a directional metric — voltage/soc have no direction, so
+      // their cell stays blank). A signed metric (power/current) also offers 'split': one ± value fanned into
+      // both out and in, so a single Solar-Assistant-style topic drives charge AND discharge.
       if (bidirectional) {
-        const dirSel = el('select', { style: { width: 'auto' } });
-        (['out', 'in'] as const).forEach(d => dirSel.appendChild(el('option', { value: d, text: dirLabels[d] })));
-        dirSel.value = src.Direction === 'in' ? 'in' : 'out';
-        dirSel.onchange = () => { src.Direction = dirSel.value === 'out' ? undefined : 'in'; rerender(); };
-        tr.appendChild(el('td', {}, dirSel));
+        const cell = el('td');
+        if (DIRECTIONAL_METRICS.includes(metric)) {
+          const opts = SIGNED_METRICS.includes(metric) ? ['out', 'in', 'split'] : ['out', 'in'];
+          const dirSel = el('select', { style: { width: 'auto' } });
+          opts.forEach(d => dirSel.appendChild(el('option', { value: d, text: dirLabels[d] })));
+          dirSel.value = opts.includes(src.Direction) ? src.Direction : 'out';
+          dirSel.onchange = () => { src.Direction = dirSel.value === 'out' ? undefined : dirSel.value; rerender(); };
+          cell.appendChild(dirSel);
+        } else {
+          cell.appendChild(el('span', { text: '—', style: { color: 'var(--muted)' }, title: 'Direction doesn’t apply to this metric.' }));
+        }
+        tr.appendChild(cell);
       }
 
       // Input unit → converted to the metric's canonical unit on ingest. Store only a non-canonical choice.

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -940,7 +940,12 @@ const kindMeta = (kind         ) => NODE_KINDS.find(k => k[0] === (kind || 'node
 const SOURCE_TYPES                     = [['mqtt', 'MQTT topic'], ['modbus', 'Modbus TCP']];
 
 // Metrics whose sign carries direction, so inverting one is meaningful (export vs import, charge vs discharge).
+// These are also the ones a single ± value can be *split* into out/in — an instantaneous quantity, unlike a
+// cumulative energy counter (which needs separate in/out totals, so it gets out/in but not split).
 const SIGNED_METRICS = ['realpower', 'apparentpower', 'current'];
+// Metrics where an in/out direction means anything at all. Voltage, frequency, power factor and state of
+// charge don't have a direction, so the Direction control is hidden for them entirely.
+const DIRECTIONAL_METRICS = [...SIGNED_METRICS, 'energy'];
 
 // Why a "Current" cell can sit empty — the thing every new binding trips over.
 const LIVE_HINT = 'Live value from the running ingest. It appears when the source next reports: an MQTT binding when the publisher sends, a Modbus one on the worker’s next poll — and a new or edited binding is not read at all until you Save. Nothing here is missing because the page needs reloading.';
@@ -1306,16 +1311,16 @@ function renderNodeEditor(node     , links       , cand                  , reren
   // reads) vs 'in' (charge/export, exported as the energy_in sensor HA's dashboard picks up). Other kinds only
   // ever flow one way, so the column stays hidden for them. Labels are role-specific so the choice reads plainly.
   const bidirectional = (node.Kind === 'battery' || node.Kind === 'grid');
-  const dirLabels                         = node.Kind === 'battery' ? { out: 'Discharge (out)', in: 'Charge (in)' }
-    : node.Kind === 'grid' ? { out: 'Import (out)', in: 'Export (in)' }
-    : { out: 'Out', in: 'In' };
+  const dirLabels                         = node.Kind === 'battery' ? { out: 'Discharge (out)', in: 'Charge (in)', split: 'Split ± (dis/charge)' }
+    : node.Kind === 'grid' ? { out: 'Import (out)', in: 'Export (in)', split: 'Split ± (import/export)' }
+    : { out: 'Out', in: 'In', split: 'Split ±' };
 
   const sources        = ensure(node, 'Sources', []);
   if (sources.length) {
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
     const colHint      = {
-      Direction: 'Which way energy flows for this source. The out direction (discharge/import) is the supply value; the in direction (charge/export) is published as a second energy sensor so Home Assistant’s Energy Dashboard can show it.',
+      Direction: 'Which way energy flows for this source. Out (discharge/import) is the supply value; In (charge/export) is a second sensor for HA’s Energy Dashboard. Split takes one ± value and fans it into both — positive as out, negative as in — for a single signed power/current topic. Hidden for metrics with no direction (voltage, frequency, power factor, state of charge).',
       Invert: 'Flip the sign of a power or current reading — for a source that publishes export/discharge as positive when your hierarchy wants it negative (or vice versa).',
       Current: LIVE_HINT,
     };
@@ -1347,13 +1352,22 @@ function renderNodeEditor(node     , links       , cand                  , reren
       metricSel.onchange = () => { src.Metric = metricSel.value; src.Unit = undefined; rerender(); };
       tr.appendChild(el('td', {}, metricSel));
 
-      // Direction (battery/grid only): bind discharge/import as 'out' and charge/export as 'in' on the same node.
+      // Direction (battery/grid only, and only for a directional metric — voltage/soc have no direction, so
+      // their cell stays blank). A signed metric (power/current) also offers 'split': one ± value fanned into
+      // both out and in, so a single Solar-Assistant-style topic drives charge AND discharge.
       if (bidirectional) {
-        const dirSel = el('select', { style: { width: 'auto' } });
-        (['out', 'in']         ).forEach(d => dirSel.appendChild(el('option', { value: d, text: dirLabels[d] })));
-        dirSel.value = src.Direction === 'in' ? 'in' : 'out';
-        dirSel.onchange = () => { src.Direction = dirSel.value === 'out' ? undefined : 'in'; rerender(); };
-        tr.appendChild(el('td', {}, dirSel));
+        const cell = el('td');
+        if (DIRECTIONAL_METRICS.includes(metric)) {
+          const opts = SIGNED_METRICS.includes(metric) ? ['out', 'in', 'split'] : ['out', 'in'];
+          const dirSel = el('select', { style: { width: 'auto' } });
+          opts.forEach(d => dirSel.appendChild(el('option', { value: d, text: dirLabels[d] })));
+          dirSel.value = opts.includes(src.Direction) ? src.Direction : 'out';
+          dirSel.onchange = () => { src.Direction = dirSel.value === 'out' ? undefined : dirSel.value; rerender(); };
+          cell.appendChild(dirSel);
+        } else {
+          cell.appendChild(el('span', { text: '—', style: { color: 'var(--muted)' }, title: 'Direction doesn’t apply to this metric.' }));
+        }
+        tr.appendChild(cell);
       }
 
       // Input unit → converted to the metric's canonical unit on ingest. Store only a non-canonical choice.


### PR DESCRIPTION
Both of your complaints, fixed.

## 1. Split a single signed value into out + in
You have **one** topic (e.g. battery power) that swings ± — positive when discharging, negative when charging — and I was forcing you to pick a single direction. Now there's a **Split** direction: bind that one source once, and it fans into **both**:
- positive part → **out** (discharge / import)
- magnitude of negative part → **in** (charge / export)

So a single Solar-Assistant-style `battery_power` drives charge *and* discharge without inventing two feeds. Offered for the signed instantaneous metrics (**realpower / apparentpower / current**). Energy keeps plain out/in — a cumulative kWh counter can't be split into two monotonic totals.

## 2. Direction hidden where it makes no sense
**Voltage, frequency, power factor, and state of charge** have no in/out — the Direction control now simply doesn't render for them (shows "—"), instead of a pointless selector.

## How it works
`FlowMetricKey.Fan(metric, direction, value)` does the routing for **both** the MQTT and Modbus ingests: normally one key, but for `split` it writes `metric` = max(0, v) and `metric#in` = max(0, −v). The Energy Overview's net calc and the diagram pick those up as before.

Tested (split fan for MQTT + the `Fan` helper); 398 pass. CRD regenerated for the new enum value.

## To use it
On a battery/grid node, bind your single ± power topic, set **Direction → Split ±**. Discharge shows as out, charge as in — and the Energy tab's battery/grid net arrows point the right way from one source.

_(Note: HA's battery/grid **energy** buckets still need cumulative kWh in/out stats — split is for the instantaneous power/current side.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)