### PR TITLE
fix(ha): grid energy_source must match HA's schema exactly (save_prefs failed)

### DIFF
--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -75,7 +75,7 @@ public static class EnergyDashboardSync
             switch (node.Kind?.ToLowerInvariant())
             {
                 case "solar" when !string.IsNullOrEmpty(outStat):
-                    sources.Add(new JsonObject { ["type"] = "solar", ["stat_energy_from"] = outStat });
+                    sources.Add(new JsonObject { ["type"] = "solar", ["stat_energy_from"] = outStat, ["config_entry_solar_forecast"] = null });
                     break;
 
                 // HA's battery source needs both a from (discharge) and a to (charge) stat; without the pair
@@ -84,13 +84,18 @@ public static class EnergyDashboardSync
                     sources.Add(new JsonObject { ["type"] = "battery", ["stat_energy_from"] = outStat, ["stat_energy_to"] = inStat });
                     break;
 
+                // HA's grid schema requires BOTH flow_from and flow_to (empty arrays are fine) and each flow
+                // entry must carry the full key set — the cost/price fields as null, not omitted. A bare
+                // {stat_energy_from} fails the grid schema, and voluptuous then falls through to the solar/
+                // battery schemas, reporting "extra keys not allowed @ flow_from" — the error users hit.
                 case "grid" when !string.IsNullOrEmpty(outStat) || !string.IsNullOrEmpty(inStat):
-                    var grid = new JsonObject { ["type"] = "grid", ["cost_adjustment_day"] = 0.0 };
+                    var flowFrom = new JsonArray();
+                    var flowTo = new JsonArray();
                     if (!string.IsNullOrEmpty(outStat))
-                        grid["flow_from"] = new JsonArray(new JsonObject { ["stat_energy_from"] = outStat });
+                        flowFrom.Add(new JsonObject { ["stat_energy_from"] = outStat, ["stat_cost"] = null, ["entity_energy_price"] = null, ["number_energy_price"] = null });
                     if (!string.IsNullOrEmpty(inStat))
-                        grid["flow_to"] = new JsonArray(new JsonObject { ["stat_energy_to"] = inStat });
-                    sources.Add(grid);
+                        flowTo.Add(new JsonObject { ["stat_energy_to"] = inStat, ["stat_compensation"] = null, ["entity_energy_price"] = null, ["number_energy_price"] = null });
+                    sources.Add(new JsonObject { ["type"] = "grid", ["flow_from"] = flowFrom, ["flow_to"] = flowTo, ["cost_adjustment_day"] = 0.0 });
                     break;
             }
         }

--- a/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
+++ b/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
@@ -54,12 +54,15 @@ public class EnergyDashboardSourcesTests
     {
         var node = new FlowNode("grid", "Grid", "grid");
 
-        // Import only -> flow_from present, flow_to omitted (not null — HA rejects nulls).
+        // Import only -> flow_from has the entry; flow_to is present but empty (HA's grid schema requires both).
         var importOnly = Assert.Single(EnergyDashboardSync.BuildEnergySources(Graph(node),
             Stats(("grid", EnergyDirection.Out, "sensor.grid_import"))));
         Assert.Equal("grid", (string?)importOnly["type"]);
         Assert.Equal("sensor.grid_import", (string?)importOnly["flow_from"]!.AsArray()[0]!["stat_energy_from"]);
-        Assert.False(importOnly.ContainsKey("flow_to"));
+        Assert.Empty(importOnly["flow_to"]!.AsArray());
+        // Each flow entry carries the full key set (cost/price as null) — a bare entry fails HA's grid schema.
+        var entry = importOnly["flow_from"]!.AsArray()[0]!.AsObject();
+        Assert.True(entry.ContainsKey("stat_cost") && entry.ContainsKey("number_energy_price"));
 
         // Both -> flow_from (import) + flow_to (export).
         var both = Assert.Single(EnergyDashboardSync.BuildEnergySources(Graph(node),


### PR DESCRIPTION
Your **"Sync failed: HA save_prefs failed: extra keys not allowed @ energy_sources[…]['flow_from']"**.

## Why
Our grid source used a **bare** flow entry — `{stat_energy_from: X}` — and omitted `flow_to` when there was no export. HA's grid schema requires **both** `flow_from` and `flow_to` present (empty array is fine) and each flow entry to carry the **full key set** (the cost/price fields, as `null`, not omitted). A partial entry fails the grid schema, and voluptuous then falls through to the solar/battery schemas — which have no `flow_from`/`flow_to` — producing that misleading "extra keys not allowed" message.

## Fix
Grid now emits **both arrays always**, with each entry's `stat_cost` / `stat_compensation` / `entity_energy_price` / `number_energy_price` = `null` — exactly what HA's own UI writes. Solar gains `config_entry_solar_forecast: null` for the same robustness.

Test updated for the new shape; 398 pass.

After deploy + **Sync**, save_prefs should succeed and the grid bucket populate.

(One thing to sanity-check on your side, from the earlier screenshot: `grid_energy_in` was bound as **Export** and `grid_energy_out` as **Import** — by the names those look swapped, which would reverse HA's consumption/return.)