### PR TITLE
feat(gui): a metric toggle on the Flow chart (Power / Energy / …)

### DIFF
--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1036,8 +1036,14 @@ export function addFlowSection(nav: any, sections: any) {
   const bar = document.createElement('div'); bar.className = 'ld-toolbar';
   const refresh = btn('Refresh');
   const instSel = instanceSelector(() => load());
+  // Which measurement the flow is drawn by — link widths follow it. Power (W) is the live snapshot; Energy
+  // (kWh) is the cumulative total, so the diagram reads as "how much has flowed" rather than "how much now".
+  const metricSel = el('select', { title: 'Draw the flow by this measurement.' }) as HTMLSelectElement;
+  [['realpower', 'Power (W)'], ['energy', 'Energy (kWh)'], ['apparentpower', 'Apparent (VA)'], ['current', 'Current (A)']]
+    .forEach(([v, t]) => metricSel.appendChild(el('option', { value: v, text: t })));
+  metricSel.onchange = () => load();
   const count = document.createElement('span'); count.className = 'ld-count';
-  bar.appendChild(refresh); bar.appendChild(instSel.wrap); bar.appendChild(count); sec.appendChild(bar);
+  bar.appendChild(refresh); bar.appendChild(el('label', { class: 'ld-inst' }, 'Show ', metricSel)); bar.appendChild(instSel.wrap); bar.appendChild(count); sec.appendChild(bar);
   const wrap = document.createElement('div'); sec.appendChild(wrap);
   const treePanel = document.createElement('div'); treePanel.style.margin = '16px 0 4px'; sec.appendChild(treePanel);
   const ed: any = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
@@ -1470,7 +1476,9 @@ export function addFlowSection(nav: any, sections: any) {
   };
 
   const load = async () => {
-    const r = await api(withInstance('/api/flow', instSel));
+    let path = withInstance('/api/flow', instSel);
+    if (metricSel.value && metricSel.value !== 'realpower') path += (path.includes('?') ? '&' : '?') + 'metric=' + metricSel.value;
+    const r = await api(path);
     if (!r.body.ok) { wrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load flow data.') + '</div>'; count.textContent = ''; lastGraph = null; renderEditor(); return; }
     lastGraph = r.body;
     draw(r.body);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1935,8 +1935,14 @@ function addFlowSection(nav     , sections     ) {
   const bar = document.createElement('div'); bar.className = 'ld-toolbar';
   const refresh = btn('Refresh');
   const instSel = instanceSelector(() => load());
+  // Which measurement the flow is drawn by — link widths follow it. Power (W) is the live snapshot; Energy
+  // (kWh) is the cumulative total, so the diagram reads as "how much has flowed" rather than "how much now".
+  const metricSel = el('select', { title: 'Draw the flow by this measurement.' })                     ;
+  [['realpower', 'Power (W)'], ['energy', 'Energy (kWh)'], ['apparentpower', 'Apparent (VA)'], ['current', 'Current (A)']]
+    .forEach(([v, t]) => metricSel.appendChild(el('option', { value: v, text: t })));
+  metricSel.onchange = () => load();
   const count = document.createElement('span'); count.className = 'ld-count';
-  bar.appendChild(refresh); bar.appendChild(instSel.wrap); bar.appendChild(count); sec.appendChild(bar);
+  bar.appendChild(refresh); bar.appendChild(el('label', { class: 'ld-inst' }, 'Show ', metricSel)); bar.appendChild(instSel.wrap); bar.appendChild(count); sec.appendChild(bar);
   const wrap = document.createElement('div'); sec.appendChild(wrap);
   const treePanel = document.createElement('div'); treePanel.style.margin = '16px 0 4px'; sec.appendChild(treePanel);
   const ed      = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
@@ -2369,7 +2375,9 @@ function addFlowSection(nav     , sections     ) {
   };
 
   const load = async () => {
-    const r = await api(withInstance('/api/flow', instSel));
+    let path = withInstance('/api/flow', instSel);
+    if (metricSel.value && metricSel.value !== 'realpower') path += (path.includes('?') ? '&' : '?') + 'metric=' + metricSel.value;
+    const r = await api(path);
     if (!r.body.ok) { wrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load flow data.') + '</div>'; count.textContent = ''; lastGraph = null; renderEditor(); return; }
     lastGraph = r.body;
     draw(r.body);


### PR DESCRIPTION
Your ask: a toggle to view the flow chart by **energy instead of power**.

A **"Show"** selector in the Flow toolbar now switches what the Sankey is drawn by:
- **Power (W)** — the live snapshot (default)
- **Energy (kWh)** — the cumulative total, so it reads as "how much has flowed"
- Apparent (VA), Current (A) — for completeness

It rides the `/api/flow?metric=` param the endpoint already accepted, so link widths and node values follow the chosen metric. No backend change.

GUI build + smoke pass.