### PR TITLE
fix(ha): grid source is flat (stat_energy_from/to), not flow_from/flow_to

### DIFF
--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -75,7 +75,7 @@ public static class EnergyDashboardSync
             switch (node.Kind?.ToLowerInvariant())
             {
                 case "solar" when !string.IsNullOrEmpty(outStat):
-                    sources.Add(new JsonObject { ["type"] = "solar", ["stat_energy_from"] = outStat, ["config_entry_solar_forecast"] = null });
+                    sources.Add(new JsonObject { ["type"] = "solar", ["stat_energy_from"] = outStat });
                     break;
 
                 // HA's battery source needs both a from (discharge) and a to (charge) stat; without the pair
@@ -84,18 +84,14 @@ public static class EnergyDashboardSync
                     sources.Add(new JsonObject { ["type"] = "battery", ["stat_energy_from"] = outStat, ["stat_energy_to"] = inStat });
                     break;
 
-                // HA's grid schema requires BOTH flow_from and flow_to (empty arrays are fine) and each flow
-                // entry must carry the full key set — the cost/price fields as null, not omitted. A bare
-                // {stat_energy_from} fails the grid schema, and voluptuous then falls through to the solar/
-                // battery schemas, reporting "extra keys not allowed @ flow_from" — the error users hit.
+                // HA's grid source is FLAT: stat_energy_from = import, stat_energy_to = export, right on the
+                // object — NOT the flow_from/flow_to arrays older docs show (those are "extra keys" to the
+                // current schema, which is what save_prefs rejected). cost_adjustment_day is required.
                 case "grid" when !string.IsNullOrEmpty(outStat) || !string.IsNullOrEmpty(inStat):
-                    var flowFrom = new JsonArray();
-                    var flowTo = new JsonArray();
-                    if (!string.IsNullOrEmpty(outStat))
-                        flowFrom.Add(new JsonObject { ["stat_energy_from"] = outStat, ["stat_cost"] = null, ["entity_energy_price"] = null, ["number_energy_price"] = null });
-                    if (!string.IsNullOrEmpty(inStat))
-                        flowTo.Add(new JsonObject { ["stat_energy_to"] = inStat, ["stat_compensation"] = null, ["entity_energy_price"] = null, ["number_energy_price"] = null });
-                    sources.Add(new JsonObject { ["type"] = "grid", ["flow_from"] = flowFrom, ["flow_to"] = flowTo, ["cost_adjustment_day"] = 0.0 });
+                    var grid = new JsonObject { ["type"] = "grid", ["cost_adjustment_day"] = 0.0 };
+                    if (!string.IsNullOrEmpty(outStat)) grid["stat_energy_from"] = outStat;
+                    if (!string.IsNullOrEmpty(inStat)) grid["stat_energy_to"] = inStat;
+                    sources.Add(grid);
                     break;
             }
         }

--- a/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
+++ b/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
@@ -54,22 +54,21 @@ public class EnergyDashboardSourcesTests
     {
         var node = new FlowNode("grid", "Grid", "grid");
 
-        // Import only -> flow_from has the entry; flow_to is present but empty (HA's grid schema requires both).
+        // HA's grid source is flat: import = stat_energy_from, export = stat_energy_to (no flow_from/flow_to).
+        // Import only -> stat_energy_from set, stat_energy_to absent.
         var importOnly = Assert.Single(EnergyDashboardSync.BuildEnergySources(Graph(node),
             Stats(("grid", EnergyDirection.Out, "sensor.grid_import"))));
         Assert.Equal("grid", (string?)importOnly["type"]);
-        Assert.Equal("sensor.grid_import", (string?)importOnly["flow_from"]!.AsArray()[0]!["stat_energy_from"]);
-        Assert.Empty(importOnly["flow_to"]!.AsArray());
-        // Each flow entry carries the full key set (cost/price as null) — a bare entry fails HA's grid schema.
-        var entry = importOnly["flow_from"]!.AsArray()[0]!.AsObject();
-        Assert.True(entry.ContainsKey("stat_cost") && entry.ContainsKey("number_energy_price"));
+        Assert.Equal("sensor.grid_import", (string?)importOnly["stat_energy_from"]);
+        Assert.False(importOnly.ContainsKey("stat_energy_to"));
+        Assert.False(importOnly.ContainsKey("flow_from"));
 
-        // Both -> flow_from (import) + flow_to (export).
+        // Both -> stat_energy_from (import) + stat_energy_to (export).
         var both = Assert.Single(EnergyDashboardSync.BuildEnergySources(Graph(node),
             Stats(("grid", EnergyDirection.Out, "sensor.grid_import"),
                   ("grid", EnergyDirection.In, "sensor.grid_export"))));
-        Assert.Equal("sensor.grid_import", (string?)both["flow_from"]!.AsArray()[0]!["stat_energy_from"]);
-        Assert.Equal("sensor.grid_export", (string?)both["flow_to"]!.AsArray()[0]!["stat_energy_to"]);
+        Assert.Equal("sensor.grid_import", (string?)both["stat_energy_from"]);
+        Assert.Equal("sensor.grid_export", (string?)both["stat_energy_to"]);
     }
 
     [Fact]


### PR DESCRIPTION
The real fix — read from HA's source, not guessed.

## What was actually wrong
I fetched HA's current `components/energy/data.py`. The grid source is **flat**:
```
{ "type": "grid",
  "stat_energy_from": <import>,   # optional
  "stat_energy_to":   <export>,   # optional
  "cost_adjustment_day": <float>  # required
}
```
There is **no `flow_from`/`flow_to`**. The dispatcher (`cv.key_value_schemas("type", …)`) routes `type: grid` to the flat schema, which then reports our nested `flow_from`/`flow_to` arrays as **"extra keys not allowed"** — exactly your save_prefs error.

So the grid source has the same `stat_energy_from`/`stat_energy_to` shape as battery, just with `cost_adjustment_day`.

## Fix
Emit the flat grid source. #274 (adding full `flow_from`/`flow_to` entries) was based on an outdated schema and still failed — this corrects it. `StatsOf` still also reads legacy `flow_from`/`flow_to`, so merging over any old-format prefs keeps working.

398 tests pass (grid test updated to the flat shape).

## On the churn
Fair hit — #274 was a guess that didn't work and shouldn't have gone in. I should've read HA's schema first, which is what this does. After deploy + Sync, `save_prefs` succeeds and the grid bucket fills.