### PR TITLE
feat(ha): sync power sensors + battery state-of-charge to the Energy Dashboard

### DIFF
--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -11,7 +11,9 @@ namespace rPDU2MQTT.Core.Flow;
 public sealed record HaDeviceConsumption(
     string stat_consumption,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? included_in_stat,
-    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? name);
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? name,
+    // stat_rate = an optional power sensor for real-time monitoring (HA's "Device power consumption").
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? stat_rate = null);
 
 /// <summary>The direction of a node's energy stat, relative to the node — see <see cref="Models.Config.EnergyFlowSource.Direction"/>.</summary>
 public enum EnergyDirection
@@ -31,7 +33,7 @@ public enum EnergyDirection
 public static class EnergyDashboardSync
 {
     public static List<HaDeviceConsumption> BuildDeviceConsumption(FlowGraph graph, Func<string, string?> statFor,
-        IReadOnlyCollection<string>? excludeKinds = null)
+        IReadOnlyCollection<string>? excludeKinds = null, Func<string, string?>? powerFor = null)
     {
         var excluded = excludeKinds is { Count: > 0 }
             ? new HashSet<string>(excludeKinds, StringComparer.OrdinalIgnoreCase)
@@ -46,7 +48,9 @@ public static class EnergyDashboardSync
             var stat = statFor(node.Id);
             if (string.IsNullOrEmpty(stat))
                 continue;   // no energy sensor for this tier -> can't be an Energy-Dashboard device
-            entries.Add(new HaDeviceConsumption(stat, NearestAncestorStat(graph, node.Id, statFor, excluded), node.Label));
+            var power = powerFor?.Invoke(node.Id);   // optional real-time power sensor
+            entries.Add(new HaDeviceConsumption(stat, NearestAncestorStat(graph, node.Id, statFor, excluded), node.Label,
+                string.IsNullOrEmpty(power) ? null : power));
         }
         return entries;
     }
@@ -65,13 +69,15 @@ public static class EnergyDashboardSync
     /// appears with whichever flow directions resolve.
     /// </para>
     /// </summary>
-    public static List<JsonObject> BuildEnergySources(FlowGraph graph, Func<string, EnergyDirection, string?> statFor)
+    public static List<JsonObject> BuildEnergySources(FlowGraph graph, Func<string, EnergyDirection, string?> statFor,
+        Func<string, string?>? powerFor = null, Func<string, string?>? socFor = null)
     {
         var sources = new List<JsonObject>();
         foreach (var node in graph.Nodes)
         {
             var outStat = statFor(node.Id, EnergyDirection.Out);
             var inStat = statFor(node.Id, EnergyDirection.In);
+            var power = powerFor?.Invoke(node.Id);   // signed power sensor (positive supplying); optional
             switch (node.Kind?.ToLowerInvariant())
             {
                 case "solar" when !string.IsNullOrEmpty(outStat):
@@ -79,18 +85,24 @@ public static class EnergyDashboardSync
                     break;
 
                 // HA's battery source needs both a from (discharge) and a to (charge) stat; without the pair
-                // it can't be expressed, so we skip it rather than emit a half-source HA will reject.
+                // it can't be expressed, so we skip it rather than emit a half-source HA will reject. Power goes
+                // in power_config (Standard = one signed stat_rate); state of charge in stat_soc.
                 case "battery" when !string.IsNullOrEmpty(outStat) && !string.IsNullOrEmpty(inStat):
-                    sources.Add(new JsonObject { ["type"] = "battery", ["stat_energy_from"] = outStat, ["stat_energy_to"] = inStat });
+                    var battery = new JsonObject { ["type"] = "battery", ["stat_energy_from"] = outStat, ["stat_energy_to"] = inStat };
+                    if (!string.IsNullOrEmpty(power)) battery["power_config"] = new JsonObject { ["stat_rate"] = power };
+                    if (socFor?.Invoke(node.Id) is { Length: > 0 } socStat) battery["stat_soc"] = socStat;
+                    sources.Add(battery);
                     break;
 
                 // HA's grid source is FLAT: stat_energy_from = import, stat_energy_to = export, right on the
                 // object — NOT the flow_from/flow_to arrays older docs show (those are "extra keys" to the
-                // current schema, which is what save_prefs rejected). cost_adjustment_day is required.
+                // current schema, which is what save_prefs rejected). cost_adjustment_day is required; a signed
+                // power sensor goes in the top-level stat_rate.
                 case "grid" when !string.IsNullOrEmpty(outStat) || !string.IsNullOrEmpty(inStat):
                     var grid = new JsonObject { ["type"] = "grid", ["cost_adjustment_day"] = 0.0 };
                     if (!string.IsNullOrEmpty(outStat)) grid["stat_energy_from"] = outStat;
                     if (!string.IsNullOrEmpty(inStat)) grid["stat_energy_to"] = inStat;
+                    if (!string.IsNullOrEmpty(power)) grid["stat_rate"] = power;
                     sources.Add(grid);
                     break;
             }

--- a/rPDU2MQTT.Core/Flow/FlowExport.cs
+++ b/rPDU2MQTT.Core/Flow/FlowExport.cs
@@ -86,6 +86,13 @@ public static class FlowExport
     /// Home Assistant's battery/grid split.</summary>
     public static string EnergyInUniqueId(string nodeId) => DeviceId(nodeId) + "_energy_in";
 
+    /// <summary>The HA unique_id of a tier's power sensor ("energyflow_&lt;key&gt;_power"). Signed for a
+    /// bidirectional node (grid/battery): positive supplying, negative drawing — what HA's stat_rate expects.</summary>
+    public static string PowerUniqueId(string nodeId) => DeviceId(nodeId) + "_power";
+
+    /// <summary>The HA unique_id of a battery tier's state-of-charge sensor ("energyflow_&lt;key&gt;_soc").</summary>
+    public static string SocUniqueId(string nodeId) => DeviceId(nodeId) + "_soc";
+
     /// <summary>
     /// Flow node id -> the unique_id of the native PDU-discovery energy sensor it already has (#177): PDU
     /// tiers (<c>pdu:{name}</c>) and outlets (<c>outlet:{name}:{key}</c>) that carry an energy measurement.
@@ -118,7 +125,7 @@ public static class FlowExport
     /// these makes the whole hierarchy — not just leaf outlets — visible to HA and linkable in the dashboard.
     /// </summary>
     public static JsonObject DiscoveryDocument(FlowNode node, string? primaryParentId, string stateTopic,
-        string energyUnits, string powerUnits, string? availabilityTopic, bool includeEnergyIn = false)
+        string energyUnits, string powerUnits, string? availabilityTopic, bool includeEnergyIn = false, bool includeSoc = false)
     {
         var id = DeviceId(node.Id);
         var device = new JsonObject
@@ -161,6 +168,10 @@ public static class FlowExport
         if (includeEnergyIn)
             doc["components"]!.AsObject()[$"{id}_energy_in"] =
                 Sensor($"{id}_energy_in", "Energy In", "energy", "total_increasing", string.IsNullOrWhiteSpace(energyUnits) ? "kWh" : energyUnits, "{{ value_json.energy_in }}");
+        // A battery tier with a state-of-charge source publishes it too, so HA's battery source can show %.
+        if (includeSoc)
+            doc["components"]!.AsObject()[$"{id}_soc"] =
+                Sensor($"{id}_soc", "State of charge", "battery", "measurement", "%", "{{ value_json.soc }}");
         if (!string.IsNullOrEmpty(availabilityTopic))
             doc["availability_topic"] = availabilityTopic;
         return doc;

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -61,7 +61,13 @@ public class EnergyFlowMqttExportService : baseMQTTService
         var energyInNodes = flow.Nodes
             .Where(n => n.AllSources().Any(s =>
                 string.Equals(s.Metric, energyMetric, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(s.Direction, "in", StringComparison.OrdinalIgnoreCase)))
+                (string.Equals(s.Direction, "in", StringComparison.OrdinalIgnoreCase) || FlowMetricKey.IsSplit(s.Direction))))
+            .Select(n => n.Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        // Nodes with a state-of-charge source (battery %) get an extra SoC sensor HA's battery source can use.
+        var socNodes = flow.Nodes
+            .Where(n => n.AllSources().Any(s => string.Equals(s.Metric, "soc", StringComparison.OrdinalIgnoreCase)))
             .Select(n => n.Id)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
@@ -82,13 +88,20 @@ public class EnergyFlowMqttExportService : baseMQTTService
             double? energyIn = energyInNodes.Contains(node.Id) && live is not null
                 && live.TryGetValue(node.Id, FlowMetricKey.For(energyMetric, "in"), out var ein) ? ein : null;
 
+            // Signed net power for a bidirectional node: out (discharge/import) minus in (charge/export), so the
+            // published power sensor swings ± the way HA's stat_rate wants. A one-way node keeps its plain power.
+            double netPower = live is not null && live.TryGetValue(node.Id, FlowMetricKey.For("realpower", "in"), out var pin) ? power - pin : power;
+            // Battery state of charge (%), when this node has a soc source with a fresh value.
+            double? soc = socNodes.Contains(node.Id) && live is not null && live.TryGetValue(node.Id, "soc", out var s) ? s : null;
+
             var payload = JsonSerializer.Serialize(new
             {
                 id = node.Id,
-                value = power,       // retained for #164 back-compat (== power)
-                power,
+                value = netPower,    // retained for #164 back-compat (== power)
+                power = netPower,
                 energy,
                 energy_in = energyIn,
+                soc,
                 units = graph.Units,
                 energyUnits = energyGraph.Units,
                 label = node.Label,
@@ -111,7 +124,7 @@ public class EnergyFlowMqttExportService : baseMQTTService
             }
             else
             {
-                var doc = FlowExport.DiscoveryDocument(node, parents.FirstOrDefault(), topic, energyGraph.Units, graph.Units, availability, includeEnergyIn: energyInNodes.Contains(node.Id));
+                var doc = FlowExport.DiscoveryDocument(node, parents.FirstOrDefault(), topic, energyGraph.Units, graph.Units, availability, includeEnergyIn: energyInNodes.Contains(node.Id), includeSoc: socNodes.Contains(node.Id));
                 await PublishString(configTopic, doc.ToJsonString(), retain: cfg.HASS.DiscoveryRetain, cancellationToken);
             }
         }

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -46,6 +46,7 @@ public sealed class HaEnergyDashboardSync
 
         var energyType = string.IsNullOrWhiteSpace(config.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : config.HASS.EnergyDashboard.EnergyMeasurementType;
         var native = FlowExport.NativeEnergyUniqueIds(merged, energyType);
+        var nativePower = FlowExport.NativeEnergyUniqueIds(merged, FlowGraphBuilder.DefaultMetric);   // realpower sensors
 
         var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric, live);
         var energyGraph = FlowGraphBuilder.Build(merged, config.EnergyFlow, energyType, live);
@@ -58,7 +59,17 @@ public sealed class HaEnergyDashboardSync
             var uid = native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id);
             return entityByUniqueId.TryGetValue(uid, out var e) ? e : null;
         };
-        return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver, excludeKinds);
+        // Optional real-time power sensor: the outlet/PDU's native power entity, else the energyflow power sensor.
+        Func<string, string?> powerFor = id => PowerStat(id, nativePower, entityByUniqueId);
+        return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver, excludeKinds, powerFor);
+    }
+
+    /// <summary>Resolve a node's power sensor entity — a native (PDU/outlet) power sensor if it has one, else
+    /// the energyflow power sensor the export publishes.</summary>
+    private static string? PowerStat(string id, IReadOnlyDictionary<string, string> nativePower, IReadOnlyDictionary<string, string> entityByUniqueId)
+    {
+        var uid = nativePower.TryGetValue(id, out var n) ? n : FlowExport.PowerUniqueId(id);
+        return entityByUniqueId.TryGetValue(uid, out var e) ? e : null;
     }
 
     /// <summary>
@@ -99,6 +110,7 @@ public sealed class HaEnergyDashboardSync
 
         var energyType = string.IsNullOrWhiteSpace(config.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : config.HASS.EnergyDashboard.EnergyMeasurementType;
         var native = FlowExport.NativeEnergyUniqueIds(merged, energyType);
+        var nativePower = FlowExport.NativeEnergyUniqueIds(merged, FlowGraphBuilder.DefaultMetric);   // realpower sensors
         var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric, live);
 
         // The three role buckets resolve purely on whether the energy ENTITY exists in HA — no live-value gate.
@@ -108,9 +120,12 @@ public sealed class HaEnergyDashboardSync
         // HA handles availability. (The dozens of individual devices keep their gate — that's where unavailable
         // clutter actually matters.)
         string? Resolve(string uid) => entityByUniqueId.TryGetValue(uid, out var e) ? e : null;
-        return EnergyDashboardSync.BuildEnergySources(graph, (id, dir) => dir == Core.Flow.EnergyDirection.Out
-            ? Resolve(native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id))
-            : Resolve(FlowExport.EnergyInUniqueId(id)));
+        return EnergyDashboardSync.BuildEnergySources(graph,
+            (id, dir) => dir == Core.Flow.EnergyDirection.Out
+                ? Resolve(native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id))
+                : Resolve(FlowExport.EnergyInUniqueId(id)),
+            powerFor: id => PowerStat(id, nativePower, entityByUniqueId),   // grid/battery real-time power
+            socFor: id => Resolve(FlowExport.SocUniqueId(id)));             // battery state of charge
     }
 
     /// <summary>Merge our hierarchy devices into HA's energy prefs (preserving the user's own). Returns the count synced.</summary>

--- a/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
+++ b/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
@@ -72,6 +72,41 @@ public class EnergyDashboardSourcesTests
     }
 
     [Fact]
+    public void Grid_And_Battery_CarryPowerAndSoc_WhenResolved()
+    {
+        var graph = Graph(new FlowNode("grid", "Grid", "grid"), new FlowNode("batt", "Battery", "battery"));
+        var stats = Stats(("grid", EnergyDirection.Out, "sensor.grid_import"), ("grid", EnergyDirection.In, "sensor.grid_export"),
+                          ("batt", EnergyDirection.Out, "sensor.batt_dis"), ("batt", EnergyDirection.In, "sensor.batt_chg"));
+        string? power(string id) => id == "grid" ? "sensor.grid_power" : id == "batt" ? "sensor.batt_power" : null;
+        string? soc(string id) => id == "batt" ? "sensor.batt_soc" : null;
+
+        var sources = EnergyDashboardSync.BuildEnergySources(graph, stats, power, soc);
+        var grid = Assert.Single(sources, s => (string?)s["type"] == "grid");
+        var batt = Assert.Single(sources, s => (string?)s["type"] == "battery");
+
+        // Grid power is a top-level stat_rate; battery power is nested under power_config; SoC is stat_soc.
+        Assert.Equal("sensor.grid_power", (string?)grid["stat_rate"]);
+        Assert.Equal("sensor.batt_power", (string?)batt["power_config"]!["stat_rate"]);
+        Assert.Equal("sensor.batt_soc", (string?)batt["stat_soc"]);
+        // Absent resolvers -> keys omitted, not null (HA rejects nulls / unknown keys).
+        var noExtras = EnergyDashboardSync.BuildEnergySources(graph, stats);
+        var gridBare = Assert.Single(noExtras, s => (string?)s["type"] == "grid");
+        Assert.False(gridBare.ContainsKey("stat_rate"));
+        Assert.False(Assert.Single(noExtras, s => (string?)s["type"] == "battery").ContainsKey("power_config"));
+    }
+
+    [Fact]
+    public void DeviceConsumption_CarriesPower_WhenResolved()
+    {
+        var graph = Graph(new FlowNode("rack", "Rack PDU", "pdu"));
+        var devices = EnergyDashboardSync.BuildDeviceConsumption(graph, _ => "sensor.rack_energy",
+            excludeKinds: null, powerFor: _ => "sensor.rack_power");
+        Assert.Equal("sensor.rack_power", Assert.Single(devices).stat_rate);
+        // No power resolver -> stat_rate null (omitted from JSON).
+        Assert.Null(Assert.Single(EnergyDashboardSync.BuildDeviceConsumption(graph, _ => "sensor.rack_energy")).stat_rate);
+    }
+
+    [Fact]
     public void NonRoleAndUnresolvedNodes_ProduceNothing()
     {
         var sources = EnergyDashboardSync.BuildEnergySources(


### PR DESCRIPTION
Everything you flagged in HA's config dialogs — grid power, battery power, battery SoC, device power. One coherent addition, verified against HA's actual `data.py` schemas (not guessed).

## What HA gets now
| Entry | Added |
|---|---|
| **Grid** | `stat_rate` — a **signed** power sensor (positive = import, negative = export) |
| **Battery** | `power_config.stat_rate` (signed: +discharge / −charge) **and** `stat_soc` |
| **Device** | `stat_rate` — the outlet/PDU's **native** power sensor, else the energyflow one |

## How it's fed
The flow export now publishes:
- a **signed net power** (`out − in`) so a bidirectional node swings ± the way HA's `stat_rate` wants (a one-way device keeps its plain positive power),
- a **state-of-charge** sensor for a battery node that has a `soc` source.

The sync resolves power via the node's native realpower entity (falling back to the energyflow power sensor) and SoC via the energyflow soc sensor. Everything is optional — a key is **omitted** (never null) when its sensor doesn't resolve, so nothing HA-invalid is sent.

## Verify
Schemas confirmed from HA source (grid/device `stat_rate`, battery `power_config` + `stat_soc`, `POWER_CONFIG_SCHEMA` Standard = single signed `stat_rate`). 400 tests pass, incl. new coverage for grid/battery power+SoC and device power.

## After deploy + Sync
- **Battery** needs its `soc` source bound (Nodes tab → metric "State of charge") for SoC to appear; the ⚠ still flags nodes missing energy.
- **Grid/battery power** show once their power sensors have data (the signed net requires the in-direction bound — e.g. your Split power binding).