### PR TITLE
fix(ha): also sync solar production power (stat_rate)

### DIFF
--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -81,7 +81,9 @@ public static class EnergyDashboardSync
             switch (node.Kind?.ToLowerInvariant())
             {
                 case "solar" when !string.IsNullOrEmpty(outStat):
-                    sources.Add(new JsonObject { ["type"] = "solar", ["stat_energy_from"] = outStat });
+                    var solar = new JsonObject { ["type"] = "solar", ["stat_energy_from"] = outStat };
+                    if (!string.IsNullOrEmpty(power)) solar["stat_rate"] = power;   // solar production power
+                    sources.Add(solar);
                     break;
 
                 // HA's battery source needs both a from (discharge) and a to (charge) stat; without the pair

--- a/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
+++ b/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
@@ -74,18 +74,21 @@ public class EnergyDashboardSourcesTests
     [Fact]
     public void Grid_And_Battery_CarryPowerAndSoc_WhenResolved()
     {
-        var graph = Graph(new FlowNode("grid", "Grid", "grid"), new FlowNode("batt", "Battery", "battery"));
+        var graph = Graph(new FlowNode("grid", "Grid", "grid"), new FlowNode("batt", "Battery", "battery"), new FlowNode("pv", "Solar", "solar"));
         var stats = Stats(("grid", EnergyDirection.Out, "sensor.grid_import"), ("grid", EnergyDirection.In, "sensor.grid_export"),
-                          ("batt", EnergyDirection.Out, "sensor.batt_dis"), ("batt", EnergyDirection.In, "sensor.batt_chg"));
-        string? power(string id) => id == "grid" ? "sensor.grid_power" : id == "batt" ? "sensor.batt_power" : null;
+                          ("batt", EnergyDirection.Out, "sensor.batt_dis"), ("batt", EnergyDirection.In, "sensor.batt_chg"),
+                          ("pv", EnergyDirection.Out, "sensor.pv_energy"));
+        string? power(string id) => id == "grid" ? "sensor.grid_power" : id == "batt" ? "sensor.batt_power" : id == "pv" ? "sensor.pv_power" : null;
         string? soc(string id) => id == "batt" ? "sensor.batt_soc" : null;
 
         var sources = EnergyDashboardSync.BuildEnergySources(graph, stats, power, soc);
         var grid = Assert.Single(sources, s => (string?)s["type"] == "grid");
         var batt = Assert.Single(sources, s => (string?)s["type"] == "battery");
+        var pv = Assert.Single(sources, s => (string?)s["type"] == "solar");
 
-        // Grid power is a top-level stat_rate; battery power is nested under power_config; SoC is stat_soc.
+        // Grid/solar power is a top-level stat_rate; battery power is nested under power_config; SoC is stat_soc.
         Assert.Equal("sensor.grid_power", (string?)grid["stat_rate"]);
+        Assert.Equal("sensor.pv_power", (string?)pv["stat_rate"]);
         Assert.Equal("sensor.batt_power", (string?)batt["power_config"]!["stat_rate"]);
         Assert.Equal("sensor.batt_soc", (string?)batt["stat_soc"]);
         // Absent resolvers -> keys omitted, not null (HA rejects nulls / unknown keys).


### PR DESCRIPTION
Follow-up to #277 — I added a power `stat_rate` to grid, battery and devices but **missed solar**. HA's solar source takes `stat_rate` too (the "Solar production power" slot in your screenshot).

Now a solar node's power sensor maps into it when it resolves. 400 tests pass (solar added to the power/SoC coverage).

## On the battery SoC (also empty in your shot)
That one's not a code gap — #277's plumbing is there, but it needs:
1. #277 deployed (just merged),
2. the **battery node's `soc` source bound** (Nodes tab → metric "State of charge") — your battery currently has no soc source, so no SoC sensor gets published,
3. a Sync.

Once soc is bound and published, `stat_soc` resolves and the "Battery state of charge sensor" fills in.