### PR TITLE
fix(flow): read live values in-process (single-binary), not just the lossy grain mirror

### DIFF
--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -162,9 +162,19 @@ public static class ServiceConfiguration
         if (worker || api || ui)
             services.AddHostedService(sp => new Hosting.FlowGrainSyncService(sp.GetRequiredService<Orleans.IGrainFactory>(), grainSyncedFlow));
 
-        // v3: every process reads flow values through the grain-synced mirror — Modbus (DeviceGrain) and MQTT
-        // (MqttToFlowBridge) both feed the flow grain, so this one source has all of it. No per-process ingest.
-        services.AddSingleton<Core.Flow.IFlowValueSource>(grainSyncedFlow);
+        // Reads prefer the in-process MQTT source cache, then fall back to the grain-synced mirror. In a
+        // single-binary (All-role) deployment the MQTT ingest runs in THIS process, so the GUI/exporters read
+        // the exact value the broker callback just wrote — no cross-process grain round-trip to delay it, and
+        // crucially it carries the direction-qualified (e.g. realpower#in — battery charge / grid export),
+        // state-of-charge (soc) and energy-in keys that the flow-grain sink strips out because they aren't
+        // canonical Metric names (Metrics.TryParse fails, so they never reach the grain or its mirror). Without
+        // this the battery SoC and every in-direction reading show "—" even though the ingest has them.
+        // In a UI-only split process the MQTT cache is never fed (the ingest isn't hosted there), so its reads
+        // return false and everything falls through to the mirror — this is strictly additive, never a
+        // regression. It is the single-binary deployment that makes it whole.
+        services.AddSingleton<Core.Flow.IFlowValueSource>(sp => new Core.Flow.CompositeFlowValueSource(
+            sp.GetRequiredService<Services.EnergyFlowMqttSourceService>(),
+            grainSyncedFlow));
 
         // v3: the MqttBusBridge is retired — cross-process PDU snapshot propagation is the PduGrain +
         // PduSyncService's job now (grains, not MQTT mirroring).


### PR DESCRIPTION
## The bug (why battery SoC / charge / export / in-direction show \"—\")

The GUI and exporters read live flow values through `IFlowValueSource`, wired solely to `grainSyncedFlow` — the cross-process mirror of the `FlowGrain`. But the flow-grain **sink only forwards readings whose metric parses as a canonical `Metric`** (`Metrics.TryParse`). Every direction-qualified / non-enum key is dropped *before it reaches the grain or its mirror*:

- `realpower#in` / `energy#in` — battery **charge**, grid **export**
- `soc` — battery **state of charge**

Those keys live only in the MQTT ingest's own in-process `FlowValueCache`. So SoC and every in-direction reading render as `—` even though the ingest has them — and in a split (multi-pod) deployment the mirror can lag or come up empty entirely, which is what took out the whole Energy Overview.

## Fix

Register `IFlowValueSource` as a **composite**: read the in-process MQTT source cache first, fall back to the grain mirror.

- **Single-binary (All-role) deployment:** ingest and GUI share the process → reads hit the exact value the broker callback just wrote, every key, no round-trip. Dead simple, reliable.
- **UI-only split process:** MQTT cache isn't fed there → reads fall through to the mirror unchanged. Strictly additive, no regression.

Run the whole app as **one process** with `split.enabled: false` (the chart default) and this path is complete end-to-end.

## Test
- `dotnet build` clean; **400/400 tests pass**. `CompositeFlowValueSource` freshness fall-through already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)