### PR TITLE
fix(mqtt): every subscription was lost on the first reconnect, permanently

### DIFF
--- a/rPDU2MQTT.Engine/Classes/MqttSubscriptions.cs
+++ b/rPDU2MQTT.Engine/Classes/MqttSubscriptions.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using HiveMQtt.Client;
+using HiveMQtt.Client.Results;
 using HiveMQtt.MQTT5.Types;
 
 namespace rPDU2MQTT.Classes;
@@ -10,26 +12,67 @@ namespace rPDU2MQTT.Classes;
 /// keeps no session and drops every subscription on a reconnect. Nothing re-added them: each service
 /// subscribes once at startup and assumes the subscription lives forever. The result is a process that works
 /// after boot and then, after the first network blip days later, goes silently deaf — no outlet commands, no
-/// energy-flow values — until it's restarted. This restores them the moment the client reconnects.
+/// energy-flow values — until it's restarted.
+/// </para>
+/// <para>
+/// The first attempt at this replayed <c>client.Subscriptions</c> on reconnect, which never worked: HiveMQtt
+/// <b>clears that list as part of reconnecting, before AfterConnect is raised</b>, so the replay always saw an
+/// empty list and returned immediately. Measured against a real client (0.45.1): 2 subscriptions before the
+/// drop, still 2 while disconnected, <b>0 by the time AfterConnect fires</b>, and 0 for the rest of the
+/// process's life. The unit test missed it because it populated <c>Subscriptions</c> by hand — the one thing
+/// the real client won't do for you.
+/// </para>
+/// <para>
+/// So the desired set is remembered <i>here</i>, as each subscription is made, and replayed from that. Route
+/// subscriptions through <see cref="SubscribeAsync"/> to get this; a direct <c>client.SubscribeAsync</c> is
+/// not remembered and will not survive a reconnect.
 /// </para>
 /// </summary>
 public static class MqttSubscriptions
 {
+    // Topic filter -> the QoS it was subscribed at. Ours, because the client's own list does not survive.
+    private static readonly ConcurrentDictionary<string, QualityOfService> Desired = new(StringComparer.Ordinal);
+
+    /// <summary>Subscribe, and remember it so a reconnect can restore it.</summary>
+    public static async Task<SubscribeResult> SubscribeAsync(IHiveMQClient client, string topic, QualityOfService qos)
+    {
+        var result = await client.SubscribeAsync(topic, qos);
+        // Remembered even when the broker denied it (a SUBACK failure code, not an exception): permissions
+        // can be granted later, and the caller's own retry decides whether to keep asking.
+        Desired[topic] = qos;
+        return result;
+    }
+
+    /// <summary>Stop restoring a topic — call when deliberately unsubscribing, or it comes back on reconnect.</summary>
+    public static void Forget(string topic) => Desired.TryRemove(topic, out _);
+
+    /// <summary>Everything currently expected to be subscribed (diagnostics/tests).</summary>
+    public static IReadOnlyDictionary<string, QualityOfService> Tracked => Desired;
+
+    /// <summary>Test seam — the registry is process-wide, so a test must be able to start from empty.</summary>
+    internal static void Reset() => Desired.Clear();
+
     /// <summary>
-    /// Re-subscribe the client to every filter it still tracks. Idempotent, and de-duplicated so repeated
+    /// Re-subscribe the client to every filter we still expect. Idempotent, and de-duplicated so repeated
     /// reconnects can't do unbounded work. A no-op on the very first connect (nothing has subscribed yet).
     /// </summary>
     public static async Task ResubscribeAllAsync(IHiveMQClient client)
     {
-        var filters = client.Subscriptions
-            .Select(s => (s.TopicFilter.Topic, s.TopicFilter.QoS))
-            .Where(f => !string.IsNullOrWhiteSpace(f.Topic))
-            .Distinct()
-            .ToList();
+        // Our own registry first; union in anything the client still lists, to cover a subscription made
+        // without going through SubscribeAsync above.
+        var filters = new Dictionary<string, QualityOfService>(Desired, StringComparer.Ordinal);
+        foreach (var sub in client.Subscriptions)
+        {
+            var topic = sub.TopicFilter?.Topic;
+            if (!string.IsNullOrWhiteSpace(topic))
+                filters[topic] = sub.TopicFilter!.QoS;
+        }
+
         if (filters.Count == 0)
             return;
 
         Log.Information($"MQTT reconnected — re-establishing {filters.Count} subscription(s).");
+        var failed = 0;
         foreach (var (topic, qos) in filters)
         {
             try
@@ -38,8 +81,13 @@ public static class MqttSubscriptions
             }
             catch (Exception ex)
             {
+                failed++;
                 Log.Warning($"Could not re-subscribe to '{topic}' after reconnect: {ex.Message}");
             }
         }
+
+        // Going quiet about a partial restore is how this stayed invisible the first time.
+        if (failed > 0)
+            Log.Error($"{failed} of {filters.Count} subscription(s) could not be restored after the reconnect — the features behind them stay deaf until it succeeds.");
     }
 }

--- a/rPDU2MQTT.Engine/Services/DiagnosticService.cs
+++ b/rPDU2MQTT.Engine/Services/DiagnosticService.cs
@@ -38,8 +38,8 @@ public class DiagnosticService : IHostedService
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         mqtt.OnMessageReceived += OnMessageReceived;
-        await mqtt.SubscribeAsync(rediscoverTopic, QualityOfService.AtLeastOnceDelivery);
-        await mqtt.SubscribeAsync(restartTopic, QualityOfService.AtLeastOnceDelivery);
+        await MqttSubscriptions.SubscribeAsync(mqtt, rediscoverTopic, QualityOfService.AtLeastOnceDelivery);
+        await MqttSubscriptions.SubscribeAsync(mqtt, restartTopic, QualityOfService.AtLeastOnceDelivery);
         Log.Information($"Diagnostic actions subscribed ({rediscoverTopic}, {restartTopic}).");
     }
 

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -49,10 +49,21 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     public bool TryGetValue(string nodeId, string metric, out double value)
         => latest.TryGetValue(nodeId, metric, out value);
 
+    // Set when the client reconnects: everything in `subscribed` is a stale belief at that point and the
+    // next reconcile must re-establish it. A flag rather than clearing the set from the event thread, so
+    // `subscribed` is only ever mutated by the reconcile loop.
+    private volatile bool connectionReset;
+
+    private void OnReconnected(object? sender, HiveMQtt.Client.Events.AfterConnectEventArgs e)
+    {
+        connectionReset = true;
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         Log.Information("Energy-flow MQTT ingest started — reconciling broker subscriptions from EnergyFlow.Nodes.");
         mqtt.OnMessageReceived += OnMessageReceived;
+        mqtt.AfterConnect += OnReconnected;
         try
         {
             using var timer = new PeriodicTimer(TimeSpan.FromSeconds(15));
@@ -65,7 +76,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             while (await timer.WaitForNextTickAsync(stoppingToken));
         }
         catch (OperationCanceledException) { /* shutting down */ }
-        finally { mqtt.OnMessageReceived -= OnMessageReceived; }
+        finally { mqtt.OnMessageReceived -= OnMessageReceived; mqtt.AfterConnect -= OnReconnected; }
     }
 
     /// <summary>Bring the broker subscriptions in line with the current config (added/removed topics).</summary>
@@ -73,6 +84,18 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
 
     private async Task Reconcile(CancellationToken ct)
     {
+        // A reconnect leaves the broker with no session and the client with an empty subscription list, so
+        // every topic in `subscribed` is now a belief about a subscription that no longer exists. Without
+        // this, `subscribed.Add` below reports "already done" and the ingest never re-subscribes — the
+        // process keeps running, keeps reporting healthy, and silently receives nothing until it restarts.
+        if (connectionReset)
+        {
+            connectionReset = false;
+            if (subscribed.Count > 0)
+                Log.Information($"Energy-flow: MQTT reconnected — re-establishing {subscribed.Count} subscription(s).");
+            subscribed.Clear();
+        }
+
         var desired = BuildBindings(cfg.EnergyFlow.Nodes);
         bindings = desired;
 
@@ -92,7 +115,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             {
                 // AtLeastOnce so a value isn't silently dropped; retained messages arrive immediately, which
                 // is what makes a restarted process pick up e.g. Solar Assistant's last reading at once.
-                var result = await mqtt.SubscribeAsync(topic, QualityOfService.AtLeastOnceDelivery);
+                var result = await MqttSubscriptions.SubscribeAsync(mqtt, topic, QualityOfService.AtLeastOnceDelivery);
 
                 // A broker can *deny* a subscription (ACL) and the client reports it in the SUBACK, not as an
                 // exception. Treating that as success is how the ingest dies silently — check it, like the
@@ -122,6 +145,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             try
             {
                 await mqtt.UnsubscribeAsync(topic);
+                MqttSubscriptions.Forget(topic);   // else the reconnect replay resurrects it
                 subscribed.Remove(topic);
                 // Drop its cached readings too, so an unbound topic stops feeding the graph immediately.
                 foreach (var key in latest.Keys.Where(k => BoundOnlyBy(k, topic))) latest.Remove(key.Node, key.Metric);

--- a/rPDU2MQTT.Engine/Services/MqttReconfigurator.cs
+++ b/rPDU2MQTT.Engine/Services/MqttReconfigurator.cs
@@ -62,18 +62,11 @@ public sealed class MqttReconfigurator
             client.Options = options;
             await client.ConnectAsync();
 
-            // Resubscribe to whatever the services had subscribed to before the reconnect.
-            foreach (var filter in previous)
-            {
-                try
-                {
-                    await client.SubscribeAsync(filter.Topic, filter.QoS);
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning($"Could not resubscribe to '{filter.Topic}' after re-pointing MQTT: {ex.Message}");
-                }
-            }
+            // Resubscribe to whatever the services had subscribed to before the reconnect. This goes through
+            // the shared registry rather than a private copy of the logic: `previous` is only correct because
+            // it was captured before the disconnect (the client empties its own list on reconnect), and a
+            // second implementation of that subtlety is one more place for it to rot.
+            await MqttSubscriptions.ResubscribeAllAsync(client);
 
             fingerprint = target;
             Log.Information($"MQTT client re-pointed at {options.Host}:{options.Port} ({previous.Count} subscription(s) restored).");

--- a/rPDU2MQTT.Engine/Services/OutletCommandService.cs
+++ b/rPDU2MQTT.Engine/Services/OutletCommandService.cs
@@ -60,7 +60,7 @@ public class OutletCommandService : IHostedService
 
         foreach (var filter in commandFilters)
         {
-            var result = await mqtt.SubscribeAsync(filter, QualityOfService.AtLeastOnceDelivery);
+            var result = await MqttSubscriptions.SubscribeAsync(mqtt, filter, QualityOfService.AtLeastOnceDelivery);
             foreach (var sub in result.Subscriptions)
             {
                 // SUBACK reason codes 0-2 are "granted QoS 0/1/2"; anything else is a failure/denial.

--- a/rPDU2MQTT.Engine/Services/RestartCommandService.cs
+++ b/rPDU2MQTT.Engine/Services/RestartCommandService.cs
@@ -41,7 +41,7 @@ public sealed class RestartCommandService : IHostedService
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         mqtt.OnMessageReceived += OnMessageReceived;
-        try { await mqtt.SubscribeAsync(Topic, QualityOfService.AtLeastOnceDelivery); }
+        try { await MqttSubscriptions.SubscribeAsync(mqtt, Topic, QualityOfService.AtLeastOnceDelivery); }
         catch (Exception ex) { Log.Warning($"Restart-command: could not subscribe to {Topic}: {ex.Message}"); }
     }
 

--- a/rPDU2MQTT.Tests/FakeHiveMQClient.cs
+++ b/rPDU2MQTT.Tests/FakeHiveMQClient.cs
@@ -42,7 +42,23 @@ internal sealed class FakeHiveMQClient : IHiveMQClient
     {
         Calls.Add("subscribe:" + topic);
         Subscribed.Add(topic);
+        // The real client tracks it here too, which is what makes SimulateReconnect's clearing meaningful.
+        Subscriptions.Add(new Subscription(new TopicFilter(topic, qos)));
         return Task.FromResult<SubscribeResult>(null!);
+    }
+
+    /// <summary>
+    /// Behave like the real client across a reconnect: HiveMQtt <b>empties Subscriptions</b> as part of
+    /// reconnecting, before AfterConnect is raised (measured against 0.45.1). Any restore that reads the
+    /// client's own list therefore sees nothing. Modelling that here is the difference between a test that
+    /// proves the reconnect path works and one that only proves a list it filled itself can be replayed.
+    /// </summary>
+    public void SimulateReconnect()
+    {
+        Subscriptions.Clear();
+        Subscribed.Clear();
+        Calls.Add("reconnect");
+        Connected = true;
     }
 
     public Task<SubscribeResult> SubscribeAsync(SubscribeOptions options) => throw new NotImplementedException();

--- a/rPDU2MQTT.Tests/MqttResubscribeTests.cs
+++ b/rPDU2MQTT.Tests/MqttResubscribeTests.cs
@@ -6,20 +6,33 @@ namespace rPDU2MQTT.Tests;
 
 /// <summary>
 /// After an MQTT reconnect the broker keeps no session (the client id carries a fresh GUID), so every
-/// subscription is dropped. Nothing re-added them — a process worked at boot then went silently deaf days
-/// later, after the first network blip. This restores them on reconnect.
+/// subscription is dropped. A process worked at boot then went silently deaf days later, after the first
+/// network blip — no outlet commands, no energy-flow values — until it was restarted.
+///
+/// The first fix replayed <c>client.Subscriptions</c> on reconnect and never worked, because HiveMQtt
+/// <b>clears that list while reconnecting, before AfterConnect fires</b> (measured against 0.45.1: 2
+/// subscriptions before the drop, 2 while down, 0 by the time the event ran). The old tests passed anyway:
+/// they populated <c>Subscriptions</c> by hand, so they only ever proved that a list someone else filled
+/// could be replayed. These use <see cref="FakeHiveMQClient.SimulateReconnect"/>, which clears the list the
+/// way the real client does, so the assumption is part of the test rather than a silent precondition.
 /// </summary>
-public class MqttResubscribeTests
+[Collection("MqttSubscriptions")]
+public class MqttResubscribeTests : IDisposable
 {
-    private static Subscription Sub(string topic, QualityOfService qos = QualityOfService.AtLeastOnceDelivery)
-        => new(new TopicFilter(topic, qos));
+    // The registry is process-wide; start each test from empty so ordering can't leak between them.
+    public MqttResubscribeTests() => MqttSubscriptions.Reset();
+    public void Dispose() => MqttSubscriptions.Reset();
 
     [Fact]
-    public async Task Reconnect_ReestablishesEveryTrackedSubscription()
+    public async Task Reconnect_ReestablishesSubscriptions_EvenThoughTheClientForgotThem()
     {
         var client = new FakeHiveMQClient();
-        client.Subscriptions.Add(Sub("rpdu2mqtt/+/outlets/+/set"));
-        client.Subscriptions.Add(Sub("solar_assistant/inverter_1/grid_power/state"));
+        await MqttSubscriptions.SubscribeAsync(client, "rpdu2mqtt/+/outlets/+/set", QualityOfService.AtLeastOnceDelivery);
+        await MqttSubscriptions.SubscribeAsync(client, "solar_assistant/inverter_1/grid_power/state", QualityOfService.AtLeastOnceDelivery);
+
+        // The real reconnect: the client's own record is gone before anyone gets a chance to read it.
+        client.SimulateReconnect();
+        Assert.Empty(client.Subscriptions);
 
         await MqttSubscriptions.ResubscribeAllAsync(client);
 
@@ -28,23 +41,39 @@ public class MqttResubscribeTests
     }
 
     [Fact]
-    public async Task RepeatedReconnects_DontDoUnboundedWork()
+    public async Task RepeatedReconnects_KeepRestoring_AndDontDoUnboundedWork()
     {
         var client = new FakeHiveMQClient();
-        // The real client appends to its subscription list on each SubscribeAsync, so after a few reconnects
-        // the list holds duplicates. We must re-subscribe each distinct topic once, not once per duplicate.
-        client.Subscriptions.Add(Sub("a/b"));
-        client.Subscriptions.Add(Sub("a/b"));
-        client.Subscriptions.Add(Sub("a/b"));
+        await MqttSubscriptions.SubscribeAsync(client, "a/b", QualityOfService.AtLeastOnceDelivery);
 
-        await MqttSubscriptions.ResubscribeAllAsync(client);
-
-        Assert.Single(client.Subscribed);
-        Assert.Equal("a/b", client.Subscribed[0]);
+        for (var i = 0; i < 3; i++)
+        {
+            client.SimulateReconnect();
+            await MqttSubscriptions.ResubscribeAllAsync(client);
+            // Each reconnect restores the topic exactly once, however many times we've been round.
+            Assert.Equal(new[] { "a/b" }, client.Subscribed);
+        }
     }
 
     [Fact]
-    public async Task FirstConnect_WithNoSubscriptions_IsANoOp()
+    public async Task AnUnsubscribedTopic_IsNotResurrectedByAReconnect()
+    {
+        var client = new FakeHiveMQClient();
+        await MqttSubscriptions.SubscribeAsync(client, "keep/me", QualityOfService.AtLeastOnceDelivery);
+        await MqttSubscriptions.SubscribeAsync(client, "drop/me", QualityOfService.AtLeastOnceDelivery);
+
+        // Unbinding a flow node unsubscribes its topic; the registry has to hear about it.
+        MqttSubscriptions.Forget("drop/me");
+
+        client.SimulateReconnect();
+        await MqttSubscriptions.ResubscribeAllAsync(client);
+
+        Assert.Contains("keep/me", client.Subscribed);
+        Assert.DoesNotContain("drop/me", client.Subscribed);
+    }
+
+    [Fact]
+    public async Task FirstConnect_WithNothingSubscribed_IsANoOp()
     {
         var client = new FakeHiveMQClient();
         await MqttSubscriptions.ResubscribeAllAsync(client);

--- a/rPDU2MQTT/Hosting/MqttTopicIndexService.cs
+++ b/rPDU2MQTT/Hosting/MqttTopicIndexService.cs
@@ -87,7 +87,7 @@ public sealed class MqttTopicIndexService : BackgroundService
         try
         {
             mqtt.OnMessageReceived += OnMessageReceived;
-            var result = await mqtt.SubscribeAsync(filter, QualityOfService.AtMostOnceDelivery);
+            var result = await MqttSubscriptions.SubscribeAsync(mqtt, filter, QualityOfService.AtMostOnceDelivery);
             subscribedFilter = filter;
 
             // A broker can *deny* the subscription (an ACL that forbids the wildcard) and report it in the
@@ -117,6 +117,7 @@ public sealed class MqttTopicIndexService : BackgroundService
         try
         {
             await mqtt.UnsubscribeAsync(filter);
+            MqttSubscriptions.Forget(filter);   // else the reconnect replay resurrects it
             Serilog.Log.Information("Topic index: nobody is browsing; unsubscribed.");
         }
         catch (Exception ex) { Serilog.Log.Debug($"Topic index: unsubscribe failed: {ex.Message}"); }


### PR DESCRIPTION
## The symptom

A running bridge goes silently deaf after its first broker blip — no energy-flow values, no outlet commands, no restart/rediscover commands, no topic index. It keeps running and keeps reporting healthy. Only a process restart brings it back.

From the outside that reads as *"it works right after a restart, then stops."*

## The cause

The guard against this already existed and **never once worked**. `ResubscribeAllAsync` replayed `client.Subscriptions` on `AfterConnect` — but HiveMQtt **clears that list as part of reconnecting, before the event is raised.**

Measured against a real `HiveMQClient` (0.45.1) over a forced drop:

```
after 2 subscribes        Subscriptions.Count = 2
t+12s connected=False     Subscriptions.Count = 2    ← survives the drop
[AfterConnect]            Subscriptions.Count = 0    ← already cleared
t+18s connected=True      Subscriptions.Count = 0    ← and stays 0 forever
```

So `filters.Count == 0` and it returned before doing anything — every reconnect, for the life of the process.

**Why the test didn't catch it:** it populated `client.Subscriptions` by hand. It proved a list *someone else* filled could be replayed; it never established that the real client still had one. That assumption was the entire bug. Confirmed in a real run too — two `MQTT Client Connected` lines with no `re-establishing` line between them.

Compounding it, `EnergyFlowMqttSourceService` keeps a `subscribed` HashSet and does `if (!subscribed.Add(topic)) continue;`. Nothing ever invalidated that set, so its 15-second reconcile loop — the thing whose whole job is keeping subscriptions in line with reality — was structurally incapable of re-establishing a lost one.

## The fix

- **`MqttSubscriptions` keeps its own registry** of desired `(topic, QoS)`, recorded as each subscription is made, and replays from that rather than from a list the client throws away. All six subscribing services route through it. `Forget()` on unsubscribe, so an unbound flow topic isn't resurrected.
- **`EnergyFlowMqttSourceService` self-heals**: `subscribed` is cleared on reconnect, so the reconcile loop re-establishes within one pass (≤15s) even if a replay is missed or denied by ACL.
- **`MqttReconfigurator`** drops its private second copy of the replay logic — correct today only because it snapshots *before* disconnecting, which is one more place for the subtlety to rot.
- **A partial restore is now an error in the log** instead of passing quietly.

## Verification

Not fakes this time — fakes are what hid it.

- A probe against a **real `HiveMQClient`** established the clearing behaviour above.
- End-to-end against a broker stub that **delivers only to genuine subscribers**, so an arriving value proves the subscription exists:

```
BEFORE the blip:  value = 1111,  delivered to 1 subscriber(s)
*** dropping all connections ***
22:46:15  MQTT reconnected — re-establishing 2 subscription(s).      ← registry replay
22:46:26  Energy-flow: MQTT reconnected — re-establishing 1 …        ← self-heal backstop
AFTER the blip:   value = 2222,  delivered to 1 subscriber(s)
```

- `FakeHiveMQClient` gains `SimulateReconnect()`, which clears `Subscriptions` the way the real client does. The tests now use it, so the assumption is under test rather than silently assumed — including that an unsubscribed topic is not resurrected.
- Build clean, 401 tests pass.

Independent of #281 (GUI) — branched off `main` so it can go out on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)