### PR TITLE
fix(gui): an idle branch no longer scatters across the flow chart

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -89,7 +89,7 @@ Nothing open.
 
 Click it again, to restore.
 
-- Energy Flow Chart- ability to display Power.... Or Energy.
+- [x] Energy Flow Chart- ability to display Power.... Or Energy.  (#275 — metric toggle on the Flow tab)
 
 - Need to aggregate energy data, using the collected power data. Will need redis broker to support
     Helm chart will need redis broker. Docker compse example, will need redis.
@@ -100,7 +100,7 @@ Click it again, to restore.
 
 The None nodes are removed form the chart, instead of displaying between the nodes.
 
-- Nodes without energy, explain extremely weird.
+- [x] Nodes without energy, explain extremely weird.
 
 In this case- MPPTs 1-3 feeds a aggregate node named Solar/PV, which feeds the inverter.
 
@@ -108,15 +108,24 @@ WELL..... since its night time, they have zero output. And... fubar.
 
 ![alt text](image.png)
 
+    Fixed: the barycenter weighted each feeder by its link value, so a zero-carrying link had no pull at
+    all and the whole idle solar chain sorted to the bottom of its column (measured: MPPTs at y=557/580/603
+    against Solar at y=29) while the inverter stayed up beside the grid — joined by ribbons that scaled to
+    ~0px, so nothing looked connected either. Weights now have a floor, a backward pass orders each column
+    by what it feeds, and an idle link draws as a visible hairline. Pinned by web/sankey.check.mjs.
+
 -----------
 
-- Hierarchy diagram, small bug-
+- [x] Hierarchy diagram, small bug-
 
 ![alt text](image-1.png)
 
 battery feeds the Flexboss/Inverter, but, is positioned to the left of Solar which also feeds the flexboss.
 
 It should, ideally be positioned below, or above Solar/PV.... since it connects to a node to the right of it. Instead, its displayed on the left side.
+
+    Already fixed by #266 (this screenshot predates it): every node now sits one column left of the
+    earliest thing it feeds, so Battery and Grid land beside Solar. Pinned by web/layout.check.mjs.
 
 -----------------------
 

--- a/rPDU2MQTT.Web/rPDU2MQTT.Web.csproj
+++ b/rPDU2MQTT.Web/rPDU2MQTT.Web.csproj
@@ -36,6 +36,9 @@
 		<GuiSource Include="web\styles.css" />
 		<GuiSource Include="web\build.mjs" />
 		<GuiSource Include="web\smoke.mjs" />
+		<GuiSource Include="web\domstub.mjs" />
+		<GuiSource Include="web\layout.check.mjs" />
+		<GuiSource Include="web\sankey.check.mjs" />
 		<GuiSource Include="web\schema.fixture.json" />
 	</ItemGroup>
 
@@ -50,6 +53,11 @@
 		<!-- Run the bundle's smoke test against the real schema: it builds every section in a stubbed DOM,
 		     so a broken cross-module reference fails the build here instead of blanking a tab at runtime. -->
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/smoke.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
+		<!-- Layout regressions render fine and mean nothing: the hierarchy left-justified a feeder away from
+		     what it powers, and a night-time (all-zero) solar chain sank to the bottom of the chart joined by
+		     invisible ribbons. Both are asserted on the real bundle's rendered geometry. -->
+		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/layout.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
+		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/sankey.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Warning Condition="'$(_NodeExitCode)' != '0'" Text="node not found; using the committed wwwroot/app.js + styles.css. Install Node 22+ to rebuild the GUI from web/src." />
 	</Target>
 

--- a/rPDU2MQTT.Web/web/domstub.mjs
+++ b/rPDU2MQTT.Web/web/domstub.mjs
@@ -1,0 +1,123 @@
+// The fake DOM the GUI tests run against: a real tree, so what was rendered can be asserted on, plus the
+// browser globals the bundle touches. Shared by smoke.mjs and layout.check.mjs — one stub, so a gap in it
+// gets fixed once and both tests get the fix.
+//
+// Where it models a browser, it models the awkward version: EventSource is deliberately absent, so the
+// no-push fallback path stays exercised. A stub that only does the convenient thing is how a bug hides.
+
+function matches(node, sel) {
+  sel = sel.trim();
+  const attr = sel.match(/^(\w+)\[type=(\w+)\]$/);
+  if (attr) return node.tag === attr[1] && node.attrs.type === attr[2];
+  if (sel.startsWith('.')) return node.classList.has(sel.slice(1));
+  const tagClass = sel.match(/^(\w+)\.([\w-]+)$/);
+  if (tagClass) return node.tag === tagClass[1] && node.classList.has(tagClass[2]);
+  return node.tag === sel;
+}
+
+// Supports the selector shapes the GUI actually uses: "a", ".field", "nav a", "input[type=checkbox]",
+// and comma lists like "input, select, textarea".
+export function query(root, sel, all) {
+  const out = [];
+  for (const branch of sel.split(',')) {
+    const parts = branch.trim().split(/\s+/);
+    let cur = [root];
+    for (const p of parts) {
+      const next = [];
+      for (const n of cur) for (const d of descendants(n)) if (matches(d, p)) next.push(d);
+      cur = next;
+    }
+    out.push(...cur);
+  }
+  return all ? out : (out[0] ?? null);
+}
+
+function* descendants(node) {
+  for (const c of node.children) { yield c; yield* descendants(c); }
+}
+
+export function makeEl(tag = 'div') {
+  const node = {
+    tag, children: [], attrs: {}, style: {}, dataset: {}, _text: '',
+    classList: {
+      _s: new Set(),
+      add(...c) { c.forEach(x => x && this._s.add(x)); },
+      remove(...c) { c.forEach(x => this._s.delete(x)); },
+      contains(c) { return this._s.has(c); },
+      has(c) { return this._s.has(c); },
+    },
+    get className() { return [...this.classList._s].join(' '); },
+    set className(v) { this.classList._s = new Set(String(v).split(/\s+/).filter(Boolean)); },
+    get textContent() { return this._text || this.children.map(c => c.textContent).join(''); },
+    set textContent(v) { this._text = String(v); this.children = []; },
+    set innerHTML(v) { if (!v) this.children = []; },
+    get innerHTML() { return ''; },
+    appendChild(c) { if (c && c.tag) this.children.push(c); return c; },
+    append(...cs) { cs.forEach(c => { if (c && c.tag) this.children.push(c); }); },
+    removeChild(c) { this.children = this.children.filter(x => x !== c); },
+    remove() {}, insertBefore(c) { this.children.push(c); return c; },
+    // Node.contains(): self or any descendant (used to tell Oidc fields from Basic ones).
+    contains(n) { if (n === this) return true; for (const d of descendants(this)) if (d === n) return true; return false; },
+    setAttribute(k, v) { this.attrs[k] = String(v); },
+    getAttribute(k) { return this.attrs[k] ?? null; },
+    removeAttribute(k) { delete this.attrs[k]; },
+    addEventListener() { }, removeEventListener() { },
+    click() { if (typeof this.onclick === 'function') this.onclick({ preventDefault() { }, stopPropagation() { } }); },
+    focus() { }, select() { }, setSelectionRange() { },
+    querySelector(s) { return query(this, s, false); },
+    querySelectorAll(s) { return query(this, s, true); },
+    getBoundingClientRect() { return { left: 0, top: 0, width: 100, height: 100 }; },
+    getScreenCTM() { return { inverse() { return {}; } }; },
+  };
+  // classList.has is used by our matcher; keep `contains` as the DOM-facing name.
+  return node;
+}
+
+// Build a sandbox whose fetch answers from `bodies(url)`. Returns the pieces a test needs to drive it.
+export function makeDom({ bodies }) {
+  const root = makeEl('body');
+  const byId = {};
+  const getEl = (id) => (byId[id] ||= Object.assign(makeEl(id === 'nav' ? 'nav' : 'div'), { id }));
+  // nav + sections live in the tree so `document.querySelectorAll('nav a')` can find the links.
+  root.appendChild(getEl('nav'));
+  root.appendChild(getEl('sections'));
+
+  // A tiny localStorage, so the theme can persist the way it does in a browser.
+  const storage = new Map();
+
+  const sandbox = {
+    console,
+    document: {
+      body: root,
+      // The theme sets data-theme here; nothing else touches it.
+      documentElement: makeEl('html'),
+      getElementById: (id) => getEl(id),
+      createElement: (t) => makeEl(t), createElementNS: (_ns, t) => makeEl(t),
+      createTextNode: () => makeEl('#text'),
+      querySelector: (s) => query(root, s, false),
+      querySelectorAll: (s) => query(root, s, true),
+      elementFromPoint: () => null,
+    },
+    window: { addEventListener() { }, removeEventListener() { }, dispatchEvent() { return true; }, prompt: () => null },
+    // protocol/hostname are read when building the API docs links (#190).
+    location: { hash: '', protocol: 'http:', hostname: 'localhost' },
+    navigator: { clipboard: { writeText() { } } },
+    localStorage: {
+      getItem: (k) => (storage.has(k) ? storage.get(k) : null),
+      setItem: (k, v) => storage.set(k, String(v)),
+      removeItem: (k) => storage.delete(k),
+    },
+    CustomEvent: class { constructor(type, init) { this.type = type; this.detail = init?.detail; } },
+    DOMPoint: class { matrixTransform() { return { x: 0, y: 0 }; } },
+    setTimeout: (fn) => { if (typeof fn === 'function') fn(); return 0; },
+    clearTimeout() { },
+    setInterval: () => 0, clearInterval() { },
+    confirm: () => true,
+    fetch: async (url) => ({ ok: true, status: 200, text: async () => '', json: async () => bodies(String(url)) }),
+    // EventSource is deliberately absent: it exercises the no-push path, where every section must still
+    // work off its manual refresh / polling fallback.
+  };
+  sandbox.globalThis = sandbox;
+
+  return { sandbox, root, byId, getEl, query, makeEl, storage };
+}

--- a/rPDU2MQTT.Web/web/layout.check.mjs
+++ b/rPDU2MQTT.Web/web/layout.check.mjs
@@ -1,0 +1,87 @@
+// Hierarchy-layout regression check: build the real bundle in the smoke DOM against a topology shaped
+// like a solar install (MPPTs -> Solar -> inverter, with Battery and Grid also feeding the inverter), open
+// the Flow tab, and read back each node's rendered x to recover its column.
+//
+// The bug this pins (ToDo.md, image-1.png): Battery and Grid feed the inverter, but longest-path-from-root
+// layering left-justified them into column 0 beside the MPPTs — so their links trailed across two columns
+// instead of starting next to what they power. A feeder must sit exactly one column left of the earliest
+// thing it feeds.
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDom } from './domstub.mjs';
+
+const code = await readFile(new URL('../wwwroot/app.js', import.meta.url), 'utf8');
+const schema = JSON.parse(await readFile(new URL('./schema.fixture.json', import.meta.url), 'utf8'))
+  .filter(n => n.key !== '_README');
+
+const config = {
+  EnergyFlow: {
+    Nodes: [
+      { Id: 'MPPT_1', Label: 'MPPT_1', Kind: 'solar' },
+      { Id: 'MPPT_2', Label: 'MPPT_2', Kind: 'solar' },
+      { Id: 'MPPT_3', Label: 'MPPT_3', Kind: 'solar' },
+      { Id: 'solar', Label: 'Solar (PV)', Kind: 'solar' },
+      { Id: 'battery', Label: 'Battery', Kind: 'battery' },
+      { Id: 'grid', Label: 'Grid', Kind: 'grid' },
+      { Id: 'inverter', Label: 'EG4 FlexBoss 21' },
+      { Id: 'main_panel', Label: 'Main Panel' },
+    ],
+    Links: [
+      { From: 'MPPT_1', To: 'solar' }, { From: 'MPPT_2', To: 'solar' }, { From: 'MPPT_3', To: 'solar' },
+      { From: 'solar', To: 'inverter' },
+      { From: 'battery', To: 'inverter' },
+      { From: 'grid', To: 'inverter' },
+      { From: 'inverter', To: 'main_panel' },
+    ],
+  },
+};
+
+const { sandbox, getEl, query } = makeDom({
+  bodies: (url) =>
+    url.includes('/api/schema') ? schema :
+    url.includes('/api/instances') ? { ok: true, instances: [] } :
+    url.includes('/api/config') ? config :
+    url.includes('/api/flow') ? { ok: true, nodes: [], links: [], metric: 'realpower', units: 'W' } :
+    { ok: true },
+});
+
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox, { filename: 'app.js' });
+await new Promise(r => setTimeout(r, 50));
+
+const nav = getEl('nav');
+const flowLink = query(nav, 'a', true).find(a => a.dataset.label === 'Flow');
+if (!flowLink) { console.error('layout check FAILED: no Flow tab'); process.exit(1); }
+flowLink.click();
+await new Promise(r => setTimeout(r, 50));
+
+// Every hierarchy node is a <g dataset.id> translated to its column's x.
+const placed = new Map();
+for (const g of query(getEl('sections'), 'g', true)) {
+  const id = g.dataset?.id, tf = g.attrs?.transform;
+  if (!id || !tf) continue;
+  const m = /translate\(([-\d.]+),/.exec(tf);
+  if (m) placed.set(id, Number(m[1]));
+}
+
+const xs = [...new Set([...placed.values()])].sort((a, b) => a - b);
+const columnOf = (id) => xs.indexOf(placed.get(id));
+
+const fail = (m) => { console.error('layout check FAILED: ' + m); process.exit(1); };
+for (const id of ['MPPT_1', 'solar', 'battery', 'grid', 'inverter', 'main_panel'])
+  if (!placed.has(id)) fail(`node "${id}" was never rendered`);
+
+// A feeder sits exactly one column left of the earliest node it feeds.
+const expect = (id, want, why) => {
+  const got = columnOf(id);
+  if (got !== want) fail(`${id} is in column ${got}, expected ${want} — ${why}`);
+};
+expect('MPPT_1', 0, 'the MPPTs feed Solar, which is in column 1');
+expect('solar', 1, 'Solar feeds the inverter in column 2');
+expect('battery', 1, 'Battery feeds the inverter, so it belongs beside Solar — not left-justified with the MPPTs');
+expect('grid', 1, 'Grid feeds the inverter, so it belongs beside Solar');
+expect('inverter', 2, 'the inverter feeds the main panel');
+expect('main_panel', 3, 'the main panel is the sink here');
+
+console.log('layout: columns ' + ['MPPT_1', 'solar', 'battery', 'grid', 'inverter', 'main_panel']
+  .map(id => `${id}=${columnOf(id)}`).join(' '));

--- a/rPDU2MQTT.Web/web/sankey.check.mjs
+++ b/rPDU2MQTT.Web/web/sankey.check.mjs
@@ -1,0 +1,93 @@
+// Sankey regression check for the night-time case (ToDo.md, image.png): the MPPTs feed a Solar (PV)
+// aggregate which feeds the inverter, and after dark every one of them reads 0 W while the grid carries
+// the whole load.
+//
+// What went wrong: the barycenter weighted each feeder by its link value, so a zero-carrying link had no
+// pull at all — `w` stayed 0, bary() returned Infinity, and the entire solar chain sorted to the bottom
+// of its column while the inverter it feeds stayed up beside the grid. The ribbons joining them scaled to
+// 0 px, so nothing visibly connected them either: five orphan markers stranded at the bottom-left.
+//
+// This asserts the two properties that were violated: the chain stays vertically together, and every link
+// is drawn thick enough to see.
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDom, query } from './domstub.mjs';
+
+const code = await readFile(new URL('../wwwroot/app.js', import.meta.url), 'utf8');
+const schema = JSON.parse(await readFile(new URL('./schema.fixture.json', import.meta.url), 'utf8'))
+  .filter(n => n.key !== '_README');
+
+// Night: solar chain measured at 0 W, grid carrying 2242 W through the inverter to the panel.
+const nightGraph = {
+  ok: true, metric: 'realpower', units: 'W',
+  nodes: [
+    { id: 'MPPT_1', label: 'MPPT_1', value: 0 },
+    { id: 'MPPT_2', label: 'MPPT_2', value: 0 },
+    { id: 'MPPT_3', label: 'MPPT_3', value: 0 },
+    { id: 'solar', label: 'Solar (PV)', value: 0 },
+    { id: 'grid', label: 'Grid', value: 2242 },
+    { id: 'inverter', label: 'EG4 FlexBoss 21', value: 2242 },
+    { id: 'panel', label: 'Main Panel', value: 2242 },
+  ],
+  links: [
+    { source: 'MPPT_1', target: 'solar', value: 0 },
+    { source: 'MPPT_2', target: 'solar', value: 0 },
+    { source: 'MPPT_3', target: 'solar', value: 0 },
+    { source: 'solar', target: 'inverter', value: 0 },
+    { source: 'grid', target: 'inverter', value: 2242 },
+    { source: 'inverter', target: 'panel', value: 2242 },
+  ],
+};
+
+const { sandbox, getEl } = makeDom({
+  bodies: (url) =>
+    url.includes('/api/schema') ? schema :
+    url.includes('/api/instances') ? { ok: true, instances: [] } :
+    url.includes('/api/config') ? { EnergyFlow: { Nodes: [], Links: [] } } :
+    url.includes('/api/flow') ? nightGraph :
+    { ok: true },
+});
+
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox, { filename: 'app.js' });
+await new Promise(r => setTimeout(r, 50));
+
+const nav = getEl('nav');
+const flowLink = query(nav, 'a', true).find(a => a.dataset.label === 'Flow');
+if (!flowLink) { console.error('sankey check FAILED: no Flow tab'); process.exit(1); }
+flowLink.click();
+await new Promise(r => setTimeout(r, 50));
+
+const fail = (m) => { console.error('sankey check FAILED: ' + m); process.exit(1); };
+
+// Node bars are <rect x y width height>; the Sankey's are the ones at the node width (12).
+const bars = query(getEl('sections'), 'rect', true)
+  .filter(r => r.attrs.width === '12')
+  .map(r => ({ x: Number(r.attrs.x), y: Number(r.attrs.y), h: Number(r.attrs.height) }));
+if (bars.length < 7) fail(`expected 7 node bars, found ${bars.length}`);
+
+// Columns by x; within the solar chain's columns, the chain must not be flung to the bottom.
+const byX = new Map();
+for (const b of bars) { const k = b.x; byX.set(k, [...(byX.get(k) || []), b]); }
+const xs = [...byX.keys()].sort((a, b) => a - b);
+if (xs.length !== 4) fail(`expected 4 columns, got ${xs.length}`);
+
+// Column 0 holds the three MPPTs and the grid; column 1 holds Solar (PV) alone. The MPPTs feed Solar,
+// so they must sit level with it. Before the fix they sorted below the grid's full-height bar — measured at
+// y=557/580/603 against Solar at y=29, a ~530px climb along ribbons that scaled to nothing.
+const solarY = byX.get(xs[1])[0].y;
+const drift = Math.max(...byX.get(xs[0]).map(b => b.h < 10 ? Math.abs(b.y - solarY) : 0));
+if (drift > 100) fail(`an idle MPPT sits ${Math.round(drift)}px from the Solar node it feeds — the chain drifted apart`);
+
+// Every ribbon must be visible. A zero-valued band used to scale to ~1px at 30% opacity, i.e. nothing.
+// (The Flow tab also renders the hierarchy editor, whose edges are stroked paths with no fill-opacity —
+// select on that attribute so only the Sankey's filled ribbons are considered.)
+const ribbons = query(getEl('sections'), 'path', true).filter(p => p.attrs['fill-opacity'] !== undefined);
+if (ribbons.length !== 6) fail(`expected 6 ribbons, found ${ribbons.length}`);
+for (const r of ribbons) {
+  const op = Number(r.attrs['fill-opacity']);
+  if (!(op >= 0.3)) fail(`a ribbon is drawn at ${op} opacity — an idle branch has to stay visible`);
+}
+
+console.log(`sankey: night-time chain holds together (MPPTs within ${Math.round(drift)}px of Solar), `
+  + `${ribbons.length} ribbons all visible`);

--- a/rPDU2MQTT.Web/web/smoke.mjs
+++ b/rPDU2MQTT.Web/web/smoke.mjs
@@ -7,87 +7,13 @@
 // them. Regenerate the fixture when config sections change — see the header note in that file.
 import { readFile } from 'node:fs/promises';
 import vm from 'node:vm';
+import { makeDom, query } from './domstub.mjs';
 
 const code = await readFile(new URL('../wwwroot/app.js', import.meta.url), 'utf8');
 // The leading _README node carries the fixture's regeneration note (JSON has no comments); it isn't
 // part of the schema, so drop it before handing it to the app.
 const schema = JSON.parse(await readFile(new URL('./schema.fixture.json', import.meta.url), 'utf8'))
   .filter(n => n.key !== '_README');
-
-// --- A small fake DOM that actually keeps a tree, so we can assert on what was rendered -------------
-// (The previous stub discarded every appendChild, so nothing about the output could be checked.)
-function matches(node, sel) {
-  sel = sel.trim();
-  const attr = sel.match(/^(\w+)\[type=(\w+)\]$/);
-  if (attr) return node.tag === attr[1] && node.attrs.type === attr[2];
-  if (sel.startsWith('.')) return node.classList.has(sel.slice(1));
-  const tagClass = sel.match(/^(\w+)\.([\w-]+)$/);
-  if (tagClass) return node.tag === tagClass[1] && node.classList.has(tagClass[2]);
-  return node.tag === sel;
-}
-// Supports the selector shapes the GUI actually uses: "a", ".field", "nav a", "input[type=checkbox]",
-// and comma lists like "input, select, textarea".
-function query(root, sel, all) {
-  const out = [];
-  for (const branch of sel.split(',')) {
-    const parts = branch.trim().split(/\s+/);
-    let cur = [root];
-    for (const p of parts) {
-      const next = [];
-      for (const n of cur) for (const d of descendants(n)) if (matches(d, p)) next.push(d);
-      cur = next;
-    }
-    out.push(...cur);
-  }
-  return all ? out : (out[0] ?? null);
-}
-function* descendants(node) {
-  for (const c of node.children) { yield c; yield* descendants(c); }
-}
-
-function makeEl(tag = 'div') {
-  const node = {
-    tag, children: [], attrs: {}, style: {}, dataset: {}, _text: '',
-    classList: {
-      _s: new Set(),
-      add(...c) { c.forEach(x => x && this._s.add(x)); },
-      remove(...c) { c.forEach(x => this._s.delete(x)); },
-      contains(c) { return this._s.has(c); },
-      has(c) { return this._s.has(c); },
-    },
-    get className() { return [...this.classList._s].join(' '); },
-    set className(v) { this.classList._s = new Set(String(v).split(/\s+/).filter(Boolean)); },
-    get textContent() { return this._text || this.children.map(c => c.textContent).join(''); },
-    set textContent(v) { this._text = String(v); this.children = []; },
-    set innerHTML(v) { if (!v) this.children = []; },
-    get innerHTML() { return ''; },
-    appendChild(c) { if (c && c.tag) this.children.push(c); return c; },
-    append(...cs) { cs.forEach(c => { if (c && c.tag) this.children.push(c); }); },
-    removeChild(c) { this.children = this.children.filter(x => x !== c); },
-    remove() {}, insertBefore(c) { this.children.push(c); return c; },
-    // Node.contains(): self or any descendant (used to tell Oidc fields from Basic ones).
-    contains(n) { if (n === this) return true; for (const d of descendants(this)) if (d === n) return true; return false; },
-    setAttribute(k, v) { this.attrs[k] = String(v); },
-    getAttribute(k) { return this.attrs[k] ?? null; },
-    removeAttribute(k) { delete this.attrs[k]; },
-    addEventListener() {}, removeEventListener() {},
-    click() { if (typeof this.onclick === 'function') this.onclick({ preventDefault() {}, stopPropagation() {} }); },
-    focus() {}, select() {}, setSelectionRange() {},
-    querySelector(s) { return query(this, s, false); },
-    querySelectorAll(s) { return query(this, s, true); },
-    getBoundingClientRect() { return { left: 0, top: 0, width: 100, height: 100 }; },
-    getScreenCTM() { return { inverse() { return {}; } }; },
-  };
-  // classList.has is used by our matcher; keep `contains` as the DOM-facing name.
-  return node;
-}
-
-const root = makeEl('body');
-const byId = {};
-const getEl = (id) => (byId[id] ||= Object.assign(makeEl(id === 'nav' ? 'nav' : 'div'), { id }));
-// nav + sections live in the tree so `document.querySelectorAll('nav a')` can find the links.
-root.appendChild(getEl('nav'));
-root.appendChild(getEl('sections'));
 
 // A config with a custom flow node already bound to an MQTT source (#205), so opening the Flow tab
 // exercises the hierarchy editor and the live-sources table rather than just their empty states.
@@ -120,42 +46,9 @@ const bodies = (url) =>
   url.includes('/api/flow') ? flowGraph :
   { ok: true };
 
-// A tiny localStorage, so the theme can persist the way it does in a browser.
-const storage = new Map();
+// The DOM + browser globals live in domstub.mjs, shared with layout.check.mjs.
+const { sandbox, getEl, storage } = makeDom({ bodies });
 
-const sandbox = {
-  console,
-  document: {
-    body: root,
-    // The theme sets data-theme here; nothing else touches it.
-    documentElement: makeEl('html'),
-    getElementById: (id) => getEl(id),
-    createElement: (t) => makeEl(t), createElementNS: (_ns, t) => makeEl(t),
-    createTextNode: () => makeEl('#text'),
-    querySelector: (s) => query(root, s, false),
-    querySelectorAll: (s) => query(root, s, true),
-    elementFromPoint: () => null,
-  },
-  window: { addEventListener() {}, removeEventListener() {}, dispatchEvent() { return true; } },
-  // protocol/hostname are read when building the API docs links (#190).
-  location: { hash: '', protocol: 'http:', hostname: 'localhost' },
-  navigator: { clipboard: { writeText() {} } },
-  localStorage: {
-    getItem: (k) => (storage.has(k) ? storage.get(k) : null),
-    setItem: (k, v) => storage.set(k, String(v)),
-    removeItem: (k) => storage.delete(k),
-  },
-  CustomEvent: class { constructor(type, init) { this.type = type; this.detail = init?.detail; } },
-  DOMPoint: class { matrixTransform() { return { x: 0, y: 0 }; } },
-  setTimeout: (fn) => { if (typeof fn === 'function') fn(); return 0; },
-  clearTimeout() {},
-  setInterval: () => 0, clearInterval() {},
-  confirm: () => true,
-  fetch: async (url) => ({ ok: true, text: async () => '', json: async () => bodies(String(url)) }),
-  // EventSource is deliberately absent: it exercises the no-push path, where every section must still
-  // work off its manual refresh / polling fallback.
-};
-sandbox.globalThis = sandbox;
 
 vm.createContext(sandbox);
 vm.runInContext(code, sandbox, { filename: 'app.js' });

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1178,13 +1178,21 @@ export function addFlowSection(nav: any, sections: any) {
     // "0 W" / "no data" nodes collides its labels into an unreadable smear. So a node occupies a *row* at
     // least this tall (its bar is centered inside it), while the bar itself stays proportional.
     const labelRow = 15;
-    // Barycenter: a node's preferred y is the value-weighted mean of its (already positioned) feeders.
-    const bary = (id: string) => { let w = 0, s = 0; (incoming[id] || []).forEach((l: any) => { const sp = pos[l.source]; if (sp) { s += (sp.y + sp.h / 2) * l.value; w += l.value; } }); return w ? s / w : Infinity; };
-    let bottom = padTop;
-    cols.forEach((cn, c) => {
-      // Roots stack by size; downstream columns follow their feeder's order (groups children, avoids crossings).
-      if (c === 0) cn.sort((a: any, b: any) => nodeValue(b.id) - nodeValue(a.id));
-      else cn.sort((a: any, b: any) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
+    // A link's pull on the layout. Weighting purely by value means a zero-carrying link exerts none at
+    // all — and at night the whole solar chain is zero, so `w` stayed 0, bary() returned Infinity, and
+    // every MPPT and the PV aggregate sorted to the bottom of their columns while the inverter they feed
+    // stayed up beside the grid. The chain came out as scattered orphans joined by invisible ribbons.
+    // A floor keeps a zero link meaning "these two are wired together" without letting it outvote a
+    // measured one.
+    const wFloor = maxTotal / 1000;
+    const linkW = (l: any) => Math.max(l.value || 0, wFloor);
+    // Barycenter of the feeders that are already positioned (forward pass) …
+    const bary = (id: string) => { let w = 0, s = 0; (incoming[id] || []).forEach((l: any) => { const sp = pos[l.source]; if (sp) { s += (sp.y + sp.h / 2) * linkW(l); w += linkW(l); } }); return w ? s / w : Infinity; };
+    // … and of what it feeds (backward pass), so a source column can be pulled level with its targets.
+    const obary = (id: string) => { let w = 0, s = 0; (outgoing[id] || []).forEach((l: any) => { const tp = pos[l.target]; if (tp) { s += (tp.y + tp.h / 2) * linkW(l); w += linkW(l); } }); return w ? s / w : Infinity; };
+
+    // Stack one column top-to-bottom in its current order; returns the y it ended at.
+    const placeColumn = (cn: any[], c: number) => {
       let y = padTop;
       cn.forEach((n: any) => {
         // Bar height is proportional; an unknown or measured-zero node is a thin marker (it has no
@@ -1194,8 +1202,26 @@ export function addFlowSection(nav: any, sections: any) {
         pos[n.id] = { x: colX(c), y: y + (rowH - h) / 2, h, outOff: 0, inOff: 0 };
         y += rowH + gap;
       });
-      bottom = Math.max(bottom, y);
+      return y;
+    };
+
+    // Forward: roots stack by size, downstream columns follow their feeders (groups children, avoids crossings).
+    cols.forEach((cn, c) => {
+      if (c === 0) cn.sort((a: any, b: any) => nodeValue(b.id) - nodeValue(a.id));
+      else cn.sort((a: any, b: any) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
+      placeColumn(cn, c);
     });
+    // Backward: right-to-left, order each column by what it feeds. The forward pass alone can only order a
+    // column by its inputs, so column 0 — which has none — was sorted purely by size and a zero-output
+    // feeder always sank to the bottom, however far that was from the node it powers.
+    for (let c = cols.length - 2; c >= 0; c--) {
+      if (!cols[c]) continue;
+      cols[c].sort((a: any, b: any) => (obary(a.id) - obary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
+      placeColumn(cols[c], c);
+    }
+    // Re-place left-to-right in the settled order so every column shares one top edge and the offsets reset.
+    let bottom = padTop;
+    cols.forEach((cn, c) => { bottom = Math.max(bottom, placeColumn(cn, c)); });
 
     // Fit the viewBox to the tallest column (stacking gaps push it past usableH), so nothing clips.
     const totalH = Math.ceil(Math.max(padTop + usableH, bottom)) + padTop;
@@ -1206,16 +1232,21 @@ export function addFlowSection(nav: any, sections: any) {
     links.sort((a: any, b: any) => pos[a.target].y - pos[b.target].y).forEach((l: any) => {
       const s = pos[l.source], t = pos[l.target];
       if (!s || !t) return;
-      // An unknown link draws as a hairline: the wiring is real, the quantity isn't known.
+      // An unknown link draws as a hairline: the wiring is real, the quantity isn't known. A *measured*
+      // zero is the same picture — 0 W scales to a 1px band at 30% opacity, i.e. nothing — so at night the
+      // solar chain looked disconnected rather than idle. Both get a visible hairline; only the ribbons
+      // carrying something get a proportional band.
       const unknownLink = l.known === false;
-      const h = unknownLink ? 1.5 : Math.max(1, l.value * pxPerUnit);
+      const idleLink = !unknownLink && l.value * pxPerUnit < 1.5;
+      const h = (unknownLink || idleLink) ? 1.5 : l.value * pxPerUnit;
       const x1 = s.x + nodeW, x2 = t.x, xc = (x1 + x2) / 2;
       const sTop = s.y + s.outOff, tTop = t.y + t.inOff;
       const color = colors[colMemo[l.source] % colors.length];
       svg.appendChild(svgEl('path', {
         d: `M${x1},${sTop} C${xc},${sTop} ${xc},${tTop} ${x2},${tTop} L${x2},${tTop + h} C${xc},${tTop + h} ${xc},${sTop + h} ${x1},${sTop + h} Z`,
         fill: unknownLink ? 'var(--muted)' : color,
-        'fill-opacity': unknownLink ? '0.25' : '0.3',
+        // A hairline at ribbon opacity is invisible; lift it so an idle branch still reads as connected.
+        'fill-opacity': unknownLink ? '0.35' : idleLink ? '0.55' : '0.3',
       }));
       s.outOff += h; t.inOff += h;
     });

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2540,13 +2540,21 @@ function addFlowSection(nav     , sections     ) {
     // "0 W" / "no data" nodes collides its labels into an unreadable smear. So a node occupies a *row* at
     // least this tall (its bar is centered inside it), while the bar itself stays proportional.
     const labelRow = 15;
-    // Barycenter: a node's preferred y is the value-weighted mean of its (already positioned) feeders.
-    const bary = (id        ) => { let w = 0, s = 0; (incoming[id] || []).forEach((l     ) => { const sp = pos[l.source]; if (sp) { s += (sp.y + sp.h / 2) * l.value; w += l.value; } }); return w ? s / w : Infinity; };
-    let bottom = padTop;
-    cols.forEach((cn, c) => {
-      // Roots stack by size; downstream columns follow their feeder's order (groups children, avoids crossings).
-      if (c === 0) cn.sort((a     , b     ) => nodeValue(b.id) - nodeValue(a.id));
-      else cn.sort((a     , b     ) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
+    // A link's pull on the layout. Weighting purely by value means a zero-carrying link exerts none at
+    // all — and at night the whole solar chain is zero, so `w` stayed 0, bary() returned Infinity, and
+    // every MPPT and the PV aggregate sorted to the bottom of their columns while the inverter they feed
+    // stayed up beside the grid. The chain came out as scattered orphans joined by invisible ribbons.
+    // A floor keeps a zero link meaning "these two are wired together" without letting it outvote a
+    // measured one.
+    const wFloor = maxTotal / 1000;
+    const linkW = (l     ) => Math.max(l.value || 0, wFloor);
+    // Barycenter of the feeders that are already positioned (forward pass) …
+    const bary = (id        ) => { let w = 0, s = 0; (incoming[id] || []).forEach((l     ) => { const sp = pos[l.source]; if (sp) { s += (sp.y + sp.h / 2) * linkW(l); w += linkW(l); } }); return w ? s / w : Infinity; };
+    // … and of what it feeds (backward pass), so a source column can be pulled level with its targets.
+    const obary = (id        ) => { let w = 0, s = 0; (outgoing[id] || []).forEach((l     ) => { const tp = pos[l.target]; if (tp) { s += (tp.y + tp.h / 2) * linkW(l); w += linkW(l); } }); return w ? s / w : Infinity; };
+
+    // Stack one column top-to-bottom in its current order; returns the y it ended at.
+    const placeColumn = (cn       , c        ) => {
       let y = padTop;
       cn.forEach((n     ) => {
         // Bar height is proportional; an unknown or measured-zero node is a thin marker (it has no
@@ -2556,8 +2564,26 @@ function addFlowSection(nav     , sections     ) {
         pos[n.id] = { x: colX(c), y: y + (rowH - h) / 2, h, outOff: 0, inOff: 0 };
         y += rowH + gap;
       });
-      bottom = Math.max(bottom, y);
+      return y;
+    };
+
+    // Forward: roots stack by size, downstream columns follow their feeders (groups children, avoids crossings).
+    cols.forEach((cn, c) => {
+      if (c === 0) cn.sort((a     , b     ) => nodeValue(b.id) - nodeValue(a.id));
+      else cn.sort((a     , b     ) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
+      placeColumn(cn, c);
     });
+    // Backward: right-to-left, order each column by what it feeds. The forward pass alone can only order a
+    // column by its inputs, so column 0 — which has none — was sorted purely by size and a zero-output
+    // feeder always sank to the bottom, however far that was from the node it powers.
+    for (let c = cols.length - 2; c >= 0; c--) {
+      if (!cols[c]) continue;
+      cols[c].sort((a     , b     ) => (obary(a.id) - obary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
+      placeColumn(cols[c], c);
+    }
+    // Re-place left-to-right in the settled order so every column shares one top edge and the offsets reset.
+    let bottom = padTop;
+    cols.forEach((cn, c) => { bottom = Math.max(bottom, placeColumn(cn, c)); });
 
     // Fit the viewBox to the tallest column (stacking gaps push it past usableH), so nothing clips.
     const totalH = Math.ceil(Math.max(padTop + usableH, bottom)) + padTop;
@@ -2568,16 +2594,21 @@ function addFlowSection(nav     , sections     ) {
     links.sort((a     , b     ) => pos[a.target].y - pos[b.target].y).forEach((l     ) => {
       const s = pos[l.source], t = pos[l.target];
       if (!s || !t) return;
-      // An unknown link draws as a hairline: the wiring is real, the quantity isn't known.
+      // An unknown link draws as a hairline: the wiring is real, the quantity isn't known. A *measured*
+      // zero is the same picture — 0 W scales to a 1px band at 30% opacity, i.e. nothing — so at night the
+      // solar chain looked disconnected rather than idle. Both get a visible hairline; only the ribbons
+      // carrying something get a proportional band.
       const unknownLink = l.known === false;
-      const h = unknownLink ? 1.5 : Math.max(1, l.value * pxPerUnit);
+      const idleLink = !unknownLink && l.value * pxPerUnit < 1.5;
+      const h = (unknownLink || idleLink) ? 1.5 : l.value * pxPerUnit;
       const x1 = s.x + nodeW, x2 = t.x, xc = (x1 + x2) / 2;
       const sTop = s.y + s.outOff, tTop = t.y + t.inOff;
       const color = colors[colMemo[l.source] % colors.length];
       svg.appendChild(svgEl('path', {
         d: `M${x1},${sTop} C${xc},${sTop} ${xc},${tTop} ${x2},${tTop} L${x2},${tTop + h} C${xc},${tTop + h} ${xc},${sTop + h} ${x1},${sTop + h} Z`,
         fill: unknownLink ? 'var(--muted)' : color,
-        'fill-opacity': unknownLink ? '0.25' : '0.3',
+        // A hairline at ribbon opacity is invisible; lift it so an idle branch still reads as connected.
+        'fill-opacity': unknownLink ? '0.35' : idleLink ? '0.55' : '0.3',
       }));
       s.outOff += h; t.inOff += h;
     });


### PR DESCRIPTION
Fixes the "nodes without energy render extremely weird" entry in `ToDo.md` (the night-time `image.png`).

## What was wrong

At night every MPPT and the Solar (PV) node they feed read 0 W, and the chart fell apart — the solar chain sank to the bottom-left as orphan markers while the inverter it feeds stayed up beside the grid, joined by ribbons that scaled to nothing.

Measured on the real bundle **before** the fix, grid carrying 2,242 W:

```
MPPT_1/2/3   y = 557 / 580 / 603
Solar (PV)   y = 29
```

A ~530px climb along invisible links. Two causes, both about zero:

1. **The barycenter weighted each feeder by its link value.** A zero-carrying link exerted no pull at all — `w` stayed `0`, `bary()` returned `Infinity`, and every idle node sorted to the bottom of its column. Weights now have a floor, so a 0 W link still means "these two are wired together" without outvoting a measured one.
2. **A column could only be ordered by its inputs, and column 0 has none.** It was sorted purely by size, so a zero-output feeder always sank below the grid's full-height bar, however far that was from what it powers. A backward pass now orders each column by what it feeds.

**After:** `MPPT_1/2/3` at y = 29 / 52 / 75, level with Solar at 29.

3. **A measured zero drew as a 1px band at 30% opacity** — i.e. nothing — so an idle branch read as *disconnected* rather than *idle*. Zero and unknown links now share the visible hairline treatment.

## The hierarchy report was already fixed

The other entry ("battery sits left of Solar, though both feed the FlexBoss") turned out to be resolved by #266 — `ToDo.md` and its screenshot are dated 2026-07-26, the fix landed 07-28. Rather than take the dates' word for it I ran the real code on that exact topology:

```
layout: columns MPPT_1=0 solar=1 battery=1 grid=1 inverter=2 main_panel=3
```

Battery and Grid beside Solar, as asked. So this PR locks that in with a test instead of "fixing" it.

## Tests

On the real bundle's rendered geometry — fakes are what hid the last two bugs:

- **`web/sankey.check.mjs`** — the night-time case: the idle chain stays with what it feeds, every ribbon visible.
- **`web/layout.check.mjs`** — the hierarchy columns. Verified it *fails* when the pull-right pass from #266 is reverted (`battery is in column 0, expected 1`), so it can actually catch the regression it describes.
- Both run in `BuildGuiAssets` next to the smoke test, so CI covers them. The DOM stub moved to **`web/domstub.mjs`** — one stub for all three, so a gap gets fixed once.
- Build clean, 402 tests pass.

`ToDo.md`: both entries marked resolved, plus the Power/Energy toggle, which #275 already shipped.

**Still open from that list**, diagnosed but not in this PR: a `None` node between two populated nodes disappears from the chart. Cause is `FlowGraphBuilder` line ~285 — a known zero-valued link is dropped unless it is a "pass-through", which unwires the node and drops it from `nodes` entirely.

**Yours to verify:** how it actually looks after dark — I can measure geometry here but not see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)