### PR TITLE
fix(flow): a 'none' node between two nodes was stranded, not drawn between them

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -96,9 +96,14 @@ Click it again, to restore.
     For those wanting simple install, should offer a simple sqlite database or mabye an inmemory cache or something.
     Cache will be responsible for aggregating Power into Energy.
 
-- Putting a "None" node between populated nodes, causing the chart to get extremely weird.
+- [x] Putting a "None" node between populated nodes, causing the chart to get extremely weird.
 
 The None nodes are removed form the chart, instead of displaying between the nodes.
+
+    Fixed: a none node carries zero by definition, and the known-zero filter dropped its inbound link —
+    leaving it with no feeders, so it laid out as a root in column 0 instead of between the pair it was
+    placed between. Its links are kept when it sits mid-chain; an inert node used as a pure source still
+    drops out, as two existing tests require.
 
 - Nodes without energy, explain extremely weird.
 

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -282,7 +282,16 @@ public static class FlowGraphBuilder
                 // topology always renders — the zero just draws as a hairline — while a zero-producing source
                 // still drops as before.
                 var passThroughZero = Wired(from, to) && incoming.TryGetValue(from, out var upstream) && upstream.Count > 0;
-                if (known && value <= 0 && !passThroughZero) continue;
+
+                // The same reasoning one step earlier, for the link *into* an inert ('none', or valueless
+                // 'static') node that sits mid-chain. Such a node contributes nothing by design, so its links
+                // carry zero forever; dropping the inbound one strands it — with no feeders left it lays out
+                // as a root in column 0 rather than between the two nodes it was deliberately wired between.
+                // Only mid-chain: an inert node used as a pure *source* has nothing to give and nothing
+                // feeding it, and still drops out (Build_NoneNode_ContributesNothing… pins that).
+                var midChainInert = Inert(Mode(to)) && outgoing.TryGetValue(to, out var below) && below.Count > 0;
+
+                if (known && value <= 0 && !passThroughZero && !midChainInert) continue;
 
                 links.Add(new FlowLink(from, to, value, known));
             }

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -721,4 +721,29 @@ public class FlowGraphTests
         Assert.False(map.ContainsKey("outlet:pdu1:1"));
         Assert.Equal(2, map.Count);
     }
+[Fact]
+    public void Build_NoneNodeBetweenPopulatedNodes_KeepsBothItsLinks()
+    {
+        // A 'none' node deliberately wired between two measured ones (ToDo.md: "putting a None node between
+        // populated nodes causes the chart to get extremely weird"). Its links carry zero by definition, and
+        // the known-zero filter dropped the inbound one — leaving the node with no feeders, so the chart laid
+        // it out as a root in column 0 rather than between the pair it was placed between.
+        var data = OnePdu(Outlet(0, "Server", "realpower", "60"));
+        var flow = new EnergyFlowConfig
+        {
+            Nodes =
+            {
+                new EnergyFlowNode { Id = "panel", Label = "Panel" },
+                new EnergyFlowNode { Id = "spacer", Label = "Sub-panel", Mode = "none" },
+            },
+            Parents = { ["spacer"] = "panel", ["pdu:pdu1"] = "spacer" },
+        };
+
+        var graph = FlowGraphBuilder.Build(data, flow);
+
+        Assert.Contains(graph.Nodes, n => n.Id == "spacer");
+        // Both halves of the wiring survive, so the node still sits between its feeder and what it feeds.
+        Assert.Contains(graph.Links, l => l.Source == "panel" && l.Target == "spacer");
+        Assert.Contains(graph.Links, l => l.Source == "spacer" && l.Target == "pdu:pdu1");
+    }
 }


### PR DESCRIPTION
Fixes the last of the three chart entries in `ToDo.md`: *"Putting a None node between populated nodes causes the chart to get extremely weird — the None nodes are removed from the chart, instead of displaying between the nodes."*

## Cause

A `none` node contributes nothing **by design**, so every link touching it carries zero forever — and the known-zero filter in `FlowGraphBuilder` dropped its *inbound* link. That left the node with no feeders at all, so the layout treated it as a root and put it in **column 0** rather than between the two nodes it had deliberately been wired between.

The link *out* of it already survived: `passThroughZero` keeps a zero link whose source has upstream flow. This is the same reasoning one step earlier, for the link *into* it.

## Scope of the fix

Deliberately narrow — **only when the inert node sits mid-chain**, i.e. it has outgoing edges of its own:

```csharp
var midChainInert = Inert(Mode(to)) && outgoing.TryGetValue(to, out var below) && below.Count > 0;
```

An inert node used as a pure *source* has nothing to give and nothing feeding it, and still drops out.

That distinction wasn't obvious to me up front. My first attempt keyed off "either endpoint is inert", which broke two existing tests — `Build_NoneNode_ContributesNothing_EvenWhenNothingElseIsMeasured` and `Build_StaticNode_WithNoValue_ContributesNothing` — that exist to pin precisely the behaviour I'd trampled. The suite caught it; the rule is now narrowed to the case actually reported.

## Verification

- `Build_NoneNodeBetweenPopulatedNodes_KeepsBothItsLinks` — asserts the node survives **and** both halves of its wiring do, so it lays out between its feeder and what it feeds.
- Verified it **fails** without the change (`Failed: 1, Passed: 29`), so it can catch the regression it describes.
- Full suite: 403 pass, build clean.

Server-side only (`rPDU2MQTT.Core`), so it's independent of #283 and branched off `main`.

**Yours to verify:** how it renders with your actual sub-panel spacer node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)