### PR TITLE
fix(flow): stop summing metrics that don't add up, and add percent/temperature

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -120,7 +120,16 @@ It should, ideally be positioned below, or above Solar/PV.... since it connects 
 
 -----------------------
 
-Need some units created for percentages. Ie- Battery Percent, Load Percent... etc.. Temperature, might be a good metric to create as well.
+- [x] Need some units created for percentages. Ie- Battery Percent, Load Percent... etc.. Temperature, might be a good metric to create as well.
+
+    Added `percent` (%, or a 0-1 fraction) and `temperature` (°C / K) alongside the existing `soc`.
+
+    While adding them: every metric was being summed up the tree, so an *intensive* one — voltage,
+    frequency, power factor, soc, and now temperature/percent — produced a figure true nowhere in the
+    system. Three 120 V outlets reported a 360 V PDU. Not reachable from the Sankey (its toggle only
+    offers additive metrics) but reachable through the API's ?metric= parameter, including the public
+    v1 API. FlowUnits now records which metrics add up, and an intensive one is reported per node with
+    no roll-up: a node shows the reading it has, a node without one shows nothing.
 
 ------------------------
 

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -200,6 +200,13 @@ public static class FlowGraphBuilder
         // must be shown as "no data" rather than as zero flow.
         bool Knowable(string from, string to)
         {
+            // An intensive metric — voltage, frequency, power factor, state of charge, temperature — does
+            // not flow, so no link carries a determinable amount of it. Saying so here makes every link
+            // "no data" (a hairline) and, because ValueOf only aggregates *known* links, leaves each node
+            // showing the reading it actually has and nothing where it has none. Without this the roll-up
+            // summed them: three 120 V outlets reported a 360 V PDU, a figure true nowhere in the system.
+            if (!FlowUnits.IsAdditive(metric)) return false;
+
             if (leaf.ContainsKey(from)) return true;         // a measured producer supplies a real figure
             if (Inert(Mode(from))) return true;              // 'none'/'static': deliberately contributes nothing
 

--- a/rPDU2MQTT.Core/Flow/FlowUnits.cs
+++ b/rPDU2MQTT.Core/Flow/FlowUnits.cs
@@ -5,23 +5,34 @@ namespace rPDU2MQTT.Core.Flow;
 /// speaks (Solar Assistant's kW, a meter's Wh); binding a <c>Unit</c> lets us normalise every reading to the
 /// metric's canonical unit on ingest, so the flow roll-up and every export stay in one consistent unit
 /// (W for power, kWh for energy, …) regardless of where the number came from.
+///
+/// It also records whether a metric is <b>additive</b>, which decides whether the flow may roll it up at
+/// all — see <see cref="IsAdditive"/>.
 /// </summary>
 public static class FlowUnits
 {
-    // metric key (matches the PDU Measurement.Type / graph metric) -> canonical unit + {unit -> factor to it}.
-    private static readonly Dictionary<string, (string Canonical, Dictionary<string, double> Factors)> Table =
+    // metric key (matches the PDU Measurement.Type / graph metric) -> canonical unit, {unit -> factor to
+    // it}, and whether the quantity adds up the tree.
+    private static readonly Dictionary<string, (string Canonical, Dictionary<string, double> Factors, bool Additive)> Table =
         new(StringComparer.OrdinalIgnoreCase)
         {
-            ["realpower"] = ("W", new(StringComparer.OrdinalIgnoreCase) { ["W"] = 1, ["kW"] = 1_000, ["MW"] = 1_000_000 }),
-            ["apparentpower"] = ("VA", new(StringComparer.OrdinalIgnoreCase) { ["VA"] = 1, ["kVA"] = 1_000 }),
-            ["energy"] = ("kWh", new(StringComparer.OrdinalIgnoreCase) { ["kWh"] = 1, ["Wh"] = 0.001, ["MWh"] = 1_000 }),
-            ["current"] = ("A", new(StringComparer.OrdinalIgnoreCase) { ["A"] = 1, ["mA"] = 0.001 }),
-            ["voltage"] = ("V", new(StringComparer.OrdinalIgnoreCase) { ["mV"] = 0.001, ["V"] = 1, ["kV"] = 1_000 }),
-            ["frequency"] = ("Hz", new(StringComparer.OrdinalIgnoreCase) { ["Hz"] = 1 }),
-            ["powerfactor"] = ("", new(StringComparer.OrdinalIgnoreCase) { [""] = 1 }),
-            // Battery state of charge — a percentage, not a roll-up quantity: it's read for display (the
-            // Energy tile), never summed across nodes. Fraction inputs (0–1) scale to a percentage.
-            ["soc"] = ("%", new(StringComparer.OrdinalIgnoreCase) { ["%"] = 1, ["fraction"] = 100 }),
+            // --- Extensive: quantities that flow, and therefore sum from the leaves upward. ---
+            ["realpower"] = ("W", new(StringComparer.OrdinalIgnoreCase) { ["W"] = 1, ["kW"] = 1_000, ["MW"] = 1_000_000 }, true),
+            ["apparentpower"] = ("VA", new(StringComparer.OrdinalIgnoreCase) { ["VA"] = 1, ["kVA"] = 1_000 }, true),
+            ["energy"] = ("kWh", new(StringComparer.OrdinalIgnoreCase) { ["kWh"] = 1, ["Wh"] = 0.001, ["MWh"] = 1_000 }, true),
+            ["current"] = ("A", new(StringComparer.OrdinalIgnoreCase) { ["A"] = 1, ["mA"] = 0.001 }, true),
+            // --- Intensive: a condition at a point, not a quantity that flows. Never summed. ---
+            ["voltage"] = ("V", new(StringComparer.OrdinalIgnoreCase) { ["mV"] = 0.001, ["V"] = 1, ["kV"] = 1_000 }, false),
+            ["frequency"] = ("Hz", new(StringComparer.OrdinalIgnoreCase) { ["Hz"] = 1 }, false),
+            ["powerfactor"] = ("", new(StringComparer.OrdinalIgnoreCase) { [""] = 1 }, false),
+            // Battery state of charge — a percentage: read for display (the Energy tile), never summed
+            // across nodes. Fraction inputs (0–1) scale to a percentage.
+            ["soc"] = ("%", new(StringComparer.OrdinalIgnoreCase) { ["%"] = 1, ["fraction"] = 100 }, false),
+            // Any other ratio a device reports: load %, fan speed %, humidity. Same rule as soc.
+            ["percent"] = ("%", new(StringComparer.OrdinalIgnoreCase) { ["%"] = 1, ["fraction"] = 100 }, false),
+            // Inlet / battery / ambient temperature. Fahrenheit is an offset scale, not a factor, so it is
+            // deliberately absent: bind °C or K, or use Scale on the source.
+            ["temperature"] = ("°C", new(StringComparer.OrdinalIgnoreCase) { ["°C"] = 1, ["C"] = 1, ["K"] = 1 }, false),
         };
 
     /// <summary>The unit the flow/exports express <paramref name="metric"/> in (blank for the unitless power factor).</summary>
@@ -30,6 +41,19 @@ public static class FlowUnits
     /// <summary>The input units offered for <paramref name="metric"/>, canonical first-or-natural order.</summary>
     public static IReadOnlyList<string> UnitsFor(string metric)
         => Table.TryGetValue(metric, out var t) ? t.Factors.Keys.ToList() : Array.Empty<string>();
+
+    /// <summary>
+    /// Does this quantity add up the tree? Power, energy, apparent power and current are <i>extensive</i>:
+    /// the outlets' watts really do sum to the PDU's. Voltage, frequency, power factor, state of charge,
+    /// temperature and any other ratio are <i>intensive</i> — they describe a condition at a point, and
+    /// adding them states a number that was never true anywhere. Three 120 V outlets do not make a 360 V
+    /// PDU, which is exactly what the roll-up reported before this existed.
+    /// <para>
+    /// An unrecognised metric is treated as additive, preserving the behaviour for any custom name; add it
+    /// to the table above to classify it.
+    /// </para>
+    /// </summary>
+    public static bool IsAdditive(string metric) => !Table.TryGetValue(metric, out var t) || t.Additive;
 
     /// <summary>
     /// Factor to multiply a reading in <paramref name="unit"/> by to express it in <paramref name="metric"/>'s

--- a/rPDU2MQTT.Tests/FlowGraphTests.cs
+++ b/rPDU2MQTT.Tests/FlowGraphTests.cs
@@ -721,4 +721,37 @@ public class FlowGraphTests
         Assert.False(map.ContainsKey("outlet:pdu1:1"));
         Assert.Equal(2, map.Count);
     }
+[Fact]
+    public void Build_IntensiveMetric_IsNeverSummedUpTheTree()
+    {
+        // Voltage is intensive: it describes a condition at a point. Three 120 V outlets do not make a
+        // 360 V PDU — but that is exactly what the roll-up reported, because every metric was summed. Each
+        // node now shows the reading it has, and a node with none shows nothing rather than a total that
+        // was true nowhere in the system.
+        var data = OnePdu(
+            Outlet(0, "A", "voltage", "120", "V"),
+            Outlet(1, "B", "voltage", "120", "V"),
+            Outlet(2, "C", "voltage", "120", "V"));
+
+        var graph = FlowGraphBuilder.Build(data, null, "voltage");
+
+        Assert.All(graph.Nodes.Where(n => n.Kind == "outlet"), n => Assert.Equal(120, n.Value));
+        Assert.Null(graph.Nodes.Single(n => n.Id == "pdu:pdu1").Value);
+        // The wiring is still drawn — as "no data" links, since no amount of voltage flows along them.
+        Assert.NotEmpty(graph.Links);
+        Assert.All(graph.Links, l => Assert.False(l.Known));
+    }
+
+    [Fact]
+    public void Build_ExtensiveMetric_StillRollsUp()
+    {
+        // The counterpart: power really does add, and must keep doing so.
+        var data = OnePdu(
+            Outlet(0, "A", "realpower", "60"),
+            Outlet(1, "B", "realpower", "40"));
+
+        var graph = FlowGraphBuilder.Build(data, null, "realpower");
+
+        Assert.Equal(100, graph.Nodes.Single(n => n.Id == "pdu:pdu1").Value);
+    }
 }

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -8,6 +8,10 @@ import { exportData } from '../overrides.js';
 // Metrics a live source can supply: [stored key (matches PDU Measurement.Type), friendly label, canonical
 // unit, selectable input units]. The key stays the PDU vocabulary so live values roll up with outlets; the
 // UI shows the friendly name and a unit picker. Mirrors EnergyFlowSource.Metric + FlowUnits (Core).
+// key, label, canonical unit, input units it can be bound in.
+// Kept in step with FlowUnits.cs (Core), which is the authority — including which of these add up the
+// tree. The intensive ones below describe a condition at a point and are never rolled up: a node shows
+// the reading it has, and one with none shows nothing rather than a sum that was true nowhere.
 const METRICS: [string, string, string, string[]][] = [
   ['realpower', 'Power', 'W', ['W', 'kW', 'MW']],
   ['apparentpower', 'Apparent power', 'VA', ['VA', 'kVA']],
@@ -17,7 +21,12 @@ const METRICS: [string, string, string, string[]][] = [
   ['frequency', 'Frequency', 'Hz', ['Hz']],
   ['powerfactor', 'Power factor', '', ['']],
   ['soc', 'State of charge', '%', ['%', 'fraction']],
+  ['percent', 'Percentage', '%', ['%', 'fraction']],
+  ['temperature', 'Temperature', '°C', ['°C', 'K']],
 ];
+// Which metrics the flow may sum from the leaves upward. Mirrors FlowUnits.IsAdditive.
+const ADDITIVE_METRICS = new Set(['realpower', 'apparentpower', 'energy', 'current']);
+const isAdditiveMetric = (key?: string) => ADDITIVE_METRICS.has(key || '');
 const SOURCE_METRICS = METRICS.map(m => m[0]);
 const metricMeta = (key?: string) => METRICS.find(m => m[0] === key) || METRICS[0];
 const metricLabel = (key?: string) => metricMeta(key)[1];
@@ -456,7 +465,18 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
       opts.forEach((m: string) => metricSel.appendChild(el('option', { value: m, text: metricLabel(m) })));
       metricSel.value = metric;
       metricSel.onchange = () => { src.Metric = metricSel.value; src.Unit = undefined; rerender(); };
-      tr.appendChild(el('td', {}, metricSel));
+      // Say at the point of choosing that this one won't roll up — otherwise the only clue is a parent
+      // node reading "no data", which looks like a broken binding rather than the correct answer.
+      const metricCell = el('td', {}, metricSel);
+      if (!isAdditiveMetric(metric)) {
+        metricCell.appendChild(el('div', {
+          class: 'desc', style: { margin: '2px 0 0', fontSize: '11px' },
+          text: 'per-node only — not summed',
+          title: `${metricLabel(metric)} describes a condition at a point, so it is never added up the tree.`
+          + ' The node you bind it to shows it; its parents show nothing rather than a total that was true nowhere.',
+        }));
+      }
+      tr.appendChild(metricCell);
 
       // Direction (battery/grid only, and only for a directional metric — voltage/soc have no direction, so
       // their cell stays blank). A signed metric (power/current) also offers 'split': one ± value fanned into

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1370,6 +1370,10 @@ function addLiveDataSection(nav     , sections     ) {
 // Metrics a live source can supply: [stored key (matches PDU Measurement.Type), friendly label, canonical
 // unit, selectable input units]. The key stays the PDU vocabulary so live values roll up with outlets; the
 // UI shows the friendly name and a unit picker. Mirrors EnergyFlowSource.Metric + FlowUnits (Core).
+// key, label, canonical unit, input units it can be bound in.
+// Kept in step with FlowUnits.cs (Core), which is the authority — including which of these add up the
+// tree. The intensive ones below describe a condition at a point and are never rolled up: a node shows
+// the reading it has, and one with none shows nothing rather than a sum that was true nowhere.
 const METRICS                                       = [
   ['realpower', 'Power', 'W', ['W', 'kW', 'MW']],
   ['apparentpower', 'Apparent power', 'VA', ['VA', 'kVA']],
@@ -1379,7 +1383,12 @@ const METRICS                                       = [
   ['frequency', 'Frequency', 'Hz', ['Hz']],
   ['powerfactor', 'Power factor', '', ['']],
   ['soc', 'State of charge', '%', ['%', 'fraction']],
+  ['percent', 'Percentage', '%', ['%', 'fraction']],
+  ['temperature', 'Temperature', '°C', ['°C', 'K']],
 ];
+// Which metrics the flow may sum from the leaves upward. Mirrors FlowUnits.IsAdditive.
+const ADDITIVE_METRICS = new Set(['realpower', 'apparentpower', 'energy', 'current']);
+const isAdditiveMetric = (key         ) => ADDITIVE_METRICS.has(key || '');
 const SOURCE_METRICS = METRICS.map(m => m[0]);
 const metricMeta = (key         ) => METRICS.find(m => m[0] === key) || METRICS[0];
 const metricLabel = (key         ) => metricMeta(key)[1];
@@ -1818,7 +1827,18 @@ function renderNodeEditor(node     , links       , cand                  , reren
       opts.forEach((m        ) => metricSel.appendChild(el('option', { value: m, text: metricLabel(m) })));
       metricSel.value = metric;
       metricSel.onchange = () => { src.Metric = metricSel.value; src.Unit = undefined; rerender(); };
-      tr.appendChild(el('td', {}, metricSel));
+      // Say at the point of choosing that this one won't roll up — otherwise the only clue is a parent
+      // node reading "no data", which looks like a broken binding rather than the correct answer.
+      const metricCell = el('td', {}, metricSel);
+      if (!isAdditiveMetric(metric)) {
+        metricCell.appendChild(el('div', {
+          class: 'desc', style: { margin: '2px 0 0', fontSize: '11px' },
+          text: 'per-node only — not summed',
+          title: `${metricLabel(metric)} describes a condition at a point, so it is never added up the tree.`
+          + ' The node you bind it to shows it; its parents show nothing rather than a total that was true nowhere.',
+        }));
+      }
+      tr.appendChild(metricCell);
 
       // Direction (battery/grid only, and only for a directional metric — voltage/soc have no direction, so
       // their cell stays blank). A signed metric (power/current) also offers 'split': one ± value fanned into


### PR DESCRIPTION
Covers the `ToDo.md` entry *"need some units created for percentages… Temperature might be a good metric as well"* — and an accuracy bug found while adding them.

## The bug

The roll-up summed **every** metric. That's correct for extensive quantities — the outlets' watts really do sum to the PDU's — and wrong for every intensive one. Measured:

```
three 120 V outlets  ->  PDU reports 360 V
```

A number true nowhere in the system, which is precisely the fabrication this project exists to avoid.

**Reachability:** not from the Sankey — its toggle only offers power / energy / apparent / current. It *is* reachable through the `?metric=` parameter on `/api/flow` **and on the public v1 API**, so anything built against those has been receiving the invented figure. (I initially said the chart toggle exposed it; that was wrong, and the API path is the real one.)

## The fix

- **`FlowUnits` now records whether a metric is additive.**
  - Extensive: `realpower`, `apparentpower`, `energy`, `current`.
  - Intensive: `voltage`, `frequency`, `powerfactor`, `soc` — plus the two this adds.
- **New metrics:** `percent` (%, or a 0–1 fraction — load %, fan %, humidity) and `temperature` (°C / K). Fahrenheit is an offset scale rather than a factor, so it's deliberately not offered; bind °C, or use `Scale`.
- **An intensive metric makes every link "not knowable"** — a concept the graph already has. Links draw as hairlines, and since `ValueOf` only aggregates *known* links, each node reports the reading it actually has while a node with none reports `null`. No new machinery, and the topology still renders.
- **An unrecognised metric stays additive**, so any custom name behaves exactly as before.
- **The binding editor says "per-node only — not summed"** when one is selected. Without it, a parent reading "no data" looks like a broken binding rather than the correct answer.

## Tests

- `Build_IntensiveMetric_IsNeverSummedUpTheTree` — the 120/120/120 case: outlets keep their 120 V, the PDU reports `null`, and the links still exist but are flagged unknown.
- `Build_ExtensiveMetric_StillRollsUp` — the counterpart, so power keeps adding.
- 404 tests pass, build clean, GUI smoke green.

Branched off `main`; independent of #283 and #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)