### PR TITLE
chore: drop a stray Claude placeholder committed by accident in #288

### DIFF
--- a/.claude/agents/Claude.agent.md
+++ b/.claude/agents/Claude.agent.md
@@ -1,9 +1,0 @@
----
-name: Claude
-description: Describe what this custom agent does and when to use it.
-tools: Read, Grep, Glob, Bash # specify the tools this agent can use. If not set, all enabled tools are allowed.
----
-
-<!-- Tip: Use /create-agent in chat to generate content with agent assistance -->
-
-Define what this custom agent does, including its behavior, capabilities, and any specific instructions for its operation.

--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,7 @@ FodyWeavers.xsd
 /rPDU2MQTT/config.yaml
 # Backup written by the GUI when saving config.
 *.yaml.bak
+
+# Local Claude Code tooling config. Drop this line if you ever want to commit shared agent/skill
+# definitions for the project; an unedited placeholder was committed by accident in #288.
+.claude/


### PR DESCRIPTION
`.claude/agents/Claude.agent.md` is an unedited scaffold — *"Describe what this custom agent does and when to use it."* — that was sitting untracked in the working tree and got swept into #288 by a `git add -A` while I was resolving that branch's merge conflicts. My mistake; it's local tooling config, not project content.

Removed, and `.claude/` added to `.gitignore`. **Delete that line** if you ever want to commit shared agent or skill definitions for the project — I've left a comment in the file saying so, since ignoring the whole directory is the presumptuous part of this fix.

No code change; `main` is otherwise green at 406/406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)