### PR TITLE
fix(chart): the config CR is seeded, not owned — and Valkey no longer collides with the bridge

### DIFF
--- a/charts/rpdu2mqtt/templates/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/templates/rpduconfig.yaml
@@ -1,11 +1,21 @@
 {{- if and .Values.kubernetesConfigSource.enabled .Values.kubernetesConfigSource.manageResource }}
 {{- $name := include "rpdu2mqtt.crName" . }}
 {{- /*
-  Create-once: when preserveExisting (default), keep the live CR's spec on upgrade so config edited
-  through the GUI isn't reverted; values.config only seeds the CR on first install. Relies on Helm's
-  `lookup`, which works for `helm upgrade` against a live cluster but returns nothing under
-  `helm template` / Argo CD — for Argo, add an ignoreDifferences for the RpduConfig spec (see the
-  chart README). Set preserveExisting: false to always apply values.config (declarative).
+  values.config SEEDS this resource; it is not the ongoing source of truth. The GUI writes here, and
+  whole sections (EnergyFlow, Modbus, Operator) typically exist ONLY here.
+
+  preserveExisting keeps the live spec on upgrade via Helm's `lookup` — which works for
+  `helm upgrade` against a live cluster and returns NOTHING under `helm template`. Argo CD renders
+  with `helm template`, so under Argo this branch never triggers and values.config is applied in full,
+  deleting any key it does not contain.
+
+  An Argo ignoreDifferences on /spec is NOT sufficient — that was in place on a real deployment and the
+  spec was still replaced on sync, losing the entire energy-flow hierarchy.
+
+  Under Argo (or any `helm template` renderer) the reliable pattern is:
+    1. install once with manageResource: true to seed the CR;
+    2. set manageResource: false so the chart stops rendering it and the cluster owns it.
+  The annotations below make step 2 safe — without them, dropping it from the render deletes it.
 */}}
 {{- $existing := dict }}
 {{- if .Values.kubernetesConfigSource.preserveExisting }}
@@ -17,6 +27,20 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "rpdu2mqtt.labels" . | nindent 4 }}
+  annotations:
+    {{- /*
+      This resource is SEEDED here and then owned by the cluster — the GUI writes to it, and sections
+      that only ever existed there (EnergyFlow, Modbus, …) are not represented in values.config.
+
+      Both annotations exist so that turning manageResource off, once the CR exists, is a safe
+      operation rather than a destructive one:
+        - resource-policy: keep   -> helm uninstall/upgrade never deletes it
+        - Prune=false             -> Argo does not delete it when it leaves the rendered manifest
+                                     (Argo reads this from the LIVE object when deciding to prune)
+      Without them, dropping the CR from the render deletes it along with every GUI-made edit.
+    */}}
+    helm.sh/resource-policy: keep
+    argocd.argoproj.io/sync-options: Prune=false
 {{- /*
   When the chart deploys Valkey, point the bridge at it — shipping the instance and leaving the bridge
   unaware of it would be worse than not shipping it. The service name can't live in values.config, which is

--- a/charts/rpdu2mqtt/templates/valkey.yaml
+++ b/charts/rpdu2mqtt/templates/valkey.yaml
@@ -19,8 +19,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "rpdu2mqtt.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: valkey
+      # NOT rpdu2mqtt.selectorLabels: the bridge Deployment selects on name+instance alone, so pods
+      # carrying those labels are adopted by ITS ReplicaSet no matter what else they carry. A distinct
+      # name keeps the two selectors disjoint.
+      app.kubernetes.io/name: {{ include "rpdu2mqtt.name" . }}-valkey
+      app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.valkey.persistence.enabled }}
   strategy:
     # The volume is ReadWriteOnce, so the old pod must release it before the new one starts.
@@ -29,7 +32,8 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "rpdu2mqtt.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "rpdu2mqtt.name" . }}-valkey
+        app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: valkey
     spec:
       containers:
@@ -92,8 +96,8 @@ spec:
       protocol: TCP
       name: valkey
   selector:
-    {{- include "rpdu2mqtt.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: valkey
+    app.kubernetes.io/name: {{ include "rpdu2mqtt.name" . }}-valkey
+    app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.valkey.persistence.enabled }}
 ---
 apiVersion: v1

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -304,7 +304,10 @@ valkey:
     # On by default: the energy counters are the reason this exists, and losing them on a pod restart reads
     # downstream as a meter reset. Turn it off to run as a pure cache with nothing worth keeping.
     enabled: true
-    size: 128Mi
+    size: 1Gi
+    # Leave empty to use the cluster's default StorageClass — but check you HAVE exactly one default
+    # first. A cluster with two marked (default) picks non-deterministically, and a cache volume is
+    # exactly the kind of thing that silently lands on the wrong (or a non-provisioning) backend.
     storageClass: ""
   resources:
     requests:


### PR DESCRIPTION
Two production failures on a live cluster, both caused by this chart. I caused both while deploying #293 there.

## 1. An Argo sync deleted a deployment's entire config

Lost: the whole energy-flow hierarchy (9 nodes, 10 links, 27 source bindings), the Modbus connection, the operator settings, and the real PDU instance — replaced by the chart's `pdu.example.com` placeholder.

**Why.** `values.config` *seeds* the `RpduConfig`; it is not the ongoing source of truth. The GUI writes to that CR, and whole sections exist **only** there. `preserveExisting` was meant to protect them, but it relies on Helm `lookup`, which returns nothing under `helm template` — so under Argo the branch never fires and `values.config` is applied in full, deleting every key it doesn't contain.

The comment here told people to add an Argo `ignoreDifferences` instead. **That deployment had one** — on `/spec`, with `RespectIgnoreDifferences=true` — and the spec was replaced anyway. That advice is now documented as insufficient rather than recommended.

**The fix.** Seeding once and then not rendering the CR was already possible via `manageResource: false`, but doing it *deleted the CR*, because leaving the rendered manifest makes Argo prune it. The CR is now annotated:

```yaml
helm.sh/resource-policy: keep
argocd.argoproj.io/sync-options: Prune=false
```

Argo reads `Prune=false` from the **live** object when deciding to prune, so the CR survives leaving the render. That turns seed-once from a trap into a supported flow, and it's documented as the pattern for Argo.

## 2. Valkey pods collided with the bridge Deployment

```
bridge selector:   {name: rpdu2mqtt, instance: rpdu2mqtt}
valkey pod labels: {name: rpdu2mqtt, instance: rpdu2mqtt, component: valkey}
```

A selector matches on **subset**, so adding `component` to the Valkey pods didn't exclude them — the bridge's ReplicaSet adopts and deletes them. Two controllers fighting over one set of pods. Observed as Valkey being recreated unprompted and `kubectl logs deploy/rpdu2mqtt` returning the *Valkey* pod. Valkey now carries its own `app.kubernetes.io/name`.

## 3. PVC storage class

The Valkey PVC fell through to the cluster's default StorageClass. On that cluster **two** were marked `(default)`, and the one it picked never provisioned. The comment now says to check you have exactly one before relying on it, and the default size is 1Gi — tiny requests fare badly with block provisioners.

Verified against the live cluster: CR restored from Velero and annotated, Valkey running and bound, bridge polling the real PDU again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)