### PR TITLE
fix(startup): a toggle in the GUI can no longer stop the bridge from starting

### DIFF
--- a/rPDU2MQTT.Core/Startup/ConfigurationFaults.cs
+++ b/rPDU2MQTT.Core/Startup/ConfigurationFaults.cs
@@ -1,0 +1,73 @@
+using System.Collections.Concurrent;
+
+namespace rPDU2MQTT.Core.Startup;
+
+/// <summary>One optional feature that is switched on but cannot run as configured.</summary>
+/// <param name="Component">Status-board component id, e.g. "emoncms".</param>
+/// <param name="Path">The config path at fault, e.g. "EmonCMS.Url".</param>
+/// <param name="Message">What to do about it, in the operator's terms.</param>
+public sealed record ConfigurationFault(string Component, string Path, string Message);
+
+/// <summary>
+/// Optional features that were enabled but are missing something they need.
+///
+/// <para>
+/// These used to throw during startup, which meant a single toggle in the GUI — "EmonCMS: on", before
+/// filling in the URL — left the process unable to start at all. Everything else the bridge does (polling
+/// the PDU, publishing to MQTT, Home Assistant discovery, the energy flow) died with it, and the only
+/// clue was a stack trace in a container that was already restarting.
+/// </para>
+/// <para>
+/// Nothing reachable from a toggle may stop the bridge starting. An optional destination that cannot run
+/// is switched off, recorded here, logged as an error, and shown on the Status board — loud and
+/// diagnosable rather than fatal. Anything genuinely required to do the job at all (the MQTT broker, a
+/// PDU host) still fails fast; that is not a state a toggle can produce.
+/// </para>
+/// </summary>
+public sealed class ConfigurationFaults
+{
+    private readonly ConcurrentDictionary<string, ConfigurationFault> faults = new(StringComparer.OrdinalIgnoreCase);
+
+    public void Record(ConfigurationFault fault) => faults[fault.Component] = fault;
+
+    /// <summary>The fault for a component, or null when it is fine.</summary>
+    public ConfigurationFault? For(string component)
+        => faults.TryGetValue(component, out var f) ? f : null;
+
+    public IReadOnlyCollection<ConfigurationFault> All => faults.Values.ToList();
+}
+
+/// <summary>
+/// Whether an optional destination has what it needs. Pure, so the rules are testable without building a
+/// host — the previous checks were inline in DI setup and could only be exercised by starting the app.
+/// </summary>
+public static class DestinationRequirements
+{
+    /// <summary>
+    /// EmonCMS over HTTP posts to a URL; over MQTT it reuses the broker and needs none. Blank counts as
+    /// missing — the old null-only check let <c>Url: ""</c> through, to fail later at runtime instead.
+    /// </summary>
+    public static ConfigurationFault? EmonCms(bool enabled, bool httpTransport, string? url)
+    {
+        if (!enabled || !httpTransport || !string.IsNullOrWhiteSpace(url)) return null;
+        return new ConfigurationFault("emoncms", "EmonCMS.Url",
+            "EmonCMS is enabled over HTTP but EmonCMS.Url is not set, so nothing can be posted. Set the URL, "
+            + "switch Transport to Mqtt, or turn EmonCMS off. Everything else keeps running.");
+    }
+
+    /// <summary>File logging needs somewhere to write.</summary>
+    public static ConfigurationFault? FileLog(bool enabled, string? path)
+    {
+        if (!enabled || !string.IsNullOrWhiteSpace(path)) return null;
+        return new ConfigurationFault("logging.file", "Logging.File.Path",
+            "File logging is enabled but Logging.File.Path is not set. Logging to file is disabled; the console sink is unaffected.");
+    }
+
+    /// <summary>Syslog needs a host to send to.</summary>
+    public static ConfigurationFault? Syslog(bool enabled, string? host)
+    {
+        if (!enabled || !string.IsNullOrWhiteSpace(host)) return null;
+        return new ConfigurationFault("logging.syslog", "Logging.Syslog.Host",
+            "Syslog logging is enabled but Logging.Syslog.Host is not set. Syslog is disabled; other log sinks are unaffected.");
+    }
+}

--- a/rPDU2MQTT.Tests/ConfigWatcherTests.cs
+++ b/rPDU2MQTT.Tests/ConfigWatcherTests.cs
@@ -186,6 +186,11 @@ public class MqttOptionsFactoryTests
 /// MqttReconfigurator (#192): the decision to re-point, and the re-point sequence itself, driven through
 /// <see cref="FakeHiveMQClient"/> so no live broker is needed.
 /// </summary>
+// Shares MqttSubscriptions' process-wide registry with MqttResubscribeTests, which resets it between
+// cases. Without pinning both to one collection xUnit runs them in parallel and the reset lands mid-
+// assertion here — passing alone, failing in a full run. Static state is the cost of that registry
+// surviving a reconnect; this is the containment.
+[Collection("MqttSubscriptions")]
 public class MqttReconfiguratorTests
 {
     private static Config Sample()

--- a/rPDU2MQTT.Tests/ConfigurationFaultTests.cs
+++ b/rPDU2MQTT.Tests/ConfigurationFaultTests.cs
@@ -1,0 +1,78 @@
+using rPDU2MQTT.Core.Startup;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Nothing reachable from a toggle in the GUI may stop the bridge from starting.
+///
+/// <para>
+/// Enabling EmonCMS before filling in its URL did exactly that: startup threw, and the process could not
+/// come up at all — no PDU polling, no MQTT, no Home Assistant, no energy flow — over one optional
+/// exporter. The only symptom was a stack trace in a container that was already restarting.
+/// </para>
+/// </summary>
+public class ConfigurationFaultTests
+{
+    [Fact]
+    public void EmonCmsOverHttpWithNoUrl_IsAFault_NotAnException()
+    {
+        // The exact state a GUI toggle produces: Enabled on, Transport Http, URL never filled in.
+        var fault = DestinationRequirements.EmonCms(enabled: true, httpTransport: true, url: null);
+
+        Assert.NotNull(fault);
+        Assert.Equal("emoncms", fault!.Component);
+        Assert.Equal("EmonCMS.Url", fault.Path);
+        // The message has to say the rest of the bridge is unaffected — that is the whole behavioural change.
+        Assert.Contains("keeps running", fault.Message);
+    }
+
+    [Fact]
+    public void ABlankUrl_CountsAsMissing()
+    {
+        // The old check tested only for null, so Url: "" sailed past startup and failed later at runtime.
+        Assert.NotNull(DestinationRequirements.EmonCms(true, true, ""));
+        Assert.NotNull(DestinationRequirements.EmonCms(true, true, "   "));
+    }
+
+    [Fact]
+    public void EmonCmsIsFine_WhenDisabled_OrOverMqtt_OrConfigured()
+    {
+        Assert.Null(DestinationRequirements.EmonCms(enabled: false, httpTransport: true, url: null));
+        // The MQTT transport reuses the broker, so it needs no URL at all.
+        Assert.Null(DestinationRequirements.EmonCms(enabled: true, httpTransport: false, url: null));
+        Assert.Null(DestinationRequirements.EmonCms(enabled: true, httpTransport: true, url: "https://emon.example.com/"));
+    }
+
+    [Fact]
+    public void LoggingSinksDegradeIndividually()
+    {
+        // Same rule for the other two toggles that could brick startup.
+        Assert.NotNull(DestinationRequirements.FileLog(enabled: true, path: null));
+        Assert.Null(DestinationRequirements.FileLog(enabled: true, path: "/var/log/rpdu.log"));
+        Assert.Null(DestinationRequirements.FileLog(enabled: false, path: null));
+
+        Assert.NotNull(DestinationRequirements.Syslog(enabled: true, host: null));
+        Assert.Null(DestinationRequirements.Syslog(enabled: true, host: "syslog.local"));
+        Assert.Null(DestinationRequirements.Syslog(enabled: false, host: null));
+
+        // Each names only its own sink, so one bad sink doesn't read as "logging is broken".
+        Assert.Contains("console sink is unaffected", DestinationRequirements.FileLog(true, null)!.Message);
+        Assert.Contains("other log sinks are unaffected", DestinationRequirements.Syslog(true, null)!.Message);
+    }
+
+    [Fact]
+    public void FaultsAreRecordedPerComponent_AndTheLatestWins()
+    {
+        var faults = new ConfigurationFaults();
+        Assert.Null(faults.For("emoncms"));
+
+        faults.Record(DestinationRequirements.EmonCms(true, true, null)!);
+        Assert.NotNull(faults.For("emoncms"));
+        Assert.Single(faults.All);
+
+        // Re-recording the same component replaces rather than accumulating — the board shows one card.
+        faults.Record(DestinationRequirements.EmonCms(true, true, null)!);
+        Assert.Single(faults.All);
+    }
+}

--- a/rPDU2MQTT/Hosting/StatusReporter.cs
+++ b/rPDU2MQTT/Hosting/StatusReporter.cs
@@ -26,8 +26,9 @@ public sealed class StatusReporter : BackgroundService
     private readonly EmonCmsStatus emon;
     private readonly ProcessIdentity self;
     private readonly Core.Flow.CacheHealth? cacheHealth;
+    private readonly Core.Startup.ConfigurationFaults? faults;
 
-    public StatusReporter(IGrainFactory grains, Config config, IHiveMQClient mqtt, ISnapshotCache snapshots, EmonCmsStatus emon, ProcessIdentity self, Core.Flow.CacheHealth? cacheHealth = null)
+    public StatusReporter(IGrainFactory grains, Config config, IHiveMQClient mqtt, ISnapshotCache snapshots, EmonCmsStatus emon, ProcessIdentity self, Core.Flow.CacheHealth? cacheHealth = null, Core.Startup.ConfigurationFaults? faults = null)
     {
         this.grains = grains;
         this.config = config;
@@ -36,6 +37,7 @@ public sealed class StatusReporter : BackgroundService
         this.emon = emon;
         this.self = self;
         this.cacheHealth = cacheHealth;
+        this.faults = faults;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -75,15 +77,21 @@ public sealed class StatusReporter : BackgroundService
         // null, which the grain treats as "no news" rather than "no export".
         var e = emon.Snapshot();
         var attempted = emon.HasAttempted;
+        // Enabled but unusable is its own state, and it has to be visible: the exporter was skipped at
+        // startup so it will never attempt anything, which would otherwise read as a healthy "on" card
+        // that simply never counts up.
+        var emonFault = faults?.For("emoncms");
         await grains.GetGrain<IEmonCmsStatusGrain>("emoncms").Report(new ComponentReport
         {
             Enabled = config.EmonCMS.Enabled,
-            Ok = attempted ? e.Ok : null,
+            Ok = emonFault is not null ? false : (attempted ? e.Ok : null),
             Count = attempted ? e.Count : 0,
             EventUtc = e.LastSuccessUtc,
-            Detail = attempted && e.Ok == false
-                ? e.LastError
-                : config.EmonCMS.Transport.ToString().ToUpperInvariant(),
+            Detail = emonFault is not null
+                ? emonFault.Message
+                : attempted && e.Ok == false
+                    ? e.LastError
+                    : config.EmonCMS.Transport.ToString().ToUpperInvariant(),
         });
 
         await grains.GetGrain<IHomeAssistantStatusGrain>("homeassistant").Report(new ComponentReport

--- a/rPDU2MQTT/Program.cs
+++ b/rPDU2MQTT/Program.cs
@@ -44,7 +44,8 @@ var host = Host.CreateDefaultBuilder(args)
 StartupSummary.Log(
     host.Services.GetRequiredService<Config>(),
     host.Services.GetRequiredService<rPDU2MQTT.Core.HostRole>(),
-    host.Services.GetRequiredService<rPDU2MQTT.Startup.ConfigSources.IConfigSource>());
+    host.Services.GetRequiredService<rPDU2MQTT.Startup.ConfigSources.IConfigSource>(),
+    host.Services.GetService<rPDU2MQTT.Core.Startup.ConfigurationFaults>());
 
 //Ensure we can actually connect to MQTT.
 var client = host.Services.GetRequiredService<IHiveMQClient>();

--- a/rPDU2MQTT/Startup/ConfigureLogging.cs
+++ b/rPDU2MQTT/Startup/ConfigureLogging.cs
@@ -18,13 +18,14 @@ public static class ConfigureLoggingExtension
                 o.WriteTo.Console(cfg.Logging.Console.Severity, outputTemplate: cfg.Logging.Console.Format);
 
             // Configure logging to file.
-            if (cfg.Logging.File.Enabled)
+            // A sink that cannot be built is dropped, not fatal: "log to file" is a toggle in the GUI, and
+            // switching it on before naming a path must not stop the bridge from starting.
+            var fileFault = Core.Startup.DestinationRequirements.FileLog(cfg.Logging.File.Enabled, cfg.Logging.File.Path);
+            if (fileFault is not null)
+                Console.Error.WriteLine("[config] " + fileFault.Message);   // the logger isn't built yet
+
+            if (cfg.Logging.File.Enabled && fileFault is null)
             {
-                if (string.IsNullOrEmpty(cfg.Logging.File.Path))
-                {
-                    Log.Fatal("Config.Logging.File.Enabled=true, but, Config.Logging.File.Path is not specified. Please either provide a path, or disable Logging to file.");
-                    ThrowError.TestRequiredConfigurationSection(cfg.Logging.File.Path, "Config.Logging.File.Path");
-                }
 
                 // The file sink's own level and format — it used to be given the console's, which made the
                 // one combination people actually want (quiet console, full detail on disk) impossible.
@@ -40,10 +41,13 @@ public static class ConfigureLoggingExtension
                 Log.Debug("Will not log to file.");
 
             // Configure logging to a remote syslog server.
-            if (cfg.Logging.Syslog.Enabled)
+            var syslogFault = Core.Startup.DestinationRequirements.Syslog(cfg.Logging.Syslog.Enabled, cfg.Logging.Syslog.Host);
+            if (syslogFault is not null)
+                Console.Error.WriteLine("[config] " + syslogFault.Message);
+
+            if (cfg.Logging.Syslog.Enabled && syslogFault is null)
             {
                 var sl = cfg.Logging.Syslog;
-                ThrowError.TestRequiredConfigurationSection(sl.Host, "Config.Logging.Syslog.Host");
 
                 if (sl.Protocol == Models.Config.Schemas.SyslogProtocol.TCP)
                     o.WriteTo.TcpSyslog(sl.Host, sl.Port, appName: sl.AppName, restrictedToMinimumLevel: sl.Severity);

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -112,6 +112,11 @@ public static class ServiceConfiguration
         // Shared liveness/readiness signals (uptime + last successful poll).
         services.AddSingleton<HealthState>();
         // EmonCMS export health (last attempt/success/error) — read by the GUI even when disabled.
+        // Optional features that were switched on but can't run. Registered before anything checks, so a
+        // fault recorded during setup is visible to the Status board rather than only in the log.
+        var faults = new Core.Startup.ConfigurationFaults();
+        services.AddSingleton(faults);
+
         services.AddSingleton<Services.EmonCmsStatus>();
 
         // The shared cache. Registered whether or not it is enabled so the Status board can say "not
@@ -247,9 +252,20 @@ public static class ServiceConfiguration
             if (cfg.EmonCMS.Enabled)
             {
                 // Url is only needed for the HTTP transport; the MQTT transport uses the existing broker.
-                if (cfg.EmonCMS.Transport == Models.Config.EmonCmsTransport.Http)
-                    ThrowError.TestRequiredConfigurationSection(cfg.EmonCMS.Url, "EmonCMS.Url");
-                services.AddHostedService<EmonCmsExportService>();
+                // A missing one used to throw here, so enabling EmonCMS in the GUI before filling in the
+                // URL left the process unable to start — taking the PDU poll, MQTT, HA and the flow with
+                // it. Skip just this exporter and say so; nothing a toggle can do may stop the bridge.
+                var emonFault = Core.Startup.DestinationRequirements.EmonCms(
+                    cfg.EmonCMS.Enabled,
+                    cfg.EmonCMS.Transport == Models.Config.EmonCmsTransport.Http,
+                    cfg.EmonCMS.Url);
+                if (emonFault is not null)
+                {
+                    Log.Error(emonFault.Message);
+                    faults.Record(emonFault);
+                }
+                else
+                    services.AddHostedService<EmonCmsExportService>();
             }
 
             // Feed auto-provisioning (#163) honors the live EmonCMS.Feeds.AutoConfigure toggle, so register

--- a/rPDU2MQTT/Startup/StartupSummary.cs
+++ b/rPDU2MQTT/Startup/StartupSummary.cs
@@ -16,7 +16,7 @@ namespace rPDU2MQTT.Startup;
 /// </summary>
 public static class StartupSummary
 {
-    public static void Log(Config cfg, HostRole roles, IConfigSource source)
+    public static void Log(Config cfg, HostRole roles, IConfigSource source, Core.Startup.ConfigurationFaults? faults = null)
     {
         var roleNames = new[] { HostRole.Worker, HostRole.Api, HostRole.Ui, HostRole.Operator }
             .Where(r => roles.HasFlag(r))
@@ -50,9 +50,13 @@ public static class StartupSummary
         Serilog.Log.Information("  Energy dashboard sync: {State}.", cfg.HASS.EnergyDashboard?.Enabled == true ? "on" : "off");
         Serilog.Log.Information("  Prometheus exporter: {State}{Port}",
             cfg.Prometheus.Exporter ? "on" : "off", cfg.Prometheus.Exporter ? $" → :{cfg.Prometheus.Port}/metrics" : "");
+        // "on" has to mean it is actually running. A destination switched on but skipped for a missing
+        // setting reported "on" here while exporting nothing, which is the least helpful line in the log.
+        var emonFault = faults?.For("emoncms");
         Serilog.Log.Information("  EmonCMS: {State}{Detail}",
-            cfg.EmonCMS.Enabled ? "on" : "off",
-            cfg.EmonCMS.Enabled ? $" via {cfg.EmonCMS.Transport} (feeds auto-configure {(cfg.EmonCMS.Feeds.AutoConfigure ? "on" : "off")})" : "");
+            emonFault is not null ? "DISABLED (misconfigured)" : cfg.EmonCMS.Enabled ? "on" : "off",
+            emonFault is not null ? $" — {emonFault.Path} is not set"
+                : cfg.EmonCMS.Enabled ? $" via {cfg.EmonCMS.Transport} (feeds auto-configure {(cfg.EmonCMS.Feeds.AutoConfigure ? "on" : "off")})" : "");
         Serilog.Log.Information("  GUI: {State}.", cfg.Gui.Enabled ? $"on :{cfg.Gui.Port}" : "off");
 
         // How to see more, said once, where someone reading the log will find it.


### PR DESCRIPTION
Switching EmonCMS on before filling in its URL made **the process** fail to start — not the exporter. No PDU polling, no MQTT, no Home Assistant, no energy flow, over one optional destination, in a container that was already restarting:

```
[FTL] Missing required configuration. Path: EmonCMS.Url
Unhandled exception. System.Exception: Missing required configuration. Path: EmonCMS.Url
   at rPDU2MQTT.Startup.ServiceConfiguration.Configure(...)
Caused application to not start.
```

Hit in production. Nothing reachable from a toggle in the GUI should be able to do that.

## Three toggles could do it, not one

| Toggle | Companion field | Result if blank |
|---|---|---|
| `EmonCMS.Enabled` | `EmonCMS.Url` | process won't start |
| `Logging.File.Enabled` | `Logging.File.Path` | process won't start |
| `Logging.Syslog.Enabled` | `Logging.Syslog.Host` | process won't start |

## The change

An optional destination that can't run is now **switched off, recorded, logged as an error, and shown on the Status board** — loud and diagnosable rather than fatal. The MQTT broker and a PDU host still fail fast: those are required to do the job at all, and no toggle can produce that state.

- **`ConfigurationFaults`** collects them; **`DestinationRequirements`** holds the rules as pure functions, so they're testable without building a host. The old checks were inline in DI setup and could only be exercised by starting the app — which is why this shipped.
- **Blank now counts as missing.** `TestRequiredConfigurationSection` only tested for `null`, so `Url: ""` sailed past startup and failed later at runtime.
- **The EmonCMS card reports the fault**, instead of a healthy-looking "on" card that never counts up because the exporter was never registered.
- **The startup summary was lying**: it printed `EmonCMS: on via Http` for a destination that had been skipped. Now `EmonCMS: DISABLED (misconfigured) — EmonCMS.Url is not set`.
- Each logging fault names only its own sink, so one bad sink doesn't read as "logging is broken".

## Verification

Against the **real binary**, with the exact config that took production down (`Enabled: true`, `Transport: Http`, no `Url`):

```
exit=124                       ← the 45s timeout killed it; it did not die on its own
[ERR] EmonCMS is enabled over HTTP but EmonCMS.Url is not set … Everything else keeps running.
[INF]   EmonCMS: DISABLED (misconfigured) — EmonCMS.Url is not set
crash markers: 0
```

Plus 5 unit tests covering the toggle state, blank-vs-null, the disabled/MQTT-transport/configured cases, per-sink logging messages, and fault recording.

## Also: a flaky test I introduced in #282

`MqttReconfiguratorTests` and `MqttResubscribeTests` both exercise `MqttSubscriptions`' process-wide registry, and the latter resets it between cases. Run in parallel, the reset landed mid-assertion — **passing alone, failing in a full run**. That's the cost of the static registry that makes subscriptions survive a reconnect; both classes are now pinned to one xUnit collection.

425 tests, three consecutive clean full runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)