### PR TITLE
feat(flow): sample power into energy — the service that drives the integrator

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -696,6 +696,20 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
                 properties:
+                  Aggregation:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      Enabled:
+                        type: boolean
+                        description: Derive energy (kWh) by integrating each node's power over time. A real energy source on a node always takes precedence.
+                      SampleIntervalSeconds:
+                        type: integer
+                        description: How often to sample power, in seconds. Shorter samples track a spiky load more closely.
+                      MaxGapSeconds:
+                        type: integer
+                        description: Longest gap between samples that still counts, in seconds. A longer gap is recorded as unmeasured rather than guessed.
+                    description: Accumulate energy (kWh) from the power readings, for nodes that report power but not energy.
                   Nodes:
                     type: array
                     items:

--- a/ToDo.md
+++ b/ToDo.md
@@ -99,7 +99,7 @@ Click it again, to restore.
 
 - [x] Energy Flow Chart- ability to display Power.... Or Energy.  (#275 — metric toggle on the Flow tab)
 
-- Need to aggregate energy data, using the collected power data. Will need redis broker to support
+- [x] Need to aggregate energy data, using the collected power data. Will need redis broker to support
     Helm chart will need redis broker. Docker compse example, will need redis.
     For those wanting simple install, should offer a simple sqlite database or mabye an inmemory cache or something.
     Cache will be responsible for aggregating Power into Energy.

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -696,6 +696,20 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
                 properties:
+                  Aggregation:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      Enabled:
+                        type: boolean
+                        description: Derive energy (kWh) by integrating each node's power over time. A real energy source on a node always takes precedence.
+                      SampleIntervalSeconds:
+                        type: integer
+                        description: How often to sample power, in seconds. Shorter samples track a spiky load more closely.
+                      MaxGapSeconds:
+                        type: integer
+                        description: Longest gap between samples that still counts, in seconds. A longer gap is recorded as unmeasured rather than guessed.
+                    description: Accumulate energy (kWh) from the power readings, for nodes that report power but not energy.
                   Nodes:
                     type: array
                     items:

--- a/rPDU2MQTT.Core/Flow/CacheHealth.cs
+++ b/rPDU2MQTT.Core/Flow/CacheHealth.cs
@@ -14,12 +14,19 @@ public sealed class CacheHealth
 {
     private volatile string? error;
 
+    /// <summary>
+    /// Whether anything has actually tried yet. Without this, a configured-but-idle cache reported as
+    /// UNREACHABLE purely because nothing had used it — indistinguishable from one that is genuinely
+    /// down, which is the same "never reported vs stopped reporting" confusion this class exists to avoid.
+    /// </summary>
+    public bool Attempted { get; private set; }
+
     /// <summary>True once an operation has succeeded; false after one has failed.</summary>
     public bool Reachable { get; private set; }
 
     /// <summary>Why the last attempt failed, when it did.</summary>
     public string? Error => error;
 
-    public void Succeeded() { Reachable = true; error = null; }
-    public void Failed(string message) { Reachable = false; error = message; }
+    public void Succeeded() { Attempted = true; Reachable = true; error = null; }
+    public void Failed(string message) { Attempted = true; Reachable = false; error = message; }
 }

--- a/rPDU2MQTT.Core/Models/Config/EnergyAggregationConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyAggregationConfig.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel;
+
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>
+/// Deriving energy (kWh) from power readings.
+///
+/// <para>
+/// Plenty of sources report instantaneous power and no cumulative energy — a CT clamp, an inverter's
+/// live wattage. Integrating that over time gives the kWh the Energy Dashboard and EmonCMS feeds want,
+/// without a second meter.
+/// </para>
+/// <para>
+/// A derived total is only ever used where nothing measures energy directly: a real energy binding on a
+/// node always wins. Off by default, because a derived figure is an estimate and should be an opt-in.
+/// </para>
+/// </summary>
+public class EnergyAggregationConfig
+{
+    [DefaultValue(false)]
+    [Description("Derive energy (kWh) by integrating each node's power over time. A real energy source on a node always takes precedence.")]
+    public bool Enabled { get; set; }
+
+    [DefaultValue(10)]
+    [Description("How often to sample power, in seconds. Shorter samples track a spiky load more closely.")]
+    public int SampleIntervalSeconds { get; set; } = 10;
+
+    /// <summary>
+    /// The longest gap between two samples that is still integrated. Beyond it the power in between is
+    /// genuinely unknown — a dead publisher, a restart, a partition — and none of that time is counted
+    /// rather than assuming the last reading held.
+    /// </summary>
+    [DefaultValue(60)]
+    [Description("Longest gap between samples that still counts, in seconds. A longer gap is recorded as unmeasured rather than guessed.")]
+    public int MaxGapSeconds { get; set; } = 60;
+}

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -10,6 +10,10 @@ namespace rPDU2MQTT.Models.Config;
 /// </summary>
 public class EnergyFlowConfig
 {
+    /// <summary>Deriving energy (kWh) from the power readings already being collected.</summary>
+    [Description("Accumulate energy (kWh) from the power readings, for nodes that report power but not energy.")]
+    public EnergyAggregationConfig Aggregation { get; set; } = new();
+
     /// <summary>
     /// Custom upstream nodes that aren't auto-derived from a PDU (e.g. a breaker, a transfer-switch
     /// output, the grid "Total"). Auto nodes use ids like <c>pdu:&lt;name&gt;</c> / <c>outlet:&lt;pdu&gt;:&lt;n&gt;</c>.

--- a/rPDU2MQTT.Engine/Services/EnergyAggregationService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyAggregationService.cs
@@ -53,15 +53,23 @@ public sealed class EnergyAggregationService : BackgroundService, IFlowValueSour
         return true;
     }
 
+    /// <summary>
+    /// Continue from wherever the last run got to. Separate from ExecuteAsync so the carry-over — the
+    /// whole reason the store exists — can be asserted directly; testing it by starting the service and
+    /// waiting for a timer was timing-dependent, and duly failed on a slower machine.
+    /// </summary>
+    public int LoadTotals()
+    {
+        states = new Dictionary<string, EnergyState>(store.Load(), StringComparer.OrdinalIgnoreCase);
+        return states.Count;
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         var agg = cfg.EnergyFlow.Aggregation;
-        // Continue from wherever the last run got to. A cold start here is the meter-reset case, so it is
-        // worth saying out loud how much was carried over.
-        var loaded = new Dictionary<string, EnergyState>(store.Load(), StringComparer.OrdinalIgnoreCase);
-        states = loaded;
+        var carried = LoadTotals();
         Log.Information($"Energy aggregation: sampling power every {agg.SampleIntervalSeconds}s "
-                      + $"(gaps over {agg.MaxGapSeconds}s are not counted); carried over {loaded.Count} node total(s).");
+                      + $"(gaps over {agg.MaxGapSeconds}s are not counted); carried over {carried} node total(s).");
 
         var maxGap = TimeSpan.FromSeconds(Math.Max(1, agg.MaxGapSeconds));
         using var timer = new PeriodicTimer(TimeSpan.FromSeconds(Math.Max(1, agg.SampleIntervalSeconds)));

--- a/rPDU2MQTT.Engine/Services/EnergyAggregationService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyAggregationService.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Hosting;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core.Flow;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// Derives energy (kWh) from the power readings already being collected, for nodes that report power but
+/// no cumulative energy — a CT clamp, an inverter's live wattage.
+///
+/// <para>
+/// It samples <c>realpower</c> for every configured node on a timer, folds each reading into a running
+/// total via <see cref="EnergyIntegrator"/>, and persists through <see cref="IEnergyStore"/> so a restart
+/// continues the count rather than starting again — a counter that resets reads downstream as a meter
+/// reset, and Home Assistant and EmonCMS correct their recorded history for it.
+/// </para>
+/// <para>
+/// It is itself an <see cref="IFlowValueSource"/> for the <c>energy</c> metric, registered LAST in the
+/// composite so that any node with a real energy binding uses that instead. A derived figure only ever
+/// fills a gap; it never overrides a measurement.
+/// </para>
+/// </summary>
+public sealed class EnergyAggregationService : BackgroundService, IFlowValueSource
+{
+    private const string PowerMetric = "realpower";
+    private const string EnergyMetric = "energy";
+
+    private readonly Config cfg;
+    private readonly IFlowValueSource upstream;
+    private readonly IEnergyStore store;
+    private volatile Dictionary<string, EnergyState> states = new(StringComparer.OrdinalIgnoreCase);
+
+    public EnergyAggregationService(Config cfg, IFlowValueSource upstream, IEnergyStore store)
+    {
+        this.cfg = cfg;
+        this.upstream = upstream;
+        this.store = store;
+    }
+
+    /// <summary>
+    /// The derived total for a node, if one has been accumulated. Only <c>energy</c>, and only once a
+    /// sample has actually been taken — reporting 0 for a node that has never been measured would be a
+    /// claim, not a gap.
+    /// </summary>
+    public bool TryGetValue(string nodeId, string metric, out double value)
+    {
+        value = 0;
+        if (!string.Equals(metric, EnergyMetric, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (!states.TryGetValue(nodeId, out var s) || s.LastSampleUtc == default)
+            return false;
+        value = s.KWh;
+        return true;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var agg = cfg.EnergyFlow.Aggregation;
+        // Continue from wherever the last run got to. A cold start here is the meter-reset case, so it is
+        // worth saying out loud how much was carried over.
+        var loaded = new Dictionary<string, EnergyState>(store.Load(), StringComparer.OrdinalIgnoreCase);
+        states = loaded;
+        Log.Information($"Energy aggregation: sampling power every {agg.SampleIntervalSeconds}s "
+                      + $"(gaps over {agg.MaxGapSeconds}s are not counted); carried over {loaded.Count} node total(s).");
+
+        var maxGap = TimeSpan.FromSeconds(Math.Max(1, agg.MaxGapSeconds));
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(Math.Max(1, agg.SampleIntervalSeconds)));
+        try
+        {
+            do
+            {
+                try { Sample(maxGap); }
+                catch (Exception ex) { Log.Warning($"Energy aggregation pass failed: {ex.Message}"); }
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+        catch (OperationCanceledException) { /* shutting down */ }
+        finally
+        {
+            // A clean stop is the one chance to record the last few samples; losing them silently would
+            // show up later as a counter that jumped backwards.
+            try { store.Save(states); } catch (Exception ex) { Log.Warning($"Could not persist energy totals on shutdown: {ex.Message}"); }
+        }
+    }
+
+    private void Sample(TimeSpan maxGap)
+    {
+        var now = DateTime.UtcNow;
+        var next = new Dictionary<string, EnergyState>(states, StringComparer.OrdinalIgnoreCase);
+        var sampled = 0;
+
+        foreach (var node in cfg.EnergyFlow.Nodes)
+        {
+            var id = node.Id?.Trim();
+            if (string.IsNullOrEmpty(id)) continue;
+
+            // Only nodes with a *fresh* power reading: TryGetValue already hides an expired one, and a
+            // stale value must be treated as a gap rather than integrated as if it were current.
+            if (!upstream.TryGetValue(id, PowerMetric, out var watts)) continue;
+
+            next[id] = EnergyIntegrator.Accumulate(
+                next.TryGetValue(id, out var prev) ? prev : EnergyState.Empty, watts, now, maxGap);
+            sampled++;
+        }
+
+        states = next;
+        if (sampled > 0) store.Save(next);
+    }
+}

--- a/rPDU2MQTT.Engine/Services/RedisCacheClient.cs
+++ b/rPDU2MQTT.Engine/Services/RedisCacheClient.cs
@@ -65,5 +65,21 @@ public sealed class RedisCacheClient : ICacheClient, IDisposable
         catch (Exception ex) { health.Failed(ex.Message); throw; }
     }
 
+    /// <summary>
+    /// A real round-trip, not just IsConnected: the multiplexer reports connected while a half-open
+    /// socket is still being reaped, and the Status board should say what the cache is doing now.
+    /// </summary>
+    public bool Ping()
+    {
+        try
+        {
+            var db = Db ?? throw new InvalidOperationException("cache is not connected");
+            db.Ping();
+            health.Succeeded();
+            return true;
+        }
+        catch (Exception ex) { health.Failed(ex.Message); return false; }
+    }
+
     public void Dispose() { if (connection.IsValueCreated) connection.Value?.Dispose(); }
 }

--- a/rPDU2MQTT.Engine/Services/RedisEnergyStore.cs
+++ b/rPDU2MQTT.Engine/Services/RedisEnergyStore.cs
@@ -15,6 +15,13 @@ public interface ICacheClient
 
     /// <summary>Replace a hash wholesale.</summary>
     void HashSet(string key, IReadOnlyDictionary<string, string> fields);
+
+    /// <summary>
+    /// Is the cache actually answering? Needed because the Status board must tell the truth about a cache
+    /// nothing happens to be using — energy aggregation is off by default, so without an active probe the
+    /// card only ever reported the state of traffic that never occurred.
+    /// </summary>
+    bool Ping();
 }
 
 /// <summary>

--- a/rPDU2MQTT.Grains/Status/ComponentStatusGrains.cs
+++ b/rPDU2MQTT.Grains/Status/ComponentStatusGrains.cs
@@ -110,7 +110,11 @@ public sealed class CacheStatusGrain : ComponentStatusGrainBase, ICacheStatusGra
     {
         if (!report.Enabled)
             return new(StatusLevel.Off, "Not configured", report.Detail);
-        // Ok is set by the reporter from an actual round-trip, not from the config saying it should work.
+        // Ok comes from an actual round-trip, not from the config saying it should work. Null means no
+        // probe has completed yet — amber, because claiming "Connected" on no evidence is the same
+        // mistake in the other direction as calling an untried cache "Unreachable".
+        if (report.Ok is null)
+            return new(StatusLevel.Warn, "Checking", report.Detail);
         return report.Ok == false
             ? new(StatusLevel.Bad, "Unreachable", report.Detail)
             : new(StatusLevel.Good, "Connected", report.Detail);

--- a/rPDU2MQTT.Tests/ConfigurationFaultTests.cs
+++ b/rPDU2MQTT.Tests/ConfigurationFaultTests.cs
@@ -76,3 +76,42 @@ public class ConfigurationFaultTests
         Assert.Single(faults.All);
     }
 }
+
+/// <summary>
+/// The Status board must distinguish a cache nobody has used from one that is down.
+/// </summary>
+public class CacheHealthTests
+{
+    [Fact]
+    public void BeforeAnythingTries_ItIsNotYetKnown_NotUnreachable()
+    {
+        // Energy aggregation is off by default, so nothing touches the cache. Reporting the initial
+        // false as "UNREACHABLE" made a perfectly healthy Valkey look broken on the board.
+        var h = new rPDU2MQTT.Core.Flow.CacheHealth();
+
+        Assert.False(h.Attempted);          // -> the card shows "checking", not a red failure
+        Assert.False(h.Reachable);
+        Assert.Null(h.Error);
+    }
+
+    [Fact]
+    public void SuccessAndFailureBothCountAsAttempted()
+    {
+        var h = new rPDU2MQTT.Core.Flow.CacheHealth();
+
+        h.Succeeded();
+        Assert.True(h.Attempted);
+        Assert.True(h.Reachable);
+        Assert.Null(h.Error);
+
+        h.Failed("connection refused");
+        Assert.True(h.Attempted);
+        Assert.False(h.Reachable);
+        Assert.Equal("connection refused", h.Error);
+
+        // And it recovers, so a transient outage doesn't leave the card red forever.
+        h.Succeeded();
+        Assert.True(h.Reachable);
+        Assert.Null(h.Error);
+    }
+}

--- a/rPDU2MQTT.Tests/EnergyAggregationTests.cs
+++ b/rPDU2MQTT.Tests/EnergyAggregationTests.cs
@@ -76,9 +76,9 @@ public class EnergyAggregationTests
         });
 
         var svc = new EnergyAggregationService(ConfigWith("solar"), new Fixed(), store);
-        // ExecuteAsync loads on start; drive one cycle and stop.
-        using var cts = new CancellationTokenSource(millisecondsDelay: 150);
-        try { svc.StartAsync(cts.Token).GetAwaiter().GetResult(); Thread.Sleep(120); } catch (OperationCanceledException) { }
+        // Call the carry-over directly. The first version started the service and slept, which passed
+        // locally and failed on a slower CI runner — a race, not a test.
+        Assert.Equal(1, svc.LoadTotals());
 
         Assert.True(svc.TryGetValue("solar", "energy", out var v));
         Assert.Equal(42.0, v);   // carried over, not restarted at 0

--- a/rPDU2MQTT.Tests/EnergyAggregationTests.cs
+++ b/rPDU2MQTT.Tests/EnergyAggregationTests.cs
@@ -1,0 +1,86 @@
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Services;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// The service around the integrator: which nodes it samples, what it reports, and — the part that could
+/// quietly corrupt data — that a derived figure never displaces a measured one.
+/// </summary>
+public class EnergyAggregationTests
+{
+    /// <summary>A source whose readings the test controls.</summary>
+    private sealed class Fixed : IFlowValueSource
+    {
+        public readonly Dictionary<(string, string), double> Values = new();
+        public bool TryGetValue(string nodeId, string metric, out double value)
+            => Values.TryGetValue((nodeId, metric), out value);
+    }
+
+    private static Config ConfigWith(params string[] nodeIds)
+    {
+        var c = new Config();
+        c.EnergyFlow.Aggregation.Enabled = true;
+        foreach (var id in nodeIds) c.EnergyFlow.Nodes.Add(new EnergyFlowNode { Id = id, Label = id });
+        return c;
+    }
+
+    [Fact]
+    public void AMeasuredEnergySource_BeatsTheDerivedOne()
+    {
+        // The precedence that protects real data: the composite takes the first source with a reading, and
+        // the aggregator is registered last. A node metered in kWh must keep reporting its meter, not an
+        // integral of its own wattage.
+        var measured = new Fixed();
+        measured.Values[("solar", "energy")] = 91.5;      // a real energy binding
+        var derived = new Fixed();
+        derived.Values[("solar", "energy")] = 12.0;       // what the aggregator would offer
+
+        var composite = new CompositeFlowValueSource(measured, derived);
+
+        Assert.True(composite.TryGetValue("solar", "energy", out var v));
+        Assert.Equal(91.5, v);
+    }
+
+    [Fact]
+    public void ANodeNeverSampled_ReportsNothing_RatherThanZero()
+    {
+        // Zero is a claim — "this node used no energy". Absent is the truth when nothing has been measured,
+        // and the flow renders absent as "no data" instead of a fabricated total.
+        var svc = new EnergyAggregationService(ConfigWith("solar"), new Fixed(), new MemoryEnergyStore());
+
+        Assert.False(svc.TryGetValue("solar", "energy", out _));
+    }
+
+    [Fact]
+    public void ItOnlyAnswersForEnergy()
+    {
+        // It derives kWh and nothing else; answering for power would shadow the real reading it integrates.
+        var svc = new EnergyAggregationService(ConfigWith("solar"), new Fixed(), new MemoryEnergyStore());
+        Assert.False(svc.TryGetValue("solar", "realpower", out _));
+        Assert.False(svc.TryGetValue("solar", "voltage", out _));
+    }
+
+    [Fact]
+    public void TotalsAreCarriedOverFromTheStore()
+    {
+        // The restart case. The service must continue a count, not restart it — a drop reads downstream as
+        // a meter reset and rewrites history that was already correct.
+        var store = new MemoryEnergyStore();
+        store.Save(new Dictionary<string, EnergyState>
+        {
+            ["solar"] = new(42.0, new DateTime(2026, 7, 31, 12, 0, 0, DateTimeKind.Utc), 1000, 0),
+        });
+
+        var svc = new EnergyAggregationService(ConfigWith("solar"), new Fixed(), store);
+        // ExecuteAsync loads on start; drive one cycle and stop.
+        using var cts = new CancellationTokenSource(millisecondsDelay: 150);
+        try { svc.StartAsync(cts.Token).GetAwaiter().GetResult(); Thread.Sleep(120); } catch (OperationCanceledException) { }
+
+        Assert.True(svc.TryGetValue("solar", "energy", out var v));
+        Assert.Equal(42.0, v);   // carried over, not restarted at 0
+    }
+}

--- a/rPDU2MQTT.Tests/RedisEnergyStoreTests.cs
+++ b/rPDU2MQTT.Tests/RedisEnergyStoreTests.cs
@@ -29,6 +29,8 @@ public class RedisEnergyStoreTests
             return Data.TryGetValue(key, out var h) ? h : new Dictionary<string, string>();
         }
 
+        public bool Ping() => !Down;
+
         public void HashSet(string key, IReadOnlyDictionary<string, string> fields)
         {
             if (Down) throw new InvalidOperationException("cache is not connected");

--- a/rPDU2MQTT.Web/web/schema.fixture.json
+++ b/rPDU2MQTT.Web/web/schema.fixture.json
@@ -1477,6 +1477,39 @@
     "required": false,
     "properties": [
       {
+        "key": "Aggregation",
+        "label": "Aggregation",
+        "description": "Accumulate energy (kWh) from the power readings, for nodes that report power but not energy.",
+        "type": "object",
+        "required": false,
+        "properties": [
+          {
+            "key": "Enabled",
+            "label": "Enabled",
+            "description": "Derive energy (kWh) by integrating each node's power over time. A real energy source on a node always takes precedence.",
+            "type": "bool",
+            "required": false,
+            "default": false
+          },
+          {
+            "key": "SampleIntervalSeconds",
+            "label": "SampleIntervalSeconds",
+            "description": "How often to sample power, in seconds. Shorter samples track a spiky load more closely.",
+            "type": "int",
+            "required": false,
+            "default": 10
+          },
+          {
+            "key": "MaxGapSeconds",
+            "label": "MaxGapSeconds",
+            "description": "Longest gap between samples that still counts, in seconds. A longer gap is recorded as unmeasured rather than guessed.",
+            "type": "int",
+            "required": false,
+            "default": 60
+          }
+        ]
+      },
+      {
         "key": "Nodes",
         "label": "Nodes",
         "description": "Custom upstream flow nodes (breakers, transfer-switch outputs, Total, ...), keyed by a stable id.",

--- a/rPDU2MQTT/Hosting/StatusReporter.cs
+++ b/rPDU2MQTT/Hosting/StatusReporter.cs
@@ -27,8 +27,9 @@ public sealed class StatusReporter : BackgroundService
     private readonly ProcessIdentity self;
     private readonly Core.Flow.CacheHealth? cacheHealth;
     private readonly Core.Startup.ConfigurationFaults? faults;
+    private readonly Services.ICacheClient? cacheProbe;
 
-    public StatusReporter(IGrainFactory grains, Config config, IHiveMQClient mqtt, ISnapshotCache snapshots, EmonCmsStatus emon, ProcessIdentity self, Core.Flow.CacheHealth? cacheHealth = null, Core.Startup.ConfigurationFaults? faults = null)
+    public StatusReporter(IGrainFactory grains, Config config, IHiveMQClient mqtt, ISnapshotCache snapshots, EmonCmsStatus emon, ProcessIdentity self, Core.Flow.CacheHealth? cacheHealth = null, Core.Startup.ConfigurationFaults? faults = null, Services.ICacheClient? cacheProbe = null)
     {
         this.grains = grains;
         this.config = config;
@@ -38,6 +39,7 @@ public sealed class StatusReporter : BackgroundService
         this.self = self;
         this.cacheHealth = cacheHealth;
         this.faults = faults;
+        this.cacheProbe = cacheProbe;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -109,10 +111,14 @@ public sealed class StatusReporter : BackgroundService
         // The shared cache. Ok comes from a real round-trip via the store, not from the config claiming it
         // should work — "configured but unreachable" is precisely the state worth surfacing, because the
         // bridge keeps running on local state and the energy counters quietly stop being shared.
+        // Probe rather than wait for traffic. Energy aggregation is off by default, so nothing else
+        // touches the cache — the card previously reported "unreachable" for a perfectly healthy instance
+        // simply because nothing had used it yet.
+        if (config.Cache.Enabled) cacheProbe?.Ping();
         await grains.GetGrain<ICacheStatusGrain>("cache").Report(new ComponentReport
         {
             Enabled = config.Cache.Enabled,
-            Ok = config.Cache.Enabled ? cacheHealth?.Reachable : null,
+            Ok = config.Cache.Enabled ? (cacheHealth?.Attempted == true ? cacheHealth.Reachable : null) : null,
             Detail = config.Cache.Enabled
                 ? (cacheHealth?.Reachable == false ? (cacheHealth.Error ?? "no connection") : config.Cache.Connection)
                 : "Energy totals kept in a local file",

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -196,9 +196,33 @@ public static class ServiceConfiguration
         // In a UI-only split process the MQTT cache is never fed (the ingest isn't hosted there), so its reads
         // return false and everything falls through to the mirror — this is strictly additive, never a
         // regression. It is the single-binary deployment that makes it whole.
-        services.AddSingleton<Core.Flow.IFlowValueSource>(sp => new Core.Flow.CompositeFlowValueSource(
-            sp.GetRequiredService<Services.EnergyFlowMqttSourceService>(),
-            grainSyncedFlow));
+        // Energy derived from power, for nodes that report watts but no cumulative kWh. It reads the
+        // MEASURED sources only — passing it the composite it belongs to would be a cycle, and it must
+        // integrate real readings rather than its own output.
+        var aggregationOn = cfg.EnergyFlow.Aggregation.Enabled;
+        if (aggregationOn)
+        {
+            services.AddSingleton(sp => new Services.EnergyAggregationService(
+                cfg,
+                new Core.Flow.CompositeFlowValueSource(
+                    sp.GetRequiredService<Services.EnergyFlowMqttSourceService>(), grainSyncedFlow),
+                sp.GetRequiredService<Core.Flow.IEnergyStore>()));
+            // Accumulating is data production, so only the worker does it — otherwise every replica would
+            // integrate the same readings into its own copy of the counter.
+            if (worker)
+                services.AddHostedService(sp => sp.GetRequiredService<Services.EnergyAggregationService>());
+        }
+
+        services.AddSingleton<Core.Flow.IFlowValueSource>(sp => aggregationOn
+            ? new Core.Flow.CompositeFlowValueSource(
+                sp.GetRequiredService<Services.EnergyFlowMqttSourceService>(),
+                grainSyncedFlow,
+                // LAST on purpose: the composite takes the first source with a fresh reading, so a node
+                // with a real energy binding uses that and the derived total only fills a gap.
+                sp.GetRequiredService<Services.EnergyAggregationService>())
+            : new Core.Flow.CompositeFlowValueSource(
+                sp.GetRequiredService<Services.EnergyFlowMqttSourceService>(),
+                grainSyncedFlow));
 
         // v3: the MqttBusBridge is retired — cross-process PDU snapshot propagation is the PduGrain +
         // PduSyncService's job now (grains, not MQTT mirroring).


### PR DESCRIPTION
Completes the last `ToDo.md` entry. #293 landed the arithmetic and the store with **nothing calling them**; this is the part that actually runs.

`EnergyAggregationService` samples `realpower` for every configured node on a timer, folds each reading through `EnergyIntegrator`, and persists via `IEnergyStore` so a restart continues the count. It is itself an `IFlowValueSource` for `energy`, so a node reporting watts but no kWh gains a cumulative total the HA Energy Dashboard and EmonCMS feeds can consume.

## Three things it deliberately won't do

**Override a measurement.** Registered **last** in the composite, which takes the first source with a fresh reading — so a node with a real energy binding keeps reporting its meter. A derived figure only ever fills a gap. It takes the *measured* composite as its input rather than the one it belongs to, which would be both a cycle and self-integration.

**Report zero for a node it never sampled.** Zero is a claim — *"this used no energy"* — where absent is the truth. The flow renders absent as "no data"; that distinction is the whole accuracy rule of this subsystem.

**Integrate a stale reading.** It samples through `IFlowValueSource`, which already hides an expired value, so a dead publisher becomes a *gap* rather than a flat line extended at the last known wattage. `EnergyIntegrator` then declines to count that span at all and records it as unmeasured.

Only the **worker** role accumulates — otherwise every replica would integrate the same readings into its own copy of the counter.

## Config

`EnergyFlow.Aggregation`: `Enabled`, `SampleIntervalSeconds` (10), `MaxGapSeconds` (60). **Off by default** — a derived total is an estimate and should be opted into. CRD manifests and the GUI schema fixture regenerated.

## Tests

- measured energy beats derived through the real composite
- an unsampled node reports **nothing**, not zero
- it answers only for `energy` — answering for power would shadow the reading it integrates
- totals carry over from the store across a restart

429 tests pass, build clean.

**Yours to verify:** turn it on against your Valkey and watch a node's kWh climb, then restart the pod and confirm it continues rather than restarting at zero — that's the behaviour the whole persistence design exists for, and it needs a real deployment to prove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)