### PR TITLE
fix(operator): never inject a container into a Deployment that isn't the app

### DIFF
--- a/rPDU2MQTT.Grains/Operator/OperatorGrain.cs
+++ b/rPDU2MQTT.Grains/Operator/OperatorGrain.cs
@@ -246,15 +246,31 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
             if (d.Metadata?.Name is not { } name) continue;
             var containers = d.Spec?.Template?.Spec?.Containers;
             if (containers is null) continue;
-            var targets = containers
-                .Where(c => ImageReference.TryParse(c.Image, out var r) && r.Repository == repository)
-                .Select(c => c.Name).DefaultIfEmpty(ContainerName).ToArray();
+            var targets = TargetContainers(containers, repository);
+            // No container here runs the app, so this Deployment is not ours to touch. It used to fall back
+            // to the conventional container name, and because a strategic-merge patch keyed on name CREATES
+            // an entry that doesn't exist, that injected a whole rPDU2MQTT container into any Deployment
+            // sharing the app's instance label — the chart's own Valkey among them, which then ran a
+            // crash-looping bridge alongside the cache.
+            if (targets.Length == 0) continue;
+
             var body = new V1Patch(BuildImagePatch(targets, newImage, envImage), V1Patch.PatchType.StrategicMergePatch);
             await source!.Client.AppsV1.PatchNamespacedDeploymentAsync(body, name, source.Namespace, cancellationToken: ct);
             patched.Add(name);
         }
         return patched;
     }
+
+    /// <summary>
+    /// The containers in a Deployment that actually run <paramref name="repository"/>. Empty means the
+    /// Deployment isn't running the app at all and must be left alone — the label selector finds every
+    /// Deployment in the release, which includes sidecar infrastructure like the Valkey cache.
+    /// </summary>
+    internal static string[] TargetContainers(IEnumerable<V1Container> containers, string repository)
+        => containers
+            .Where(c => ImageReference.TryParse(c.Image, out var r) && r.Repository == repository)
+            .Select(c => c.Name)
+            .ToArray();
 
     /// <summary>
     /// The strategic-merge patch body that sets each target container's image and its <c>RPDU2MQTT_IMAGE</c>

--- a/rPDU2MQTT.Tests/OperatorGrainTests.cs
+++ b/rPDU2MQTT.Tests/OperatorGrainTests.cs
@@ -64,4 +64,33 @@ public class OperatorGrainTests
         Assert.Null(rPDU2MQTT.Grains.Operator.ImageDigest.Normalize("repo:unstable"));
         Assert.Null(rPDU2MQTT.Grains.Operator.ImageDigest.Normalize(null));
     }
+[Fact]
+    public void ADeploymentNotRunningTheApp_IsLeftAlone()
+    {
+        // The label selector finds every Deployment in the release, and the chart's Valkey cache carries the
+        // same app.kubernetes.io/instance label. Selecting a container name for it used to fall back to the
+        // conventional "rpdu2mqtt" — and a strategic-merge patch keyed on name CREATES what isn't there, so
+        // the operator injected a whole crash-looping bridge container into the cache's pod.
+        var valkey = new[] { new k8s.Models.V1Container { Name = "valkey", Image = "valkey/valkey:8-alpine" } };
+
+        var targets = rPDU2MQTT.Grains.Operator.OperatorGrain.TargetContainers(valkey, "xtremeownage/rpdu2mqtt");
+
+        Assert.Empty(targets);   // empty means "skip this Deployment", never "invent a container"
+    }
+
+    [Fact]
+    public void ContainersRunningTheApp_AreTargeted()
+    {
+        // The counterpart: a real deployment, including a multi-container pod, still gets patched — and only
+        // the containers that actually run the app.
+        var pod = new[]
+        {
+            new k8s.Models.V1Container { Name = "rpdu2mqtt", Image = "ghcr.io/xtremeownage/rpdu2mqtt:unstable" },
+            new k8s.Models.V1Container { Name = "sidecar", Image = "busybox:latest" },
+        };
+
+        var targets = rPDU2MQTT.Grains.Operator.OperatorGrain.TargetContainers(pod, "xtremeownage/rpdu2mqtt");
+
+        Assert.Equal(new[] { "rpdu2mqtt" }, targets);
+    }
 }


### PR DESCRIPTION
**Actively breaking a live deployment** — splitting this out of #297 so it can go in on its own.

## What happens

The operator finds Deployments to roll by label (`app.kubernetes.io/instance`), which matches **every** Deployment in the release — including infrastructure the chart deploys alongside the bridge. It then chose which containers to patch:

```csharp
.Select(c => c.Name).DefaultIfEmpty(ContainerName)   // "rpdu2mqtt"
```

For a Deployment with no container running the app image, that sequence is **empty**, so it fell back to the conventional name. A strategic-merge patch keyed on container name **creates** an entry that doesn't exist — so the operator added a whole rPDU2MQTT container to an unrelated pod.

Observed on a real cluster once the chart gained the Valkey cache:

```
NAME                                CONTAINERS         IMAGE
rpdu2mqtt-valkey-65545fdfdc-hp2bk   rpdu2mqtt,valkey   ghcr.io/…/rpdu2mqtt:unstable@sha256:2e07…, valkey/valkey:8-alpine
```

The injected container crash-looped every 15s on `Unable to locate config.yaml` — it has no config mount, because it was never meant to be there. The pinned digest is the operator's own signature.

## Fix

An empty match now means *"this Deployment is not ours — skip it"*. The fallback only ever made sense for a bridge Deployment whose image failed to parse, and that is not worth the risk of writing into something else.

## Tests

- A Valkey-only Deployment yields **no** targets — empty means skip, never invent.
- A real app Deployment, including a multi-container pod, still targets exactly the containers running the app image.

427 tests pass.

## Recovery for an affected cluster

Merge, let the image rebuild, then:

```bash
kubectl -n rpdu2mqtt delete deploy rpdu2mqtt-valkey    # Argo recreates it clean from the chart
```

Deleting it before the fixed operator image is running only buys time — the next operator pass re-injects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)