### PR TITLE
fix(cache): the bridge could not start with the cache enabled

### DIFF
--- a/rPDU2MQTT.Tests/CacheRegistrationTests.cs
+++ b/rPDU2MQTT.Tests/CacheRegistrationTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.DependencyInjection;
+using rPDU2MQTT.Classes;
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Services;
+using rPDU2MQTT.Startup;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// The cache half of the DI graph, built for real.
+///
+/// <para>
+/// RedisCacheClient was registered by type while its constructor asks for a CacheConfig, and only the whole
+/// Config is ever put in the container. Nothing caught it: every test built the pieces by hand, and the
+/// registration itself was only reachable by starting the process. So it shipped, the cache defaulted to on,
+/// and the bridge crash-looped on boot with "Unable to resolve service for type CacheConfig" — a container
+/// that never got as far as connecting to anything.
+/// </para>
+/// <para>
+/// These build a real ServiceProvider from the real registration. Constructing RedisCacheClient does not
+/// connect — the multiplexer is Lazy — so this stays a unit test and still proves the graph resolves.
+/// </para>
+/// </summary>
+public class CacheRegistrationTests
+{
+    private static Config ConfigWithCache(bool enabled) => new()
+    {
+        Cache = new CacheConfig
+        {
+            Enabled = enabled,
+            Connection = "localhost:6379",
+            KeyPrefix = "rpdu2mqtt:",
+            ConnectTimeoutSeconds = 5,
+        },
+    };
+
+    private static ServiceProvider Build(bool cacheEnabled)
+    {
+        var services = new ServiceCollection();
+        ServiceConfiguration.AddCache(services, ConfigWithCache(cacheEnabled));
+        // ValidateOnBuild is the point: it forces every registration to be constructible now, rather than
+        // at the first resolve — which in the real host was during startup, in a crash loop.
+        return services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true,
+        });
+    }
+
+    [Fact]
+    public void AnEnabledCacheResolves()
+    {
+        using var sp = Build(cacheEnabled: true);
+
+        Assert.NotNull(sp.GetRequiredService<CacheHealth>());
+        Assert.IsType<RedisCacheClient>(sp.GetRequiredService<ICacheClient>());
+        Assert.IsType<RedisEnergyStore>(sp.GetRequiredService<IEnergyStore>());
+    }
+
+    [Fact]
+    public void TheCacheClientIsOneSharedInstance()
+    {
+        using var sp = Build(cacheEnabled: true);
+
+        // The concrete registration and the interface must be the same object: one connection, and one
+        // CacheHealth being written to, or the Status board reports on a client nothing else is using.
+        Assert.Same(sp.GetRequiredService<RedisCacheClient>(), sp.GetRequiredService<ICacheClient>());
+    }
+
+    [Fact]
+    public void ADisabledCacheFallsBackToTheFileStore()
+    {
+        using var sp = Build(cacheEnabled: false);
+
+        Assert.IsType<FileEnergyStore>(sp.GetRequiredService<IEnergyStore>());
+        // Still registered when off, so the Status board can say "not configured" rather than showing nothing.
+        Assert.NotNull(sp.GetRequiredService<CacheHealth>());
+        Assert.Null(sp.GetService<ICacheClient>());
+    }
+}

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -119,24 +119,7 @@ public static class ServiceConfiguration
 
         services.AddSingleton<Services.EmonCmsStatus>();
 
-        // The shared cache. Registered whether or not it is enabled so the Status board can say "not
-        // configured" rather than the card simply being absent — an absent card looks like a feature that
-        // doesn't exist, which is exactly the confusion this is meant to remove.
-        services.AddSingleton<Core.Flow.CacheHealth>();
-        if (cfg.Cache.Enabled)
-        {
-            services.AddSingleton<Services.RedisCacheClient>();
-            services.AddSingleton<Services.ICacheClient>(sp => sp.GetRequiredService<Services.RedisCacheClient>());
-            services.AddSingleton<Core.Flow.IEnergyStore>(sp => new Services.RedisEnergyStore(
-                sp.GetRequiredService<Services.ICacheClient>(), cfg.Cache.KeyPrefix, m => Log.Warning(m)));
-        }
-        else
-        {
-            // A local file: correct for one process, and it keeps the counter across a restart, which is
-            // the property that actually matters. It just can't be shared between replicas.
-            services.AddSingleton<Core.Flow.IEnergyStore>(_ => new Core.Flow.FileEnergyStore(
-                Path.Combine(AppContext.BaseDirectory, "energy-totals.json"), m => Log.Warning(m)));
-        }
+        AddCache(services, cfg);
 
         // Coordinates on-demand rediscovery (the "Rediscover" diagnostic button).
         services.AddSingleton<DiscoveryCoordinator>();
@@ -308,5 +291,41 @@ public static class ServiceConfiguration
         // ---- Ui role: the embedded configuration GUI. ----
         if (ui && cfg.Gui.Enabled)
             services.AddHostedService<Services.Gui.GuiService>();
+    }
+
+    /// <summary>
+    /// The shared cache and the energy store that sits on it.
+    ///
+    /// <para>
+    /// Split out of <see cref="Configure"/> so it can be built in a test. Configure reads the config off
+    /// disk before it registers anything, so the only way to exercise this was to start the whole app —
+    /// which is why a registration that could never resolve reached a cluster. See
+    /// CacheRegistrationTests: with the cache enabled the graph is now built for real, and a constructor
+    /// that asks for something absent fails the build instead of the deployment.
+    /// </para>
+    /// </summary>
+    public static void AddCache(IServiceCollection services, Config cfg)
+    {
+        // Registered whether or not the cache is enabled, so the Status board can say "not configured"
+        // rather than the card simply being absent — an absent card looks like a feature that doesn't
+        // exist, which is exactly the confusion this is meant to remove.
+        services.AddSingleton<Core.Flow.CacheHealth>();
+        if (cfg.Cache.Enabled)
+        {
+            // Constructed explicitly: RedisCacheClient takes a CacheConfig, and only the whole Config is
+            // ever registered. Adding it by type left DI hunting for a CacheConfig that was never there,
+            // so the process died on boot — and with the cache on by default, on the default path.
+            services.AddSingleton(sp => new Services.RedisCacheClient(cfg.Cache, sp.GetRequiredService<Core.Flow.CacheHealth>()));
+            services.AddSingleton<Services.ICacheClient>(sp => sp.GetRequiredService<Services.RedisCacheClient>());
+            services.AddSingleton<Core.Flow.IEnergyStore>(sp => new Services.RedisEnergyStore(
+                sp.GetRequiredService<Services.ICacheClient>(), cfg.Cache.KeyPrefix, m => Log.Warning(m)));
+        }
+        else
+        {
+            // A local file: correct for one process, and it keeps the counter across a restart, which is
+            // the property that actually matters. It just can't be shared between replicas.
+            services.AddSingleton<Core.Flow.IEnergyStore>(_ => new Core.Flow.FileEnergyStore(
+                Path.Combine(AppContext.BaseDirectory, "energy-totals.json"), m => Log.Warning(m)));
+        }
     }
 }


### PR DESCRIPTION
**Crash on boot, on the default path.** Found while verifying the operator fix from #298 on a live cluster — the freshly built image crash-looped seven times before I got to it.

```
Unhandled exception. System.InvalidOperationException: Unable to resolve service for type
'rPDU2MQTT.Models.Config.CacheConfig' while attempting to activate 'rPDU2MQTT.Services.RedisCacheClient'.
```

## Cause

```csharp
services.AddSingleton<Services.RedisCacheClient>();   // ctor takes CacheConfig
```

Only the whole `Config` is ever registered — never `Config.Cache`. DI looks for a `CacheConfig` that isn't there and the host dies during startup. It never gets as far as connecting; this is purely the object graph.

`Cache.Enabled` defaults to **true** and the chart now ships Valkey by default, so this is the path everyone takes, not a corner case. `RedisEnergyStore` two lines below was already constructed explicitly from `cfg.Cache` — the client just wasn't.

## Why no test caught it

Every existing test assembles these by hand. The registration itself was only reachable by starting the whole process, because `Configure` reads config off disk before registering anything.

So the cache registrations move into `ServiceConfiguration.AddCache(services, cfg)`, and `CacheRegistrationTests` builds a **real `ServiceProvider` from the real registration** with `ValidateOnBuild: true` — which forces every registration to be constructible at build time rather than at first resolve (which, in the host, meant startup). Constructing the client doesn't connect — the multiplexer is `Lazy` — so it stays a unit test with no network.

Verified the guard works: **2 of 3 fail** with the old registration restored.

Two further properties the crash was hiding:
- the concrete client and `ICacheClient` must resolve to the **same instance** — one connection, one `CacheHealth`, or the Status board reports on a client nothing else uses;
- a **disabled** cache still registers `CacheHealth`, so the board says "not configured" rather than the card vanishing.

430 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)