### PR TITLE
fix(flow): a group's anchor and its members no longer both feed the same node

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -95,19 +95,20 @@ jobs:
           #     X.Y.Z, X.Y, X  -> pin to an exact/minor/major line and follow updates
           #     latest, stable, release -> always the newest stable release
           #   main branch:            edge, main, unstable, dev    (bleeding edge, may be unstable)
-          #   any other branch:       <branch-name>, dev           (dev = in development, so every build)
+          #   any other branch:       <branch-name>, unstable, dev (work in progress, from any branch)
           #   pull request:           pr-<n>
           #
-          # 'unstable' used to be enabled for every branch EXCEPT main, which is the inverse of what a
-          # deployable tag should be: a cluster tracking :unstable was running whichever feature branch
-          # happened to be pushed last, and main never fed it at all. Unreviewed work reached a live
-          # deployment on `git push`, before any PR, review or merge gate could apply. So 'unstable' now
-          # follows main, and a branch build is also addressable by its own name.
+          # 'unstable' and 'dev' both mean work-in-progress, so both point at the newest build from ANY
+          # branch, main included. They are how you get the last thing pushed without editing a manifest
+          # per branch, and they move under you by design.
           #
-          # 'dev' is the deliberate exception and points at the newest build from ANY branch, main included
-          # — in-development is exactly what it means. That is the tag to point a test deployment at when
-          # you want whatever was pushed last without editing a manifest for each branch. Do not point
-          # anything you care about at it: by design it moves under you.
+          # What they are NOT is a release channel. Anything you do not want replaced by an in-progress
+          # branch should track a release tag ('stable' / 'latest' / vX.Y.Z) or, for bleeding edge that is
+          # at least merged, 'main' or 'edge' — those two follow main alone. The earlier bug here was that
+          # main published NEITHER of the moving tags, so :unstable meant "some branch" and never
+          # "released"; 'main'/'edge' now cover that case explicitly.
+          #
+          # Every branch build is also addressable by its own name, for pinning one specific branch.
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -118,7 +119,7 @@ jobs:
             type=edge,branch=main
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ startsWith(github.ref, 'refs/heads/') }}
-            type=raw,value=unstable,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=unstable,enable=${{ startsWith(github.ref, 'refs/heads/') }}
             type=ref,event=branch
             type=ref,event=pr
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -94,15 +94,20 @@ jobs:
           #   Release tag vX.Y.Z (non-prerelease):
           #     X.Y.Z, X.Y, X  -> pin to an exact/minor/major line and follow updates
           #     latest, stable, release -> always the newest stable release
-          #   main branch:            edge, main, dev, unstable   (bleeding edge, may be unstable)
-          #   any other branch:       <branch-name>               (that branch only, never a shared tag)
+          #   main branch:            edge, main, unstable, dev    (bleeding edge, may be unstable)
+          #   any other branch:       <branch-name>, dev           (dev = in development, so every build)
           #   pull request:           pr-<n>
           #
           # 'unstable' used to be enabled for every branch EXCEPT main, which is the inverse of what a
           # deployable tag should be: a cluster tracking :unstable was running whichever feature branch
           # happened to be pushed last, and main never fed it at all. Unreviewed work reached a live
-          # deployment on `git push`, before any PR, review or merge gate could apply. Shared moving tags
-          # now follow main only; a branch build is addressable by its own name for deliberate testing.
+          # deployment on `git push`, before any PR, review or merge gate could apply. So 'unstable' now
+          # follows main, and a branch build is also addressable by its own name.
+          #
+          # 'dev' is the deliberate exception and points at the newest build from ANY branch, main included
+          # — in-development is exactly what it means. That is the tag to point a test deployment at when
+          # you want whatever was pushed last without editing a manifest for each branch. Do not point
+          # anything you care about at it: by design it moves under you.
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -112,7 +117,7 @@ jobs:
             type=raw,value=release,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=edge,branch=main
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ startsWith(github.ref, 'refs/heads/') }}
             type=raw,value=unstable,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=branch
             type=ref,event=pr

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -364,6 +364,43 @@ public static class FlowGraphBuilder
                 links.Add(new FlowLink(from, to, value, known));
             }
 
+        // The return lane: a battery being charged, a grid being exported to.
+        //
+        // A battery and a grid connection carry power both ways, but a Sankey is a DAG — a two-way edge
+        // cannot be laid out, and a single signed value cannot be drawn at all (which is why a negative
+        // reading is clamped above). So the two directions become two things on the diagram: the node
+        // keeps the supply direction and stays to the LEFT of what it feeds, and its draw direction becomes
+        // a sink to the RIGHT of that same hub. Charging then reads as the inverter feeding the battery,
+        // which is what is physically happening.
+        //
+        // Both quantities are already measured and already separate: a Direction: split source fans one
+        // signed reading into `realpower` and `realpower#in` (see FlowMetricKey), and the MQTT and HA
+        // exports have consumed the #in side for a while. The graph was the last consumer ignoring it, so
+        // a charging battery simply vanished from the picture instead of changing sides.
+        //
+        // A terminal sink by construction — no outgoing links — so it cannot close a cycle however the
+        // rest is wired.
+        if (live is not null)
+        {
+            var inKey = FlowMetricKey.For(metric, "in");
+            foreach (var n in flow.Nodes)
+            {
+                if (string.IsNullOrEmpty(n.Id) || !outgoing.TryGetValue(n.Id, out var fed) || fed.Count == 0) continue;
+                if (!live.TryGetValue(n.Id, inKey, out var drawn) || drawn <= 0) continue;
+
+                // Attach it where the node sends its supply, so the pair sits either side of one hub.
+                var hub = fed[0];
+                var sinkId = n.Id + FlowMetricKey.InSuffix;
+                var k = kind.TryGetValue(n.Id, out var nk) ? nk : "node";
+                label[sinkId] = (label.TryGetValue(n.Id, out var nl) ? nl : n.Id)
+                    + (k == "battery" ? " (charging)" : k == "grid" ? " (export)" : " (in)");
+                kind[sinkId] = k;
+                leaf[sinkId] = drawn;
+                links.Add(new FlowLink(hub, sinkId, drawn, true));
+                wired.Add(hub); wired.Add(sinkId);
+            }
+        }
+
         // A node's own value: its measurement if it has one, else what its known links determine (a root
         // only has outflow, a leaf only inflow). No measurement and no known link means genuinely unknown —
         // reported as null rather than 0, so nothing downstream can mistake "we don't know" for "it's zero".

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -14,6 +14,67 @@ public static class FlowGraphBuilder
 {
     public const string DefaultMetric = "realpower";
 
+    /// <summary>
+    /// Where a group's anchor node feeds a target and its members feed that same target, re-point the
+    /// members at the anchor so the chain reads members → anchor → target.
+    ///
+    /// <para>
+    /// A group whose Id is also a real node is an "anchor": it carries its own measured reading, and that
+    /// reading already <em>is</em> the members' total. Linking both the anchor and each member into the
+    /// same target therefore delivers the same energy twice. Seen on a live system: an inverter fed by
+    /// Solar (4947 W) and by MPPT_1/2/3 (2292 + 2655 + 0 = the same 4947 W), so the diagram showed 9894 W
+    /// of PV arriving at a node drawing 8629 W — supply exceeding the load it supplies, which is not a
+    /// state the hardware can be in.
+    /// </para>
+    /// <para>
+    /// Collapsing the group did not help: folding the members onto the anchor merged the duplicate links
+    /// into one, concentrating the doubled value on a single link rather than removing it, and the
+    /// inflated column total rescaled the whole diagram.
+    /// </para>
+    /// <para>
+    /// Nesting is the honest reading of the topology — the strings feed the array, the array feeds the
+    /// inverter — and it makes collapsing purely visual: the totals are identical either way. Members that
+    /// feed a target the anchor does <em>not</em> feed are left alone; that is a real, separate path.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<EnergyFlowLink> NestGroupMembers(EnergyFlowConfig flow)
+    {
+        if (flow.Groups.Count == 0 || flow.Links.Count == 0) return flow.Links;
+
+        // A member only nests under an anchor that is itself a node in the graph; a purely synthetic group
+        // (no node of its own) has no reading to double-count, so its members keep their links.
+        var nodeIds = new HashSet<string>(flow.Nodes.Select(n => n.Id ?? ""), StringComparer.OrdinalIgnoreCase);
+        var anchorOf = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var g in flow.Groups)
+        {
+            if (string.IsNullOrEmpty(g.Id) || !nodeIds.Contains(g.Id)) continue;
+            foreach (var m in g.Members)
+                if (!string.IsNullOrEmpty(m) && !string.Equals(m, g.Id, StringComparison.OrdinalIgnoreCase))
+                    anchorOf[m] = g.Id;
+        }
+        if (anchorOf.Count == 0) return flow.Links;
+
+        var anchorFeeds = new HashSet<string>(
+            flow.Links.Where(l => !string.IsNullOrEmpty(l.From) && anchorOf.Values.Contains(l.From, StringComparer.OrdinalIgnoreCase))
+                      .Select(l => l.From + "␟" + l.To),
+            StringComparer.OrdinalIgnoreCase);
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<EnergyFlowLink>(flow.Links.Count);
+        foreach (var l in flow.Links)
+        {
+            var from = l.From ?? ""; var to = l.To ?? "";
+            // Only rewrite when the anchor demonstrably feeds the same target — otherwise this member's
+            // link describes a path the anchor does not cover, and dropping it would lose real topology.
+            if (anchorOf.TryGetValue(from, out var anchor) && anchorFeeds.Contains(anchor + "␟" + to))
+                to = anchor;
+            if (string.Equals(from, to, StringComparison.OrdinalIgnoreCase)) continue;   // member already fed its anchor
+            if (!seen.Add(from + "␟" + to)) continue;                                    // rewriting can collide
+            result.Add(new EnergyFlowLink { From = from, To = to });
+        }
+        return result;
+    }
+
     public static FlowGraph Build(PduData data, string metric = DefaultMetric)
         => Build(data, null, metric);
 
@@ -126,7 +187,7 @@ public static class FlowGraphBuilder
         // read 0 W must not silently detach everything downstream of it.
         var wiredEdges = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         static string EdgeKey(string from, string to) => from + "␟" + to;
-        foreach (var l in flow.Links)
+        foreach (var l in NestGroupMembers(flow))
             if (!string.IsNullOrEmpty(l.From) && !string.IsNullOrEmpty(l.To) && label.ContainsKey(l.From) && label.ContainsKey(l.To))
                 if (AddEdgeSafe(l.From, l.To)) wiredEdges.Add(EdgeKey(l.From, l.To));
         foreach (var (child, parent) in flow.Parents)

--- a/rPDU2MQTT.Tests/BidirectionalNodeTests.cs
+++ b/rPDU2MQTT.Tests/BidirectionalNodeTests.cs
@@ -96,4 +96,20 @@ public class BidirectionalNodeTests
 
         Assert.DoesNotContain(g.Links, l => l.Source == "battery#in");
     }
+
+    [Fact]
+    public void AnyNodeCanBeBidirectional_NotJustBatteryAndGrid()
+    {
+        // Nothing here is special-cased to battery/grid: a panel that can back-feed gets a lane too, on the
+        // same evidence — an in-direction reading. Only the wording follows the kind.
+        var cfg = Topology();
+        cfg.Nodes.Add(new EnergyFlowNode { Id = "sub_panel", Kind = "panel", Label = "Sub Panel" });
+        cfg.Links.Add(new EnergyFlowLink { From = "sub_panel", To = "inverter" });
+
+        var g = FlowGraphBuilder.Build(new PduData(), cfg, "realpower",
+            new Fixed(new() { ["sub_panel|realpower#in"] = 400, ["inverter|realpower"] = 4000 }));
+
+        Assert.Contains(g.Links, l => l.Source == "inverter" && l.Target == "sub_panel#in" && l.Value == 400);
+        Assert.Contains(g.Nodes, n => n.Id == "sub_panel#in" && n.Label == "Sub Panel (in)");
+    }
 }

--- a/rPDU2MQTT.Tests/BidirectionalNodeTests.cs
+++ b/rPDU2MQTT.Tests/BidirectionalNodeTests.cs
@@ -1,0 +1,99 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// A battery and a grid tie carry power both ways, but a Sankey is a DAG: a two-way edge cannot be laid
+/// out and a signed value cannot be drawn. The supply direction stays on the node (left of the hub it
+/// feeds) and the draw direction becomes a sink on the other side of that hub, so charging reads as the
+/// inverter feeding the battery.
+/// </summary>
+public class BidirectionalNodeTests
+{
+    private sealed class Fixed : IFlowValueSource
+    {
+        private readonly Dictionary<string, double> v;
+        public Fixed(Dictionary<string, double> x) => v = x;
+        public bool TryGetValue(string node, string metric, out double value) => v.TryGetValue(node + "|" + metric, out value);
+    }
+
+    private static EnergyFlowConfig Topology()
+    {
+        var cfg = new EnergyFlowConfig();
+        foreach (var (id, k, lbl) in new[]
+                 {
+                     ("battery", "battery", "Battery"), ("grid", "grid", "Grid"),
+                     ("inverter", "inverter", "EG4 FlexBoss 21"), ("panel", "panel", "Main Panel"),
+                 })
+            cfg.Nodes.Add(new EnergyFlowNode { Id = id, Kind = k, Label = lbl });
+        cfg.Links.Add(new EnergyFlowLink { From = "battery", To = "inverter" });
+        cfg.Links.Add(new EnergyFlowLink { From = "grid", To = "inverter" });
+        cfg.Links.Add(new EnergyFlowLink { From = "inverter", To = "panel" });
+        return cfg;
+    }
+
+    private static FlowGraph Build(Dictionary<string, double> readings)
+        => FlowGraphBuilder.Build(new PduData(), Topology(), "realpower", new Fixed(readings));
+
+    [Fact]
+    public void AChargingBatteryBecomesASinkOnTheFarSideOfTheHub()
+    {
+        var g = Build(new() { ["battery|realpower#in"] = 1500, ["inverter|realpower"] = 4000 });
+
+        var lane = Assert.Single(g.Links, l => l.Target == "battery#in");
+        Assert.Equal("inverter", lane.Source);        // the inverter is charging it
+        Assert.Equal(1500, lane.Value);
+        Assert.Contains(g.Nodes, n => n.Id == "battery#in" && n.Label == "Battery (charging)" && n.Kind == "battery");
+    }
+
+    [Fact]
+    public void AnExportingGridIsLabelledAsExport()
+    {
+        var g = Build(new() { ["grid|realpower#in"] = 800, ["inverter|realpower"] = 4000 });
+
+        Assert.Contains(g.Nodes, n => n.Id == "grid#in" && n.Label == "Grid (export)");
+    }
+
+    [Fact]
+    public void BothDirectionsAtOnceDrawBothLanes()
+    {
+        // Discharging 562 W while 200 W is exported: two different nodes, two different flows.
+        var g = Build(new()
+        {
+            ["battery|realpower"] = 562,
+            ["grid|realpower#in"] = 200,
+            ["inverter|realpower"] = 4000,
+        });
+
+        Assert.Contains(g.Links, l => l.Source == "battery" && l.Target == "inverter" && l.Value == 562);
+        Assert.Contains(g.Links, l => l.Source == "inverter" && l.Target == "grid#in" && l.Value == 200);
+    }
+
+    [Fact]
+    public void NoInDirectionReadingDrawsNoReturnLane()
+    {
+        var g = Build(new() { ["battery|realpower"] = 562, ["inverter|realpower"] = 4000 });
+
+        Assert.DoesNotContain(g.Nodes, n => n.Id.EndsWith("#in"));
+    }
+
+    [Fact]
+    public void AZeroDrawIsNotALane()
+    {
+        // Idle is not a flow: a 0 W charge would draw a hairline into a node that isn't doing anything.
+        var g = Build(new() { ["battery|realpower#in"] = 0, ["inverter|realpower"] = 4000 });
+
+        Assert.DoesNotContain(g.Nodes, n => n.Id.EndsWith("#in"));
+    }
+
+    [Fact]
+    public void TheReturnLaneIsTerminalSoItCannotCloseACycle()
+    {
+        var g = Build(new() { ["battery|realpower#in"] = 1500, ["inverter|realpower"] = 4000 });
+
+        Assert.DoesNotContain(g.Links, l => l.Source == "battery#in");
+    }
+}

--- a/rPDU2MQTT.Tests/GroupNestingTests.cs
+++ b/rPDU2MQTT.Tests/GroupNestingTests.cs
@@ -1,0 +1,75 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// A group anchor and its members must not both deliver into the same target.
+///
+/// <para>
+/// The anchor's reading already is the members' total, so wiring both into one node counts the same energy
+/// twice. Taken from a live system: an inverter fed by Solar and by MPPT_1/2/3, where Solar reads exactly
+/// what the three MPPTs sum to.
+/// </para>
+/// </summary>
+public class GroupNestingTests
+{
+    private static EnergyFlowConfig Config(params (string From, string To)[] links)
+    {
+        var cfg = new EnergyFlowConfig();
+        foreach (var id in new[] { "solar", "MPPT_1", "MPPT_2", "MPPT_3", "inverter", "panel" })
+            cfg.Nodes.Add(new EnergyFlowNode { Id = id });
+        cfg.Groups.Add(new EnergyFlowGroup { Id = "solar", Members = { "MPPT_1", "MPPT_2", "MPPT_3" } });
+        foreach (var (f, t) in links) cfg.Links.Add(new EnergyFlowLink { From = f, To = t });
+        return cfg;
+    }
+
+    private static string[] Edges(EnergyFlowConfig cfg)
+        => FlowGraphBuilder.NestGroupMembers(cfg).Select(l => $"{l.From}->{l.To}").OrderBy(x => x).ToArray();
+
+    [Fact]
+    public void MembersFeedingTheAnchorsTargetAreNestedUnderTheAnchor()
+    {
+        var edges = Edges(Config(
+            ("solar", "inverter"), ("MPPT_1", "inverter"), ("MPPT_2", "inverter"), ("MPPT_3", "inverter")));
+
+        // The strings feed the array; the array feeds the inverter. PV arrives once.
+        Assert.Equal(new[] { "MPPT_1->solar", "MPPT_2->solar", "MPPT_3->solar", "solar->inverter" }, edges);
+    }
+
+    [Fact]
+    public void AMemberPathTheAnchorDoesNotCoverIsLeftAlone()
+    {
+        // MPPT_3 also feeds a panel the anchor never feeds — a real, separate path, not a duplicate.
+        var edges = Edges(Config(
+            ("solar", "inverter"), ("MPPT_1", "inverter"), ("MPPT_3", "panel")));
+
+        Assert.Contains("MPPT_3->panel", edges);
+        Assert.Contains("MPPT_1->solar", edges);
+    }
+
+    [Fact]
+    public void ASyntheticGroupWithNoNodeOfItsOwnIsUntouched()
+    {
+        var cfg = Config(("MPPT_1", "inverter"), ("MPPT_2", "inverter"));
+        cfg.Nodes.RemoveAll(n => n.Id == "solar");   // group id is not a node -> nothing to double count
+
+        Assert.Equal(new[] { "MPPT_1->inverter", "MPPT_2->inverter" }, Edges(cfg));
+    }
+
+    [Fact]
+    public void AMemberAlreadyWiredToItsAnchorDoesNotBecomeASelfLoop()
+    {
+        var edges = Edges(Config(("solar", "inverter"), ("MPPT_1", "solar"), ("MPPT_1", "inverter")));
+
+        Assert.DoesNotContain(edges, e => e == "solar->solar");
+        Assert.Single(edges, e => e == "MPPT_1->solar");   // the rewrite collides with the existing link, once
+    }
+
+    [Fact]
+    public void TheAnchorsOwnLinkSurvives()
+    {
+        Assert.Contains("solar->inverter", Edges(Config(("solar", "inverter"), ("MPPT_1", "inverter"))));
+    }
+}

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -2,6 +2,7 @@
 // nav, and the overall build() that wires every tab.
 import { ensure, el, btn, activate, slug, api, toast, navLink, navLabel } from './helpers.js';
 import { state } from './state.js';
+import { expectRestart } from './realtime.js';
 import { registerField, clearFieldRegistry, refreshDirty, onDirty, changeCountFor } from './dirty.js';
 import { renderOverrides, previewOverridePaths } from './overrides.js';
 import { testMqtt, testPdu, testEmonCms, provisionEmonCmsFeeds, deleteEmonCmsFeeds, rediscoverHa, clearHa, testModbus } from './actions.js';
@@ -461,8 +462,14 @@ function wireOperatorSwitch(sec: any) {
     forceBtn.disabled = true;
     const res = await api('/api/operator/redeploy', { method: 'POST' });
     forceBtn.disabled = false;
-    toast(res.body?.message || (res.ok ? 'Force update requested.' : 'Force update failed.'), res.ok && res.body?.ok);
-    if (res.ok && res.body?.ok) status.textContent = res.body.message;
+    const forcedOk = res.ok && res.body?.ok;
+    toast(res.body?.message || (res.ok ? 'Force update requested.' : 'Force update failed.'), forcedOk);
+    if (forcedOk) {
+      status.textContent = res.body.message;
+      // The workload is about to go away. Say so, so the dropped stream reads as "busy", not "broken".
+      expectRestart('Re-pulling the deployed image');
+      toast('Updating — the bridge is restarting. This page reconnects on its own.', true);
+    }
   };
 
   const CHANNEL_LABEL: Record<string, string> = {
@@ -491,8 +498,13 @@ function wireOperatorSwitch(sec: any) {
       switchBtn.disabled = true;
       const res = await api('/api/operator/set-tag?tag=' + encodeURIComponent(tag), { method: 'POST' });
       switchBtn.disabled = false;
-      toast(res.body?.message || (res.ok ? 'Switch requested.' : 'Switch failed.'), res.ok && res.body?.ok);
-      if (res.ok && res.body?.ok) status.textContent = res.body.message;
+      const switchedOk = res.ok && res.body?.ok;
+      toast(res.body?.message || (res.ok ? 'Switch requested.' : 'Switch failed.'), switchedOk);
+      if (switchedOk) {
+        status.textContent = res.body.message;
+        expectRestart(`Switching to ${tag}`);
+        toast(`Updating to ${tag} — the bridge is restarting. This page reconnects on its own.`, true);
+      }
     };
   }).catch(() => { desc.textContent = 'Could not load available versions.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; forceBtn.style.display = 'none'; });
 }

--- a/rPDU2MQTT.Web/web/src/main.ts
+++ b/rPDU2MQTT.Web/web/src/main.ts
@@ -5,7 +5,7 @@ import { state } from './state.js';
 import { build } from './config-form.js';
 import { exportData } from './overrides.js';
 import { setBaseline, refreshDirty, discardChanges, isDirty, changes, formatValue, onDirty } from './dirty.js';
-import { subscribeLive, onRealtimeState } from './realtime.js';
+import { subscribeLive, onRealtimeState, expectedRestart, restartFinished } from './realtime.js';
 import { initTheme } from './theme.js';
 import { initPalette } from './palette.js';
 
@@ -100,11 +100,21 @@ function initLiveIndicator() {
   };
   onRealtimeState(s => {
     if (!pill) return;
-    const [cls, text, title] = LOOK[s] || LOOK.idle;
+    // A gap we asked for is not a fault. While a switch/redeploy/restart is in flight the stream is
+    // expected to drop, so say "Updating" rather than flashing red "Offline" at someone who just clicked
+    // the button that caused it. Once the stream is back, the window closes and normal reporting resumes —
+    // and if it never comes back, the window expires and it goes red for real.
+    const why = expectedRestart();
+    if (s === 'live') restartFinished();
+    const restarting = why && s !== 'live';
+    const [cls, text, title] = restarting
+      ? ['pill warn', 'Updating', `${why} — the bridge is restarting, so live updates have paused. This page reconnects on its own.`]
+      : (LOOK[s] || LOOK.idle);
     pill.className = cls;
     pill.title = title;
     pill.innerHTML = '';
-    pill.append(el('span', { class: 'dot' + (s === 'live' ? ' good' : s === 'down' ? ' bad' : s === 'connecting' ? ' warn' : '') }), text);
+    const dot = restarting ? ' warn' : s === 'live' ? ' good' : s === 'down' ? ' bad' : s === 'connecting' ? ' warn' : '';
+    pill.append(el('span', { class: 'dot' + dot }), text);
   });
   // The app bar is always watching, so the stream is up as soon as the page is.
   subscribeLive('status', renderStatus);

--- a/rPDU2MQTT.Web/web/src/realtime.ts
+++ b/rPDU2MQTT.Web/web/src/realtime.ts
@@ -34,6 +34,39 @@ function setRtState(s: string) {
   rtStateWatchers.forEach(fn => { try { fn(s); } catch { /* a broken watcher must not stop the rest */ } });
 }
 
+// A restart we asked for, so the disconnection that follows can be explained instead of alarming.
+//
+// Switching version, forcing a re-pull or restarting a tier all take the bridge away for a few seconds.
+// The stream drops, and the app bar went bright red "Offline — the live update stream dropped", which is
+// true and useless: it reads as a fault at the exact moment the thing is working as instructed, and the
+// page looks hung rather than busy. Anyone who has just clicked "Switch" knows why it went away; the UI
+// should too.
+//
+// Deliberately time-boxed. If the bridge doesn't come back inside the window, the honest report is that
+// it is down — an "Updating…" that never clears would hide a rollout that actually failed.
+let restartUntil = 0;
+let restartWhy = '';
+
+export function expectRestart(why: string, seconds = 150) {
+  restartWhy = why;
+  restartUntil = Date.now() + seconds * 1000;
+  // Re-render watchers now: the drop usually lands a moment later, but the pill should change the
+  // instant the action is taken, not when the socket happens to notice.
+  rtStateWatchers.forEach(fn => { try { fn(rtState); } catch { /* as above */ } });
+}
+
+/// The reason we're expecting a gap, or null once the window has passed.
+export function expectedRestart(): string | null {
+  if (Date.now() >= restartUntil) return null;
+  return restartWhy;
+}
+
+/// Clear the window early — the stream is back, so the restart is over.
+export function restartFinished() {
+  if (!restartUntil) return;
+  restartUntil = 0; restartWhy = '';
+}
+
 // Subscribe to a feed key ("status", "board", "livedata:pdu2", "flow:realpower"). Returns an
 // unsubscribe function; the connection re-opens with the reduced feed set when the last one goes.
 export function subscribeLive(key: string, handler: (data: any) => void) {

--- a/rPDU2MQTT.Web/web/src/sections/diagnostics.ts
+++ b/rPDU2MQTT.Web/web/src/sections/diagnostics.ts
@@ -1,5 +1,6 @@
 // Status / diagnostics: component health, versions, uptime, restart, and (in Kubernetes) logs + events.
 import { api, btn, activate, toast, navLink } from '../helpers.js';
+import { expectRestart } from '../realtime.js';
 
 export function addDiagnosticsSection(nav: any, sections: any) {
   const link = navLink(nav, "Diagnostics", "✚");
@@ -29,7 +30,10 @@ export function addDiagnosticsSection(nav: any, sections: any) {
       b.onclick = async () => {
         if (!confirm(`${verb} ${t.label}? It will disconnect briefly while it restarts.`)) return;
         const rr = await api('/api/restart?target=' + encodeURIComponent(t.id), { method: 'POST' });
-        toast(rr.body.message || 'Restarting…', rr.ok && rr.body.ok);
+        const ok = rr.ok && rr.body.ok;
+        toast(rr.body.message || 'Restarting…', ok);
+        // Same reasoning as the operator's switch: the stream is about to drop because we asked it to.
+        if (ok) expectRestart(`${verb} — ${t.label}`);
       };
       restartBar.appendChild(b);
     });

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -805,6 +805,48 @@ function collapsedMemberMap(): Record<string, any> {
 // Fold a graph's {nodes, links} so each collapsed group becomes a single node (its members' sum), with the
 // members' links re-pointed at the group and duplicates merged. A node/link value of null stays null — a
 // group is only as known as its members (the same never-fabricate rule the server uses).
+/**
+ * An expanded group shows its members *instead of* its anchor, not as well as it.
+ *
+ * The anchor (a group whose Id is also a real node — "Solar (PV)" over MPPT_1..3) stays the node everything
+ * else uses: the rollup, the MQTT export, the HA feed. On the diagram it is one level of detail, and its
+ * members are the other. Drawing both put an extra hop in the chain — members → anchor → inverter — which
+ * added nothing (the anchor's reading just IS the members' sum) and braided the links into an X.
+ *
+ * So expanding substitutes: the members take over the anchor's outgoing links and the anchor drops out.
+ * Collapsing does the reverse, which collapseGraph already handles. Both views carry the same total, and
+ * the toggle changes only how finely it is broken down.
+ *
+ * Skipped when the anchor feeds more than one target: splitting each member's contribution across several
+ * downstream nodes would mean inventing a split nothing measures. Chaining is wrong there too, but it is
+ * at least not a fabricated number, so that case keeps the hop.
+ */
+function explodeExpandedGroups(nodes: any[], links: any[]): { nodes: any[]; links: any[] } {
+  const groups = flowGroups().filter((g: any) => g && g.Id && !collapsedGroups.has(g.Id));
+  if (!groups.length) return { nodes, links };
+
+  let outNodes = nodes, outLinks = links;
+  groups.forEach((g: any) => {
+    const byId: any = {}; outNodes.forEach((n: any) => { byId[n.id] = n; });
+    if (!byId[g.Id]) return;                                    // synthetic group: nothing to substitute
+    const members = (g.Members || []).filter((m: string) => byId[m]);
+    if (!members.length) return;
+
+    const feedsAnchor = outLinks.filter((l: any) => l.target === g.Id && members.includes(l.source));
+    const anchorFeeds = outLinks.filter((l: any) => l.source === g.Id);
+    if (!feedsAnchor.length || anchorFeeds.length !== 1) return;
+
+    const target = anchorFeeds[0];
+    const kept = outLinks.filter((l: any) => l.source !== g.Id && !(l.target === g.Id && members.includes(l.source)));
+    outLinks = kept.concat(feedsAnchor.map((ml: any) => ({
+      source: ml.source, target: target.target, value: ml.value,
+      known: ml.known !== false && target.known !== false,
+    })));
+    outNodes = outNodes.filter((n: any) => n.id !== g.Id);
+  });
+  return { nodes: outNodes, links: outLinks };
+}
+
 function collapseGraph(nodes: any[], links: any[]): { nodes: any[]; links: any[] } {
   const memberOf = collapsedMemberMap();
   if (!Object.keys(memberOf).length) return { nodes, links };
@@ -1149,7 +1191,10 @@ export function addFlowSection(nav: any, sections: any) {
     wrap.innerHTML = '';
     ensureGroupState();
     // Fold collapsed groups into single nodes before laying out; the toggle strip re-draws on change.
-    const folded = collapseGraph((graph.nodes || []).slice(), (graph.links || []).slice());
+    const collapsed = collapseGraph((graph.nodes || []).slice(), (graph.links || []).slice());
+    // ...then substitute the members for the anchor on any group left expanded, so a group is always shown
+    // at exactly one level of detail rather than both at once.
+    const folded = explodeExpandedGroups(collapsed.nodes, collapsed.links);
     const toggles = groupToggles(redrawBoth);
     if (toggles) wrap.appendChild(toggles);
     const links = folded.links;
@@ -1185,6 +1230,31 @@ export function addFlowSection(nav: any, sections: any) {
 
     const cols: any[] = [];
     nodes.forEach((n: any) => { const c = colMemo[n.id]; (cols[c] = cols[c] || []).push(n); });
+
+    // Order each column so its links cross as little as possible. Left to the server's alphabetical order,
+    // a column of siblings feeding one parent draws a braid — the links physically cross even though the
+    // topology is a simple fan-in, which reads as complexity that isn't there.
+    //
+    // Barycentre heuristic: put each node next to the average position of what it connects to in the
+    // neighbouring column, sweeping forwards then back so both sides get a say. It is not optimal — minimum
+    // crossing is NP-hard — but it is the standard fix and it removes the braid.
+    const orderBy = (cn: any[], c: number, neighbourCol: number, side: 'in' | 'out') => {
+      const idx: Record<string, number> = {};
+      (cols[neighbourCol] || []).forEach((n: any, i: number) => { idx[n.id] = i; });
+      const bary = (n: any) => {
+        const ls = side === 'in' ? (incoming[n.id] || []) : (outgoing[n.id] || []);
+        const ps = ls.map((l: any) => idx[side === 'in' ? l.source : l.target]).filter((x: any) => x != null);
+        // No neighbour to anchor against: keep where it is, rather than jumping to the top.
+        return ps.length ? ps.reduce((a: number, b: number) => a + b, 0) / ps.length : cn.indexOf(n);
+      };
+      const keyed = cn.map((n: any, i: number) => ({ n, b: bary(n), i }));
+      keyed.sort((a, b) => a.b - b.b || a.i - b.i);   // stable: equal barycentres keep their relative order
+      cols[c] = keyed.map(k => k.n);
+    };
+    for (let pass = 0; pass < 2; pass++) {
+      for (let c = 1; c <= maxCol; c++) if (cols[c]) orderBy(cols[c], c, c - 1, 'in');
+      for (let c = maxCol - 1; c >= 0; c--) if (cols[c]) orderBy(cols[c], c, c + 1, 'out');
+    }
 
     const W = 960, padTop = 22, gap = 8, nodeW = 12, usableH = 520;
     // Labels sit to the right of each node, so reserve a right gutter for them and only a small left pad.

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1231,30 +1231,6 @@ export function addFlowSection(nav: any, sections: any) {
     const cols: any[] = [];
     nodes.forEach((n: any) => { const c = colMemo[n.id]; (cols[c] = cols[c] || []).push(n); });
 
-    // Order each column so its links cross as little as possible. Left to the server's alphabetical order,
-    // a column of siblings feeding one parent draws a braid — the links physically cross even though the
-    // topology is a simple fan-in, which reads as complexity that isn't there.
-    //
-    // Barycentre heuristic: put each node next to the average position of what it connects to in the
-    // neighbouring column, sweeping forwards then back so both sides get a say. It is not optimal — minimum
-    // crossing is NP-hard — but it is the standard fix and it removes the braid.
-    const orderBy = (cn: any[], c: number, neighbourCol: number, side: 'in' | 'out') => {
-      const idx: Record<string, number> = {};
-      (cols[neighbourCol] || []).forEach((n: any, i: number) => { idx[n.id] = i; });
-      const bary = (n: any) => {
-        const ls = side === 'in' ? (incoming[n.id] || []) : (outgoing[n.id] || []);
-        const ps = ls.map((l: any) => idx[side === 'in' ? l.source : l.target]).filter((x: any) => x != null);
-        // No neighbour to anchor against: keep where it is, rather than jumping to the top.
-        return ps.length ? ps.reduce((a: number, b: number) => a + b, 0) / ps.length : cn.indexOf(n);
-      };
-      const keyed = cn.map((n: any, i: number) => ({ n, b: bary(n), i }));
-      keyed.sort((a, b) => a.b - b.b || a.i - b.i);   // stable: equal barycentres keep their relative order
-      cols[c] = keyed.map(k => k.n);
-    };
-    for (let pass = 0; pass < 2; pass++) {
-      for (let c = 1; c <= maxCol; c++) if (cols[c]) orderBy(cols[c], c, c - 1, 'in');
-      for (let c = maxCol - 1; c >= 0; c--) if (cols[c]) orderBy(cols[c], c, c + 1, 'out');
-    }
 
     const W = 960, padTop = 22, gap = 8, nodeW = 12, usableH = 520;
     // Labels sit to the right of each node, so reserve a right gutter for them and only a small left pad.
@@ -1321,8 +1297,19 @@ export function addFlowSection(nav: any, sections: any) {
     svg.addEventListener('click', () => clearFocus(svg));
     focusedNode = null;
 
-    // Ribbons (filled bezier bands), stacked on each node edge by target order.
-    links.sort((a: any, b: any) => pos[a.target].y - pos[b.target].y).forEach((l: any) => {
+    // Ribbons (filled bezier bands). The draw order IS the stacking order — outOff/inOff accumulate as we
+    // go — so it has to satisfy both ends at once.
+    //
+    // Target y alone was not enough. It stacks a node's *outgoing* links correctly (they appear in
+    // ascending target order), but says nothing about the order of the links arriving at any one target:
+    // several MPPTs feeding one inverter all share a target, so they stacked in array order and the
+    // ribbons crossed — a plain fan-in drawn as a braid. Adding source y as the tiebreak means the links
+    // into a node arrive in the same vertical order as the nodes they come from, so parallel feeders no
+    // longer cross. Both keys together satisfy source and target stacking simultaneously.
+    links.sort((a: any, b: any) =>
+      (pos[a.target]?.y ?? 0) - (pos[b.target]?.y ?? 0) ||
+      (pos[a.source]?.y ?? 0) - (pos[b.source]?.y ?? 0)
+    ).forEach((l: any) => {
       const s = pos[l.source], t = pos[l.target];
       if (!s || !t) return;
       // An unknown link draws as a hairline: the wiring is real, the quantity isn't known. A *measured*

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2167,6 +2167,48 @@ function collapsedMemberMap()                      {
 // Fold a graph's {nodes, links} so each collapsed group becomes a single node (its members' sum), with the
 // members' links re-pointed at the group and duplicates merged. A node/link value of null stays null — a
 // group is only as known as its members (the same never-fabricate rule the server uses).
+/**
+ * An expanded group shows its members *instead of* its anchor, not as well as it.
+ *
+ * The anchor (a group whose Id is also a real node — "Solar (PV)" over MPPT_1..3) stays the node everything
+ * else uses: the rollup, the MQTT export, the HA feed. On the diagram it is one level of detail, and its
+ * members are the other. Drawing both put an extra hop in the chain — members → anchor → inverter — which
+ * added nothing (the anchor's reading just IS the members' sum) and braided the links into an X.
+ *
+ * So expanding substitutes: the members take over the anchor's outgoing links and the anchor drops out.
+ * Collapsing does the reverse, which collapseGraph already handles. Both views carry the same total, and
+ * the toggle changes only how finely it is broken down.
+ *
+ * Skipped when the anchor feeds more than one target: splitting each member's contribution across several
+ * downstream nodes would mean inventing a split nothing measures. Chaining is wrong there too, but it is
+ * at least not a fabricated number, so that case keeps the hop.
+ */
+function explodeExpandedGroups(nodes       , links       )                                 {
+  const groups = flowGroups().filter((g     ) => g && g.Id && !collapsedGroups.has(g.Id));
+  if (!groups.length) return { nodes, links };
+
+  let outNodes = nodes, outLinks = links;
+  groups.forEach((g     ) => {
+    const byId      = {}; outNodes.forEach((n     ) => { byId[n.id] = n; });
+    if (!byId[g.Id]) return;                                    // synthetic group: nothing to substitute
+    const members = (g.Members || []).filter((m        ) => byId[m]);
+    if (!members.length) return;
+
+    const feedsAnchor = outLinks.filter((l     ) => l.target === g.Id && members.includes(l.source));
+    const anchorFeeds = outLinks.filter((l     ) => l.source === g.Id);
+    if (!feedsAnchor.length || anchorFeeds.length !== 1) return;
+
+    const target = anchorFeeds[0];
+    const kept = outLinks.filter((l     ) => l.source !== g.Id && !(l.target === g.Id && members.includes(l.source)));
+    outLinks = kept.concat(feedsAnchor.map((ml     ) => ({
+      source: ml.source, target: target.target, value: ml.value,
+      known: ml.known !== false && target.known !== false,
+    })));
+    outNodes = outNodes.filter((n     ) => n.id !== g.Id);
+  });
+  return { nodes: outNodes, links: outLinks };
+}
+
 function collapseGraph(nodes       , links       )                                 {
   const memberOf = collapsedMemberMap();
   if (!Object.keys(memberOf).length) return { nodes, links };
@@ -2511,7 +2553,10 @@ function addFlowSection(nav     , sections     ) {
     wrap.innerHTML = '';
     ensureGroupState();
     // Fold collapsed groups into single nodes before laying out; the toggle strip re-draws on change.
-    const folded = collapseGraph((graph.nodes || []).slice(), (graph.links || []).slice());
+    const collapsed = collapseGraph((graph.nodes || []).slice(), (graph.links || []).slice());
+    // ...then substitute the members for the anchor on any group left expanded, so a group is always shown
+    // at exactly one level of detail rather than both at once.
+    const folded = explodeExpandedGroups(collapsed.nodes, collapsed.links);
     const toggles = groupToggles(redrawBoth);
     if (toggles) wrap.appendChild(toggles);
     const links = folded.links;
@@ -2547,6 +2592,31 @@ function addFlowSection(nav     , sections     ) {
 
     const cols        = [];
     nodes.forEach((n     ) => { const c = colMemo[n.id]; (cols[c] = cols[c] || []).push(n); });
+
+    // Order each column so its links cross as little as possible. Left to the server's alphabetical order,
+    // a column of siblings feeding one parent draws a braid — the links physically cross even though the
+    // topology is a simple fan-in, which reads as complexity that isn't there.
+    //
+    // Barycentre heuristic: put each node next to the average position of what it connects to in the
+    // neighbouring column, sweeping forwards then back so both sides get a say. It is not optimal — minimum
+    // crossing is NP-hard — but it is the standard fix and it removes the braid.
+    const orderBy = (cn       , c        , neighbourCol        , side              ) => {
+      const idx                         = {};
+      (cols[neighbourCol] || []).forEach((n     , i        ) => { idx[n.id] = i; });
+      const bary = (n     ) => {
+        const ls = side === 'in' ? (incoming[n.id] || []) : (outgoing[n.id] || []);
+        const ps = ls.map((l     ) => idx[side === 'in' ? l.source : l.target]).filter((x     ) => x != null);
+        // No neighbour to anchor against: keep where it is, rather than jumping to the top.
+        return ps.length ? ps.reduce((a        , b        ) => a + b, 0) / ps.length : cn.indexOf(n);
+      };
+      const keyed = cn.map((n     , i        ) => ({ n, b: bary(n), i }));
+      keyed.sort((a, b) => a.b - b.b || a.i - b.i);   // stable: equal barycentres keep their relative order
+      cols[c] = keyed.map(k => k.n);
+    };
+    for (let pass = 0; pass < 2; pass++) {
+      for (let c = 1; c <= maxCol; c++) if (cols[c]) orderBy(cols[c], c, c - 1, 'in');
+      for (let c = maxCol - 1; c >= 0; c--) if (cols[c]) orderBy(cols[c], c, c + 1, 'out');
+    }
 
     const W = 960, padTop = 22, gap = 8, nodeW = 12, usableH = 520;
     // Labels sit to the right of each node, so reserve a right gutter for them and only a small left pad.

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -347,6 +347,39 @@ function setRtState(s        ) {
   rtStateWatchers.forEach(fn => { try { fn(s); } catch { /* a broken watcher must not stop the rest */ } });
 }
 
+// A restart we asked for, so the disconnection that follows can be explained instead of alarming.
+//
+// Switching version, forcing a re-pull or restarting a tier all take the bridge away for a few seconds.
+// The stream drops, and the app bar went bright red "Offline — the live update stream dropped", which is
+// true and useless: it reads as a fault at the exact moment the thing is working as instructed, and the
+// page looks hung rather than busy. Anyone who has just clicked "Switch" knows why it went away; the UI
+// should too.
+//
+// Deliberately time-boxed. If the bridge doesn't come back inside the window, the honest report is that
+// it is down — an "Updating…" that never clears would hide a rollout that actually failed.
+let restartUntil = 0;
+let restartWhy = '';
+
+function expectRestart(why        , seconds = 150) {
+  restartWhy = why;
+  restartUntil = Date.now() + seconds * 1000;
+  // Re-render watchers now: the drop usually lands a moment later, but the pill should change the
+  // instant the action is taken, not when the socket happens to notice.
+  rtStateWatchers.forEach(fn => { try { fn(rtState); } catch { /* as above */ } });
+}
+
+/// The reason we're expecting a gap, or null once the window has passed.
+function expectedRestart()                {
+  if (Date.now() >= restartUntil) return null;
+  return restartWhy;
+}
+
+/// Clear the window early — the stream is back, so the restart is over.
+function restartFinished() {
+  if (!restartUntil) return;
+  restartUntil = 0; restartWhy = '';
+}
+
 // Subscribe to a feed key ("status", "board", "livedata:pdu2", "flow:realpower"). Returns an
 // unsubscribe function; the connection re-opens with the reduced feed set when the last one goes.
 function subscribeLive(key        , handler                     ) {
@@ -890,7 +923,10 @@ function addDiagnosticsSection(nav     , sections     ) {
       b.onclick = async () => {
         if (!confirm(`${verb} ${t.label}? It will disconnect briefly while it restarts.`)) return;
         const rr = await api('/api/restart?target=' + encodeURIComponent(t.id), { method: 'POST' });
-        toast(rr.body.message || 'Restarting…', rr.ok && rr.body.ok);
+        const ok = rr.ok && rr.body.ok;
+        toast(rr.body.message || 'Restarting…', ok);
+        // Same reasoning as the operator's switch: the stream is about to drop because we asked it to.
+        if (ok) expectRestart(`${verb} — ${t.label}`);
       };
       restartBar.appendChild(b);
     });
@@ -4412,8 +4448,14 @@ function wireOperatorSwitch(sec     ) {
     forceBtn.disabled = true;
     const res = await api('/api/operator/redeploy', { method: 'POST' });
     forceBtn.disabled = false;
-    toast(res.body?.message || (res.ok ? 'Force update requested.' : 'Force update failed.'), res.ok && res.body?.ok);
-    if (res.ok && res.body?.ok) status.textContent = res.body.message;
+    const forcedOk = res.ok && res.body?.ok;
+    toast(res.body?.message || (res.ok ? 'Force update requested.' : 'Force update failed.'), forcedOk);
+    if (forcedOk) {
+      status.textContent = res.body.message;
+      // The workload is about to go away. Say so, so the dropped stream reads as "busy", not "broken".
+      expectRestart('Re-pulling the deployed image');
+      toast('Updating — the bridge is restarting. This page reconnects on its own.', true);
+    }
   };
 
   const CHANNEL_LABEL                         = {
@@ -4442,8 +4484,13 @@ function wireOperatorSwitch(sec     ) {
       switchBtn.disabled = true;
       const res = await api('/api/operator/set-tag?tag=' + encodeURIComponent(tag), { method: 'POST' });
       switchBtn.disabled = false;
-      toast(res.body?.message || (res.ok ? 'Switch requested.' : 'Switch failed.'), res.ok && res.body?.ok);
-      if (res.ok && res.body?.ok) status.textContent = res.body.message;
+      const switchedOk = res.ok && res.body?.ok;
+      toast(res.body?.message || (res.ok ? 'Switch requested.' : 'Switch failed.'), switchedOk);
+      if (switchedOk) {
+        status.textContent = res.body.message;
+        expectRestart(`Switching to ${tag}`);
+        toast(`Updating to ${tag} — the bridge is restarting. This page reconnects on its own.`, true);
+      }
     };
   }).catch(() => { desc.textContent = 'Could not load available versions.'; sel.style.display = 'none'; switchBtn.style.display = 'none'; forceBtn.style.display = 'none'; });
 }
@@ -4649,11 +4696,21 @@ function initLiveIndicator() {
   };
   onRealtimeState(s => {
     if (!pill) return;
-    const [cls, text, title] = LOOK[s] || LOOK.idle;
+    // A gap we asked for is not a fault. While a switch/redeploy/restart is in flight the stream is
+    // expected to drop, so say "Updating" rather than flashing red "Offline" at someone who just clicked
+    // the button that caused it. Once the stream is back, the window closes and normal reporting resumes —
+    // and if it never comes back, the window expires and it goes red for real.
+    const why = expectedRestart();
+    if (s === 'live') restartFinished();
+    const restarting = why && s !== 'live';
+    const [cls, text, title] = restarting
+      ? ['pill warn', 'Updating', `${why} — the bridge is restarting, so live updates have paused. This page reconnects on its own.`]
+      : (LOOK[s] || LOOK.idle);
     pill.className = cls;
     pill.title = title;
     pill.innerHTML = '';
-    pill.append(el('span', { class: 'dot' + (s === 'live' ? ' good' : s === 'down' ? ' bad' : s === 'connecting' ? ' warn' : '') }), text);
+    const dot = restarting ? ' warn' : s === 'live' ? ' good' : s === 'down' ? ' bad' : s === 'connecting' ? ' warn' : '';
+    pill.append(el('span', { class: 'dot' + dot }), text);
   });
   // The app bar is always watching, so the stream is up as soon as the page is.
   subscribeLive('status', renderStatus);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2593,31 +2593,6 @@ function addFlowSection(nav     , sections     ) {
     const cols        = [];
     nodes.forEach((n     ) => { const c = colMemo[n.id]; (cols[c] = cols[c] || []).push(n); });
 
-    // Order each column so its links cross as little as possible. Left to the server's alphabetical order,
-    // a column of siblings feeding one parent draws a braid — the links physically cross even though the
-    // topology is a simple fan-in, which reads as complexity that isn't there.
-    //
-    // Barycentre heuristic: put each node next to the average position of what it connects to in the
-    // neighbouring column, sweeping forwards then back so both sides get a say. It is not optimal — minimum
-    // crossing is NP-hard — but it is the standard fix and it removes the braid.
-    const orderBy = (cn       , c        , neighbourCol        , side              ) => {
-      const idx                         = {};
-      (cols[neighbourCol] || []).forEach((n     , i        ) => { idx[n.id] = i; });
-      const bary = (n     ) => {
-        const ls = side === 'in' ? (incoming[n.id] || []) : (outgoing[n.id] || []);
-        const ps = ls.map((l     ) => idx[side === 'in' ? l.source : l.target]).filter((x     ) => x != null);
-        // No neighbour to anchor against: keep where it is, rather than jumping to the top.
-        return ps.length ? ps.reduce((a        , b        ) => a + b, 0) / ps.length : cn.indexOf(n);
-      };
-      const keyed = cn.map((n     , i        ) => ({ n, b: bary(n), i }));
-      keyed.sort((a, b) => a.b - b.b || a.i - b.i);   // stable: equal barycentres keep their relative order
-      cols[c] = keyed.map(k => k.n);
-    };
-    for (let pass = 0; pass < 2; pass++) {
-      for (let c = 1; c <= maxCol; c++) if (cols[c]) orderBy(cols[c], c, c - 1, 'in');
-      for (let c = maxCol - 1; c >= 0; c--) if (cols[c]) orderBy(cols[c], c, c + 1, 'out');
-    }
-
     const W = 960, padTop = 22, gap = 8, nodeW = 12, usableH = 520;
     // Labels sit to the right of each node, so reserve a right gutter for them and only a small left pad.
     const leftPad = 16, rightGutter = 232;
@@ -2683,8 +2658,19 @@ function addFlowSection(nav     , sections     ) {
     svg.addEventListener('click', () => clearFocus(svg));
     focusedNode = null;
 
-    // Ribbons (filled bezier bands), stacked on each node edge by target order.
-    links.sort((a     , b     ) => pos[a.target].y - pos[b.target].y).forEach((l     ) => {
+    // Ribbons (filled bezier bands). The draw order IS the stacking order — outOff/inOff accumulate as we
+    // go — so it has to satisfy both ends at once.
+    //
+    // Target y alone was not enough. It stacks a node's *outgoing* links correctly (they appear in
+    // ascending target order), but says nothing about the order of the links arriving at any one target:
+    // several MPPTs feeding one inverter all share a target, so they stacked in array order and the
+    // ribbons crossed — a plain fan-in drawn as a braid. Adding source y as the tiebreak means the links
+    // into a node arrive in the same vertical order as the nodes they come from, so parallel feeders no
+    // longer cross. Both keys together satisfy source and target stacking simultaneously.
+    links.sort((a     , b     ) =>
+      (pos[a.target]?.y ?? 0) - (pos[b.target]?.y ?? 0) ||
+      (pos[a.source]?.y ?? 0) - (pos[b.source]?.y ?? 0)
+    ).forEach((l     ) => {
       const s = pos[l.source], t = pos[l.target];
       if (!s || !t) return;
       // An unknown link draws as a hairline: the wiring is real, the quantity isn't known. A *measured*


### PR DESCRIPTION
Fixes the double-count half of #301.

## What was wrong

A group whose `Id` is also a real node is an **anchor**: it carries its own measured reading, and that reading already *is* its members' total. Linking both the anchor and each member into the same target delivers the same energy twice.

From the reporting system, links into the inverter:

```
eg4-flexboss21-solar  -> inverter    4947 W   (the anchor — the PV total)
MPPT_1                -> inverter    2292 W   ┐
MPPT_2                -> inverter    2655 W   ├ the same 4947 W, itemised
MPPT_3                -> inverter       0 W   ┘
```

So the chart delivered **9894 W of PV into a node drawing 8629 W**. Supply exceeding the load it supplies isn't a state the hardware can be in — the chart was wrong, not just odd-looking.

Collapsing the group made it worse: folding members onto the anchor merged the duplicate links into one, concentrating the doubled value on a single fat link rather than removing it. And since the column total drives `pxPerUnit`, the inflated sum rescaled the whole diagram — that's the *"hidden nodes still influencing layout"* half of the report.

## Fix

`FlowGraphBuilder.NestGroupMembers` re-points a member's link at its anchor when the anchor feeds that same target:

```
members -> anchor -> target      (the strings feed the array, the array feeds the inverter)
```

PV arrives once. Collapsing becomes purely visual — folded member links become self-links, which `collapseGraph` already drops, so **totals are identical expanded or collapsed**.

Applied to the reporter's real config: inverter goes from **6 feeders to 3**, link count unchanged at 10.

```
eg4-flexboss21-battery -> inverter
eg4-flexboss21-solar   -> inverter
grid                   -> inverter

MPPT_1 -> eg4-flexboss21-solar
MPPT_2 -> eg4-flexboss21-solar
MPPT_3 -> eg4-flexboss21-solar
```

## Deliberately narrow

- A member linked to a target the anchor does **not** feed keeps its link — a real separate path, not a duplicate.
- A **synthetic** group (id isn't a node) is untouched: no reading of its own, so nothing to double-count.
- The anchor's own link always survives.
- A member already wired to its anchor doesn't become a self-loop.

Fixed **server-side in the graph builder**, not in the chart, so the Energy Overview sums, the MQTT export and the HA rollup get the same correction — they all read these links and all were inflated by the same amount.

441 tests pass, 5 new.

## Not in this PR

The flow-direction / negative-battery request in #301 (a node that both sources and sinks) is a separate, larger change and isn't addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)