### PR TITLE
feat(gui): an auto-applied update announces itself too

### DIFF
--- a/rPDU2MQTT.Web/web/src/main.ts
+++ b/rPDU2MQTT.Web/web/src/main.ts
@@ -5,7 +5,7 @@ import { state } from './state.js';
 import { build } from './config-form.js';
 import { exportData } from './overrides.js';
 import { setBaseline, refreshDirty, discardChanges, isDirty, changes, formatValue, onDirty } from './dirty.js';
-import { subscribeLive, onRealtimeState, expectedRestart, restartFinished } from './realtime.js';
+import { subscribeLive, onRealtimeState, expectedRestart, restartFinished, expectRestart } from './realtime.js';
 import { initTheme } from './theme.js';
 import { initPalette } from './palette.js';
 
@@ -33,6 +33,29 @@ export async function load() {
 // Last-seen operator update report, so "check now" can tell when a fresh result has landed.
 let lastCheckedAt: string | null = null;
 let configWritable = true;
+// The tag the operator last reported having rolled to. null means "we haven't seen a report yet", which
+// is deliberately different from "" — see appliedTagChanged.
+let lastApplied: string | null = null;
+
+/// Did the operator just roll the deployment to a different tag?
+///
+/// AutoUpdate rolls on the operator's own schedule, so unlike Switch or Force update there is no click to
+/// hang an expectRestart() on: the page's first and only warning is the stream dying, which shows as a red
+/// "Offline" for something entirely routine. The operator does report the tag it applied, and that arrives
+/// on the status feed before the pod goes down, so a change in it is the signal.
+///
+/// Never fires on the first report. On a fresh page load every value is "new", and announcing a restart
+/// that already happened (or never happened) would put the app bar into a state nothing is going to clear.
+export function appliedTagChanged(applied: string | undefined | null): boolean {
+  const now = applied || '';
+  // No tag in this report is not a change of tag — the operator can simply stop reporting one (restarting,
+  // briefly unreachable). Forgetting the last tag here would make the next report of the SAME tag look
+  // like a fresh roll, and announce a restart that never happened.
+  if (now === '') return false;
+  const changed = lastApplied !== null && now !== lastApplied;
+  lastApplied = now;
+  return changed;
+}
 
 // Render the header update chip from the operator's report (#210). Hidden when no operator is reporting.
 function renderUpdate(u: any) {
@@ -40,6 +63,12 @@ function renderUpdate(u: any) {
   if (!upd) return;
   if (!u) { upd.classList.add('is-hidden'); lastCheckedAt = null; return; }
   lastCheckedAt = u.checkedAt || null;
+  // An update the operator applied by itself: the workload is going away and nobody here asked for it.
+  // Same treatment as a manual switch, so the drop that follows reads as "busy", not "broken".
+  if (appliedTagChanged(u.applied)) {
+    expectRestart(`Auto-updating to ${u.applied}`);
+    toast(`Update applied — rolling to ${u.applied}. The bridge is restarting.`, true);
+  }
   upd.classList.remove('is-hidden', 'busy');
   if (u.available) {
     upd.className = 'pill pill-btn warn';

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -4629,6 +4629,29 @@ async function load() {
 // Last-seen operator update report, so "check now" can tell when a fresh result has landed.
 let lastCheckedAt                = null;
 let configWritable = true;
+// The tag the operator last reported having rolled to. null means "we haven't seen a report yet", which
+// is deliberately different from "" — see appliedTagChanged.
+let lastApplied                = null;
+
+/// Did the operator just roll the deployment to a different tag?
+///
+/// AutoUpdate rolls on the operator's own schedule, so unlike Switch or Force update there is no click to
+/// hang an expectRestart() on: the page's first and only warning is the stream dying, which shows as a red
+/// "Offline" for something entirely routine. The operator does report the tag it applied, and that arrives
+/// on the status feed before the pod goes down, so a change in it is the signal.
+///
+/// Never fires on the first report. On a fresh page load every value is "new", and announcing a restart
+/// that already happened (or never happened) would put the app bar into a state nothing is going to clear.
+function appliedTagChanged(applied                           )          {
+  const now = applied || '';
+  // No tag in this report is not a change of tag — the operator can simply stop reporting one (restarting,
+  // briefly unreachable). Forgetting the last tag here would make the next report of the SAME tag look
+  // like a fresh roll, and announce a restart that never happened.
+  if (now === '') return false;
+  const changed = lastApplied !== null && now !== lastApplied;
+  lastApplied = now;
+  return changed;
+}
 
 // Render the header update chip from the operator's report (#210). Hidden when no operator is reporting.
 function renderUpdate(u     ) {
@@ -4636,6 +4659,12 @@ function renderUpdate(u     ) {
   if (!upd) return;
   if (!u) { upd.classList.add('is-hidden'); lastCheckedAt = null; return; }
   lastCheckedAt = u.checkedAt || null;
+  // An update the operator applied by itself: the workload is going away and nobody here asked for it.
+  // Same treatment as a manual switch, so the drop that follows reads as "busy", not "broken".
+  if (appliedTagChanged(u.applied)) {
+    expectRestart(`Auto-updating to ${u.applied}`);
+    toast(`Update applied — rolling to ${u.applied}. The bridge is restarting.`, true);
+  }
   upd.classList.remove('is-hidden', 'busy');
   if (u.available) {
     upd.className = 'pill pill-btn warn';


### PR DESCRIPTION
Follow-up to the restart notifications in #303 — this commit was pushed just after that PR merged, so it missed the squash.

**Switch** and **Force update** hang an `expectRestart()` on the click that causes them. **AutoUpdate** rolls on the operator's own schedule, so there's no click: the page's first and only warning was the stream dying, showing a red **Offline** for something entirely routine.

The operator already reports the tag it applied, and that lands on the status feed before the pod goes down — so a change in it is the signal. No server change needed; the client just wasn't watching it.

## Two ways it could cry wolf, both handled

```
first report on page load (unstable)   -> quiet
same tag reported again                -> quiet
operator auto-updates to main          -> FIRES
steady on main                         -> quiet
operator stops reporting a tag         -> quiet
reports main again after the gap       -> quiet
rolled back to unstable                -> FIRES
```

- **Never fires on the first report.** On a fresh load every value is new, and announcing a restart that already happened leaves the pill amber with nothing to clear it.
- **An absent tag is not a change of tag.** The operator can stop reporting one while it restarts or is briefly unreachable. My first version forgot the last tag there, so the next report of the *same* tag looked like a fresh roll — the transition table above caught it.

448 tests pass; GUI bundle rebuilt; DOM smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)