### PR TITLE
feat(flow): name the unmetered load instead of drawing it as bar height

### DIFF
--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -401,6 +401,45 @@ public static class FlowGraphBuilder
             }
         }
 
+        // Name the load nobody is metering, instead of drawing it as a blank slab.
+        //
+        // A node's bar is as tall as its throughput, but only its links carry flow. A panel passing 8299 W
+        // whose metered children draw 547 W therefore renders as an enormous bar with a few hairlines
+        // leaving it and ~7.7 kW of unexplained height. That reads as a broken chart, when the actual
+        // finding — most of the load downstream of this panel is not metered — is worth knowing and is
+        // arithmetic on measurements already trusted.
+        //
+        // Not a fabricated reading: the difference is inflow minus what the children account for, and the
+        // energy demonstrably went somewhere. What would be fabrication is attributing it to a device, so
+        // it gets its own 'unmeasured' kind and its own node rather than being folded into a sibling.
+        //
+        // Only where the node already has outgoing links (a terminal leaf's reading IS its consumption, so
+        // there is no gap to explain) and only above a 2% floor, to keep rounding noise off the diagram.
+        var unmeasured = new List<FlowLink>();
+        foreach (var id in outgoing.Keys)
+        {
+            double inflow = 0, outflow = 0;
+            bool anyIn = false, anyOut = false;
+            foreach (var l in links)
+            {
+                if (!l.Known) continue;
+                if (string.Equals(l.Target, id, StringComparison.OrdinalIgnoreCase)) { inflow += l.Value; anyIn = true; }
+                if (string.Equals(l.Source, id, StringComparison.OrdinalIgnoreCase)) { outflow += l.Value; anyOut = true; }
+            }
+            if (!anyOut) continue;
+            // What the node actually passes: its own measurement if it has one, else what reached it.
+            double total = leaf.TryGetValue(id, out var measured) ? measured : (anyIn ? inflow : 0);
+            var gap = total - outflow;
+            if (total <= 0 || gap <= 1 || gap <= total * 0.02) continue;
+
+            var uid = id + "#unmeasured";
+            label[uid] = "Unmeasured load";
+            kind[uid] = "unmeasured";
+            leaf[uid] = gap;
+            unmeasured.Add(new FlowLink(id, uid, gap, true));
+        }
+        foreach (var l in unmeasured) { links.Add(l); wired.Add(l.Source); wired.Add(l.Target); }
+
         // A node's own value: its measurement if it has one, else what its known links determine (a root
         // only has outflow, a leaf only inflow). No measurement and no known link means genuinely unknown —
         // reported as null rather than 0, so nothing downstream can mistake "we don't know" for "it's zero".

--- a/rPDU2MQTT.Tests/UnmeasuredLoadTests.cs
+++ b/rPDU2MQTT.Tests/UnmeasuredLoadTests.cs
@@ -1,0 +1,101 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// A node's bar is as tall as its throughput, but only its links carry flow — so a gap between the two
+/// draws as unexplained height. Shaped after a real system: an inverter feeding a panel whose only metered
+/// children are two rack PDUs drawing a few hundred watts of an 8 kW throughput.
+/// </summary>
+public class UnmeasuredLoadTests
+{
+    private sealed class Fixed : IFlowValueSource
+    {
+        private readonly Dictionary<string, double> v;
+        public Fixed(Dictionary<string, double> x) => v = x;
+        public bool TryGetValue(string node, string metric, out double value) => v.TryGetValue(node + "|" + metric, out value);
+    }
+
+    /// <summary>inverter (measured) → main_panel (untracked, unmetered) → two metered PDUs.</summary>
+    private static EnergyFlowConfig Topology()
+    {
+        var cfg = new EnergyFlowConfig();
+        cfg.Nodes.Add(new EnergyFlowNode { Id = "inverter", Kind = "inverter" });
+        cfg.Nodes.Add(new EnergyFlowNode { Id = "main_panel", Kind = "panel", Mode = "untracked" });
+        cfg.Nodes.Add(new EnergyFlowNode { Id = "pdu_1" });
+        cfg.Nodes.Add(new EnergyFlowNode { Id = "pdu_2" });
+        cfg.Links.Add(new EnergyFlowLink { From = "inverter", To = "main_panel" });
+        cfg.Links.Add(new EnergyFlowLink { From = "main_panel", To = "pdu_1" });
+        cfg.Links.Add(new EnergyFlowLink { From = "main_panel", To = "pdu_2" });
+        return cfg;
+    }
+
+    private static FlowGraph Build(Dictionary<string, double> readings)
+        => FlowGraphBuilder.Build(new PduData(), Topology(), "realpower", new Fixed(readings));
+
+    private static readonly Dictionary<string, double> Live = new()
+    {
+        ["inverter|realpower"] = 8299,
+        ["pdu_1|realpower"] = 273,
+        ["pdu_2|realpower"] = 274,
+    };
+
+    [Fact]
+    public void ThePanelsUnmeteredLoadIsNamedRatherThanLeftAsBarHeight()
+    {
+        var g = Build(Live);
+
+        var gap = Assert.Single(g.Links, l => l.Source == "main_panel" && l.Target == "main_panel#unmeasured");
+        Assert.Equal(8299 - 273 - 274, gap.Value, 0);
+        Assert.Contains(g.Nodes, n => n.Id == "main_panel#unmeasured" && n.Label == "Unmeasured load" && n.Kind == "unmeasured");
+    }
+
+    [Fact]
+    public void TheMeteredChildrenKeepTheirOwnReadings()
+    {
+        // The point of naming the gap is that it is NOT taken from the children: they still report what
+        // they actually measure.
+        var g = Build(Live);
+
+        Assert.Contains(g.Links, l => l.Target == "pdu_1" && l.Value == 273);
+        Assert.Contains(g.Links, l => l.Target == "pdu_2" && l.Value == 274);
+    }
+
+    [Fact]
+    public void TheNodesOutflowNowAccountsForItsWholeThroughput()
+    {
+        var g = Build(Live);
+
+        var outflow = g.Links.Where(l => l.Source == "main_panel").Sum(l => l.Value);
+        Assert.Equal(8299, outflow, 0);   // nothing left unexplained
+    }
+
+    [Fact]
+    public void AFullyMeteredNodeGetsNoUnmeasuredChild()
+    {
+        var g = Build(new() { ["inverter|realpower"] = 547, ["pdu_1|realpower"] = 273, ["pdu_2|realpower"] = 274 });
+
+        Assert.DoesNotContain(g.Nodes, n => n.Kind == "unmeasured");
+    }
+
+    [Fact]
+    public void RoundingNoiseDoesNotDrawAGap()
+    {
+        // Half a watt adrift on 547 W is measurement noise, not an unmetered load.
+        var g = Build(new() { ["inverter|realpower"] = 547.5, ["pdu_1|realpower"] = 273, ["pdu_2|realpower"] = 274 });
+
+        Assert.DoesNotContain(g.Nodes, n => n.Kind == "unmeasured");
+    }
+
+    [Fact]
+    public void ATerminalLeafIsNeverGivenOne()
+    {
+        // pdu_1 has nothing below it, so its reading IS its consumption — there is no gap to explain.
+        var g = Build(Live);
+
+        Assert.DoesNotContain(g.Links, l => l.Source == "pdu_1" && l.Target.Contains("unmeasured"));
+    }
+}


### PR DESCRIPTION
Addresses the "chart looks wrong" half of #301.

## The problem

A node's bar is as tall as its throughput, but only its **links** carry flow. Your Main Panel passes 8299 W while its metered children draw 547 W, so it rendered as an enormous bar with a few hairlines leaving it and **~7.7 kW of unexplained height**.

That reads as a broken chart. The real finding — *most of the load below that panel isn't metered* — is worth knowing, and it's arithmetic on measurements already trusted.

## Fix

The gap draws as an explicit **"Unmeasured load"** child, so a node's outflow accounts for its whole throughput and the diagram balances.

This is **not** a fabricated reading: the value is inflow minus what the children account for, and that energy demonstrably went somewhere. What *would* be fabrication is attributing it to a device — so it's its own node with its own `unmeasured` kind, never folded into a sibling. The metered children keep their own readings untouched, which is the entire point.

Bounded:
- only where a node already has outgoing links — a terminal leaf's reading **is** its consumption, so there's no gap to explain
- only when the node's throughput is known
- only above a 2% floor, so rounding noise stays off the diagram

## A correction

I abandoned this once, having concluded from a failing test that no remainder was available to draw. That was wrong, and **the test was the reason**: it gave the parent a single measured child, which takes `EdgeFlow`'s

```csharp
if (kids.Count <= 1) return produced;
```

path — handing over the parent's entire production and leaving nothing over. A topology shaped like the real one (an unmetered pass-through panel with two metered PDUs beneath it) has the gap the whole time. The idea was sound; the case I tested it with wasn't.

That `kids.Count <= 1` behaviour is arguably its own bug — a measured parent overriding a measured child — but it's untouched here, since changing it moves exported figures.

454 tests pass, 6 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)