### PR TITLE
fix(flow): derived lanes are for the diagram, not the Energy Overview totals

### DIFF
--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2068,7 +2068,15 @@ export function addEnergyOverviewSection(nav: any, sections: any) {
       grid.appendChild(el('div', { class: 'desc', style: { color: 'var(--bad)' }, text: 'Could not load energy data — ' + why }));
       status.textContent = ''; return;
     }
-    const nodes = r.body.nodes || [];
+    // Derived lanes are for the diagram, not the totals. The graph carries synthetic nodes the builder
+    // adds to make the picture balance — a bidirectional node's return lane (`battery#in`, `grid#in`) and
+    // a pass-through's unmetered remainder (`…#unmeasured`). The return lanes deliberately inherit their
+    // parent's kind so they colour and read as the same device, which means a plain sumKind('battery')
+    // would add charge to discharge and sumKind('grid') would add export to import — the tiles would
+    // report a battery doing both at once. These tiles compute the in-direction themselves, from the live
+    // cache, a few lines below. '#' appears in no real id (PDU and outlet ids use ':'), so it is a safe
+    // marker for "the builder made this".
+    const nodes = (r.body.nodes || []).filter((n: any) => !String(n.id || '').includes('#'));
 
     // Live cache reads: the in-direction (charge/export) power for battery/grid nodes, plus battery state of
     // charge — none of which the flow graph carries. Keyed by node|metric so one round-trip covers them all.

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3465,7 +3465,15 @@ function addEnergyOverviewSection(nav     , sections     ) {
       grid.appendChild(el('div', { class: 'desc', style: { color: 'var(--bad)' }, text: 'Could not load energy data — ' + why }));
       status.textContent = ''; return;
     }
-    const nodes = r.body.nodes || [];
+    // Derived lanes are for the diagram, not the totals. The graph carries synthetic nodes the builder
+    // adds to make the picture balance — a bidirectional node's return lane (`battery#in`, `grid#in`) and
+    // a pass-through's unmetered remainder (`…#unmeasured`). The return lanes deliberately inherit their
+    // parent's kind so they colour and read as the same device, which means a plain sumKind('battery')
+    // would add charge to discharge and sumKind('grid') would add export to import — the tiles would
+    // report a battery doing both at once. These tiles compute the in-direction themselves, from the live
+    // cache, a few lines below. '#' appears in no real id (PDU and outlet ids use ':'), so it is a safe
+    // marker for "the builder made this".
+    const nodes = (r.body.nodes || []).filter((n     ) => !String(n.id || '').includes('#'));
 
     // Live cache reads: the in-direction (charge/export) power for battery/grid nodes, plus battery state of
     // charge — none of which the flow graph carries. Keyed by node|metric so one round-trip covers them all.


### PR DESCRIPTION
**A regression I introduced**, in the bidirectional lanes and the unmetered-load node.

Both add synthetic nodes so the diagram balances, and a return lane deliberately inherits its parent's `kind` so it colours and reads as the same device. The Energy Overview sums by kind — so it counted them as extra devices:

```
battery: 562 W discharging + 1500 W charging = 2062 W
grid:    4283 W importing  +  200 W exporting = 4483 W
```

A battery cannot charge and discharge at once, and the tile said it was doing both.

The tiles already compute the in-direction themselves from the live cache a few lines further down, so these nodes were pure duplication there.

## Fix

The overview drops nodes the builder synthesised. `#` appears in no real id — PDU and outlet ids use `:` — so it's a safe marker for "the builder made this", and it covers both `#in` and `#unmeasured` without the tiles needing to know which lanes exist.

Verified on the shape the builder now emits:

```
before fix  battery: 2062  grid: 4483
after fix   battery: 562   grid: 4283
```

The **diagram is unaffected** — it wants those nodes, which is the whole reason they exist.

454 tests pass; GUI bundle rebuilt; DOM smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)