### PR TITLE
feat(flow): Sankey columns hug what they feed, so no ribbon skips a tier

### DIFF
--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1226,6 +1226,30 @@ export function addFlowSection(nav: any, sections: any) {
       return colMemo[id] = c;
     };
     nodes.forEach((n: any) => col(n.id));
+
+    // Then pull every node as far RIGHT as its nearest child allows, so it lands next to what it powers.
+    //
+    // Longest-path alone left-justifies every root, which is fine while the graph is shallow but breaks as
+    // soon as one branch is deeper than another. Add panels -> strings -> MPPTs upstream of an inverter and
+    // Grid, having no feeder of its own, stays pinned in column 0 while the inverter moves out to column 3
+    // — so its ribbon, several kW wide, is dragged straight across the string and MPPT columns and over
+    // their bars and labels. Nothing reserves a lane for a link that skips a tier.
+    //
+    // A sink keeps its column; everyone else sits one step left of its earliest child. Every edge still
+    // points strictly rightward, because a node always ends up strictly left of all its children.
+    // Processed children-first (descending depth) so a child's column is final before its parent reads it.
+    //
+    // This is the same rule the hierarchy editor on the Nodes tab already applies, for the same reason —
+    // it hit this first with Battery -> inverter skipping past Solar. The two views now agree on where a
+    // node belongs, instead of the diagram and its editor disagreeing about the same topology.
+    nodes.slice().sort((a: any, b: any) => colMemo[b.id] - colMemo[a.id]).forEach((n: any) => {
+      const outs = outgoing[n.id] || [];
+      if (outs.length) colMemo[n.id] = Math.max(0, Math.min(...outs.map((l: any) => colMemo[l.target])) - 1);
+    });
+    // Never leave an empty left margin if every node pulled off column 0.
+    const minCol = Math.min(...nodes.map((n: any) => colMemo[n.id]));
+    if (minCol > 0) nodes.forEach((n: any) => { colMemo[n.id] -= minCol; });
+
     const maxCol = Math.max(0, ...nodes.map((n: any) => colMemo[n.id]));
 
     const cols: any[] = [];

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2624,6 +2624,30 @@ function addFlowSection(nav     , sections     ) {
       return colMemo[id] = c;
     };
     nodes.forEach((n     ) => col(n.id));
+
+    // Then pull every node as far RIGHT as its nearest child allows, so it lands next to what it powers.
+    //
+    // Longest-path alone left-justifies every root, which is fine while the graph is shallow but breaks as
+    // soon as one branch is deeper than another. Add panels -> strings -> MPPTs upstream of an inverter and
+    // Grid, having no feeder of its own, stays pinned in column 0 while the inverter moves out to column 3
+    // — so its ribbon, several kW wide, is dragged straight across the string and MPPT columns and over
+    // their bars and labels. Nothing reserves a lane for a link that skips a tier.
+    //
+    // A sink keeps its column; everyone else sits one step left of its earliest child. Every edge still
+    // points strictly rightward, because a node always ends up strictly left of all its children.
+    // Processed children-first (descending depth) so a child's column is final before its parent reads it.
+    //
+    // This is the same rule the hierarchy editor on the Nodes tab already applies, for the same reason —
+    // it hit this first with Battery -> inverter skipping past Solar. The two views now agree on where a
+    // node belongs, instead of the diagram and its editor disagreeing about the same topology.
+    nodes.slice().sort((a     , b     ) => colMemo[b.id] - colMemo[a.id]).forEach((n     ) => {
+      const outs = outgoing[n.id] || [];
+      if (outs.length) colMemo[n.id] = Math.max(0, Math.min(...outs.map((l     ) => colMemo[l.target])) - 1);
+    });
+    // Never leave an empty left margin if every node pulled off column 0.
+    const minCol = Math.min(...nodes.map((n     ) => colMemo[n.id]));
+    if (minCol > 0) nodes.forEach((n     ) => { colMemo[n.id] -= minCol; });
+
     const maxCol = Math.max(0, ...nodes.map((n     ) => colMemo[n.id]));
 
     const cols        = [];


### PR DESCRIPTION
Built per "build it and I'll tell you if I don't like it" — this is the **right-pull** option.

## Why

Longest-path alone left-justifies every root. Fine while the graph is shallow; breaks as soon as one branch is deeper than another.

Adding `panels -> strings -> MPPTs` upstream of the inverter does exactly that. Grid, having no feeder of its own, stays pinned in column 0 while the inverter moves out to column 3 — so its ribbon, several kW wide, gets dragged straight across the string and MPPT columns and over their bars and labels. Nothing reserves a lane for a link that skips a tier.

## What it does

Every node is pulled as far **right** as its nearest child allows, landing next to what it powers. A sink keeps its column; everyone else sits one step left of its earliest child. Every edge still points strictly rightward, because a node always ends up strictly left of all its children.

```
today                        with panels + strings
col 0: MPPTs, grid, batt     col 0: panels
col 1: inverter              col 1: strings
col 2: main_panel            col 2: MPPTs, grid, battery
col 3: pdu_1                 col 3: inverter …

widest ribbon span: 1 column      (grid spanned 3 before)
```

## Worth knowing

- **Your current chart is unchanged.** The left column is identical to today's, so nothing moves on screen until the deeper tiers exist. Safe to merge now.
- **Grid and Battery will not be in the leftmost column** once panels and strings are added — they'll sit with the MPPTs, one hop from the inverter. That is the opposite of "grid stays far left", which was the stated expectation, so it's the thing to look at and reject if it reads wrong.
- Same rule the **hierarchy editor already applies** (it hit this first with `Battery -> inverter` skipping past Solar), so the diagram and its editor now agree about one topology instead of disagreeing.

If you'd rather keep sources left-justified, the alternative is reserving a routing lane for skip-tier ribbons — real layout work, but I'll do it instead if this looks wrong.

454 tests pass; GUI bundle rebuilt; DOM smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)