### PR TITLE
fix(flow): the builder's synthetic nodes stay out of the hierarchy editor

### DIFF
--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -912,9 +912,23 @@ function groupToggles(onToggle: () => void): HTMLElement | null {
 }
 
 // The candidate node universe for wiring: the built graph's nodes (pdu/outlet/…) plus the custom defs.
+//
+// Not the nodes the builder synthesises to make the diagram balance — a bidirectional node's return lane
+// (`…#in`) and a pass-through's unmetered remainder (`…#unmeasured`). They describe an arithmetic result,
+// not a thing you can wire: they exist only in the built graph, are recomputed on every build, and have no
+// entry in the config at all.
+//
+// Leaving them in put "Unmeasured load" into the hierarchy editor as a node with no links — orphaned and
+// unexplained, because the editor draws links from the config while that node's link exists only in the
+// graph. It also offered them in the "wire to" picker and as group members, where selecting one would
+// write a config link to an id that is regenerated from scratch on the next build.
+//
+// '#' appears in no real id (PDU and outlet ids use ':'), so it marks exactly the builder's own inventions.
 function flowCandidates(lastGraph: any, customNodes: any[]) {
   const cand = new Map<string, any>();
-  (lastGraph?.nodes || []).forEach((n: any) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
+  (lastGraph?.nodes || [])
+    .filter((n: any) => !String(n.id || '').includes('#'))
+    .forEach((n: any) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
   customNodes.forEach((n: any) => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: n.Kind || 'node', custom: true }));
   return cand;
 }

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2310,9 +2310,23 @@ function groupToggles(onToggle            )                     {
 }
 
 // The candidate node universe for wiring: the built graph's nodes (pdu/outlet/…) plus the custom defs.
+//
+// Not the nodes the builder synthesises to make the diagram balance — a bidirectional node's return lane
+// (`…#in`) and a pass-through's unmetered remainder (`…#unmeasured`). They describe an arithmetic result,
+// not a thing you can wire: they exist only in the built graph, are recomputed on every build, and have no
+// entry in the config at all.
+//
+// Leaving them in put "Unmeasured load" into the hierarchy editor as a node with no links — orphaned and
+// unexplained, because the editor draws links from the config while that node's link exists only in the
+// graph. It also offered them in the "wire to" picker and as group members, where selecting one would
+// write a config link to an id that is regenerated from scratch on the next build.
+//
+// '#' appears in no real id (PDU and outlet ids use ':'), so it marks exactly the builder's own inventions.
 function flowCandidates(lastGraph     , customNodes       ) {
   const cand = new Map             ();
-  (lastGraph?.nodes || []).forEach((n     ) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
+  (lastGraph?.nodes || [])
+    .filter((n     ) => !String(n.id || '').includes('#'))
+    .forEach((n     ) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
   customNodes.forEach((n     ) => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: n.Kind || 'node', custom: true }));
   return cand;
 }


### PR DESCRIPTION
**"Unmeasured load" appeared in the hierarchy editor as a node with no links** — floating, unexplained, and absent from the Nodes tab, which is exactly how a bug looks.

## Where it comes from

It isn't a configured node. `FlowGraphBuilder` emits it — along with a bidirectional node's return lane (`…#in`) — to make the diagram balance. Main Panel passes 8184 W while its metered children draw 289 + 271 + 0 = 560 W, so the **7624 W** difference is drawn explicitly rather than left as unexplained bar height.

Those nodes describe an *arithmetic result*, not a thing that can be wired. They exist only in the built graph and are recomputed from scratch on every build.

## Why it looked broken

The editor draws its links from the **config**, while that node's link exists only in the **graph** — so it rendered as an orphan.

Worse, `flowCandidates` offered these ids in the "wire to" picker and as group members. Selecting one would have written a config link pointing at an id that doesn't survive the next build.

## Fix

```
wireable nodes: main_panel, eg4-flexboss21-battery, pdu:pdu_1, outlet:pdu_1:0
```

`main_panel#unmeasured` and `eg4-flexboss21-battery#in` are excluded. `#` appears in no real id (PDU and outlet ids use `:`), so it marks exactly the builder's own inventions.

This is the **same leak** as the Energy Overview totals fixed in #306 — I fixed that consumer and missed this one. Both now filter the same way.

The **diagram is unaffected**; it wants those nodes, which is the whole reason they exist.

454 tests pass; GUI bundle rebuilt; DOM smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)