### PR TITLE
fix(flow): diagram-only nodes are never published, and can be switched off

### DIFF
--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -39,7 +39,8 @@ public static class EnergyDashboardSync
             ? new HashSet<string>(excludeKinds, StringComparer.OrdinalIgnoreCase)
             : null;
         var entries = new List<HaDeviceConsumption>();
-        foreach (var node in graph.Nodes)
+        // Diagram-only nodes are not devices — see FlowNode.Synthetic.
+        foreach (var node in graph.Nodes.Where(n => !n.Synthetic))
         {
             // Sources/storage/pass-through (grid, solar, battery, inverter) aren't "device consumption" — they
             // clutter the list and double-count against the dashboard's own grid/solar/battery buckets.
@@ -73,7 +74,8 @@ public static class EnergyDashboardSync
         Func<string, string?>? powerFor = null, Func<string, string?>? socFor = null)
     {
         var sources = new List<JsonObject>();
-        foreach (var node in graph.Nodes)
+        // …and they are not energy sources either.
+        foreach (var node in graph.Nodes.Where(n => !n.Synthetic))
         {
             var outStat = statFor(node.Id, EnergyDirection.Out);
             var inStat = statFor(node.Id, EnergyDirection.In);

--- a/rPDU2MQTT.Core/Flow/FlowGraph.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraph.cs
@@ -12,7 +12,27 @@ namespace rPDU2MQTT.Core.Flow;
 /// a diagram ends up stating a number nobody supplied, so the distinction is carried in the type.
 /// </para>
 /// </param>
-public sealed record FlowNode(string Id, string Label, string Kind, double? Value = null);
+public sealed record FlowNode(string Id, string Label, string Kind, double? Value = null)
+{
+    /// <summary>
+    /// A node the builder invented for the diagram, rather than one the operator configured: a
+    /// bidirectional node's return lane (<c>…#in</c>) and a pass-through's unmetered remainder
+    /// (<c>…#unmeasured</c>).
+    ///
+    /// <para>
+    /// These describe an arithmetic result, not a device. They must never be published: the id would
+    /// become an MQTT topic, and '#' is the multi-level wildcard — <c>energy/main_panel#unmeasured</c> is
+    /// not a legal publish topic at all. They would also duplicate figures the export already sends
+    /// properly (the in-direction goes out as the parent's <c>energy_in</c>, not as a separate device).
+    /// </para>
+    /// <para>
+    /// Centralised here because every consumer has to make this distinction and three of them got it wrong
+    /// independently — the Energy Overview double-counted a battery as charging and discharging at once,
+    /// the hierarchy editor offered these as wiring targets, and both exports published them.
+    /// </para>
+    /// </summary>
+    public bool Synthetic => Id.Contains('#');
+}
 
 /// <summary>A weighted link between two <see cref="FlowNode"/>s (energy flows Source → Target).</summary>
 /// <param name="Known">

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -71,7 +71,9 @@ public class EnergyFlowMqttExportService : baseMQTTService
             .Select(n => n.Id)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var node in graph.Nodes)
+        // Synthetic nodes are for the diagram only — see FlowNode.Synthetic. Publishing one would put a
+        // '#' in the topic, which is the MQTT wildcard and not legal in a publish topic.
+        foreach (var node in graph.Nodes.Where(n => !n.Synthetic))
         {
             // Nothing determines this tier's power — no measurement, and no single path that conservation
             // pins down. Publishing it would put a fabricated 0 W into Home Assistant's history, which is

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -88,7 +88,8 @@ public sealed class HaEnergyDashboardSync
         var energyType = string.IsNullOrWhiteSpace(config.HASS.EnergyDashboard.EnergyMeasurementType) ? "energy" : config.HASS.EnergyDashboard.EnergyMeasurementType;
         var native = FlowExport.NativeEnergyUniqueIds(merged, energyType);
         var graph = FlowGraphBuilder.Build(merged, config.EnergyFlow, FlowGraphBuilder.DefaultMetric, live);
-        foreach (var node in graph.Nodes)
+        // Diagram-only nodes are not devices; they must not become Home Assistant entities.
+        foreach (var node in graph.Nodes.Where(n => !n.Synthetic))
         {
             var uid = native.TryGetValue(node.Id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(node.Id);
             if (entityByUniqueId.TryGetValue(uid, out var e)) stats.Add(e);

--- a/rPDU2MQTT.Tests/SyntheticNodesAreNotExportedTests.cs
+++ b/rPDU2MQTT.Tests/SyntheticNodesAreNotExportedTests.cs
@@ -1,0 +1,55 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Nodes the builder invents for the diagram must never reach an export. Three consumers got this wrong
+/// independently, so the rule lives on the node itself rather than in each caller.
+/// </summary>
+public class SyntheticNodesAreNotExportedTests
+{
+    [Theory]
+    [InlineData("main_panel#unmeasured")]
+    [InlineData("eg4-flexboss21-battery#in")]
+    [InlineData("grid#in")]
+    public void BuilderInventionsAreSynthetic(string id)
+        => Assert.True(new FlowNode(id, "x", "node").Synthetic);
+
+    [Theory]
+    [InlineData("main_panel")]
+    [InlineData("eg4-flexboss21-battery")]
+    [InlineData("pdu:pdu_1")]          // real ids use ':' as their separator, never '#'
+    [InlineData("outlet:pdu_1:0")]
+    [InlineData("MPPT_1")]
+    public void ConfiguredAndAutoNodesAreNot(string id)
+        => Assert.False(new FlowNode(id, "x", "node").Synthetic);
+
+    [Fact]
+    public void ASyntheticIdWouldNotBeALegalMqttTopic()
+    {
+        // The export publishes to `energy/{id}`. '#' is the multi-level wildcard and is not allowed in a
+        // publish topic at all, so this is why these can never be exported — not merely why they should not.
+        var topic = "energy/" + new FlowNode("main_panel#unmeasured", "Unmeasured load", "unmeasured").Id;
+
+        Assert.Contains('#', topic);
+        Assert.True(new FlowNode("main_panel#unmeasured", "x", "x").Synthetic);
+    }
+
+    [Fact]
+    public void TheEnergyDashboardSkipsThem()
+    {
+        var graph = new FlowGraph(
+            new List<FlowNode>
+            {
+                new("main_panel", "Main Panel", "panel", 8184),
+                new("main_panel#unmeasured", "Unmeasured load", "unmeasured", 7624),
+            },
+            new List<FlowLink> { new("main_panel", "main_panel#unmeasured", 7624) },
+            "realpower", "W");
+
+        var sources = EnergyDashboardSync.BuildEnergySources(graph, (id, _) => "sensor." + id.Replace('#', '_'));
+
+        Assert.DoesNotContain(sources, s => s.ToJsonString().Contains("unmeasured"));
+    }
+}

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -886,10 +886,50 @@ function collapseGraph(nodes: any[], links: any[]): { nodes: any[]; links: any[]
 }
 
 // The toggle strip above the diagram: one chip per group, click to collapse/expand on both graphs.
+// Show the "Unmeasured load" node on the diagram? A view preference, not config: the node is drawn from
+// figures already measured and is never exported (see FlowNode.Synthetic), so hiding it changes what you
+// are looking at and nothing else. On by default — a panel passing 8 kW to 560 W of metered outlets is
+// worth seeing — but it can dominate a chart when most of the load is unmetered, which is exactly when
+// someone wants the metered detail back.
+let showUnmeasured = (() => { try { return localStorage.getItem('rpdu-flow-unmeasured') !== '0'; } catch { return true; } })();
+
+function setShowUnmeasured(on: boolean) {
+  showUnmeasured = on;
+  try { localStorage.setItem('rpdu-flow-unmeasured', on ? '1' : '0'); } catch { /* private mode: this session only */ }
+}
+
+/// Drop the unmetered-remainder nodes and their links when the view is switched off. Return lanes (#in)
+/// are real measured flows and are never hidden by this.
+function applyUnmeasuredPref(nodes: any[], links: any[]): { nodes: any[]; links: any[] } {
+  if (showUnmeasured) return { nodes, links };
+  const hidden = new Set(nodes.filter((n: any) => String(n.id || '').endsWith('#unmeasured')).map((n: any) => n.id));
+  if (!hidden.size) return { nodes, links };
+  return {
+    nodes: nodes.filter((n: any) => !hidden.has(n.id)),
+    links: links.filter((l: any) => !hidden.has(l.target) && !hidden.has(l.source)),
+  };
+}
+
+/// The "Unmeasured load" view switch, shown wherever the group chips are.
+function unmeasuredToggle(onToggle: () => void): HTMLElement {
+  const lbl = el('label', {
+    class: 'desc',
+    style: { margin: '0', display: 'inline-flex', alignItems: 'center', gap: '4px', cursor: 'pointer' },
+    title: 'Show the gap between what a node passes and what its metered children draw, as its own node. '
+      + 'A view setting only — the figure is never published, and turning it off does not change any total.',
+  });
+  const cb: any = el('input', { type: 'checkbox' });
+  cb.checked = showUnmeasured;
+  cb.onchange = () => { setShowUnmeasured(cb.checked); onToggle(); };
+  lbl.append(cb, document.createTextNode('Unmeasured load'));
+  return lbl;
+}
+
 function groupToggles(onToggle: () => void): HTMLElement | null {
   const groups = flowGroups();
   if (!groups.length) return null;
   const row = el('div', { class: 'ld-toolbar', style: { flexWrap: 'wrap', gap: '6px', margin: '0 0 8px' } });
+  row.appendChild(unmeasuredToggle(onToggle));
   row.appendChild(el('span', { class: 'desc', style: { margin: '0' }, text: 'Groups:' }));
   groups.forEach((g: any) => {
     const on = collapsedGroups.has(g.Id);
@@ -1207,8 +1247,10 @@ export function addFlowSection(nav: any, sections: any) {
     // Fold collapsed groups into single nodes before laying out; the toggle strip re-draws on change.
     const collapsed = collapseGraph((graph.nodes || []).slice(), (graph.links || []).slice());
     // ...then substitute the members for the anchor on any group left expanded, so a group is always shown
-    // at exactly one level of detail rather than both at once.
-    const folded = explodeExpandedGroups(collapsed.nodes, collapsed.links);
+    // at exactly one level of detail rather than both at once...
+    const expanded = explodeExpandedGroups(collapsed.nodes, collapsed.links);
+    // ...and finally honour the unmetered-remainder view switch.
+    const folded = applyUnmeasuredPref(expanded.nodes, expanded.links);
     const toggles = groupToggles(redrawBoth);
     if (toggles) wrap.appendChild(toggles);
     const links = folded.links;

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -912,9 +912,23 @@ function groupToggles(onToggle: () => void): HTMLElement | null {
 }
 
 // The candidate node universe for wiring: the built graph's nodes (pdu/outlet/…) plus the custom defs.
+//
+// Not the nodes the builder synthesises to make the diagram balance — a bidirectional node's return lane
+// (`…#in`) and a pass-through's unmetered remainder (`…#unmeasured`). They describe an arithmetic result,
+// not a thing you can wire: they exist only in the built graph, are recomputed on every build, and have no
+// entry in the config at all.
+//
+// Leaving them in put "Unmeasured load" into the hierarchy editor as a node with no links — orphaned and
+// unexplained, because the editor draws links from the config while that node's link exists only in the
+// graph. It also offered them in the "wire to" picker and as group members, where selecting one would
+// write a config link to an id that is regenerated from scratch on the next build.
+//
+// '#' appears in no real id (PDU and outlet ids use ':'), so it marks exactly the builder's own inventions.
 function flowCandidates(lastGraph: any, customNodes: any[]) {
   const cand = new Map<string, any>();
-  (lastGraph?.nodes || []).forEach((n: any) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
+  (lastGraph?.nodes || [])
+    .filter((n: any) => !String(n.id || '').includes('#'))
+    .forEach((n: any) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
   customNodes.forEach((n: any) => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: n.Kind || 'node', custom: true }));
   return cand;
 }

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2310,9 +2310,23 @@ function groupToggles(onToggle            )                     {
 }
 
 // The candidate node universe for wiring: the built graph's nodes (pdu/outlet/…) plus the custom defs.
+//
+// Not the nodes the builder synthesises to make the diagram balance — a bidirectional node's return lane
+// (`…#in`) and a pass-through's unmetered remainder (`…#unmeasured`). They describe an arithmetic result,
+// not a thing you can wire: they exist only in the built graph, are recomputed on every build, and have no
+// entry in the config at all.
+//
+// Leaving them in put "Unmeasured load" into the hierarchy editor as a node with no links — orphaned and
+// unexplained, because the editor draws links from the config while that node's link exists only in the
+// graph. It also offered them in the "wire to" picker and as group members, where selecting one would
+// write a config link to an id that is regenerated from scratch on the next build.
+//
+// '#' appears in no real id (PDU and outlet ids use ':'), so it marks exactly the builder's own inventions.
 function flowCandidates(lastGraph     , customNodes       ) {
   const cand = new Map             ();
-  (lastGraph?.nodes || []).forEach((n     ) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
+  (lastGraph?.nodes || [])
+    .filter((n     ) => !String(n.id || '').includes('#'))
+    .forEach((n     ) => cand.set(n.id, { id: n.id, label: n.label, kind: n.kind }));
   customNodes.forEach((n     ) => cand.set(n.Id, { id: n.Id, label: n.Label || n.Id, kind: n.Kind || 'node', custom: true }));
   return cand;
 }

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2284,10 +2284,50 @@ function collapseGraph(nodes       , links       )                              
 }
 
 // The toggle strip above the diagram: one chip per group, click to collapse/expand on both graphs.
+// Show the "Unmeasured load" node on the diagram? A view preference, not config: the node is drawn from
+// figures already measured and is never exported (see FlowNode.Synthetic), so hiding it changes what you
+// are looking at and nothing else. On by default — a panel passing 8 kW to 560 W of metered outlets is
+// worth seeing — but it can dominate a chart when most of the load is unmetered, which is exactly when
+// someone wants the metered detail back.
+let showUnmeasured = (() => { try { return localStorage.getItem('rpdu-flow-unmeasured') !== '0'; } catch { return true; } })();
+
+function setShowUnmeasured(on         ) {
+  showUnmeasured = on;
+  try { localStorage.setItem('rpdu-flow-unmeasured', on ? '1' : '0'); } catch { /* private mode: this session only */ }
+}
+
+/// Drop the unmetered-remainder nodes and their links when the view is switched off. Return lanes (#in)
+/// are real measured flows and are never hidden by this.
+function applyUnmeasuredPref(nodes       , links       )                                 {
+  if (showUnmeasured) return { nodes, links };
+  const hidden = new Set(nodes.filter((n     ) => String(n.id || '').endsWith('#unmeasured')).map((n     ) => n.id));
+  if (!hidden.size) return { nodes, links };
+  return {
+    nodes: nodes.filter((n     ) => !hidden.has(n.id)),
+    links: links.filter((l     ) => !hidden.has(l.target) && !hidden.has(l.source)),
+  };
+}
+
+/// The "Unmeasured load" view switch, shown wherever the group chips are.
+function unmeasuredToggle(onToggle            )              {
+  const lbl = el('label', {
+    class: 'desc',
+    style: { margin: '0', display: 'inline-flex', alignItems: 'center', gap: '4px', cursor: 'pointer' },
+    title: 'Show the gap between what a node passes and what its metered children draw, as its own node. '
+      + 'A view setting only — the figure is never published, and turning it off does not change any total.',
+  });
+  const cb      = el('input', { type: 'checkbox' });
+  cb.checked = showUnmeasured;
+  cb.onchange = () => { setShowUnmeasured(cb.checked); onToggle(); };
+  lbl.append(cb, document.createTextNode('Unmeasured load'));
+  return lbl;
+}
+
 function groupToggles(onToggle            )                     {
   const groups = flowGroups();
   if (!groups.length) return null;
   const row = el('div', { class: 'ld-toolbar', style: { flexWrap: 'wrap', gap: '6px', margin: '0 0 8px' } });
+  row.appendChild(unmeasuredToggle(onToggle));
   row.appendChild(el('span', { class: 'desc', style: { margin: '0' }, text: 'Groups:' }));
   groups.forEach((g     ) => {
     const on = collapsedGroups.has(g.Id);
@@ -2605,8 +2645,10 @@ function addFlowSection(nav     , sections     ) {
     // Fold collapsed groups into single nodes before laying out; the toggle strip re-draws on change.
     const collapsed = collapseGraph((graph.nodes || []).slice(), (graph.links || []).slice());
     // ...then substitute the members for the anchor on any group left expanded, so a group is always shown
-    // at exactly one level of detail rather than both at once.
-    const folded = explodeExpandedGroups(collapsed.nodes, collapsed.links);
+    // at exactly one level of detail rather than both at once...
+    const expanded = explodeExpandedGroups(collapsed.nodes, collapsed.links);
+    // ...and finally honour the unmetered-remainder view switch.
+    const folded = applyUnmeasuredPref(expanded.nodes, expanded.links);
     const toggles = groupToggles(redrawBoth);
     if (toggles) wrap.appendChild(toggles);
     const links = folded.links;


### PR DESCRIPTION
Adds the requested on/off switch — and fixes something worse I found while adding it.

## 1. They were being exported

Both the MQTT export and the two Home Assistant paths iterate `graph.Nodes`, so `Unmeasured load` and the return lanes were published as if they were devices.

Not merely untidy. The topic template is `energy/{id}`, so it would publish to:

```
energy/main_panel#unmeasured
```

`#` is the MQTT **multi-level wildcard** and is not legal in a publish topic at all. They'd also duplicate figures the export already sends properly — the in-direction goes out as the parent's `energy_in`, not as a separate device.

**I claimed in review that the exports handled these correctly. I hadn't checked; they didn't.**

The rule now lives on the node — `FlowNode.Synthetic` — rather than in each caller, because **three consumers got it wrong independently**:

- the Energy Overview double-counted a battery as charging *and* discharging at once (#306)
- the hierarchy editor offered them as wiring targets (#308)
- both exports published them (here)

A fourth consumer would have made the same mistake.

## 2. The switch

A **view preference**, persisted in `localStorage`, sitting on the same strip as the group chips. Not config: the node is derived from figures already measured and is never exported, so hiding it changes what you're looking at and nothing else — **no total moves**.

On by default, because a panel passing 8184 W to 560 W of metered outlets is worth seeing. But it can dominate the chart precisely when most of the load is unmetered, which is exactly when you want the metered detail back.

Return lanes (`#in`) are **real measured flows** and are not hidden by this switch.

464 tests pass, 10 new; GUI bundle rebuilt; DOM smoke test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)