### PR TITLE
fix(gui): the API doc links are clickable, and say when nothing is listening

### DIFF
--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -396,9 +396,20 @@ function wireApiDocs(sec: any) {
       a.href = base + path; a.textContent = base + path;
       a.target = '_blank'; a.rel = 'noopener';
       a.style.cssText = 'font:12px ui-monospace,Consolas,monospace;';
-      if (!on) { a.style.pointerEvents = 'none'; a.style.opacity = '0.5'; }
-      row.appendChild(document.createTextNode(label + ': '));
-      row.appendChild(a);
+      // Left clickable even when the API is off. Killing pointer-events made these look like ordinary
+      // links that silently ignored a click — reported as "API links not clickable" (#295), because a
+      // dead-looking link is indistinguishable from a broken page. The reason is now on the row itself
+      // rather than only in the paragraph above it, so the state is legible where the link is.
+      if (!on) {
+        a.style.opacity = '0.55';
+        a.title = 'The API is disabled, so nothing is listening on this port yet — enable it above, save, and restart.';
+        row.appendChild(document.createTextNode(label + ': '));
+        row.appendChild(a);
+        row.appendChild(el('span', { class: 'desc', style: { margin: '0 0 0 6px' }, text: '· API disabled' }));
+      } else {
+        row.appendChild(document.createTextNode(label + ': '));
+        row.appendChild(a);
+      }
       list.appendChild(row);
     }
   };

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -4470,9 +4470,20 @@ function wireApiDocs(sec     ) {
       a.href = base + path; a.textContent = base + path;
       a.target = '_blank'; a.rel = 'noopener';
       a.style.cssText = 'font:12px ui-monospace,Consolas,monospace;';
-      if (!on) { a.style.pointerEvents = 'none'; a.style.opacity = '0.5'; }
-      row.appendChild(document.createTextNode(label + ': '));
-      row.appendChild(a);
+      // Left clickable even when the API is off. Killing pointer-events made these look like ordinary
+      // links that silently ignored a click — reported as "API links not clickable" (#295), because a
+      // dead-looking link is indistinguishable from a broken page. The reason is now on the row itself
+      // rather than only in the paragraph above it, so the state is legible where the link is.
+      if (!on) {
+        a.style.opacity = '0.55';
+        a.title = 'The API is disabled, so nothing is listening on this port yet — enable it above, save, and restart.';
+        row.appendChild(document.createTextNode(label + ': '));
+        row.appendChild(a);
+        row.appendChild(el('span', { class: 'desc', style: { margin: '0 0 0 6px' }, text: '· API disabled' }));
+      } else {
+        row.appendChild(document.createTextNode(label + ': '));
+        row.appendChild(a);
+      }
       list.appendChild(row);
     }
   };


### PR DESCRIPTION
Closes #295.

They genuinely weren't clickable. With `Api.Enabled` off:

```js
if (!on) { a.style.pointerEvents = 'none'; a.style.opacity = '0.5'; }
```

Working as designed — and indistinguishable from a broken page. They still looked like links, a click did nothing, and the only explanation sat in a separate paragraph above the list. The natural reading is "the UI is stuck", not "a setting is off".

Now clickable whatever the state, with the reason on the row itself: a `· API disabled` marker beside each link and a title saying to enable it, save and restart. A link that opens and fails to connect is at least honest about what it did.

GUI bundle rebuilt; DOM smoke test passes; 464 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)