### PR TITLE
A stray zero no longer books a lifetime as today's energy; inverted split signs get caught

### DIFF
--- a/rPDU2MQTT.Core/Flow/DirectionAudit.cs
+++ b/rPDU2MQTT.Core/Flow/DirectionAudit.cs
@@ -1,0 +1,74 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// Cross-checks a <c>split</c> power source's sign convention against the node's own in/out energy counters.
+///
+/// <para>
+/// A <c>split</c> source fans one signed number into two directions: positive is <em>out</em> (battery
+/// discharge, grid import), the magnitude of negative is <em>in</em> (charge, export). Half the devices in
+/// the world use the opposite convention, and getting it backwards is invisible — the diagram still balances,
+/// the numbers are still plausible, and the only symptom is that a charging battery reads as discharging.
+/// </para>
+/// <para>
+/// Seen on a live system: Solar Assistant publishes battery power positive while charging, so a battery
+/// taking 1.65 kW <em>in</em> was drawn as 1.77 kW coming <em>out</em>. It cost twice its own magnitude on
+/// the headline figure, because a charging battery is a load and was being added where it should have been
+/// subtracted — home read 11.3 kW against an actual 7.0 kW.
+/// </para>
+/// <para>
+/// The check exists because we already hold the answer. A node like that usually also binds explicit
+/// <c>in</c> and <c>out</c> <em>energy</em> counters, on separate topics with no sign convention to get
+/// wrong. When those counters say the battery has been charging all day and the power source says it is
+/// discharging right now, they cannot both be right, and the energy counters are the ones that cannot be
+/// misread. Reporting the contradiction is not the same as resolving it — the fix is <c>Scale: -1</c> on the
+/// source, which is the operator's to apply — but nobody can apply a fix they have no way of noticing.
+/// </para>
+/// </summary>
+public static class DirectionAudit
+{
+    /// <summary>
+    /// Does the sign of <paramref name="powerOut"/>/<paramref name="powerIn"/> disagree with what the day's
+    /// energy counters say the node has actually been doing?
+    ///
+    /// <para>
+    /// True only when the disagreement is unambiguous: one direction of power is live and non-trivial, the
+    /// energy counters clearly favour the other direction, and neither figure is small enough to be noise.
+    /// A battery that is genuinely idle, or one that has done a bit of both today, is not evidence of
+    /// anything and must not raise a warning that then gets ignored.
+    /// </para>
+    /// </summary>
+    /// <param name="powerOut">Power the node is supplying right now (the <c>out</c> lane), in W.</param>
+    /// <param name="powerIn">Power the node is drawing right now (the <c>in</c> lane), in W.</param>
+    /// <param name="energyOutToday">Energy supplied so far this period, kWh.</param>
+    /// <param name="energyInToday">Energy drawn so far this period, kWh.</param>
+    public static bool LooksInverted(double powerOut, double powerIn, double energyOutToday, double energyInToday)
+    {
+        // Below this a reading is noise, not a direction: a few watts of standby, a few Wh of rounding.
+        const double PowerFloor = 50;      // W
+        const double EnergyFloor = 0.5;    // kWh
+        // How lopsided the day has to be before it counts as evidence. A battery that cycled both ways today
+        // says nothing about which way it is going right now.
+        const double Ratio = 5;
+
+        var flowingOut = powerOut > PowerFloor && powerIn <= PowerFloor;
+        var flowingIn = powerIn > PowerFloor && powerOut <= PowerFloor;
+        if (!flowingOut && !flowingIn) return false;
+
+        var dayWasIn = energyInToday > EnergyFloor && energyInToday > energyOutToday * Ratio;
+        var dayWasOut = energyOutToday > EnergyFloor && energyOutToday > energyInToday * Ratio;
+
+        // Power says one way, the whole day's metered energy says the other.
+        return (flowingOut && dayWasIn) || (flowingIn && dayWasOut);
+    }
+
+    /// <summary>The warning to log for a node whose convention looks inverted. Shaped as an instruction,
+    /// because the operator can fix it in one field and otherwise has no way to know.</summary>
+    public static string Explain(string nodeId, double powerOut, double powerIn, double energyOutToday, double energyInToday)
+        => $"Node '{nodeId}': its split power source reads "
+         + (powerOut > powerIn ? $"{powerOut:0} W flowing OUT (discharge/import)" : $"{powerIn:0} W flowing IN (charge/export)")
+         + $", but today's metered energy says the opposite — {energyInToday:0.##} kWh in against {energyOutToday:0.##} kWh out. "
+         + "The energy counters come from separate topics with no sign convention to get wrong, so the power "
+         + "source's sign is most likely inverted for this device. Set Scale: -1 on it. Until then a charging "
+         + "battery is counted as supplying the house rather than loading it, which roughly doubles its error "
+         + "on any total that includes it.";
+}

--- a/rPDU2MQTT.Core/Flow/EnergyIntegrator.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyIntegrator.cs
@@ -19,8 +19,15 @@ namespace rPDU2MQTT.Core.Flow;
 /// </param>
 /// <param name="PeriodStartKWh"><see cref="KWh"/> as it read when the current period began.</param>
 /// <param name="LastCounterKWh">
-/// The last raw reading of a device-maintained counter, for <see cref="EnergyIntegrator.Observe"/> to take
-/// a delta against. Null for a node whose total we integrate ourselves.
+/// The last <b>accepted</b> reading of a device-maintained counter — the high-water mark
+/// <see cref="EnergyIntegrator.Observe"/> takes a delta against. Null for a node whose total we integrate
+/// ourselves.
+/// </param>
+/// <param name="PendingResetKWh">
+/// A reading that came in below the mark and is being held pending confirmation. Non-null means "the counter
+/// may have restarted"; a second consecutive low reading confirms it and a reading back above the mark
+/// discards it. Exists so one stray zero cannot re-baseline the mark and turn the next ordinary reading into
+/// a lifetime's worth of energy.
 /// </param>
 public readonly record struct EnergyState(
     double KWh,
@@ -29,7 +36,8 @@ public readonly record struct EnergyState(
     double UnmeasuredSeconds,
     string? PeriodKey = null,
     double PeriodStartKWh = 0,
-    double? LastCounterKWh = null)
+    double? LastCounterKWh = null,
+    double? PendingResetKWh = null)
 {
     public static readonly EnergyState Empty = new(0, default, 0, 0);
 
@@ -135,10 +143,21 @@ public static class EnergyIntegrator
     /// interval, and accumulating it gives a total on the same footing as an integrated one.
     /// </para>
     /// <para>
-    /// A counter reading lower than last time was reset — a reboot, a firmware clear, an outlet re-provisioned.
-    /// What it reads now is what has accrued since that reset, so it counts as the delta; treating it as
-    /// <c>now - last</c> would go negative and drag the total backwards, which is the one thing a cumulative
-    /// counter must never do. Energy from before the reset stays counted, because it genuinely happened.
+    /// A reading <b>below</b> the last one is not trusted on sight, and this is the expensive lesson in this
+    /// file. It used to be read as a device reset and counted at face value — which is right for a real reset,
+    /// but a single spurious low reading (a publisher restarting, an empty retained payload parsing as zero)
+    /// then re-baselined the mark at that bogus value, and the next perfectly ordinary reading was measured
+    /// against it. Seen on a live system: one stray zero, then a normal 791.9 kWh reading, and 791.9 kWh of
+    /// lifetime energy was booked as having happened today. The drop was handled; the <em>recovery</em> was
+    /// what destroyed the figure.
+    /// </para>
+    /// <para>
+    /// So a low reading is held, not accepted: the high-water mark stands, and a stray dip is ignored because
+    /// the reading after it comes back above the mark and contributes its honest delta. A genuine reset does
+    /// not go away — the counter keeps reading low and climbing from its new base — so a second consecutive
+    /// low reading confirms it, and the mark moves there counting <b>nothing</b> across the discontinuity.
+    /// That loses at most one interval of real energy, which is bounded and visible; the alternative lost
+    /// nothing and invented a year's worth.
     /// </para>
     /// <para>
     /// The first ever reading advances nothing: there is no interval behind it, so it only establishes the
@@ -156,12 +175,27 @@ public static class EnergyIntegrator
         if (prev.LastCounterKWh is not { } last)
             return state with { LastCounterKWh = counterKWh, LastSampleUtc = nowUtc };
 
-        var delta = counterKWh >= last ? counterKWh - last : counterKWh;
+        // Back above the mark: an ordinary rise, and any dip before it is forgotten as the noise it was.
+        if (counterKWh >= last)
+            return state with
+            {
+                KWh = state.KWh + (counterKWh - last),
+                LastCounterKWh = counterKWh,
+                LastSampleUtc = nowUtc,
+                PendingResetKWh = null,
+            };
 
+        // Below the mark. The first one is only a suspicion — hold it and count nothing.
+        if (state.PendingResetKWh is not { } pending)
+            return state with { PendingResetKWh = counterKWh, LastSampleUtc = nowUtc };
+
+        // A second one confirms the counter really did restart. Adopt the new base, still counting nothing:
+        // whatever the device accrued between the reset and now is genuinely unobserved, and guessing at it
+        // is what produced the 791.9 kWh day.
         return state with
         {
-            KWh = state.KWh + delta,
             LastCounterKWh = counterKWh,
+            PendingResetKWh = null,
             LastSampleUtc = nowUtc,
         };
     }

--- a/rPDU2MQTT.Engine/Services/EnergyAggregationService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyAggregationService.cs
@@ -200,6 +200,12 @@ public sealed class EnergyAggregationService : BackgroundService, IFlowValueSour
                 var inId = id + FlowMetricKey.InSuffix;
                 next[inId] = EnergyIntegrator.Observe(Prev(next, inId), inCounter, now, periodKey);
                 sampled++;
+
+                // Now that both energy directions are known for this node, check the power source's sign
+                // against them. An inverted split convention is otherwise invisible — the diagram balances
+                // and the numbers look plausible; a charging battery just reads as discharging and gets
+                // added to the house total instead of subtracted. See DirectionAudit.
+                AuditDirection(id, next);
             }
         }
 
@@ -207,6 +213,26 @@ public sealed class EnergyAggregationService : BackgroundService, IFlowValueSour
 
         states = next;
         if (sampled > 0) store.Save(next);
+    }
+
+    // Warned nodes, so a contradiction that persists is said once rather than every sampling pass.
+    private readonly HashSet<string> warnedDirection = new(StringComparer.OrdinalIgnoreCase);
+
+    private void AuditDirection(string id, Dictionary<string, EnergyState> next)
+    {
+        if (!upstream.TryGetValue(id, PowerMetric, out var pOut)) return;
+        upstream.TryGetValue(id, FlowMetricKey.For(PowerMetric, "in"), out var pIn);
+
+        var outToday = next.TryGetValue(id, out var o) ? o.PeriodKWh : 0;
+        var inToday = next.TryGetValue(id + FlowMetricKey.InSuffix, out var i) ? i.PeriodKWh : 0;
+
+        if (!DirectionAudit.LooksInverted(pOut, pIn, outToday, inToday))
+        {
+            warnedDirection.Remove(id);   // it agrees again; a later contradiction is worth saying afresh
+            return;
+        }
+        if (warnedDirection.Add(id))
+            Log.Warning(DirectionAudit.Explain(id, pOut, pIn, outToday, inToday));
     }
 
     /// <summary>

--- a/rPDU2MQTT.Tests/DirectionAuditTests.cs
+++ b/rPDU2MQTT.Tests/DirectionAuditTests.cs
@@ -1,0 +1,60 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Catching an inverted split sign convention. It is invisible without a cross-check: the diagram still
+/// balances and the numbers still look plausible — a charging battery simply reads as discharging, and gets
+/// added to the house total where it should be subtracted.
+/// </summary>
+public class DirectionAuditTests
+{
+    [Fact]
+    public void TheLiveCase_IsCaught()
+    {
+        // Solar Assistant publishes battery power positive while charging, so a battery taking 1.65 kW in was
+        // drawn as 1.77 kW coming out — and home read 11.3 kW against an actual 7.0 kW. Today's metered
+        // energy (11.7 kWh in, 0.1 kWh out) says charging, flatly contradicting the power sign.
+        Assert.True(DirectionAudit.LooksInverted(powerOut: 1771, powerIn: 0, energyOutToday: 0.1, energyInToday: 11.7));
+
+        var msg = DirectionAudit.Explain("battery", 1771, 0, 0.1, 11.7);
+        Assert.Contains("Scale: -1", msg);
+        Assert.Contains("battery", msg);
+    }
+
+    [Fact]
+    public void TheOtherDirection_IsCaughtToo()
+        => Assert.True(DirectionAudit.LooksInverted(powerOut: 0, powerIn: 2000, energyOutToday: 14.0, energyInToday: 0.2));
+
+    [Fact]
+    public void AgreementIsNotAWarning()
+    {
+        // Discharging, and the day says discharging.
+        Assert.False(DirectionAudit.LooksInverted(1771, 0, 11.7, 0.1));
+        // Charging, and the day says charging.
+        Assert.False(DirectionAudit.LooksInverted(0, 1771, 0.1, 11.7));
+    }
+
+    [Fact]
+    public void AnIdleNode_IsNotEvidence()
+    {
+        // A few watts of standby says nothing about direction, and a warning that fires on noise is a
+        // warning that gets ignored.
+        Assert.False(DirectionAudit.LooksInverted(5, 0, 0.1, 11.7));
+        Assert.False(DirectionAudit.LooksInverted(0, 0, 0.1, 11.7));
+    }
+
+    [Fact]
+    public void ADayThatWentBothWays_IsNotEvidence()
+    {
+        // A battery that cycled today says nothing about which way it is going right now.
+        Assert.False(DirectionAudit.LooksInverted(1771, 0, 6.0, 7.0));
+        // Nor does a day with almost no energy either way.
+        Assert.False(DirectionAudit.LooksInverted(1771, 0, 0.0, 0.2));
+    }
+
+    [Fact]
+    public void ANodeWithNoEnergyCountersAtAll_IsNeverFlagged()
+        => Assert.False(DirectionAudit.LooksInverted(1771, 0, 0, 0));
+}

--- a/rPDU2MQTT.Tests/EnergyPeriodTests.cs
+++ b/rPDU2MQTT.Tests/EnergyPeriodTests.cs
@@ -61,18 +61,69 @@ public class EnergyPeriodTests
     }
 
     [Fact]
-    public void ACounterThatWentBackwards_WasReset_AndDoesNotDragTheTotalDown()
+    public void AStrayLowReading_IsIgnored_AndTheNextRealOneDoesNotBookTheWholeCounter()
     {
-        // A PDU reboot or firmware clear restarts the counter. What it reads now is what has accrued since
-        // that moment; treating it as now-minus-last would subtract, and a cumulative total must never fall.
+        // The bug that made a live system report 817 kWh of energy "today" on a rig that generates ~27.
+        // A publisher restarting emitted one bogus low value; that was taken as a device reset and became the
+        // new mark, so the very next ordinary reading measured against it booked the counter's entire
+        // lifetime as today's energy. The drop was handled — the recovery was what destroyed the figure.
+        var s = EnergyIntegrator.Observe(EnergyState.Empty, 750.0, Utc(1, 8), "2026-08-01");
+        s = EnergyIntegrator.Observe(s, 751.5, Utc(1, 9), "2026-08-01");
+        Assert.Equal(1.5, s.KWh, 6);
+
+        s = EnergyIntegrator.Observe(s, 0, Utc(1, 10), "2026-08-01");     // the stray
+        Assert.Equal(1.5, s.KWh, 6);                                      // counts nothing yet
+        Assert.Equal(751.5, s.LastCounterKWh!.Value, 6);                  // and the mark does NOT move
+
+        s = EnergyIntegrator.Observe(s, 791.9, Utc(1, 11), "2026-08-01"); // back to normal
+        Assert.Equal(41.9, s.KWh, 6);                                     // 791.9 - 751.5, not 791.9
+        Assert.Null(s.PendingResetKWh);
+    }
+
+    [Fact]
+    public void ACounterThatStaysLow_WasGenuinelyReset_AndAdoptsTheNewBaseWithoutInventingEnergy()
+    {
+        // A real reset does not go away: the counter keeps reading low and climbing from its new base. Two
+        // consecutive lows confirm it. Nothing is counted across the discontinuity — what the device accrued
+        // between resetting and being seen again is genuinely unobserved, and guessing is what caused the bug
+        // above. Energy from before the reset stays counted, because it genuinely happened.
         var s = EnergyIntegrator.Observe(EnergyState.Empty, 100, Utc(1, 8), "2026-08-01");
-        s = EnergyIntegrator.Observe(s, 140, Utc(1, 10), "2026-08-01");
+        s = EnergyIntegrator.Observe(s, 140, Utc(1, 9), "2026-08-01");
         Assert.Equal(40, s.KWh, 6);
 
-        s = EnergyIntegrator.Observe(s, 3, Utc(1, 12), "2026-08-01");
+        s = EnergyIntegrator.Observe(s, 3, Utc(1, 10), "2026-08-01");     // suspicion
+        s = EnergyIntegrator.Observe(s, 5, Utc(1, 11), "2026-08-01");     // confirmed: counting up from 0
+        Assert.Equal(40, s.KWh, 6);
+        Assert.Equal(5, s.LastCounterKWh!.Value, 6);
 
-        Assert.Equal(43, s.KWh, 6);          // the 40 before the reset genuinely happened; keep it
-        Assert.Equal(43, s.PeriodKWh, 6);
+        s = EnergyIntegrator.Observe(s, 9, Utc(1, 12), "2026-08-01");     // now measured against the new base
+        Assert.Equal(44, s.KWh, 6);
+    }
+
+    [Fact]
+    public void ACumulativeTotal_NeverFalls_WhateverTheCounterDoes()
+    {
+        // The invariant everything downstream depends on: Home Assistant and EmonCMS read a drop as a meter
+        // reset and rewrite history that was already correct.
+        var s = EnergyState.Empty;
+        var last = 0.0;
+        foreach (var reading in new[] { 10.0, 20, 0, 21, 22, 3, 4, 5, 0, 0, 1, 900, 901 })
+        {
+            s = EnergyIntegrator.Observe(s, reading, Utc(1, 8), "2026-08-01");
+            Assert.True(s.KWh >= last, $"total fell after reading {reading}");
+            last = s.KWh;
+        }
+        // A stray dip followed by recovery must not leak the counter's face value — the 791.9 kWh bug.
+        var stray = EnergyIntegrator.Observe(EnergyState.Empty, 750, Utc(1, 8), "2026-08-01");
+        stray = EnergyIntegrator.Observe(stray, 0, Utc(1, 9), "2026-08-01");
+        stray = EnergyIntegrator.Observe(stray, 791.9, Utc(1, 10), "2026-08-01");
+        Assert.Equal(41.9, stray.KWh, 6);
+
+        // Not asserted, and deliberately so: a *confirmed* reset (two lows) followed by a jump back to a
+        // large value is genuinely ambiguous — the counter either restarted and climbed fast, or the low
+        // period was a longer glitch. Nothing in the reading distinguishes them, so this counts the rise
+        // from the adopted base. Bounding it would need a plausible-rate ceiling, which needs a capacity
+        // this class does not have. Tracked in #314.
     }
 
     [Fact]


### PR DESCRIPTION
First two fixes for #314 — the two that produced confident, wrong headline numbers.

## 1. One stray zero booked 791.9 kWh as today's energy

The live system reported **817 kWh "today"** on a rig that generates about 27. `PeriodKWh` was almost exactly the counter's whole face value.

`Observe()` read any reading below the last one as a device reset and counted it at face value — correct for a real reset. But a single spurious low reading (a publisher restarting, an empty retained payload parsing as zero) re-based the mark at that bogus value, so the next perfectly ordinary reading was measured against it:

```
mark 751.5  →  stray 0  →  next 791.9  →  791.9 kWh booked as today
```

The drop was handled. The **recovery** destroyed the figure.

A low reading is now held rather than accepted. The high-water mark stands, so a stray dip is ignored and the reading after it contributes its honest delta. A genuine reset doesn't go away — the counter keeps reading low and climbing from its new base — so a second consecutive low confirms it and the mark moves there, counting **nothing** across the discontinuity. That loses at most one sample interval of real energy, bounded and visible, against an alternative that lost nothing and invented a year's worth.

**Deliberately not fixed:** a *confirmed* reset followed by a jump back to a large value is genuinely ambiguous — the counter either restarted and climbed fast, or the low period was a longer glitch, and nothing in the reading tells them apart. Bounding it needs a plausible-rate ceiling, which needs a capacity this class doesn't have. A test documents the gap rather than asserting a number I can't justify.

Existing daily totals stay wrong until the next rollover, which re-bases them.

## 2. An inverted split sign quietly halved the truth

A `split` source fans one signed number into two directions: positive out, negative in. Half the devices use the opposite convention, and getting it backwards is invisible — the diagram still balances and every number looks plausible. A charging battery just reads as discharging.

Not cosmetic: a charging battery is a **load**, so it gets added to the house total where it should be subtracted, costing twice its own magnitude. Live: Solar Assistant publishes battery power positive while charging, so 1.65 kW going in was drawn as 1.77 kW coming out, and home read **11.3 kW against an actual 7.0 kW**.

We already hold the answer. That node also binds explicit `in` and `out` *energy* counters, on separate topics with no sign convention to get wrong. When they say the battery has been charging all day (11.7 kWh in, 0.1 kWh out) and the power source says it's discharging right now, they can't both be right — and the energy counters are the ones that can't be misread.

`DirectionAudit` reports the contradiction; it doesn't resolve it. The fix is `Scale: -1` on the source and that's the operator's call — but nobody can apply a fix they have no way of noticing. Warned once per node, only when the evidence is unambiguous: power clearly one way, the day's energy clearly the other, both above a noise floor. An idle battery, or one that cycled both ways today, is not evidence — and a warning that fires on noise is one that gets ignored.

508 tests pass.

Refs #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)