### PR TITLE
A counter the device resets daily is no longer mistaken for a lifetime one

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -787,6 +787,13 @@ spec:
                                 - powerfactor
                                 - soc
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, powerfactor, or soc (battery state of charge %, shown on the Energy tile — not rolled up).'
+                              Accumulation:
+                                type: string
+                                enum:
+                                - ''
+                                - lifetime
+                                - period
+                                description: "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight."
                               Direction:
                                 type: string
                                 enum:
@@ -869,6 +876,13 @@ spec:
                                 - powerfactor
                                 - soc
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, powerfactor, or soc (battery state of charge %, shown on the Energy tile — not rolled up).'
+                              Accumulation:
+                                type: string
+                                enum:
+                                - ''
+                                - lifetime
+                                - period
+                                description: "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight."
                               Direction:
                                 type: string
                                 enum:

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -787,6 +787,13 @@ spec:
                                 - powerfactor
                                 - soc
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, powerfactor, or soc (battery state of charge %, shown on the Energy tile — not rolled up).'
+                              Accumulation:
+                                type: string
+                                enum:
+                                - ''
+                                - lifetime
+                                - period
+                                description: "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight."
                               Direction:
                                 type: string
                                 enum:
@@ -869,6 +876,13 @@ spec:
                                 - powerfactor
                                 - soc
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, powerfactor, or soc (battery state of charge %, shown on the Energy tile — not rolled up).'
+                              Accumulation:
+                                type: string
+                                enum:
+                                - ''
+                                - lifetime
+                                - period
+                                description: "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight."
                               Direction:
                                 type: string
                                 enum:

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -833,10 +833,17 @@ Per-source settings:
 | `Metric` | Which roll-up this feeds (`realpower`, `energy`, …). Bind one topic per metric to drive both power and energy. |
 | `JsonField` | For JSON payloads, the field to read — dotted for nesting (`battery.power`). Blank means the whole payload is the number. |
 | `Scale` | Multiplier for unit conversion (`0.001` for W → kW) or to flip a sign convention (`-1`). |
+| `Accumulation` | For an `energy` source: `lifetime` (default — a cumulative counter whose *rise* is measured) or `period` (the device resets it daily, so the reading already **is** today's total). |
 | `StaleAfterSeconds` | Ignore the value once it's this old (default 900). Stops a dead publisher from propping up the flow with a reading that stopped being true. `0` disables the check. |
 
 Notes:
 
+- **Check `Accumulation` on every energy source.** One publisher can do both: Solar Assistant's
+  `total/load_energy` and `total/grid_energy_in` are cumulative, while `total/pv_energy` rolls over at
+  midnight. Measuring the "rise" of a resetting counter loses the day — it drops to zero and climbs again
+  unobserved, and the next reading measured against yesterday's high-water mark gives a fraction of the
+  truth (seen live: 2.76 kWh of solar reported against 27.4 kWh actually generated). It cannot be inferred
+  from the topic, so it has to be declared.
 - A live reading **supersedes** the node's fixed `Value`, which stays as the fallback for anything you're
   modelling by hand. A live `0` is a real reading (solar at night), not a fall-back to `Value`.
 - Negative readings are clamped to `0` — a directed flow graph can't carry a negative, and it would

--- a/rPDU2MQTT.Core/Flow/FlowMetricKey.cs
+++ b/rPDU2MQTT.Core/Flow/FlowMetricKey.cs
@@ -36,6 +36,29 @@ public static class FlowMetricKey
             ? new[] { (metric, System.Math.Max(0, value)), (metric + InSuffix, System.Math.Max(0, -value)) }
             : new[] { (For(metric, direction), value) };
 
+    /// <summary>
+    /// The metric a source's readings are stored under, given how its counter accumulates.
+    ///
+    /// <para>
+    /// A <c>period</c> energy source has already done the re-basing for us — the device resets the counter
+    /// each day, so the reading <em>is</em> the daily total. Storing it under the daily metric hands it
+    /// straight to every consumer, and because the derived accumulator is registered last in the composite,
+    /// a real figure always wins over a computed one.
+    /// </para>
+    /// <para>
+    /// Only energy accumulates; power and the rest are instantaneous and pass through unchanged, whatever
+    /// the field says.
+    /// </para>
+    /// </summary>
+    public static string ForAccumulation(string metric, string? accumulation)
+        => IsPeriod(accumulation) && string.Equals(metric, "energy", System.StringComparison.OrdinalIgnoreCase)
+            ? EnergyPeriod.Metric
+            : metric;
+
+    /// <summary>True for a counter the device resets each period, rather than a cumulative one.</summary>
+    public static bool IsPeriod(string? accumulation)
+        => string.Equals(accumulation, "period", System.StringComparison.OrdinalIgnoreCase);
+
     /// <summary>The cache key(s) a source writes, without values — for staleness/binding bookkeeping.</summary>
     public static IEnumerable<string> Keys(string metric, string? direction)
         => IsSplit(direction) ? new[] { metric, metric + InSuffix } : new[] { For(metric, direction) };

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -205,6 +205,31 @@ public class EnergyFlowSource
     /// <c>stat_energy_from</c> and its <c>in</c> becomes <c>stat_energy_to</c>; a grid's <c>out</c> is
     /// <c>flow_from</c> (consumption) and its <c>in</c> is <c>flow_to</c> (return).
     /// </summary>
+    /// <summary>
+    /// Whether this source's counter runs forever or restarts each period.
+    ///
+    /// <list type="bullet">
+    /// <item><c>lifetime</c> (default): a cumulative counter that only rises — a PDU's firmware total, an
+    /// inverter's all-time production. Its daily figure is derived by taking its rise since the period
+    /// began.</item>
+    /// <item><c>period</c>: a counter the device itself resets each day, so the reading <em>already is</em>
+    /// the daily total and is used as-is.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// This is not a detail you can ignore, and one publisher can do both: Solar Assistant's
+    /// <c>total/load_energy</c> and <c>total/grid_energy_in</c> are cumulative, while
+    /// <c>total/pv_energy</c> resets at midnight. Taking the "rise" of a resetting counter loses the day —
+    /// the counter drops to zero and climbs again unobserved, and the next reading measured against
+    /// yesterday's high-water mark yields a small fraction of the truth. Seen live: 2.76 kWh of solar
+    /// reported against 27.4 kWh actually generated.
+    /// </para>
+    /// </summary>
+    [DefaultValue("lifetime")]
+    [Description("Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight.")]
+    [AllowedValues("lifetime", "period")]
+    public string Accumulation { get; set; } = "lifetime";
+
     [DefaultValue("out")]
     [Description("Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production), 'in' (battery charge, grid export), or 'split' — one signed value fanned into both directions, positive as out and the magnitude of negative as in (for a single ± power/current topic or register). Only meaningful for directional metrics (realpower, apparentpower, current, energy); ignored for voltage/frequency/powerfactor/soc.")]
     [AllowedValues("out", "in", "split")]

--- a/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
@@ -55,7 +55,7 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
 
         // Prune readings no longer produced by any current modbus binding (a removed/retyped source).
         var live = bindings.Values.SelectMany(v => v)
-            .SelectMany(b => FlowMetricKey.Keys(b.Source.Metric, b.Source.Direction).Select(k => (b.NodeId, Key: k))).ToHashSet();
+            .SelectMany(b => FlowMetricKey.Keys(FlowMetricKey.ForAccumulation(b.Source.Metric, b.Source.Accumulation), b.Source.Direction).Select(k => (b.NodeId, Key: k))).ToHashSet();
         foreach (var key in latest.Keys.Where(k => !live.Contains((k.Node, k.Metric))).ToList())
             latest.Remove(key.Node, key.Metric);
 
@@ -83,7 +83,7 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         var framing = resolvedFraming.TryGetValue(conn.Id, out var cached) ? cached : conn.Framing;
 
         ReadBatch(conn.Host, conn.Port, conn.UnitId, framing, conn.TimeoutMs, forConn.Select(f => f.Source).ToList(),
-            onValue: (src, value) => { foreach (var (key, v) in FlowMetricKey.Fan(src.Metric, src.Direction, value)) latest.Set(nodeOf[src], key, v, src.StaleAfterSeconds, nowUtc); },
+            onValue: (src, value) => { foreach (var (key, v) in FlowMetricKey.Fan(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction, value)) latest.Set(nodeOf[src], key, v, src.StaleAfterSeconds, nowUtc); },
             onError: (src, msg) => Log.Debug($"Energy-flow Modbus: node '{nodeOf[src]}' register {src.Register} on {conn.Id} — {msg}"),
             onResolved: f => resolvedFraming[conn.Id] = f);
     }

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -169,7 +169,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
         {
             if (topic == removedTopic) continue;
             foreach (var (nodeId, src) in list)
-                if (nodeId == key.Node && FlowMetricKey.Keys(src.Metric, src.Direction).Any(k => string.Equals(k, key.Metric, StringComparison.OrdinalIgnoreCase)))
+                if (nodeId == key.Node && FlowMetricKey.Keys(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction).Any(k => string.Equals(k, key.Metric, StringComparison.OrdinalIgnoreCase)))
                     return false;
         }
         return true;
@@ -245,7 +245,10 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             // value) writes both the out (positive part) and in (negative magnitude) keys. The 'in' key is
             // direction-qualified so it doesn't overwrite the out supply value, and — being a non-metric key —
             // is skipped by the grain sink below (Metrics.TryParse fails), keeping charge/export out of the flow.
-            foreach (var (key, v) in FlowMetricKey.Fan(src.Metric, src.Direction, value))
+            // A 'period' energy counter is reset by the device each day, so it already IS the daily total —
+            // store it under the daily metric rather than pretending it is cumulative and measuring its
+            // "rise", which loses the whole day every time the device rolls it over.
+            foreach (var (key, v) in FlowMetricKey.Fan(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction, value))
             {
                 cache.Set(nodeId, key, v, src.StaleAfterSeconds, nowUtc);
                 onReading?.Invoke(nodeId, key, v, src.StaleAfterSeconds);

--- a/rPDU2MQTT.Tests/PeriodAccumulationTests.cs
+++ b/rPDU2MQTT.Tests/PeriodAccumulationTests.cs
@@ -1,0 +1,68 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Counters the device resets each day, as opposed to cumulative ones. One publisher does both — Solar
+/// Assistant's <c>total/load_energy</c> is cumulative while <c>total/pv_energy</c> rolls over at midnight —
+/// so which it is cannot be inferred and has to be declared.
+/// </summary>
+public class PeriodAccumulationTests
+{
+    [Fact]
+    public void ADailyCounter_IsStoredAsTheDailyTotal_NotAsLifetimeEnergy()
+    {
+        // The reading already IS today's total, so it goes straight to the metric that means that. Measuring
+        // its "rise" instead is what reported 2.76 kWh of solar against 27.4 kWh actually generated: the
+        // counter dropped to zero at midnight and climbed again unobserved, and the next reading was
+        // measured against yesterday's high-water mark.
+        Assert.Equal(EnergyPeriod.Metric, FlowMetricKey.ForAccumulation("energy", "period"));
+        Assert.Equal("energy", FlowMetricKey.ForAccumulation("energy", "lifetime"));
+        Assert.Equal("energy", FlowMetricKey.ForAccumulation("energy", null));
+    }
+
+    [Fact]
+    public void OnlyEnergyAccumulates()
+    {
+        // Power, current and the rest are instantaneous — there is no counter to reset, so the setting is
+        // meaningless for them and must not silently redirect them somewhere strange.
+        Assert.Equal("realpower", FlowMetricKey.ForAccumulation("realpower", "period"));
+        Assert.Equal("voltage", FlowMetricKey.ForAccumulation("voltage", "period"));
+        Assert.Equal("soc", FlowMetricKey.ForAccumulation("soc", "period"));
+    }
+
+    [Fact]
+    public void ADailyCounter_StillSplitsIntoBothDirections()
+    {
+        // A battery publishing separate daily charge/discharge totals must keep them apart, exactly as the
+        // cumulative pair does.
+        var keys = FlowMetricKey.Keys(FlowMetricKey.ForAccumulation("energy", "period"), "in").ToList();
+        Assert.Equal(new[] { EnergyPeriod.Metric + FlowMetricKey.InSuffix }, keys);
+
+        var fanned = FlowMetricKey.Fan(FlowMetricKey.ForAccumulation("energy", "period"), "out", 27.4).ToList();
+        Assert.Equal(EnergyPeriod.Metric, fanned.Single().Key);
+        Assert.Equal(27.4, fanned.Single().Value);
+    }
+
+    [Fact]
+    public void TheDeclaredDailyFigure_ReachesTheGraph_AndIsNotOverriddenByADerivedOne()
+    {
+        // A real reading always beats a computed one: the composite takes the first source with a value and
+        // the derived accumulator is registered last. This is what makes the declared counter authoritative.
+        var real = new Stub(new() { ["solar|" + EnergyPeriod.Metric] = 27.4 });
+        var derived = new Stub(new() { ["solar|" + EnergyPeriod.Metric] = 2.76 });
+
+        var composite = new CompositeFlowValueSource(real, derived);
+
+        Assert.True(composite.TryGetValue("solar", EnergyPeriod.Metric, out var v));
+        Assert.Equal(27.4, v);
+    }
+
+    private sealed class Stub : IFlowValueSource
+    {
+        private readonly Dictionary<string, double> v;
+        public Stub(Dictionary<string, double> x) => v = x;
+        public bool TryGetValue(string node, string metric, out double value) => v.TryGetValue(node + "|" + metric, out value);
+    }
+}

--- a/rPDU2MQTT.Web/web/schema.fixture.json
+++ b/rPDU2MQTT.Web/web/schema.fixture.json
@@ -2077,6 +2077,19 @@
                     ]
                   },
                   {
+                    "key": "Accumulation",
+                    "label": "Accumulation",
+                    "description": "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight.",
+                    "type": "enum",
+                    "required": false,
+                    "default": "lifetime",
+                    "enumValues": [
+                      "",
+                      "lifetime",
+                      "period"
+                    ]
+                  },
+                  {
                     "key": "Direction",
                     "label": "Direction",
                     "description": "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production), 'in' (battery charge, grid export), or 'split' — one signed value fanned into both directions, positive as out and the magnitude of negative as in (for a single ± power/current topic or register). Only meaningful for directional metrics (realpower, apparentpower, current, energy); ignored for voltage/frequency/powerfactor/soc.",
@@ -2230,6 +2243,19 @@
                       "frequency",
                       "powerfactor",
                       "soc"
+                    ]
+                  },
+                  {
+                    "key": "Accumulation",
+                    "label": "Accumulation",
+                    "description": "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight.",
+                    "type": "enum",
+                    "required": false,
+                    "default": "lifetime",
+                    "enumValues": [
+                      "",
+                      "lifetime",
+                      "period"
                     ]
                   },
                   {

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -442,7 +442,7 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
       Invert: 'Flip the sign of a power or current reading — for a source that publishes export/discharge as positive when your hierarchy wants it negative (or vice versa).',
       Current: LIVE_HINT,
     };
-    ['Type', 'Metric', ...(bidirectional ? ['Direction'] : []), 'Unit', 'Source', 'Details', 'Scale', 'Invert', 'Current', ''].forEach(h => {
+    ['Type', 'Metric', ...(bidirectional ? ['Direction'] : []), 'Counter', 'Unit', 'Source', 'Details', 'Scale', 'Invert', 'Current', ''].forEach(h => {
       const th = el('th', { text: h });
       if (colHint[h]) th.title = colHint[h];
       head.appendChild(th);
@@ -500,6 +500,27 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
           cell.appendChild(dirSel);
         } else {
           cell.appendChild(el('span', { text: '—', style: { color: 'var(--muted)' }, title: 'Direction doesn’t apply to this metric.' }));
+        }
+        tr.appendChild(cell);
+      }
+
+      // Does this counter run forever, or does the device reset it every day? Only energy accumulates, so
+      // every other metric's cell stays blank. Getting it wrong is silent and expensive: measuring the
+      // "rise" of a counter the device resets at midnight loses the whole day, because it drops to zero and
+      // climbs again unobserved. One publisher can do both — Solar Assistant's total/load_energy is
+      // cumulative while total/pv_energy resets — so it cannot be inferred from the source.
+      {
+        const cell = el('td');
+        if (metric === 'energy') {
+          const accSel = el('select', { style: { width: 'auto' } });
+          [['lifetime', 'Lifetime'], ['period', 'Daily']].forEach(([v, t]) => accSel.appendChild(el('option', { value: v, text: t })));
+          accSel.value = src.Accumulation === 'period' ? 'period' : 'lifetime';
+          accSel.title = 'Lifetime: a cumulative total that only rises; its daily figure is its rise since midnight. '
+            + 'Daily: the device resets this counter itself, so the reading already is today\u2019s total and is used as-is.';
+          accSel.onchange = () => { src.Accumulation = accSel.value === 'lifetime' ? undefined : accSel.value; refreshDirty(); };
+          cell.appendChild(accSel);
+        } else {
+          cell.appendChild(el('span', { text: '\u2014', style: { color: 'var(--muted)' }, title: 'Only energy accumulates; this metric is instantaneous.' }));
         }
         tr.appendChild(cell);
       }

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1870,7 +1870,7 @@ function renderNodeEditor(node     , links       , cand                  , reren
       Invert: 'Flip the sign of a power or current reading — for a source that publishes export/discharge as positive when your hierarchy wants it negative (or vice versa).',
       Current: LIVE_HINT,
     };
-    ['Type', 'Metric', ...(bidirectional ? ['Direction'] : []), 'Unit', 'Source', 'Details', 'Scale', 'Invert', 'Current', ''].forEach(h => {
+    ['Type', 'Metric', ...(bidirectional ? ['Direction'] : []), 'Counter', 'Unit', 'Source', 'Details', 'Scale', 'Invert', 'Current', ''].forEach(h => {
       const th = el('th', { text: h });
       if (colHint[h]) th.title = colHint[h];
       head.appendChild(th);
@@ -1928,6 +1928,27 @@ function renderNodeEditor(node     , links       , cand                  , reren
           cell.appendChild(dirSel);
         } else {
           cell.appendChild(el('span', { text: '—', style: { color: 'var(--muted)' }, title: 'Direction doesn’t apply to this metric.' }));
+        }
+        tr.appendChild(cell);
+      }
+
+      // Does this counter run forever, or does the device reset it every day? Only energy accumulates, so
+      // every other metric's cell stays blank. Getting it wrong is silent and expensive: measuring the
+      // "rise" of a counter the device resets at midnight loses the whole day, because it drops to zero and
+      // climbs again unobserved. One publisher can do both — Solar Assistant's total/load_energy is
+      // cumulative while total/pv_energy resets — so it cannot be inferred from the source.
+      {
+        const cell = el('td');
+        if (metric === 'energy') {
+          const accSel = el('select', { style: { width: 'auto' } });
+          [['lifetime', 'Lifetime'], ['period', 'Daily']].forEach(([v, t]) => accSel.appendChild(el('option', { value: v, text: t })));
+          accSel.value = src.Accumulation === 'period' ? 'period' : 'lifetime';
+          accSel.title = 'Lifetime: a cumulative total that only rises; its daily figure is its rise since midnight. '
+            + 'Daily: the device resets this counter itself, so the reading already is today\u2019s total and is used as-is.';
+          accSel.onchange = () => { src.Accumulation = accSel.value === 'lifetime' ? undefined : accSel.value; refreshDirty(); };
+          cell.appendChild(accSel);
+        } else {
+          cell.appendChild(el('span', { text: '\u2014', style: { color: 'var(--muted)' }, title: 'Only energy accumulates; this metric is instantaneous.' }));
         }
         tr.appendChild(cell);
       }


### PR DESCRIPTION
#314 item 4. Solar Assistant reported **27.4 kWh** of PV generated today; the flow showed **2.76**.

`solar_assistant/total/pv_energy/state` rolls over at midnight — the stored counter read `28.72`, which is a day's generation, not an all-time total. We treated it as cumulative and measured its rise, so the rollover was invisible: the counter dropped to zero and climbed again unobserved while the feed was down, and on recovery the reading was measured against yesterday's high-water mark, yielding a tenth of the truth.

**This can't be inferred from the topic**, because one publisher does both. The same Solar Assistant install has `total/load_energy` (791.9) and `total/grid_energy_in` (534.4) as cumulative counters right alongside `total/pv_energy` (28.72) as a daily one. So sources declare it:

```yaml
- Topic: solar_assistant/total/pv_energy/state
  Metric: energy
  Accumulation: period      # lifetime (default) | period
```

`period` means the reading already **is** the daily total, so it's stored under the daily metric directly — no re-basing, nothing to lose at the rollover. And because the derived accumulator is registered last in the composite, a declared figure always beats a computed one.

Rendered as a **Counter** column on the Nodes tab (Lifetime / Daily), blank for every metric other than energy — nothing else accumulates, so there's no counter to reset.

512 tests pass; CRDs and schema fixture regenerated.

Refs #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)