### PR TITLE
A dead feed is not a licence to invent generation

### DIFF
--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -263,10 +263,34 @@ public static class FlowGraphBuilder
         //    solar, the battery or the grid, so NONE of them carry anything. Dividing it between them —
         //    which is what this used to do — states a number the user never supplied, on the diagram whose
         //    whole purpose is to be accurate. Mark one 'residual' to say where the remainder actually goes.
+        // Nodes that are SUPPOSED to report this metric — someone bound a source for it — but have no fresh
+        // reading right now. "Unmeasured" and "unavailable" are not the same thing, and conflating them is how
+        // the diagram invented solar generation in the dark.
+        //
+        // A node with no source bound is genuinely unmeasured: nothing was ever going to measure it, so if the
+        // topology leaves exactly one path for the load to arrive by, conservation really does determine it.
+        // A node with a source bound and nothing coming out of it is a different situation entirely — the
+        // measurement failed. Letting it absorb the remainder says "we don't know what solar was doing, so
+        // assume it was doing all of it", which on a live system at night attributed the entire house load to
+        // a PV array in the dark while the grid that was actually carrying it read "no data".
+        //
+        // The project's rule is that unknown is never zero. This is the same rule pointing the other way:
+        // unknown is never "whatever balances the equation" either.
+        var expectsReading = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var n in flow.Nodes)
+        {
+            if (string.IsNullOrEmpty(n.Id) || leaf.ContainsKey(n.Id)) continue;
+            // Metric-specific on purpose: a node bound only for realpower is not "failing" to report energy,
+            // it was never asked to. Only a binding for THIS metric makes silence a failure.
+            if (n.AllSources().Any(src => string.Equals(src.Metric, metric, StringComparison.OrdinalIgnoreCase)))
+                expectsReading.Add(n.Id);
+        }
+        bool Unavailable(string id) => expectsReading.Contains(id);
+
         List<string> Absorbers(string to)
         {
             var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
-            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f))).ToList();
+            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f)) && !Unavailable(f)).ToList();
             var residual = unmeasured.Where(f => Mode(f) == "residual").ToList();
             if (residual.Count > 0) return residual;
             return unmeasured.Count == 1 ? unmeasured : new List<string>();
@@ -287,8 +311,12 @@ public static class FlowGraphBuilder
             if (leaf.ContainsKey(from)) return true;         // a measured producer supplies a real figure
             if (Inert(Mode(from))) return true;              // 'none'/'static': deliberately contributes nothing
 
+            // A feeder whose own source has stopped reporting carries an unknowable amount — not zero. Its
+            // link must draw as "no data" so the failure is visible, rather than as a confident hairline.
+            if (Unavailable(from)) return false;
+
             var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
-            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f))).ToList();
+            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f)) && !Unavailable(f)).ToList();
 
             // A designated residual is told what it carries, so its own flow is determined. Its unmeasured
             // siblings are not: "the residual takes the remainder" says nothing about how much solar was

--- a/rPDU2MQTT.Tests/UnavailableFeederTests.cs
+++ b/rPDU2MQTT.Tests/UnavailableFeederTests.cs
@@ -1,0 +1,110 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// "Unmeasured" and "unavailable" are not the same thing. Reconstructed from the live system that showed
+/// 5.81 A of solar generation after dark, which was the whole house load back-filled from the PDU totals and
+/// attributed to a PV array in the night because its feed had stopped reporting.
+/// </summary>
+public class UnavailableFeederTests
+{
+    private sealed class Fixed : IFlowValueSource
+    {
+        private readonly Dictionary<string, double> v;
+        public Fixed(Dictionary<string, double> x) => v = x;
+        public bool TryGetValue(string node, string metric, out double value) => v.TryGetValue(node + "|" + metric, out value);
+    }
+
+    /// <summary>solar + grid feed the inverter, which feeds the panel, which feeds a metered load.</summary>
+    private static EnergyFlowConfig Topology(bool solarHasSource = true, bool gridInert = true)
+    {
+        var c = new EnergyFlowConfig();
+        var solar = new EnergyFlowNode { Id = "solar", Kind = "solar" };
+        if (solarHasSource)
+            solar.Sources.Add(new EnergyFlowSource { Type = "mqtt", Metric = "realpower", Topic = "sa/pv_power" });
+        c.Nodes.Add(solar);
+        c.Nodes.Add(new EnergyFlowNode { Id = "grid", Kind = "grid", Mode = gridInert ? "none" : "auto" });
+        c.Nodes.Add(new EnergyFlowNode { Id = "inverter", Kind = "inverter" });
+        c.Nodes.Add(new EnergyFlowNode { Id = "panel", Kind = "panel" });
+        c.Links.Add(new EnergyFlowLink { From = "solar", To = "inverter" });
+        c.Links.Add(new EnergyFlowLink { From = "grid", To = "inverter" });
+        c.Links.Add(new EnergyFlowLink { From = "inverter", To = "panel" });
+        c.Links.Add(new EnergyFlowLink { From = "panel", To = "pdu:pdu1" });
+        return c;
+    }
+
+    private static PduData Pdu(double watts)
+    {
+        var o = new Outlet { Key = 0, Entity_Name = "o0", Entity_DisplayName = "Load" };
+        o.Measurements.Add(new Measurement { Type = "realpower", Value = watts.ToString(), Units = "W" });
+        o.Measurements.Add(new Measurement { Type = "apparentpower", Value = watts.ToString(), Units = "VA" });
+        var d = new Device { Key = "pdu1", Entity_Name = "pdu1", Entity_DisplayName = "PDU 1" };
+        d.Outlets.Add(o);
+        var data = new PduData();
+        data.Devices.Add(d);
+        return data;
+    }
+
+    [Fact]
+    public void ASolarNodeWhoseFeedIsDead_DoesNotGetCreditedWithTheWholeHouseLoad()
+    {
+        // Solar has a realpower source bound and it is reporting nothing. Grid is Mode:none, so solar was
+        // the only remaining candidate and conservation handed it the entire load — 5.81 A of generation
+        // after dark, on the diagram whose whole purpose is to be accurate.
+        var graph = FlowGraphBuilder.Build(Pdu(700), Topology(), "realpower", new Fixed(new()));
+
+        var solar = graph.Nodes.Single(n => n.Id == "solar");
+        Assert.Null(solar.Value);   // unknown, not "whatever balances the equation"
+
+        var link = graph.Links.Single(l => l.Source == "solar" && l.Target == "inverter");
+        Assert.False(link.Known);   // drawn as no-data, so the failed feed is visible
+        Assert.Equal(0, link.Value);
+    }
+
+    [Fact]
+    public void AZeroReading_IsStillHonoured_BecauseSolarAtNightGenuinelyGeneratesNothing()
+    {
+        // The distinction that matters: a source reporting 0 is a measurement. It must keep making solar a
+        // measured producer supplying nothing, not revert it to an inferable unknown.
+        var graph = FlowGraphBuilder.Build(Pdu(700), Topology(), "realpower",
+            new Fixed(new() { ["solar|realpower"] = 0 }));
+
+        Assert.Equal(0, graph.Nodes.Single(n => n.Id == "solar").Value);
+    }
+
+    [Fact]
+    public void AReportingSolarNode_SuppliesItsRealFigure_Unchanged()
+    {
+        var graph = FlowGraphBuilder.Build(Pdu(700), Topology(), "realpower",
+            new Fixed(new() { ["solar|realpower"] = 900 }));
+
+        Assert.Equal(900, graph.Nodes.Single(n => n.Id == "solar").Value);
+        Assert.True(graph.Links.Single(l => l.Source == "solar" && l.Target == "inverter").Known);
+    }
+
+    [Fact]
+    public void ANodeWithNoSourceBoundAtAll_CanStillBeInferred()
+    {
+        // The rule must not kill legitimate inference. A node nothing was ever going to measure, with exactly
+        // one path for the load to arrive by, really is determined by conservation — that is the whole point
+        // of the single-unmeasured-feeder rule and it stays.
+        var graph = FlowGraphBuilder.Build(Pdu(700), Topology(solarHasSource: false), "realpower", new Fixed(new()));
+
+        Assert.Equal(700, graph.Nodes.Single(n => n.Id == "solar").Value);
+    }
+
+    [Fact]
+    public void ABindingForADifferentMetric_IsNotAFailureToReportThisOne()
+    {
+        // Solar is bound for realpower only. Viewed in apparentpower it was never asked to report, so it is
+        // unmeasured rather than unavailable and inference applies as before.
+        var graph = FlowGraphBuilder.Build(
+            Pdu(700), Topology(), "apparentpower", new Fixed(new()));
+
+        Assert.NotNull(graph.Nodes.Single(n => n.Id == "solar").Value);
+    }
+}


### PR DESCRIPTION
#314 item 1. The diagram showed **5.81 A of solar generation after dark**.

It was the whole house load — Rack-PDU-1 2.91 A plus Rack-PDU-2 2.90 A — back-filled up the chain and attributed to a PV array in the night, while the grid actually carrying it read "no data".

`Absorbers` lets a *single* unmeasured feeder convey a target's remaining demand. That is right when the topology genuinely leaves one path: the load really is being drawn, and it has to have arrived somehow. But it treated **"nobody measures this"** and **"the thing that measures this has stopped reporting"** as the same state. With `grid` and the MPPTs at `Mode: none`, solar was the last candidate standing and took the lot.

A node with a source bound for this metric and no fresh reading is now **unavailable**, not unmeasured: it can't absorb a remainder, and its links draw as no-data so the failed feed is visible instead of quietly papered over. A node with nothing bound is untouched — conservation still determines it, which is the whole point of the rule.

Metric-specific, because a node bound only for `realpower` isn't failing to report `energy`; it was never asked to. And a source reporting **0** still counts as a measurement — solar at night genuinely generates nothing, and that must stay a measured zero rather than reverting to an inferable unknown.

This is the project's own rule pointing the other way: unknown is never zero, and unknown is never "whatever balances the equation" either.

Worth noting the ⚠ imbalance marker from #312 could never have caught this — the arithmetic reconciled perfectly. It was attributed to the wrong node.

513 tests pass.

Refs #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)