### PR TITLE
Nothing computed behind your back, and nothing inferred shown as measured

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -787,6 +787,13 @@ spec:
                                 - powerfactor
                                 - soc
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, powerfactor, or soc (battery state of charge %, shown on the Energy tile — not rolled up).'
+                              Accumulation:
+                                type: string
+                                enum:
+                                - ''
+                                - lifetime
+                                - period
+                                description: "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight."
                               Direction:
                                 type: string
                                 enum:
@@ -869,6 +876,13 @@ spec:
                                 - powerfactor
                                 - soc
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, powerfactor, or soc (battery state of charge %, shown on the Energy tile — not rolled up).'
+                              Accumulation:
+                                type: string
+                                enum:
+                                - ''
+                                - lifetime
+                                - period
+                                description: "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight."
                               Direction:
                                 type: string
                                 enum:

--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -989,6 +989,9 @@ spec:
                     additionalProperties:
                       type: string
                     description: Legacy single-feeder map (child id -> parent id). Prefer Links; still honored for back-compat.
+                  InferFromConservation:
+                    type: boolean
+                    description: Work out an unmeasured node's value from what it feeds, when exactly one path could have supplied it. Sound arithmetic, but it describes the hierarchy you drew rather than anything measured — so results are always labelled 'inferred'. Turn it off to show 'no data' instead.
                   MqttExport:
                     type: boolean
                     description: Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -787,6 +787,13 @@ spec:
                                 - powerfactor
                                 - soc
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, powerfactor, or soc (battery state of charge %, shown on the Energy tile — not rolled up).'
+                              Accumulation:
+                                type: string
+                                enum:
+                                - ''
+                                - lifetime
+                                - period
+                                description: "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight."
                               Direction:
                                 type: string
                                 enum:
@@ -869,6 +876,13 @@ spec:
                                 - powerfactor
                                 - soc
                                 description: 'Which measurement this source supplies (the flow is rolled up per metric): realpower = power, apparentpower, energy, current, voltage, frequency, powerfactor, or soc (battery state of charge %, shown on the Energy tile — not rolled up).'
+                              Accumulation:
+                                type: string
+                                enum:
+                                - ''
+                                - lifetime
+                                - period
+                                description: "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight."
                               Direction:
                                 type: string
                                 enum:

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -989,6 +989,9 @@ spec:
                     additionalProperties:
                       type: string
                     description: Legacy single-feeder map (child id -> parent id). Prefer Links; still honored for back-compat.
+                  InferFromConservation:
+                    type: boolean
+                    description: Work out an unmeasured node's value from what it feeds, when exactly one path could have supplied it. Sound arithmetic, but it describes the hierarchy you drew rather than anything measured — so results are always labelled 'inferred'. Turn it off to show 'no data' instead.
                   MqttExport:
                     type: boolean
                     description: Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -888,6 +888,27 @@ plus pre-wired nodes (solar / battery / grid / inverter) with the register bindi
 > its source. Included today: **EG4 FlexBoss 21**. More can be added — paste a device's register table and
 > it can be turned into a template.
 
+### Nothing is computed behind your back
+
+Every number the flow shows is either measured, summed from measured children, or **inferred** — and the
+diagram says which. An inferred value is labelled `· inferred` on the chart and explained in the hover card;
+it is never rendered the way a metered reading is.
+
+Two behaviours compute rather than read, and both are switches you can see on the **Flow** tab under
+*Energy roll-up*:
+
+| Switch | What it does | Default |
+| --- | --- | --- |
+| Derive kWh from power | Integrates watts over time for nodes with no energy counter. An estimate — a real energy source always wins. | Off |
+| Infer from a single supply path | Fills in an unmeasured node from what it feeds, when only one of several possible routes could have supplied it. | On |
+
+The second one is worth understanding. When a node has exactly **one** feeder, propagating demand up it is
+arithmetic, not a guess — a PDU's total is its outlets' — and that is always done. When a node has
+**several** feeders and all but one are ruled out (by `Mode: none`, or by their source having gone silent),
+picking the survivor is a claim about the hierarchy you drew rather than anything measured. That is what this
+switch governs, and what gets labelled `inferred`. Turn it off and such a node reads "no data" instead;
+plain roll-ups are unaffected either way.
+
 ### Energy today vs. energy lifetime
 
 Two cumulative counters can only be compared if they started counting at the same moment, and the ones on

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -833,10 +833,17 @@ Per-source settings:
 | `Metric` | Which roll-up this feeds (`realpower`, `energy`, …). Bind one topic per metric to drive both power and energy. |
 | `JsonField` | For JSON payloads, the field to read — dotted for nesting (`battery.power`). Blank means the whole payload is the number. |
 | `Scale` | Multiplier for unit conversion (`0.001` for W → kW) or to flip a sign convention (`-1`). |
+| `Accumulation` | For an `energy` source: `lifetime` (default — a cumulative counter whose *rise* is measured) or `period` (the device resets it daily, so the reading already **is** today's total). |
 | `StaleAfterSeconds` | Ignore the value once it's this old (default 900). Stops a dead publisher from propping up the flow with a reading that stopped being true. `0` disables the check. |
 
 Notes:
 
+- **Check `Accumulation` on every energy source.** One publisher can do both: Solar Assistant's
+  `total/load_energy` and `total/grid_energy_in` are cumulative, while `total/pv_energy` rolls over at
+  midnight. Measuring the "rise" of a resetting counter loses the day — it drops to zero and climbs again
+  unobserved, and the next reading measured against yesterday's high-water mark gives a fraction of the
+  truth (seen live: 2.76 kWh of solar reported against 27.4 kWh actually generated). It cannot be inferred
+  from the topic, so it has to be declared.
 - A live reading **supersedes** the node's fixed `Value`, which stays as the fallback for anything you're
   modelling by hand. A live `0` is a real reading (solar at night), not a fall-back to `Value`.
 - Negative readings are clamped to `0` — a directed flow graph can't carry a negative, and it would

--- a/rPDU2MQTT.Core/Flow/FlowGraph.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraph.cs
@@ -1,5 +1,27 @@
 namespace rPDU2MQTT.Core.Flow;
 
+/// <summary>
+/// How a <see cref="FlowNode"/> came by its value.
+///
+/// <para>
+/// <c>summed</c> is deliberately distinct from <c>measured</c>: a PDU's total is real, but it is real
+/// <em>because</em> its outlets are. <c>inferred</c> is the one that matters most — conservation says the
+/// load arrived by the one path left open, which is sound arithmetic about a topology someone drew, and only
+/// as true as that topology.
+/// </para>
+/// </summary>
+public static class FlowDerivation
+{
+    /// <summary>The node reports this value itself — a live source, a static value, an outlet measurement.</summary>
+    public const string Measured = "measured";
+    /// <summary>Aggregated from links that are themselves known: a PDU's outlets, a panel's circuits.</summary>
+    public const string Summed = "summed";
+    /// <summary>Back-filled by conservation: the only unmeasured path into a node whose demand is known.</summary>
+    public const string Inferred = "inferred";
+    /// <summary>Nothing measures it and nothing determines it. <c>Value</c> is null.</summary>
+    public const string Unknown = "unknown";
+}
+
 /// <summary>A node in an energy/power flow graph (a PDU, an outlet, a circuit, …).</summary>
 /// <param name="Id">Stable unique id (used to wire links).</param>
 /// <param name="Label">Human-readable display name.</param>
@@ -24,7 +46,14 @@ namespace rPDU2MQTT.Core.Flow;
 /// meantime, rather than quietly rendering the larger of the two numbers and letting it look deliberate.
 /// </para>
 /// </param>
-public sealed record FlowNode(string Id, string Label, string Kind, double? Value = null, double? Imbalance = null)
+/// <param name="Derivation">
+/// How this node's value was arrived at — see <see cref="FlowDerivation"/>. Carried because a number's
+/// provenance is part of the number: an inferred figure is not wrong, but it is not a measurement either,
+/// and rendering it identically to a metered reading is how a diagram states something it cannot back up.
+/// </param>
+public sealed record FlowNode(
+    string Id, string Label, string Kind, double? Value = null, double? Imbalance = null,
+    string Derivation = FlowDerivation.Unknown)
 {
     /// <summary>
     /// A node the builder invented for the diagram, rather than one the operator configured: a

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -263,10 +263,34 @@ public static class FlowGraphBuilder
         //    solar, the battery or the grid, so NONE of them carry anything. Dividing it between them —
         //    which is what this used to do — states a number the user never supplied, on the diagram whose
         //    whole purpose is to be accurate. Mark one 'residual' to say where the remainder actually goes.
+        // Nodes that are SUPPOSED to report this metric — someone bound a source for it — but have no fresh
+        // reading right now. "Unmeasured" and "unavailable" are not the same thing, and conflating them is how
+        // the diagram invented solar generation in the dark.
+        //
+        // A node with no source bound is genuinely unmeasured: nothing was ever going to measure it, so if the
+        // topology leaves exactly one path for the load to arrive by, conservation really does determine it.
+        // A node with a source bound and nothing coming out of it is a different situation entirely — the
+        // measurement failed. Letting it absorb the remainder says "we don't know what solar was doing, so
+        // assume it was doing all of it", which on a live system at night attributed the entire house load to
+        // a PV array in the dark while the grid that was actually carrying it read "no data".
+        //
+        // The project's rule is that unknown is never zero. This is the same rule pointing the other way:
+        // unknown is never "whatever balances the equation" either.
+        var expectsReading = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var n in flow.Nodes)
+        {
+            if (string.IsNullOrEmpty(n.Id) || leaf.ContainsKey(n.Id)) continue;
+            // Metric-specific on purpose: a node bound only for realpower is not "failing" to report energy,
+            // it was never asked to. Only a binding for THIS metric makes silence a failure.
+            if (n.AllSources().Any(src => string.Equals(src.Metric, metric, StringComparison.OrdinalIgnoreCase)))
+                expectsReading.Add(n.Id);
+        }
+        bool Unavailable(string id) => expectsReading.Contains(id);
+
         List<string> Absorbers(string to)
         {
             var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
-            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f))).ToList();
+            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f)) && !Unavailable(f)).ToList();
             var residual = unmeasured.Where(f => Mode(f) == "residual").ToList();
             if (residual.Count > 0) return residual;
             return unmeasured.Count == 1 ? unmeasured : new List<string>();
@@ -287,8 +311,12 @@ public static class FlowGraphBuilder
             if (leaf.ContainsKey(from)) return true;         // a measured producer supplies a real figure
             if (Inert(Mode(from))) return true;              // 'none'/'static': deliberately contributes nothing
 
+            // A feeder whose own source has stopped reporting carries an unknowable amount — not zero. Its
+            // link must draw as "no data" so the failure is visible, rather than as a confident hairline.
+            if (Unavailable(from)) return false;
+
             var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
-            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f))).ToList();
+            var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f)) && !Unavailable(f)).ToList();
 
             // A designated residual is told what it carries, so its own flow is determined. Its unmeasured
             // siblings are not: "the residual takes the remainder" says nothing about how much solar was

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -282,13 +282,32 @@ public static class FlowGraphBuilder
             if (string.IsNullOrEmpty(n.Id) || leaf.ContainsKey(n.Id)) continue;
             // Metric-specific on purpose: a node bound only for realpower is not "failing" to report energy,
             // it was never asked to. Only a binding for THIS metric makes silence a failure.
-            if (n.AllSources().Any(src => string.Equals(src.Metric, metric, StringComparison.OrdinalIgnoreCase)))
+            if (n.AllSources().Any(src => string.Equals(
+                    FlowMetricKey.ForAccumulation(src.Metric ?? "", src.Accumulation), metric, StringComparison.OrdinalIgnoreCase)))
                 expectsReading.Add(n.Id);
         }
         bool Unavailable(string id) => expectsReading.Contains(id);
 
+        // Every node that ended up carrying a conservation back-fill, so its value can be labelled `inferred`
+        // rather than presented the way a metered one is.
+        var inferred = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Did this node have a CHOICE of feeders? That is the line between a roll-up and an attribution.
+        //
+        // One feeder is not an inference at all: a PDU's total is its outlets' demand arriving by the only
+        // route there is, and calling that a guess would label most of the diagram. Several feeders, with all
+        // but one ruled out by Mode or by having gone silent, is different — the load is real but *which*
+        // source supplied it is a claim about the hierarchy someone drew. That is the case that credited a PV
+        // array with the whole house load after dark, and the case the switch governs.
+        bool HasAlternatives(string to)
+            => (incoming.TryGetValue(to, out var fs) ? fs.Count : 0) > 1;
+
         List<string> Absorbers(string to)
         {
+            // Switched off: an attribution among alternatives is not made, and the node reads "no data"
+            // instead. Roll-ups are untouched — turning off inference must not blank out the PDU totals.
+            if (HasAlternatives(to) && !flow.InferFromConservation) return new List<string>();
+
             var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
             var unmeasured = feeders.Where(f => !leaf.ContainsKey(f) && !Inert(Mode(f)) && !Unavailable(f)).ToList();
             var residual = unmeasured.Where(f => Mode(f) == "residual").ToList();
@@ -324,6 +343,8 @@ public static class FlowGraphBuilder
             if (unmeasured.Any(f => Mode(f) == "residual")) return Mode(from) == "residual";
 
             // One unmeasured path is determined by conservation. Several is a real unknown.
+            // With inference off we decline to pick between alternatives, but a plain roll-up still stands.
+            if (HasAlternatives(to) && !flow.InferFromConservation) return false;
             return unmeasured.Count <= 1;
         }
 
@@ -368,7 +389,11 @@ public static class FlowGraphBuilder
             var feeders = incoming.TryGetValue(to, out var fs) ? fs : new List<string>();
             var measured = feeders.Where(leaf.ContainsKey).Sum(f => EdgeFlow(f, to, path));
             var remainder = Math.Max(0, Need(to, path) - measured);
-            return remainder / absorbers.Count;
+            var share = remainder / absorbers.Count;
+            // Only an attribution gets the label. Where this feeder was the only route, the figure is the
+            // downstream measurement arriving intact — a roll-up, and marking it inferred would cry wolf.
+            if (share > 0 && HasAlternatives(to)) inferred.Add(from);
+            return share;
         }
 
         // Emit one link per edge, valued by the flow it carries. A link whose flow is *unknowable* is still
@@ -529,12 +554,24 @@ public static class FlowGraphBuilder
             return gap > 1 && gap > inflow * 0.02 ? gap : null;
         }
 
+        // Where a node's number came from. Provenance travels with the value so no consumer has to guess,
+        // and so an inferred figure can never be mistaken for a metered one.
+        string DerivationOf(string id)
+        {
+            if (leaf.ContainsKey(id)) return FlowDerivation.Measured;
+            if (ValueOf(id) is null) return FlowDerivation.Unknown;
+            // A node that absorbed a remainder is inferred even if it also sums children — the back-fill is
+            // the part that isn't measured, and that is what the label has to warn about.
+            return inferred.Contains(id) ? FlowDerivation.Inferred : FlowDerivation.Summed;
+        }
+
         // Every node the user declared, plus every auto (pdu/outlet) node that reported a measurement —
         // whether or not a value could be determined for it. A configured node that silently disappears is
         // its own kind of inaccuracy: it reads as "my config is broken" rather than "nothing measures this".
         var nodes = label.Keys
             .Where(id => wired.Contains(id) || leaf.ContainsKey(id))
-            .Select(id => new FlowNode(id, label[id], kind.TryGetValue(id, out var k) ? k : "node", ValueOf(id), ImbalanceOf(id)))
+            .Select(id => new FlowNode(id, label[id], kind.TryGetValue(id, out var k) ? k : "node",
+                                       ValueOf(id), ImbalanceOf(id), DerivationOf(id)))
             .OrderBy(n => n.Id, StringComparer.OrdinalIgnoreCase)
             .ToList();
 

--- a/rPDU2MQTT.Core/Flow/FlowMetricKey.cs
+++ b/rPDU2MQTT.Core/Flow/FlowMetricKey.cs
@@ -36,6 +36,29 @@ public static class FlowMetricKey
             ? new[] { (metric, System.Math.Max(0, value)), (metric + InSuffix, System.Math.Max(0, -value)) }
             : new[] { (For(metric, direction), value) };
 
+    /// <summary>
+    /// The metric a source's readings are stored under, given how its counter accumulates.
+    ///
+    /// <para>
+    /// A <c>period</c> energy source has already done the re-basing for us — the device resets the counter
+    /// each day, so the reading <em>is</em> the daily total. Storing it under the daily metric hands it
+    /// straight to every consumer, and because the derived accumulator is registered last in the composite,
+    /// a real figure always wins over a computed one.
+    /// </para>
+    /// <para>
+    /// Only energy accumulates; power and the rest are instantaneous and pass through unchanged, whatever
+    /// the field says.
+    /// </para>
+    /// </summary>
+    public static string ForAccumulation(string metric, string? accumulation)
+        => IsPeriod(accumulation) && string.Equals(metric, "energy", System.StringComparison.OrdinalIgnoreCase)
+            ? EnergyPeriod.Metric
+            : metric;
+
+    /// <summary>True for a counter the device resets each period, rather than a cumulative one.</summary>
+    public static bool IsPeriod(string? accumulation)
+        => string.Equals(accumulation, "period", System.StringComparison.OrdinalIgnoreCase);
+
     /// <summary>The cache key(s) a source writes, without values — for staleness/binding bookkeeping.</summary>
     public static IEnumerable<string> Keys(string metric, string? direction)
         => IsSplit(direction) ? new[] { metric, metric + InSuffix } : new[] { For(metric, direction) };

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -47,6 +47,25 @@ public class EnergyFlowConfig
     [Description("Legacy single-feeder map (child id -> parent id). Prefer Links; still honored for back-compat.")]
     public Dictionary<string, string> Parents { get; set; } = new();
 
+    /// <summary>
+    /// Back-fill a node's value from what it feeds, when the topology leaves exactly one path for that load
+    /// to have arrived by.
+    ///
+    /// <para>
+    /// Sound arithmetic — the load really is being drawn and it really did come from somewhere — but it is a
+    /// statement about a hierarchy someone drew, not a measurement, and it is only as true as that hierarchy.
+    /// So it is a switch you can see and turn off, not something the code quietly does on your behalf, and
+    /// anything it produces is labelled <c>inferred</c> everywhere it is shown.
+    /// </para>
+    /// <para>
+    /// Turning it off does not fabricate the other way: a node it would have filled in simply reads "no data"
+    /// and its links draw as unknown, which is the honest rendering of a hierarchy nobody is metering.
+    /// </para>
+    /// </summary>
+    [DefaultValue(true)]
+    [Description("Work out an unmeasured node's value from what it feeds, when exactly one path could have supplied it. Sound arithmetic, but it describes the hierarchy you drew rather than anything measured — so results are always labelled 'inferred'. Turn it off to show 'no data' instead.")]
+    public bool InferFromConservation { get; set; } = true;
+
     /// <summary>Publish each hierarchy tier's rolled-up value to MQTT every poll (#164).</summary>
     [DefaultValue(false)]
     [Description("Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.")]

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -205,6 +205,31 @@ public class EnergyFlowSource
     /// <c>stat_energy_from</c> and its <c>in</c> becomes <c>stat_energy_to</c>; a grid's <c>out</c> is
     /// <c>flow_from</c> (consumption) and its <c>in</c> is <c>flow_to</c> (return).
     /// </summary>
+    /// <summary>
+    /// Whether this source's counter runs forever or restarts each period.
+    ///
+    /// <list type="bullet">
+    /// <item><c>lifetime</c> (default): a cumulative counter that only rises — a PDU's firmware total, an
+    /// inverter's all-time production. Its daily figure is derived by taking its rise since the period
+    /// began.</item>
+    /// <item><c>period</c>: a counter the device itself resets each day, so the reading <em>already is</em>
+    /// the daily total and is used as-is.</item>
+    /// </list>
+    ///
+    /// <para>
+    /// This is not a detail you can ignore, and one publisher can do both: Solar Assistant's
+    /// <c>total/load_energy</c> and <c>total/grid_energy_in</c> are cumulative, while
+    /// <c>total/pv_energy</c> resets at midnight. Taking the "rise" of a resetting counter loses the day —
+    /// the counter drops to zero and climbs again unobserved, and the next reading measured against
+    /// yesterday's high-water mark yields a small fraction of the truth. Seen live: 2.76 kWh of solar
+    /// reported against 27.4 kWh actually generated.
+    /// </para>
+    /// </summary>
+    [DefaultValue("lifetime")]
+    [Description("Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight.")]
+    [AllowedValues("lifetime", "period")]
+    public string Accumulation { get; set; } = "lifetime";
+
     [DefaultValue("out")]
     [Description("Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production), 'in' (battery charge, grid export), or 'split' — one signed value fanned into both directions, positive as out and the magnitude of negative as in (for a single ± power/current topic or register). Only meaningful for directional metrics (realpower, apparentpower, current, energy); ignored for voltage/frequency/powerfactor/soc.")]
     [AllowedValues("out", "in", "split")]

--- a/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
@@ -55,7 +55,7 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
 
         // Prune readings no longer produced by any current modbus binding (a removed/retyped source).
         var live = bindings.Values.SelectMany(v => v)
-            .SelectMany(b => FlowMetricKey.Keys(b.Source.Metric, b.Source.Direction).Select(k => (b.NodeId, Key: k))).ToHashSet();
+            .SelectMany(b => FlowMetricKey.Keys(FlowMetricKey.ForAccumulation(b.Source.Metric, b.Source.Accumulation), b.Source.Direction).Select(k => (b.NodeId, Key: k))).ToHashSet();
         foreach (var key in latest.Keys.Where(k => !live.Contains((k.Node, k.Metric))).ToList())
             latest.Remove(key.Node, key.Metric);
 
@@ -83,7 +83,7 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         var framing = resolvedFraming.TryGetValue(conn.Id, out var cached) ? cached : conn.Framing;
 
         ReadBatch(conn.Host, conn.Port, conn.UnitId, framing, conn.TimeoutMs, forConn.Select(f => f.Source).ToList(),
-            onValue: (src, value) => { foreach (var (key, v) in FlowMetricKey.Fan(src.Metric, src.Direction, value)) latest.Set(nodeOf[src], key, v, src.StaleAfterSeconds, nowUtc); },
+            onValue: (src, value) => { foreach (var (key, v) in FlowMetricKey.Fan(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction, value)) latest.Set(nodeOf[src], key, v, src.StaleAfterSeconds, nowUtc); },
             onError: (src, msg) => Log.Debug($"Energy-flow Modbus: node '{nodeOf[src]}' register {src.Register} on {conn.Id} — {msg}"),
             onResolved: f => resolvedFraming[conn.Id] = f);
     }

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -169,7 +169,7 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
         {
             if (topic == removedTopic) continue;
             foreach (var (nodeId, src) in list)
-                if (nodeId == key.Node && FlowMetricKey.Keys(src.Metric, src.Direction).Any(k => string.Equals(k, key.Metric, StringComparison.OrdinalIgnoreCase)))
+                if (nodeId == key.Node && FlowMetricKey.Keys(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction).Any(k => string.Equals(k, key.Metric, StringComparison.OrdinalIgnoreCase)))
                     return false;
         }
         return true;
@@ -245,7 +245,10 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             // value) writes both the out (positive part) and in (negative magnitude) keys. The 'in' key is
             // direction-qualified so it doesn't overwrite the out supply value, and — being a non-metric key —
             // is skipped by the grain sink below (Metrics.TryParse fails), keeping charge/export out of the flow.
-            foreach (var (key, v) in FlowMetricKey.Fan(src.Metric, src.Direction, value))
+            // A 'period' energy counter is reset by the device each day, so it already IS the daily total —
+            // store it under the daily metric rather than pretending it is cumulative and measuring its
+            // "rise", which loses the whole day every time the device rolls it over.
+            foreach (var (key, v) in FlowMetricKey.Fan(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction, value))
             {
                 cache.Set(nodeId, key, v, src.StaleAfterSeconds, nowUtc);
                 onReading?.Invoke(nodeId, key, v, src.StaleAfterSeconds);

--- a/rPDU2MQTT.Tests/DerivationTests.cs
+++ b/rPDU2MQTT.Tests/DerivationTests.cs
@@ -1,0 +1,144 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Provenance travels with the value. A figure conservation worked out is not wrong, but it is not a
+/// measurement either, and a diagram that renders the two identically is stating something it cannot back up.
+/// </summary>
+public class DerivationTests
+{
+    private sealed class Fixed : IFlowValueSource
+    {
+        private readonly Dictionary<string, double> v;
+        public Fixed(Dictionary<string, double> x) => v = x;
+        public bool TryGetValue(string node, string metric, out double value) => v.TryGetValue(node + "|" + metric, out value);
+    }
+
+    private static PduData Pdu(double watts)
+    {
+        var o = new Outlet { Key = 0, Entity_Name = "o0", Entity_DisplayName = "Load" };
+        o.Measurements.Add(new Measurement { Type = "realpower", Value = watts.ToString(), Units = "W" });
+        var d = new Device { Key = "pdu1", Entity_Name = "pdu1", Entity_DisplayName = "PDU 1" };
+        d.Outlets.Add(o);
+        var data = new PduData();
+        data.Devices.Add(d);
+        return data;
+    }
+
+    /// <summary>
+    /// feeder → panel → the metered PDU. Nothing measures the feeder.
+    /// <paramref name="alternative"/> adds a second, inert feeder into the panel, which is what turns the
+    /// back-fill from a roll-up (one possible route) into an attribution (a choice between routes) — the
+    /// shape that credited a PV array with the whole house load after dark.
+    /// </summary>
+    private static EnergyFlowConfig Topology(bool infer = true, bool alternative = false)
+    {
+        var c = new EnergyFlowConfig { InferFromConservation = infer };
+        c.Nodes.Add(new EnergyFlowNode { Id = "feeder", Kind = "grid" });
+        c.Nodes.Add(new EnergyFlowNode { Id = "panel", Kind = "panel" });
+        c.Links.Add(new EnergyFlowLink { From = "feeder", To = "panel" });
+        c.Links.Add(new EnergyFlowLink { From = "panel", To = "pdu:pdu1" });
+        if (alternative)
+        {
+            c.Nodes.Add(new EnergyFlowNode { Id = "solar", Kind = "solar", Mode = "none" });
+            c.Links.Add(new EnergyFlowLink { From = "solar", To = "panel" });
+        }
+        return c;
+    }
+
+    private static FlowNode Node(FlowGraph g, string id) => g.Nodes.Single(n => n.Id == id);
+
+    [Fact]
+    public void AMeasuredNode_SaysSo()
+    {
+        var g = FlowGraphBuilder.Build(Pdu(700), Topology(), "realpower",
+            new Fixed(new() { ["feeder|realpower"] = 700 }));
+
+        Assert.Equal(FlowDerivation.Measured, Node(g, "feeder").Derivation);
+        Assert.Equal(FlowDerivation.Measured, Node(g, "outlet:pdu1:0").Derivation);
+    }
+
+    [Fact]
+    public void ARollUpOfMeasuredChildren_IsSummed_NotInferred()
+    {
+        // A PDU's total is real because its outlets are. Worth distinguishing from a back-fill.
+        var g = FlowGraphBuilder.Build(Pdu(700), Topology(), "realpower",
+            new Fixed(new() { ["feeder|realpower"] = 700 }));
+
+        Assert.Equal(FlowDerivation.Summed, Node(g, "pdu:pdu1").Derivation);
+    }
+
+    [Fact]
+    public void AnAttributionAmongAlternatives_IsLabelledInferred()
+    {
+        // Two feeders into the panel, one ruled out. The 700 W really was drawn, but saying it came through
+        // *this* feeder is a claim about the hierarchy, not a reading — so it is labelled as one.
+        var g = FlowGraphBuilder.Build(Pdu(700), Topology(alternative: true), "realpower", new Fixed(new()));
+
+        var feeder = Node(g, "feeder");
+        Assert.Equal(700, feeder.Value);
+        Assert.Equal(FlowDerivation.Inferred, feeder.Derivation);
+    }
+
+    [Fact]
+    public void ASoleRoute_IsARollUp_NotAnInference()
+    {
+        // One feeder is not a choice: the demand arrives by the only route there is. Labelling that inferred
+        // would put the warning on most of the diagram and train people to ignore it.
+        var g = FlowGraphBuilder.Build(Pdu(700), Topology(), "realpower", new Fixed(new()));
+
+        Assert.Equal(700, Node(g, "feeder").Value);
+        Assert.Equal(FlowDerivation.Summed, Node(g, "feeder").Derivation);
+    }
+
+    [Fact]
+    public void WithInferenceOff_TheAttributionIsNotMade_AndNothingIsFabricatedTheOtherWay()
+    {
+        var g = FlowGraphBuilder.Build(Pdu(700), Topology(infer: false, alternative: true), "realpower", new Fixed(new()));
+
+        var feeder = Node(g, "feeder");
+        Assert.Null(feeder.Value);
+        Assert.Equal(FlowDerivation.Unknown, feeder.Derivation);
+        Assert.False(g.Links.Single(l => l.Source == "feeder" && l.Target == "panel").Known);
+    }
+
+    [Fact]
+    public void WithInferenceOff_PlainRollUpsStillWork()
+    {
+        // The switch governs attribution, not arithmetic. Blanking out every PDU total would make it
+        // unusable, and nobody would find out until their dashboards went empty.
+        var g = FlowGraphBuilder.Build(Pdu(700), Topology(infer: false), "realpower", new Fixed(new()));
+
+        Assert.Equal(700, Node(g, "pdu:pdu1").Value);
+        Assert.Equal(700, Node(g, "feeder").Value);
+    }
+
+    [Fact]
+    public void WithInferenceOff_MeasuredNodesAreUnaffected()
+    {
+        // The switch governs inference only. Anything actually metered keeps reporting.
+        var g = FlowGraphBuilder.Build(Pdu(700), Topology(infer: false), "realpower",
+            new Fixed(new() { ["feeder|realpower"] = 700 }));
+
+        Assert.Equal(700, Node(g, "feeder").Value);
+        Assert.Equal(FlowDerivation.Measured, Node(g, "feeder").Derivation);
+        Assert.Equal(700, Node(g, "pdu:pdu1").Value);
+    }
+
+    [Fact]
+    public void AnUnknownNode_IsNeverLabelledAsAnythingElse()
+    {
+        var c = Topology();
+        c.Nodes.Add(new EnergyFlowNode { Id = "orphan", Kind = "node", Mode = "none" });
+        c.Links.Add(new EnergyFlowLink { From = "orphan", To = "panel" });
+
+        var g = FlowGraphBuilder.Build(Pdu(700), c, "realpower", new Fixed(new()));
+
+        Assert.Equal(FlowDerivation.Unknown, Node(g, "orphan").Derivation);
+        Assert.Null(Node(g, "orphan").Value);
+    }
+}

--- a/rPDU2MQTT.Tests/PeriodAccumulationTests.cs
+++ b/rPDU2MQTT.Tests/PeriodAccumulationTests.cs
@@ -1,0 +1,68 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Counters the device resets each day, as opposed to cumulative ones. One publisher does both — Solar
+/// Assistant's <c>total/load_energy</c> is cumulative while <c>total/pv_energy</c> rolls over at midnight —
+/// so which it is cannot be inferred and has to be declared.
+/// </summary>
+public class PeriodAccumulationTests
+{
+    [Fact]
+    public void ADailyCounter_IsStoredAsTheDailyTotal_NotAsLifetimeEnergy()
+    {
+        // The reading already IS today's total, so it goes straight to the metric that means that. Measuring
+        // its "rise" instead is what reported 2.76 kWh of solar against 27.4 kWh actually generated: the
+        // counter dropped to zero at midnight and climbed again unobserved, and the next reading was
+        // measured against yesterday's high-water mark.
+        Assert.Equal(EnergyPeriod.Metric, FlowMetricKey.ForAccumulation("energy", "period"));
+        Assert.Equal("energy", FlowMetricKey.ForAccumulation("energy", "lifetime"));
+        Assert.Equal("energy", FlowMetricKey.ForAccumulation("energy", null));
+    }
+
+    [Fact]
+    public void OnlyEnergyAccumulates()
+    {
+        // Power, current and the rest are instantaneous — there is no counter to reset, so the setting is
+        // meaningless for them and must not silently redirect them somewhere strange.
+        Assert.Equal("realpower", FlowMetricKey.ForAccumulation("realpower", "period"));
+        Assert.Equal("voltage", FlowMetricKey.ForAccumulation("voltage", "period"));
+        Assert.Equal("soc", FlowMetricKey.ForAccumulation("soc", "period"));
+    }
+
+    [Fact]
+    public void ADailyCounter_StillSplitsIntoBothDirections()
+    {
+        // A battery publishing separate daily charge/discharge totals must keep them apart, exactly as the
+        // cumulative pair does.
+        var keys = FlowMetricKey.Keys(FlowMetricKey.ForAccumulation("energy", "period"), "in").ToList();
+        Assert.Equal(new[] { EnergyPeriod.Metric + FlowMetricKey.InSuffix }, keys);
+
+        var fanned = FlowMetricKey.Fan(FlowMetricKey.ForAccumulation("energy", "period"), "out", 27.4).ToList();
+        Assert.Equal(EnergyPeriod.Metric, fanned.Single().Key);
+        Assert.Equal(27.4, fanned.Single().Value);
+    }
+
+    [Fact]
+    public void TheDeclaredDailyFigure_ReachesTheGraph_AndIsNotOverriddenByADerivedOne()
+    {
+        // A real reading always beats a computed one: the composite takes the first source with a value and
+        // the derived accumulator is registered last. This is what makes the declared counter authoritative.
+        var real = new Stub(new() { ["solar|" + EnergyPeriod.Metric] = 27.4 });
+        var derived = new Stub(new() { ["solar|" + EnergyPeriod.Metric] = 2.76 });
+
+        var composite = new CompositeFlowValueSource(real, derived);
+
+        Assert.True(composite.TryGetValue("solar", EnergyPeriod.Metric, out var v));
+        Assert.Equal(27.4, v);
+    }
+
+    private sealed class Stub : IFlowValueSource
+    {
+        private readonly Dictionary<string, double> v;
+        public Stub(Dictionary<string, double> x) => v = x;
+        public bool TryGetValue(string node, string metric, out double value) => v.TryGetValue(node + "|" + metric, out value);
+    }
+}

--- a/rPDU2MQTT.Tests/UnavailableFeederTests.cs
+++ b/rPDU2MQTT.Tests/UnavailableFeederTests.cs
@@ -1,0 +1,110 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// "Unmeasured" and "unavailable" are not the same thing. Reconstructed from the live system that showed
+/// 5.81 A of solar generation after dark, which was the whole house load back-filled from the PDU totals and
+/// attributed to a PV array in the night because its feed had stopped reporting.
+/// </summary>
+public class UnavailableFeederTests
+{
+    private sealed class Fixed : IFlowValueSource
+    {
+        private readonly Dictionary<string, double> v;
+        public Fixed(Dictionary<string, double> x) => v = x;
+        public bool TryGetValue(string node, string metric, out double value) => v.TryGetValue(node + "|" + metric, out value);
+    }
+
+    /// <summary>solar + grid feed the inverter, which feeds the panel, which feeds a metered load.</summary>
+    private static EnergyFlowConfig Topology(bool solarHasSource = true, bool gridInert = true)
+    {
+        var c = new EnergyFlowConfig();
+        var solar = new EnergyFlowNode { Id = "solar", Kind = "solar" };
+        if (solarHasSource)
+            solar.Sources.Add(new EnergyFlowSource { Type = "mqtt", Metric = "realpower", Topic = "sa/pv_power" });
+        c.Nodes.Add(solar);
+        c.Nodes.Add(new EnergyFlowNode { Id = "grid", Kind = "grid", Mode = gridInert ? "none" : "auto" });
+        c.Nodes.Add(new EnergyFlowNode { Id = "inverter", Kind = "inverter" });
+        c.Nodes.Add(new EnergyFlowNode { Id = "panel", Kind = "panel" });
+        c.Links.Add(new EnergyFlowLink { From = "solar", To = "inverter" });
+        c.Links.Add(new EnergyFlowLink { From = "grid", To = "inverter" });
+        c.Links.Add(new EnergyFlowLink { From = "inverter", To = "panel" });
+        c.Links.Add(new EnergyFlowLink { From = "panel", To = "pdu:pdu1" });
+        return c;
+    }
+
+    private static PduData Pdu(double watts)
+    {
+        var o = new Outlet { Key = 0, Entity_Name = "o0", Entity_DisplayName = "Load" };
+        o.Measurements.Add(new Measurement { Type = "realpower", Value = watts.ToString(), Units = "W" });
+        o.Measurements.Add(new Measurement { Type = "apparentpower", Value = watts.ToString(), Units = "VA" });
+        var d = new Device { Key = "pdu1", Entity_Name = "pdu1", Entity_DisplayName = "PDU 1" };
+        d.Outlets.Add(o);
+        var data = new PduData();
+        data.Devices.Add(d);
+        return data;
+    }
+
+    [Fact]
+    public void ASolarNodeWhoseFeedIsDead_DoesNotGetCreditedWithTheWholeHouseLoad()
+    {
+        // Solar has a realpower source bound and it is reporting nothing. Grid is Mode:none, so solar was
+        // the only remaining candidate and conservation handed it the entire load — 5.81 A of generation
+        // after dark, on the diagram whose whole purpose is to be accurate.
+        var graph = FlowGraphBuilder.Build(Pdu(700), Topology(), "realpower", new Fixed(new()));
+
+        var solar = graph.Nodes.Single(n => n.Id == "solar");
+        Assert.Null(solar.Value);   // unknown, not "whatever balances the equation"
+
+        var link = graph.Links.Single(l => l.Source == "solar" && l.Target == "inverter");
+        Assert.False(link.Known);   // drawn as no-data, so the failed feed is visible
+        Assert.Equal(0, link.Value);
+    }
+
+    [Fact]
+    public void AZeroReading_IsStillHonoured_BecauseSolarAtNightGenuinelyGeneratesNothing()
+    {
+        // The distinction that matters: a source reporting 0 is a measurement. It must keep making solar a
+        // measured producer supplying nothing, not revert it to an inferable unknown.
+        var graph = FlowGraphBuilder.Build(Pdu(700), Topology(), "realpower",
+            new Fixed(new() { ["solar|realpower"] = 0 }));
+
+        Assert.Equal(0, graph.Nodes.Single(n => n.Id == "solar").Value);
+    }
+
+    [Fact]
+    public void AReportingSolarNode_SuppliesItsRealFigure_Unchanged()
+    {
+        var graph = FlowGraphBuilder.Build(Pdu(700), Topology(), "realpower",
+            new Fixed(new() { ["solar|realpower"] = 900 }));
+
+        Assert.Equal(900, graph.Nodes.Single(n => n.Id == "solar").Value);
+        Assert.True(graph.Links.Single(l => l.Source == "solar" && l.Target == "inverter").Known);
+    }
+
+    [Fact]
+    public void ANodeWithNoSourceBoundAtAll_CanStillBeInferred()
+    {
+        // The rule must not kill legitimate inference. A node nothing was ever going to measure, with exactly
+        // one path for the load to arrive by, really is determined by conservation — that is the whole point
+        // of the single-unmeasured-feeder rule and it stays.
+        var graph = FlowGraphBuilder.Build(Pdu(700), Topology(solarHasSource: false), "realpower", new Fixed(new()));
+
+        Assert.Equal(700, graph.Nodes.Single(n => n.Id == "solar").Value);
+    }
+
+    [Fact]
+    public void ABindingForADifferentMetric_IsNotAFailureToReportThisOne()
+    {
+        // Solar is bound for realpower only. Viewed in apparentpower it was never asked to report, so it is
+        // unmeasured rather than unavailable and inference applies as before.
+        var graph = FlowGraphBuilder.Build(
+            Pdu(700), Topology(), "apparentpower", new Fixed(new()));
+
+        Assert.NotNull(graph.Nodes.Single(n => n.Id == "solar").Value);
+    }
+}

--- a/rPDU2MQTT.Web/web/schema.fixture.json
+++ b/rPDU2MQTT.Web/web/schema.fixture.json
@@ -2077,6 +2077,19 @@
                     ]
                   },
                   {
+                    "key": "Accumulation",
+                    "label": "Accumulation",
+                    "description": "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight.",
+                    "type": "enum",
+                    "required": false,
+                    "default": "lifetime",
+                    "enumValues": [
+                      "",
+                      "lifetime",
+                      "period"
+                    ]
+                  },
+                  {
                     "key": "Direction",
                     "label": "Direction",
                     "description": "Which way energy flows for this source, relative to the node: 'out' (default — battery discharge, grid import, solar production), 'in' (battery charge, grid export), or 'split' — one signed value fanned into both directions, positive as out and the magnitude of negative as in (for a single ± power/current topic or register). Only meaningful for directional metrics (realpower, apparentpower, current, energy); ignored for voltage/frequency/powerfactor/soc.",
@@ -2230,6 +2243,19 @@
                       "frequency",
                       "powerfactor",
                       "soc"
+                    ]
+                  },
+                  {
+                    "key": "Accumulation",
+                    "label": "Accumulation",
+                    "description": "Whether this counter runs forever or restarts each day: 'lifetime' (default — a cumulative total whose rise is measured) or 'period' (the device resets it daily, so the reading already is today's total). Only meaningful for energy. Solar Assistant mixes both: total/load_energy is lifetime, total/pv_energy resets at midnight.",
+                    "type": "enum",
+                    "required": false,
+                    "default": "lifetime",
+                    "enumValues": [
+                      "",
+                      "lifetime",
+                      "period"
                     ]
                   },
                   {

--- a/rPDU2MQTT.Web/web/schema.fixture.json
+++ b/rPDU2MQTT.Web/web/schema.fixture.json
@@ -2477,6 +2477,14 @@
         "keyType": "string"
       },
       {
+        "key": "InferFromConservation",
+        "label": "InferFromConservation",
+        "description": "Work out an unmeasured node's value from what it feeds, when exactly one path could have supplied it. Sound arithmetic, but it describes the hierarchy you drew rather than anything measured — so results are always labelled 'inferred'. Turn it off to show 'no data' instead.",
+        "type": "bool",
+        "required": false,
+        "default": true
+      },
+      {
         "key": "MqttExport",
         "label": "MqttExport",
         "description": "Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.",

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -442,7 +442,7 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
       Invert: 'Flip the sign of a power or current reading — for a source that publishes export/discharge as positive when your hierarchy wants it negative (or vice versa).',
       Current: LIVE_HINT,
     };
-    ['Type', 'Metric', ...(bidirectional ? ['Direction'] : []), 'Unit', 'Source', 'Details', 'Scale', 'Invert', 'Current', ''].forEach(h => {
+    ['Type', 'Metric', ...(bidirectional ? ['Direction'] : []), 'Counter', 'Unit', 'Source', 'Details', 'Scale', 'Invert', 'Current', ''].forEach(h => {
       const th = el('th', { text: h });
       if (colHint[h]) th.title = colHint[h];
       head.appendChild(th);
@@ -500,6 +500,27 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
           cell.appendChild(dirSel);
         } else {
           cell.appendChild(el('span', { text: '—', style: { color: 'var(--muted)' }, title: 'Direction doesn’t apply to this metric.' }));
+        }
+        tr.appendChild(cell);
+      }
+
+      // Does this counter run forever, or does the device reset it every day? Only energy accumulates, so
+      // every other metric's cell stays blank. Getting it wrong is silent and expensive: measuring the
+      // "rise" of a counter the device resets at midnight loses the whole day, because it drops to zero and
+      // climbs again unobserved. One publisher can do both — Solar Assistant's total/load_energy is
+      // cumulative while total/pv_energy resets — so it cannot be inferred from the source.
+      {
+        const cell = el('td');
+        if (metric === 'energy') {
+          const accSel = el('select', { style: { width: 'auto' } });
+          [['lifetime', 'Lifetime'], ['period', 'Daily']].forEach(([v, t]) => accSel.appendChild(el('option', { value: v, text: t })));
+          accSel.value = src.Accumulation === 'period' ? 'period' : 'lifetime';
+          accSel.title = 'Lifetime: a cumulative total that only rises; its daily figure is its rise since midnight. '
+            + 'Daily: the device resets this counter itself, so the reading already is today\u2019s total and is used as-is.';
+          accSel.onchange = () => { src.Accumulation = accSel.value === 'lifetime' ? undefined : accSel.value; refreshDirty(); };
+          cell.appendChild(accSel);
+        } else {
+          cell.appendChild(el('span', { text: '\u2014', style: { color: 'var(--muted)' }, title: 'Only energy accumulates; this metric is instantaneous.' }));
         }
         tr.appendChild(cell);
       }

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1527,7 +1527,12 @@ export function addFlowSection(nav: any, sections: any) {
         'dominant-baseline': 'middle', 'paint-order': 'stroke', stroke: 'var(--panel2)', 'stroke-width': '3', 'stroke-linejoin': 'round',
         'data-node': n.id,
       });
-      lab.textContent = unknownNode ? `${n.label} · no data` : `${n.label} · ${formatNum(nodeValue(n.id))} ${units}`;
+      // An inferred figure is never dressed as a measured one. It is arithmetic about the hierarchy someone
+      // drew — sound, but not something anything metered — so it says so on its face, in the one place the
+      // number is actually read.
+      const inferredNode = n.derivation === 'inferred';
+      lab.textContent = unknownNode ? `${n.label} · no data`
+        : `${n.label} · ${formatNum(nodeValue(n.id))} ${units}${inferredNode ? ' · inferred' : ''}`;
       if (unknownNode) {
         lab.setAttribute('fill', 'var(--muted)');
         lab.setAttribute('font-style', 'italic');
@@ -1537,6 +1542,16 @@ export function addFlowSection(nav: any, sections: any) {
       }
       // More leaves this node than arrives at it — not a state the hardware can be in, so say so on the
       // diagram instead of drawing the larger number at full height and letting it look intentional.
+      else if (inferredNode) {
+        lab.setAttribute('font-style', 'italic');
+        lab.setAttribute('fill-opacity', '0.85');
+        const why = svgEl('title');
+        why.textContent = 'Nothing measures this node. The figure is what conservation requires: the load '
+          + 'downstream is really being drawn, and the hierarchy you drew leaves exactly one path it could '
+          + 'have arrived by. It is only as true as that hierarchy. Bind a source to measure it, or turn off '
+          + '"Infer from a single supply path" under Energy roll-up to show no data instead.';
+        lab.appendChild(why);
+      }
       else if (n.imbalance != null) {
         lab.textContent += ' ⚠';
         const why = svgEl('title');
@@ -1561,6 +1576,12 @@ export function addFlowSection(nav: any, sections: any) {
         rows.push(el('div', { class: 'nh-value' + (unknownNode ? ' nh-unknown' : '') },
           unknownNode ? 'no data' : `${formatNum(nodeValue(n.id))} ${units}`.trim(),
           el('span', { class: 'nh-metric', text: ' ' + metricLabel(metricSel.value).toLowerCase() })));
+        // Provenance sits with the value, not in a legend somewhere else.
+        if (!unknownNode && n.derivation && n.derivation !== 'measured')
+          rows.push(el('div', { class: n.derivation === 'inferred' ? 'nh-warn' : 'desc', style: { margin: '2px 0 0' } },
+            n.derivation === 'inferred'
+              ? 'inferred — nothing measures this; conservation leaves one path it could have come by'
+              : 'summed from what it feeds'));
         if (n.imbalance != null)
           rows.push(el('div', { class: 'nh-warn', text: `${formatNum(n.imbalance)} ${units} more leaves than arrives` }));
 
@@ -1731,6 +1752,16 @@ export function addFlowSection(nav: any, sections: any) {
         clock.style.color = 'var(--warn, #d08700)';
       }
     }).catch(() => { });
+
+    // Conservation back-fill. A switch you can see, because it is the one place the diagram states a number
+    // nothing measured — sound arithmetic about the hierarchy you drew, and only as true as that hierarchy.
+    const inferRow = el('div', { class: 'desc' }) as HTMLElement;
+    const inferChk = el('input', { type: 'checkbox' }) as HTMLInputElement;
+    inferChk.checked = flow.InferFromConservation !== false;   // defaults on
+    inferChk.onchange = () => { flow.InferFromConservation = inferChk.checked ? undefined : false; refreshDirty(); };
+    inferRow.append(el('label', {}, inferChk,
+      ' Infer from a single supply path — fill in an unmeasured node from what it feeds, when only one path could have supplied it. Results are labelled “inferred”; off shows “no data”.'));
+    ed.appendChild(inferRow);
 
     // The aggregation settings are saved by the same Save button as the hierarchy (it posts the whole config).
     const aggIntegrate = el('div', { class: 'desc' }) as HTMLElement;

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2954,7 +2954,12 @@ function addFlowSection(nav     , sections     ) {
         'dominant-baseline': 'middle', 'paint-order': 'stroke', stroke: 'var(--panel2)', 'stroke-width': '3', 'stroke-linejoin': 'round',
         'data-node': n.id,
       });
-      lab.textContent = unknownNode ? `${n.label} · no data` : `${n.label} · ${formatNum(nodeValue(n.id))} ${units}`;
+      // An inferred figure is never dressed as a measured one. It is arithmetic about the hierarchy someone
+      // drew — sound, but not something anything metered — so it says so on its face, in the one place the
+      // number is actually read.
+      const inferredNode = n.derivation === 'inferred';
+      lab.textContent = unknownNode ? `${n.label} · no data`
+        : `${n.label} · ${formatNum(nodeValue(n.id))} ${units}${inferredNode ? ' · inferred' : ''}`;
       if (unknownNode) {
         lab.setAttribute('fill', 'var(--muted)');
         lab.setAttribute('font-style', 'italic');
@@ -2964,6 +2969,16 @@ function addFlowSection(nav     , sections     ) {
       }
       // More leaves this node than arrives at it — not a state the hardware can be in, so say so on the
       // diagram instead of drawing the larger number at full height and letting it look intentional.
+      else if (inferredNode) {
+        lab.setAttribute('font-style', 'italic');
+        lab.setAttribute('fill-opacity', '0.85');
+        const why = svgEl('title');
+        why.textContent = 'Nothing measures this node. The figure is what conservation requires: the load '
+          + 'downstream is really being drawn, and the hierarchy you drew leaves exactly one path it could '
+          + 'have arrived by. It is only as true as that hierarchy. Bind a source to measure it, or turn off '
+          + '"Infer from a single supply path" under Energy roll-up to show no data instead.';
+        lab.appendChild(why);
+      }
       else if (n.imbalance != null) {
         lab.textContent += ' ⚠';
         const why = svgEl('title');
@@ -2988,6 +3003,12 @@ function addFlowSection(nav     , sections     ) {
         rows.push(el('div', { class: 'nh-value' + (unknownNode ? ' nh-unknown' : '') },
           unknownNode ? 'no data' : `${formatNum(nodeValue(n.id))} ${units}`.trim(),
           el('span', { class: 'nh-metric', text: ' ' + metricLabel(metricSel.value).toLowerCase() })));
+        // Provenance sits with the value, not in a legend somewhere else.
+        if (!unknownNode && n.derivation && n.derivation !== 'measured')
+          rows.push(el('div', { class: n.derivation === 'inferred' ? 'nh-warn' : 'desc', style: { margin: '2px 0 0' } },
+            n.derivation === 'inferred'
+              ? 'inferred — nothing measures this; conservation leaves one path it could have come by'
+              : 'summed from what it feeds'));
         if (n.imbalance != null)
           rows.push(el('div', { class: 'nh-warn', text: `${formatNum(n.imbalance)} ${units} more leaves than arrives` }));
 
@@ -3158,6 +3179,16 @@ function addFlowSection(nav     , sections     ) {
         clock.style.color = 'var(--warn, #d08700)';
       }
     }).catch(() => { });
+
+    // Conservation back-fill. A switch you can see, because it is the one place the diagram states a number
+    // nothing measured — sound arithmetic about the hierarchy you drew, and only as true as that hierarchy.
+    const inferRow = el('div', { class: 'desc' })               ;
+    const inferChk = el('input', { type: 'checkbox' })                    ;
+    inferChk.checked = flow.InferFromConservation !== false;   // defaults on
+    inferChk.onchange = () => { flow.InferFromConservation = inferChk.checked ? undefined : false; refreshDirty(); };
+    inferRow.append(el('label', {}, inferChk,
+      ' Infer from a single supply path — fill in an unmeasured node from what it feeds, when only one path could have supplied it. Results are labelled “inferred”; off shows “no data”.'));
+    ed.appendChild(inferRow);
 
     // The aggregation settings are saved by the same Save button as the hierarchy (it posts the whole config).
     const aggIntegrate = el('div', { class: 'desc' })               ;

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1870,7 +1870,7 @@ function renderNodeEditor(node     , links       , cand                  , reren
       Invert: 'Flip the sign of a power or current reading — for a source that publishes export/discharge as positive when your hierarchy wants it negative (or vice versa).',
       Current: LIVE_HINT,
     };
-    ['Type', 'Metric', ...(bidirectional ? ['Direction'] : []), 'Unit', 'Source', 'Details', 'Scale', 'Invert', 'Current', ''].forEach(h => {
+    ['Type', 'Metric', ...(bidirectional ? ['Direction'] : []), 'Counter', 'Unit', 'Source', 'Details', 'Scale', 'Invert', 'Current', ''].forEach(h => {
       const th = el('th', { text: h });
       if (colHint[h]) th.title = colHint[h];
       head.appendChild(th);
@@ -1928,6 +1928,27 @@ function renderNodeEditor(node     , links       , cand                  , reren
           cell.appendChild(dirSel);
         } else {
           cell.appendChild(el('span', { text: '—', style: { color: 'var(--muted)' }, title: 'Direction doesn’t apply to this metric.' }));
+        }
+        tr.appendChild(cell);
+      }
+
+      // Does this counter run forever, or does the device reset it every day? Only energy accumulates, so
+      // every other metric's cell stays blank. Getting it wrong is silent and expensive: measuring the
+      // "rise" of a counter the device resets at midnight loses the whole day, because it drops to zero and
+      // climbs again unobserved. One publisher can do both — Solar Assistant's total/load_energy is
+      // cumulative while total/pv_energy resets — so it cannot be inferred from the source.
+      {
+        const cell = el('td');
+        if (metric === 'energy') {
+          const accSel = el('select', { style: { width: 'auto' } });
+          [['lifetime', 'Lifetime'], ['period', 'Daily']].forEach(([v, t]) => accSel.appendChild(el('option', { value: v, text: t })));
+          accSel.value = src.Accumulation === 'period' ? 'period' : 'lifetime';
+          accSel.title = 'Lifetime: a cumulative total that only rises; its daily figure is its rise since midnight. '
+            + 'Daily: the device resets this counter itself, so the reading already is today\u2019s total and is used as-is.';
+          accSel.onchange = () => { src.Accumulation = accSel.value === 'lifetime' ? undefined : accSel.value; refreshDirty(); };
+          cell.appendChild(accSel);
+        } else {
+          cell.appendChild(el('span', { text: '\u2014', style: { color: 'var(--muted)' }, title: 'Only energy accumulates; this metric is instantaneous.' }));
         }
         tr.appendChild(cell);
       }


### PR DESCRIPTION
Supersedes #316 and #317 — all three answer the same complaint, so they're one PR.

Two rules, applied to everything the flow computes.

## 1. Never show inaccurate data

A figure conservation worked out isn't *wrong*, but it isn't a measurement either — it's a statement about a hierarchy someone drew, only as true as that hierarchy. Rendering it identically to a metered reading is how the diagram credited a PV array with **5.81 A after dark** and said it with a straight face.

`FlowNode` now carries `Derivation` — `measured` / `summed` / `inferred` / `unknown` — so provenance travels with the value to every consumer. On the chart an inferred node renders italic and labelled `· inferred`, with the reasoning in the hover card. `summed` is kept distinct from `measured` on purpose: a PDU's total is real, but it's real *because* its outlets are.

## 2. No mystery functions

Anything that computes rather than reads is a switch you can see, on the **Flow** tab under *Energy roll-up*:

| Switch | What it does | Default |
| --- | --- | --- |
| Derive kWh from power | Integrates watts for nodes with no energy counter. An estimate — a real energy source always wins. | Off |
| Infer from a single supply path | Fills in an unmeasured node from what it feeds, when only one of several routes could have supplied it. | On |

Both state what they do in the control itself, not in a doc somewhere.

### The distinction that took two failing tests to get right

**One feeder is not an inference.** A PDU's total is its outlets' demand arriving by the only route there is; labelling that "inferred" would put a warning on most of the diagram and train people to ignore it. **Several feeders with all but one ruled out** — by `Mode: none`, or by a source going silent — is an *attribution*, and that's what gets labelled and what the switch governs.

Getting this wrong first also meant turning inference off blanked every PDU total. That would have shipped as an empty dashboard.

## Folded in

- **#316** — a counter the device resets daily is no longer mistaken for a lifetime one. SA's `total/pv_energy` rolls over at midnight while `total/load_energy` doesn't, so measuring its "rise" reported **2.76 kWh against 27.4 kWh** actually generated. Sources declare `Accumulation: lifetime | period`, shown as a **Counter** column on the Nodes tab.
- **#317** — a dead feed is not a licence to invent generation. A node with a source bound and nothing coming out of it is *unavailable*, not *unmeasured*: it can't absorb a remainder, and its links draw as no-data so the failure is visible.

525 tests pass; CRDs and schema fixture regenerated; GUI smoke/layout/sankey checks pass.

Closes #316, closes #317. Refs #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)