### PR TITLE
The direction audit no longer cries wolf at a grid doing its job

### DIFF
--- a/rPDU2MQTT.Core/Flow/DirectionAudit.cs
+++ b/rPDU2MQTT.Core/Flow/DirectionAudit.cs
@@ -27,48 +27,57 @@ namespace rPDU2MQTT.Core.Flow;
 public static class DirectionAudit
 {
     /// <summary>
-    /// Does the sign of <paramref name="powerOut"/>/<paramref name="powerIn"/> disagree with what the day's
-    /// energy counters say the node has actually been doing?
+    /// Does the sign of <paramref name="powerOut"/>/<paramref name="powerIn"/> disagree with which of the
+    /// node's energy counters has actually been rising?
     ///
     /// <para>
-    /// True only when the disagreement is unambiguous: one direction of power is live and non-trivial, the
-    /// energy counters clearly favour the other direction, and neither figure is small enough to be noise.
-    /// A battery that is genuinely idle, or one that has done a bit of both today, is not evidence of
-    /// anything and must not raise a warning that then gets ignored.
+    /// The comparison is against a <b>recent window</b>, not against the day. A grid connection and a battery
+    /// both reverse direction as a matter of course — importing overnight and exporting at noon, discharging
+    /// in the evening and charging in the morning — so "the day was mostly import" says nothing about which
+    /// way the power is going right now. An earlier version compared against the day's totals and duly
+    /// warned about a grid that was exporting 150 W on an otherwise import-heavy afternoon, which was simply
+    /// the truth. A warning that fires on normal behaviour is worse than no warning: it gets ignored, and
+    /// then the real one gets ignored too.
+    /// </para>
+    /// <para>
+    /// The counters are the honest witness because they are explicit — separate topics for in and out, no
+    /// sign convention to get backwards. If the out counter is the one climbing while the power source
+    /// insists energy is flowing in, those two cannot both be describing the same interval.
     /// </para>
     /// </summary>
     /// <param name="powerOut">Power the node is supplying right now (the <c>out</c> lane), in W.</param>
     /// <param name="powerIn">Power the node is drawing right now (the <c>in</c> lane), in W.</param>
-    /// <param name="energyOutToday">Energy supplied so far this period, kWh.</param>
-    /// <param name="energyInToday">Energy drawn so far this period, kWh.</param>
-    public static bool LooksInverted(double powerOut, double powerIn, double energyOutToday, double energyInToday)
+    /// <param name="outRiseKWh">How much the out counter rose across the comparison window.</param>
+    /// <param name="inRiseKWh">How much the in counter rose across the comparison window.</param>
+    public static bool LooksInverted(double powerOut, double powerIn, double outRiseKWh, double inRiseKWh)
     {
-        // Below this a reading is noise, not a direction: a few watts of standby, a few Wh of rounding.
+        // Below this a power reading is standby noise, not a direction.
         const double PowerFloor = 50;      // W
-        const double EnergyFloor = 0.5;    // kWh
-        // How lopsided the day has to be before it counts as evidence. A battery that cycled both ways today
-        // says nothing about which way it is going right now.
-        const double Ratio = 5;
+        // Counters publish at coarse resolution (often 0.1 kWh), so a window has to have moved by more than
+        // one tick before its direction means anything.
+        const double RiseFloor = 0.15;     // kWh
+        // How one-sided the window must be. Both counters moving means the node reversed inside it, which is
+        // normal and tells us nothing.
+        const double Ratio = 4;
 
         var flowingOut = powerOut > PowerFloor && powerIn <= PowerFloor;
         var flowingIn = powerIn > PowerFloor && powerOut <= PowerFloor;
         if (!flowingOut && !flowingIn) return false;
 
-        var dayWasIn = energyInToday > EnergyFloor && energyInToday > energyOutToday * Ratio;
-        var dayWasOut = energyOutToday > EnergyFloor && energyOutToday > energyInToday * Ratio;
+        var roseIn = inRiseKWh > RiseFloor && inRiseKWh > outRiseKWh * Ratio;
+        var roseOut = outRiseKWh > RiseFloor && outRiseKWh > inRiseKWh * Ratio;
 
-        // Power says one way, the whole day's metered energy says the other.
-        return (flowingOut && dayWasIn) || (flowingIn && dayWasOut);
+        // Power says one way; the counter that actually moved over the same window says the other.
+        return (flowingOut && roseIn) || (flowingIn && roseOut);
     }
 
     /// <summary>The warning to log for a node whose convention looks inverted. Shaped as an instruction,
     /// because the operator can fix it in one field and otherwise has no way to know.</summary>
-    public static string Explain(string nodeId, double powerOut, double powerIn, double energyOutToday, double energyInToday)
+    public static string Explain(string nodeId, double powerOut, double powerIn, double outRiseKWh, double inRiseKWh)
         => $"Node '{nodeId}': its split power source reads "
          + (powerOut > powerIn ? $"{powerOut:0} W flowing OUT (discharge/import)" : $"{powerIn:0} W flowing IN (charge/export)")
-         + $", but today's metered energy says the opposite — {energyInToday:0.##} kWh in against {energyOutToday:0.##} kWh out. "
-         + "The energy counters come from separate topics with no sign convention to get wrong, so the power "
-         + "source's sign is most likely inverted for this device. Set Scale: -1 on it. Until then a charging "
-         + "battery is counted as supplying the house rather than loading it, which roughly doubles its error "
-         + "on any total that includes it.";
+         + $", but over the same window the counters moved the other way — {inRiseKWh:0.##} kWh in against "
+         + $"{outRiseKWh:0.##} kWh out. The energy counters come from separate topics with no sign convention "
+         + "to get wrong, so this source's sign is most likely inverted for this device. Set Scale: -1 on it. "
+         + "Until then its contribution is counted on the wrong side of every total that includes it.";
 }

--- a/rPDU2MQTT.Engine/Services/EnergyAggregationService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyAggregationService.cs
@@ -205,7 +205,7 @@ public sealed class EnergyAggregationService : BackgroundService, IFlowValueSour
                 // against them. An inverted split convention is otherwise invisible — the diagram balances
                 // and the numbers look plausible; a charging battery just reads as discharging and gets
                 // added to the house total instead of subtracted. See DirectionAudit.
-                AuditDirection(id, next);
+                AuditDirection(id, next, now);
             }
         }
 
@@ -218,21 +218,48 @@ public sealed class EnergyAggregationService : BackgroundService, IFlowValueSour
     // Warned nodes, so a contradiction that persists is said once rather than every sampling pass.
     private readonly HashSet<string> warnedDirection = new(StringComparer.OrdinalIgnoreCase);
 
-    private void AuditDirection(string id, Dictionary<string, EnergyState> next)
+    /// <summary>
+    /// Where each node's counters stood at the start of the current comparison window.
+    ///
+    /// <para>
+    /// A window, not the day, because a grid connection and a battery both reverse direction as a matter of
+    /// course — importing overnight and exporting at noon — so what the day did says nothing about now.
+    /// Comparing against the day warned about a grid genuinely exporting 150 W on an import-heavy afternoon,
+    /// which is exactly the false positive that teaches people to ignore warnings.
+    /// </para>
+    /// </summary>
+    private readonly Dictionary<string, (DateTime At, double Out, double In)> directionWindow = new(StringComparer.OrdinalIgnoreCase);
+
+    // Long enough that a coarse counter (often 0.1 kWh resolution) has actually moved, short enough that the
+    // node has probably not reversed inside it.
+    private static readonly TimeSpan DirectionWindow = TimeSpan.FromMinutes(10);
+
+    private void AuditDirection(string id, Dictionary<string, EnergyState> next, DateTime now)
     {
+        var outNow = next.TryGetValue(id, out var o) ? o.KWh : 0;
+        var inNow = next.TryGetValue(id + FlowMetricKey.InSuffix, out var i) ? i.KWh : 0;
+
+        if (!directionWindow.TryGetValue(id, out var start))
+        {
+            directionWindow[id] = (now, outNow, inNow);
+            return;
+        }
+        if (now - start.At < DirectionWindow) return;
+        directionWindow[id] = (now, outNow, inNow);   // next window starts here either way
+
         if (!upstream.TryGetValue(id, PowerMetric, out var pOut)) return;
         upstream.TryGetValue(id, FlowMetricKey.For(PowerMetric, "in"), out var pIn);
 
-        var outToday = next.TryGetValue(id, out var o) ? o.PeriodKWh : 0;
-        var inToday = next.TryGetValue(id + FlowMetricKey.InSuffix, out var i) ? i.PeriodKWh : 0;
+        var outRise = Math.Max(0, outNow - start.Out);
+        var inRise = Math.Max(0, inNow - start.In);
 
-        if (!DirectionAudit.LooksInverted(pOut, pIn, outToday, inToday))
+        if (!DirectionAudit.LooksInverted(pOut, pIn, outRise, inRise))
         {
             warnedDirection.Remove(id);   // it agrees again; a later contradiction is worth saying afresh
             return;
         }
         if (warnedDirection.Add(id))
-            Log.Warning(DirectionAudit.Explain(id, pOut, pIn, outToday, inToday));
+            Log.Warning(DirectionAudit.Explain(id, pOut, pIn, outRise, inRise));
     }
 
     /// <summary>

--- a/rPDU2MQTT.Tests/DirectionAuditTests.cs
+++ b/rPDU2MQTT.Tests/DirectionAuditTests.cs
@@ -16,24 +16,24 @@ public class DirectionAuditTests
         // Solar Assistant publishes battery power positive while charging, so a battery taking 1.65 kW in was
         // drawn as 1.77 kW coming out — and home read 11.3 kW against an actual 7.0 kW. Today's metered
         // energy (11.7 kWh in, 0.1 kWh out) says charging, flatly contradicting the power sign.
-        Assert.True(DirectionAudit.LooksInverted(powerOut: 1771, powerIn: 0, energyOutToday: 0.1, energyInToday: 11.7));
+        Assert.True(DirectionAudit.LooksInverted(powerOut: 1771, powerIn: 0, outRiseKWh: 0.0, inRiseKWh: 0.9));
 
-        var msg = DirectionAudit.Explain("battery", 1771, 0, 0.1, 11.7);
+        var msg = DirectionAudit.Explain("battery", 1771, 0, 0.0, 0.9);
         Assert.Contains("Scale: -1", msg);
         Assert.Contains("battery", msg);
     }
 
     [Fact]
     public void TheOtherDirection_IsCaughtToo()
-        => Assert.True(DirectionAudit.LooksInverted(powerOut: 0, powerIn: 2000, energyOutToday: 14.0, energyInToday: 0.2));
+        => Assert.True(DirectionAudit.LooksInverted(powerOut: 0, powerIn: 2000, outRiseKWh: 1.4, inRiseKWh: 0.0));
 
     [Fact]
     public void AgreementIsNotAWarning()
     {
         // Discharging, and the day says discharging.
-        Assert.False(DirectionAudit.LooksInverted(1771, 0, 11.7, 0.1));
+        Assert.False(DirectionAudit.LooksInverted(1771, 0, 0.9, 0.0));
         // Charging, and the day says charging.
-        Assert.False(DirectionAudit.LooksInverted(0, 1771, 0.1, 11.7));
+        Assert.False(DirectionAudit.LooksInverted(0, 1771, 0.0, 0.9));
     }
 
     [Fact]
@@ -41,17 +41,34 @@ public class DirectionAuditTests
     {
         // A few watts of standby says nothing about direction, and a warning that fires on noise is a
         // warning that gets ignored.
-        Assert.False(DirectionAudit.LooksInverted(5, 0, 0.1, 11.7));
-        Assert.False(DirectionAudit.LooksInverted(0, 0, 0.1, 11.7));
+        Assert.False(DirectionAudit.LooksInverted(5, 0, 0.0, 0.9));
+        Assert.False(DirectionAudit.LooksInverted(0, 0, 0.0, 0.9));
     }
 
     [Fact]
-    public void ADayThatWentBothWays_IsNotEvidence()
+    public void AWindowThatWentBothWays_IsNotEvidence()
     {
-        // A battery that cycled today says nothing about which way it is going right now.
+        // Both counters moving means the node reversed inside the window, which is normal.
         Assert.False(DirectionAudit.LooksInverted(1771, 0, 6.0, 7.0));
-        // Nor does a day with almost no energy either way.
-        Assert.False(DirectionAudit.LooksInverted(1771, 0, 0.0, 0.2));
+        // Nor does a window in which almost nothing moved either way.
+        Assert.False(DirectionAudit.LooksInverted(1771, 0, 0.0, 0.05));
+    }
+
+    [Fact]
+    public void AGridExportingAtNoonOnAnImportHeavyDay_IsNotAFalsePositive()
+    {
+        // The live false positive. A grid exporting 150 W mid-afternoon after importing 25 kWh overnight is
+        // simply telling the truth, and warning about it teaches people to ignore warnings. Comparing against
+        // a recent window instead of the day is what fixes it: over the last ten minutes nothing was
+        // imported, so there is no contradiction to report.
+        Assert.False(DirectionAudit.LooksInverted(powerOut: 0, powerIn: 150, outRiseKWh: 0.0, inRiseKWh: 0.03));
+    }
+
+    [Fact]
+    public void TheSameGrid_IsStillCaughtWhenItGenuinelyContradicts()
+    {
+        // Same node, same direction of power — but this time the import counter really is the one climbing.
+        Assert.True(DirectionAudit.LooksInverted(powerOut: 0, powerIn: 150, outRiseKWh: 0.9, inRiseKWh: 0.0));
     }
 
     [Fact]


### PR DESCRIPTION
The audit I added in #315 fired on the live system within a minute of deploying:

```
WRN Node 'grid': its split power source reads 166 W flowing IN (charge/export),
    but today's metered energy says the opposite — 0.4 kWh in against 25.69 kWh out.
```

**The grid was right.** At 3pm with 9 kW of solar it was exporting a little, after importing 25 kWh overnight.

Comparing an instantaneous reading against the whole day's totals isn't evidence of anything. A grid connection and a battery both reverse direction as a matter of course — importing overnight and exporting at noon, discharging in the evening and charging in the morning. The day says nothing about now.

My own test comment in #315 said *"a warning that fires on noise is a warning that gets ignored"*, and I shipped one anyway. That's worse than useless: it trains people to ignore the real one.

Now compared over a **ten-minute window** — which counter actually moved while the power source was claiming a direction. Long enough for a coarse counter (often 0.1 kWh resolution) to register, short enough that the node has probably not reversed inside it. Both counters moving means it *did* reverse, and nothing is reported.

The battery case that motivated the audit is still caught: there the in counter climbs steadily while the power insists it's discharging.

527 tests pass, with the exact false positive pinned as a case.

Refs #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)