### PR TITLE
A service that silently does nothing now says so

### DIFF
--- a/rPDU2MQTT.Engine/Services/baseTypes/baseMQTTService.cs
+++ b/rPDU2MQTT.Engine/Services/baseTypes/baseMQTTService.cs
@@ -28,6 +28,9 @@ public abstract class baseMQTTService : IHostedService, IDisposable
     /// </summary>
     protected virtual bool LeaderGated => true;
 
+    // Said once per idle spell, so a permanent skip is visible without a line every tick.
+    private bool warnedNotLeader;
+
     /// <summary>
     /// When the data currently being published was read from the device (#205). A publishing loop sets this
     /// per snapshot; null means "no better answer than now" (e.g. a state echo after a control action).
@@ -70,7 +73,13 @@ public abstract class baseMQTTService : IHostedService, IDisposable
     {
         if (timer is null)
         {
-            Log.Information($"{GetType().Name} - performing single execution.");
+            // A non-positive interval means this service runs ONCE and then never again. For a publisher or
+            // an exporter that is indistinguishable from being broken — the broker keeps serving whatever was
+            // retained on that single pass, so the data looks present and is simply frozen. Say so as a
+            // warning, not an info line lost in the startup noise.
+            Log.Warning($"{GetType().Name} has no repeat interval, so it runs once and then stops. Anything it "
+                      + "publishes will stay at its startup values; consumers will keep reading the retained "
+                      + "message as if it were current. Set a positive PollInterval to make it repeat.");
             await tick(cancellationToken);
             return;
         }
@@ -107,9 +116,19 @@ public abstract class baseMQTTService : IHostedService, IDisposable
             // v3: only the leader runs the run-once work; other instances no-op this tick (null leader = tests).
             if (LeaderGated && leader is { IsLeader: false })
             {
-                Log.Verbose($"{GetType().Name} - skipped (not cluster leader).");
+                // Debug, not Verbose. A service that quietly does nothing forever is indistinguishable from a
+                // broken one, and Verbose is off in every deployment anyone actually runs — so the one clue
+                // that publishing had stopped was invisible exactly when it was needed.
+                Log.Debug($"{GetType().Name} - skipped (not cluster leader).");
+                if (!warnedNotLeader)
+                {
+                    warnedNotLeader = true;
+                    Log.Information($"{GetType().Name} is idle: this instance does not hold cluster leadership. "
+                                  + "Retained values on the broker are from the last instance that did, and are not being refreshed.");
+                }
                 return;
             }
+            warnedNotLeader = false;
 
             Log.Debug($"{GetType().Name} - start.");
             await Execute(cancellationToken);

--- a/rPDU2MQTT/Hosting/LeaderRenewalService.cs
+++ b/rPDU2MQTT/Hosting/LeaderRenewalService.cs
@@ -31,10 +31,42 @@ public sealed class LeaderRenewalService : BackgroundService
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         using var timer = new PeriodicTimer(Interval);
+        bool? was = null;        // null = nothing reported yet, so the first outcome is always announced
+        var complained = false;  // one line per outage, not one every five seconds
+
         do
         {
-            try { state.IsLeader = await grains.GetGrain<ILeaderGrain>(0).Renew(id, LeaseSeconds); }
-            catch { state.IsLeader = false; }   // can't reach the cluster → never assume leadership
+            bool now;
+            try
+            {
+                now = await grains.GetGrain<ILeaderGrain>(0).Renew(id, LeaseSeconds);
+                complained = false;
+            }
+            catch (Exception ex)
+            {
+                // Never assume leadership when the cluster is unreachable — but never lose the reason either.
+                // This used to be a bare `catch { }`, and the cost of that silence was total: every run-once
+                // service self-gates on this flag, so a failing renewal stopped the MQTT publish, the Home
+                // Assistant discovery and the energy-flow export dead, with nothing in the log to say so and
+                // a broker still showing yesterday's retained values as if they were current.
+                now = false;
+                if (!complained)
+                {
+                    complained = true;
+                    Log.Warning($"Cluster leadership could not be renewed ({ex.GetType().Name}: {ex.Message}). "
+                              + "This instance will not publish, export or run Home Assistant discovery until it "
+                              + "recovers — those all run on the leader only.");
+                }
+            }
+
+            if (was != now)
+            {
+                Log.Information(now
+                    ? "Cluster leadership acquired — this instance runs the publishers, exporters and discovery."
+                    : "Cluster leadership lost or held elsewhere — this instance publishes nothing until it returns.");
+                was = now;
+            }
+            state.IsLeader = now;
         }
         while (await SafeWait(timer, stoppingToken));
 


### PR DESCRIPTION
While chasing why no PDU measurement had reached MQTT for hours on the live system, the code offered nothing to go on. Three separate silences, all of which had to be reasoned around rather than read.

**`LeaderRenewalService` swallowed every failure in a bare `catch { }`** and set `IsLeader = false`. Every run-once service self-gates on that flag, so a failing renewal stops the MQTT publish, HA discovery and the energy-flow export dead — and the only trace is their absence. Now the first failure of each outage is logged with the exception, and every transition in and out of leadership is stated plainly.

**`baseMQTTService` logged its leader-gate skip at `Verbose`**, which is off in every deployment anyone actually runs. The one clue that a service had stopped publishing was invisible exactly when it was needed. Now `Debug`, plus one `Information` line when a service goes idle noting that retained values on the broker are stale rather than current.

**A non-positive interval silently put a service on the "single execution" path.** For a publisher that's indistinguishable from broken: the broker keeps serving whatever was retained on that one pass, so the data looks present and is merely frozen. Now a warning saying exactly that.

No behaviour changes. This is the difference between a system that's wrong and a system that's wrong and won't tell you.

525 tests pass.

Refs #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)