### PR TITLE
The bar is as tall as what goes through it, not as what it reports

### DIFF
--- a/rPDU2MQTT.Core/Flow/FlowGraph.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraph.cs
@@ -35,8 +35,9 @@ public static class FlowDerivation
 /// </para>
 /// </param>
 /// <param name="Imbalance">
-/// How far this node's outflow exceeds its inflow (<c>outflow - inflow</c>), when both are determined and
-/// they materially disagree; <see langword="null"/> when they reconcile or when one of them is unknown.
+/// How far this node's flows exceed what it claims. For an unmeasured node that is <c>outflow - inflow</c>;
+/// for a measured one it is how far its throughput exceeds its own reading. <see langword="null"/> when they
+/// reconcile, or when there is not enough determined on both sides to compare.
 ///
 /// <para>
 /// Supply below load is not a state the hardware can be in, so a positive value here always means the two

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -543,10 +543,20 @@ public static class FlowGraphBuilder
         // which of the two numbers to believe. Carrying the gap explicitly lets the diagram say so.
         double? ImbalanceOf(string id)
         {
-            if (leaf.ContainsKey(id)) return null;   // a measured node's own reading settles it
-
             var (inflow, outflow, anyIn, anyOut) = Sides(id);
             if (!anyIn || !anyOut) return null;
+
+            // A measured node is NOT exempt, which is what this used to assume. Its reading settles what that
+            // sensor measures — not what passes through the node. An inverter bound to `load_power` reports
+            // the AC-load leg only, so a unit taking 8,344 W of PV and sending 5,652 W of it to charge a
+            // battery reported 2,526 W and drew a bar a third the width of its own ribbons. Nothing was
+            // wrong with the number; it was answering a different question from the one the diagram asked.
+            if (leaf.TryGetValue(id, out var reading))
+            {
+                var throughput = Math.Max(inflow, outflow);
+                var short_ = throughput - reading;
+                return short_ > 1 && short_ > reading * 0.02 ? short_ : null;
+            }
 
             var gap = outflow - inflow;
             // Rounding noise and honest conversion loss are not contradictions; 2% matches the floor the

--- a/rPDU2MQTT.Tests/ThroughputImbalanceTests.cs
+++ b/rPDU2MQTT.Tests/ThroughputImbalanceTests.cs
@@ -1,0 +1,89 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// A measured node's reading answers what its sensor measures, which is not always what passes through the
+/// node. Reconstructed from the live inverter: bound to <c>load_power</c>, it reported its AC-load leg while
+/// also sending several kW to charge a battery.
+/// </summary>
+public class ThroughputImbalanceTests
+{
+    private sealed class Fixed : IFlowValueSource
+    {
+        private readonly Dictionary<string, double> v;
+        public Fixed(Dictionary<string, double> x) => v = x;
+        public bool TryGetValue(string node, string metric, out double value) => v.TryGetValue(node + "|" + metric, out value);
+    }
+
+    /// <summary>solar → inverter → panel, with the inverter also charging a battery via its in-lane.</summary>
+    private static EnergyFlowConfig Topology()
+    {
+        var c = new EnergyFlowConfig();
+        c.Nodes.Add(new EnergyFlowNode { Id = "solar", Kind = "solar" });
+        c.Nodes.Add(new EnergyFlowNode { Id = "inverter", Kind = "inverter" });
+        c.Nodes.Add(new EnergyFlowNode { Id = "battery", Kind = "battery" });
+        c.Nodes.Add(new EnergyFlowNode { Id = "panel", Kind = "panel" });
+        c.Links.Add(new EnergyFlowLink { From = "solar", To = "inverter" });
+        c.Links.Add(new EnergyFlowLink { From = "battery", To = "inverter" });
+        c.Links.Add(new EnergyFlowLink { From = "inverter", To = "panel" });
+        return c;
+    }
+
+    // The live figures: 8,344 W of PV in, 2,526 W to the panel, 5,652 W into the battery.
+    private static readonly Dictionary<string, double> Live = new()
+    {
+        ["solar|realpower"] = 8344,
+        ["inverter|realpower"] = 2526,
+        ["battery|realpower"] = 0,
+        ["battery|realpower#in"] = 5652,
+    };
+
+    [Fact]
+    public void AMeasuredNodeCarryingMoreThanItReports_IsFlagged()
+    {
+        // This used to return null on sight for anything measured — "its own reading settles it" — so an
+        // inverter drawing a bar a third the width of its own ribbons said nothing at all.
+        var graph = FlowGraphBuilder.Build(new PduData(), Topology(), "realpower", new Fixed(Live));
+
+        var inverter = graph.Nodes.Single(n => n.Id == "inverter");
+        Assert.Equal(2526, inverter.Value);              // the reading is still the reading
+        Assert.NotNull(inverter.Imbalance);              // but the discrepancy is no longer silent
+        Assert.True(inverter.Imbalance > 5000, $"expected the ~5.8 kW shortfall, got {inverter.Imbalance}");
+    }
+
+    [Fact]
+    public void AMeasuredNodeWhoseFlowsAgree_IsNotFlagged()
+    {
+        // The common case must stay quiet, or the marker means nothing.
+        var live = new Dictionary<string, double>(Live) { ["inverter|realpower"] = 8344 };
+        live.Remove("battery|realpower#in");
+
+        var graph = FlowGraphBuilder.Build(new PduData(), Topology(), "realpower", new Fixed(live));
+
+        Assert.Null(graph.Nodes.Single(n => n.Id == "inverter").Imbalance);
+    }
+
+    [Fact]
+    public void RoundingIsNotADiscrepancy()
+    {
+        var live = new Dictionary<string, double>(Live) { ["inverter|realpower"] = 8300 };
+        live.Remove("battery|realpower#in");
+
+        var graph = FlowGraphBuilder.Build(new PduData(), Topology(), "realpower", new Fixed(live));
+
+        Assert.Null(graph.Nodes.Single(n => n.Id == "inverter").Imbalance);
+    }
+
+    [Fact]
+    public void ATerminalLeaf_IsNeverFlagged()
+    {
+        // Nothing leaves it, so there is no throughput to contradict its reading.
+        var graph = FlowGraphBuilder.Build(new PduData(), Topology(), "realpower", new Fixed(Live));
+
+        Assert.Null(graph.Nodes.Single(n => n.Id == "solar").Imbalance);
+    }
+}

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1372,7 +1372,16 @@ export function addFlowSection(nav: any, sections: any) {
     const W = 960, padTop = 22, gap = 8, nodeW = 12, usableH = 520;
     // Labels sit to the right of each node, so reserve a right gutter for them and only a small left pad.
     const leftPad = 16, rightGutter = 232;
-    const maxTotal = Math.max(1, ...cols.map(cn => cn.reduce((s: number, n: any) => s + nodeValue(n.id), 0)));
+    // What the node has to be tall enough to carry: its own reading, or the flows through it if those are
+    // larger. Never smaller than the ribbons it must accommodate.
+    const throughput = (id: string) => {
+      let inSum = 0, outSum = 0;
+      (incoming[id] || []).forEach((l: any) => { if (l.known !== false) inSum += l.value || 0; });
+      (outgoing[id] || []).forEach((l: any) => { if (l.known !== false) outSum += l.value || 0; });
+      return Math.max(nodeValue(id) || 0, inSum, outSum);
+    };
+
+    const maxTotal = Math.max(1, ...cols.map(cn => cn.reduce((s: number, n: any) => s + throughput(n.id), 0)));
     const pxPerUnit = usableH / maxTotal;
     const colX = (c: number) => leftPad + (maxCol > 0 ? c * ((W - leftPad - rightGutter - nodeW) / maxCol) : 0);
 
@@ -1398,9 +1407,18 @@ export function addFlowSection(nav: any, sections: any) {
     const placeColumn = (cn: any[], c: number) => {
       let y = padTop;
       cn.forEach((n: any) => {
-        // Bar height is proportional; an unknown or measured-zero node is a thin marker (it has no
-        // magnitude to show) rather than a fixed slab. The row it sits in is what guarantees label spacing.
-        const h = known(n.id) ? Math.max(2, nodeValue(n.id) * pxPerUnit) : 3;
+        // Bar height is proportional to what actually passes THROUGH the node, not to its own reading.
+        //
+        // Those are not always the same number, and when they differ the bar is the thing that lies. An
+        // inverter bound to `load_power` reports its AC-load leg only, so one taking 8,344 W of PV and
+        // sending 5,652 W of it to charge a battery reported 2,526 W — and drew a bar a third the width of
+        // the ribbons entering and leaving it. The reading was correct; the geometry was not, and geometry is
+        // the whole point of a Sankey. The label still shows the node's own value, and the discrepancy is
+        // flagged separately.
+        //
+        // An unknown or measured-zero node is a thin marker (it has no magnitude to show) rather than a
+        // fixed slab. The row it sits in is what guarantees label spacing.
+        const h = known(n.id) ? Math.max(2, throughput(n.id) * pxPerUnit) : 3;
         const rowH = Math.max(h, labelRow);
         pos[n.id] = { x: colX(c), y: y + (rowH - h) / 2, h, outOff: 0, inOff: 0 };
         y += rowH + gap;

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2799,7 +2799,16 @@ function addFlowSection(nav     , sections     ) {
     const W = 960, padTop = 22, gap = 8, nodeW = 12, usableH = 520;
     // Labels sit to the right of each node, so reserve a right gutter for them and only a small left pad.
     const leftPad = 16, rightGutter = 232;
-    const maxTotal = Math.max(1, ...cols.map(cn => cn.reduce((s        , n     ) => s + nodeValue(n.id), 0)));
+    // What the node has to be tall enough to carry: its own reading, or the flows through it if those are
+    // larger. Never smaller than the ribbons it must accommodate.
+    const throughput = (id        ) => {
+      let inSum = 0, outSum = 0;
+      (incoming[id] || []).forEach((l     ) => { if (l.known !== false) inSum += l.value || 0; });
+      (outgoing[id] || []).forEach((l     ) => { if (l.known !== false) outSum += l.value || 0; });
+      return Math.max(nodeValue(id) || 0, inSum, outSum);
+    };
+
+    const maxTotal = Math.max(1, ...cols.map(cn => cn.reduce((s        , n     ) => s + throughput(n.id), 0)));
     const pxPerUnit = usableH / maxTotal;
     const colX = (c        ) => leftPad + (maxCol > 0 ? c * ((W - leftPad - rightGutter - nodeW) / maxCol) : 0);
 
@@ -2825,9 +2834,18 @@ function addFlowSection(nav     , sections     ) {
     const placeColumn = (cn       , c        ) => {
       let y = padTop;
       cn.forEach((n     ) => {
-        // Bar height is proportional; an unknown or measured-zero node is a thin marker (it has no
-        // magnitude to show) rather than a fixed slab. The row it sits in is what guarantees label spacing.
-        const h = known(n.id) ? Math.max(2, nodeValue(n.id) * pxPerUnit) : 3;
+        // Bar height is proportional to what actually passes THROUGH the node, not to its own reading.
+        //
+        // Those are not always the same number, and when they differ the bar is the thing that lies. An
+        // inverter bound to `load_power` reports its AC-load leg only, so one taking 8,344 W of PV and
+        // sending 5,652 W of it to charge a battery reported 2,526 W — and drew a bar a third the width of
+        // the ribbons entering and leaving it. The reading was correct; the geometry was not, and geometry is
+        // the whole point of a Sankey. The label still shows the node's own value, and the discrepancy is
+        // flagged separately.
+        //
+        // An unknown or measured-zero node is a thin marker (it has no magnitude to show) rather than a
+        // fixed slab. The row it sits in is what guarantees label spacing.
+        const h = known(n.id) ? Math.max(2, throughput(n.id) * pxPerUnit) : 3;
         const rowH = Math.max(h, labelRow);
         pos[n.id] = { x: colX(c), y: y + (rowH - h) / 2, h, outOff: 0, inOff: 0 };
         y += rowH + gap;


### PR DESCRIPTION
The inverter drew a bar a third the width of its own ribbons:

```
Solar (PV) 8,344 W ──▶ EG4 FlexBoss 21 · 2,526 W ──▶ Main Panel      2,526 W
                                                 └─▶ Battery (charging) 5,652 W
```

8,344 W in, 2,526 W on the node, 8,178 W out.

**Nothing was wrong with the number.** Its source is `inverter_1/load_power`, which measures the AC-load leg — a real reading, answering a different question from the one the diagram asks. The *geometry* was what lied, and geometry is the whole point of a Sankey: a ribbon wider than the node it passes through can't be read.

Bars are now sized by **throughput** — the node's own reading, or the flows through it when those are larger — so a bar is never narrower than the ribbons it has to carry. The column scale uses the same measure, or a tall column overflows the canvas. The label still shows the node's own value, because that *is* the reading and it's true.

And the discrepancy is no longer silent. `ImbalanceOf` returned `null` on sight for anything measured — *"its own reading settles it"* — which is exactly backwards. A measured node is the only kind that can disagree with its own flows, and this one was out by 5.8 kW without a mark on it. That was my line, from #312.

529 tests pass; GUI smoke/layout/sankey checks pass.

Refs #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)