### PR TITLE
A series whose subject is gone no longer haunts the scrape

### DIFF
--- a/rPDU2MQTT.Engine/Services/PrometheusExportService.cs
+++ b/rPDU2MQTT.Engine/Services/PrometheusExportService.cs
@@ -72,13 +72,25 @@ public class PrometheusExportService : baseMQTTService
         // The energy-flow tier feeding each reading — only built when the hierarchy label is wanted.
         var hierarchy = labelNames.Contains("hierarchy") ? BuildHierarchy() : null;
 
+        // What each gauge was given this pass, so anything it held from a previous one can be dropped below.
+        var written = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+
         foreach (var snapshot in FreshSnapshotsWithId())
             foreach (var r in MetricsHelper.EnumerateReadings(snapshot.Data))
             {
                 var tier = hierarchy is null ? string.Empty : HierarchyFor(hierarchy, r);
                 var values = PrometheusLabels.Values(labelNames, r, cfg, snapshot.InstanceId, tier);
-                GetGauge(MetricsHelper.PrometheusMetricName(r, cfg), labelNames, r).WithLabels(values).Set(r.Value);
+                var name = MetricsHelper.PrometheusMetricName(r, cfg);
+                GetGauge(name, labelNames, r).WithLabels(values).Set(r.Value);
+                if (!written.TryGetValue(name, out var set)) written[name] = set = new(StringComparer.Ordinal);
+                set.Add(LabelKey(values));
             }
+
+        // An outlet that goes away — unplugged, renamed, a PDU dropped from the config — otherwise leaves its
+        // series behind frozen at its last reading, indefinitely, looking exactly like a live one.
+        foreach (var (name, set) in written)
+            if (gauges.TryGetValue(name, out var g))
+                Prune(g, set);
 
         ExportFlowTiers();
         return Task.CompletedTask;
@@ -123,6 +135,7 @@ public class PrometheusExportService : baseMQTTService
             {
                 var name = MetricsHelper.PrometheusMetricName($"flow_{metric}", "", "", graph.Units, cfg);
                 var gauge = FlowGauge(name, metric, graph.Units);
+                var written = new HashSet<string>(StringComparer.Ordinal);
 
                 foreach (var node in graph.Nodes)
                 {
@@ -134,18 +147,53 @@ public class PrometheusExportService : baseMQTTService
                     if (node.Value is not { } v) continue;
 
                     var tier = Core.Flow.FlowExport.Parents(power, node.Id).FirstOrDefault() ?? "";
-                    gauge.WithLabels(
-                        node.Id,
-                        node.Label,
-                        node.Kind,
-                        labels.TryGetValue(tier, out var p) ? p.Label : tier).Set(v);
+                    var set = new[] { node.Id, node.Label, node.Kind, labels.TryGetValue(tier, out var p) ? p.Label : tier };
+                    gauge.WithLabels(set).Set(v);
+                    written.Add(LabelKey(set));
                 }
+
+                // Drop every label set we did NOT write this pass.
+                //
+                // A Prometheus gauge remembers every combination of labels it has ever been given, and keeps
+                // serving each one's last value forever. So a node that stops reporting, or whose `tier`
+                // changes when the hierarchy is re-wired, leaves its old series behind frozen at whatever it
+                // last read — and the scrape then carries two contradictory rows for the same node. Seen on a
+                // live system: the inverter appearing twice, at 82.6 and 67.1 kWh, one of them a ghost.
+                //
+                // This is the same rule the rest of the flow already follows. A value we can no longer stand
+                // behind must disappear, not linger looking current.
+                Prune(gauge, written);
             }
         }
         catch (Exception ex) { Log.Debug($"Prometheus flow-tier export skipped: {ex.Message}"); }
     }
 
     private static readonly string[] FlowLabelNames = ["node", "name", "kind", "tier"];
+
+    /// <summary>A label set as one comparable string. The separator is a unit separator, which cannot occur
+    /// in a label value, so two different sets can never collide into one key.</summary>
+    internal static string LabelKey(IReadOnlyList<string> labels) => string.Join('\u241F', labels);
+
+    /// <summary>
+    /// Forget every label set this gauge holds that was not written in the pass just finished.
+    ///
+    /// <para>
+    /// A Prometheus gauge remembers every combination of labels it has ever been given and keeps serving each
+    /// one's last value forever. Nothing ages out. So a series whose subject disappeared — an outlet
+    /// unplugged, a node re-wired so its tier label changed — stays in the scrape at whatever it last read,
+    /// indistinguishable from a live reading. Seen on this system: the inverter appearing twice in one
+    /// scrape, 82.6 kWh and 67.1 kWh, one of them a ghost.
+    /// </para>
+    /// <para>
+    /// Same rule as everywhere else here: a value we can no longer stand behind disappears rather than
+    /// lingering while it looks current.
+    /// </para>
+    /// </summary>
+    internal static void Prune(Collector<Gauge.Child> gauge, HashSet<string> written)
+    {
+        foreach (var stale in gauge.GetAllLabelValues().Where(l => !written.Contains(LabelKey(l))).ToList())
+            gauge.RemoveLabelled(stale);
+    }
 
     private Gauge FlowGauge(string name, string metric, string units)
     {

--- a/rPDU2MQTT.Tests/StaleSeriesTests.cs
+++ b/rPDU2MQTT.Tests/StaleSeriesTests.cs
@@ -1,0 +1,76 @@
+using Prometheus;
+using rPDU2MQTT.Services;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// A Prometheus gauge remembers every label set it has ever been given and serves each one's last value
+/// forever. Nothing ages out, so a series whose subject disappeared keeps being scraped as if it were live.
+/// </summary>
+public class StaleSeriesTests
+{
+    private static Gauge NewGauge(string name) =>
+        Metrics.WithCustomRegistry(Metrics.NewCustomRegistry())
+               .CreateGauge(name, "test", "node", "name", "kind", "tier");
+
+    [Fact]
+    public void ASeriesNotWrittenThisPass_IsRemoved()
+    {
+        // The live symptom: the inverter appeared twice in one scrape — 82.6 and 67.1 kWh — because its
+        // `tier` label changed and the old combination stayed behind frozen.
+        var g = NewGauge("test_flow_a");
+        g.WithLabels("inv", "Inverter", "inverter", "Solar (PV)").Set(82.6);
+        g.WithLabels("inv", "Inverter", "inverter", "MPPT_1").Set(67.1);
+        Assert.Equal(2, g.GetAllLabelValues().Count());
+
+        var written = new HashSet<string>(System.StringComparer.Ordinal)
+        {
+            PrometheusExportService.LabelKey(new[] { "inv", "Inverter", "inverter", "MPPT_1" }),
+        };
+        PrometheusExportService.Prune(g, written);
+
+        var left = g.GetAllLabelValues().ToList();
+        Assert.Single(left);
+        Assert.Equal("MPPT_1", left[0][3]);
+    }
+
+    [Fact]
+    public void EverythingStillReported_SurvivesUntouched()
+    {
+        var g = NewGauge("test_flow_b");
+        g.WithLabels("a", "A", "node", "").Set(1);
+        g.WithLabels("b", "B", "node", "").Set(2);
+
+        var written = new HashSet<string>(System.StringComparer.Ordinal)
+        {
+            PrometheusExportService.LabelKey(new[] { "a", "A", "node", "" }),
+            PrometheusExportService.LabelKey(new[] { "b", "B", "node", "" }),
+        };
+        PrometheusExportService.Prune(g, written);
+
+        Assert.Equal(2, g.GetAllLabelValues().Count());
+    }
+
+    [Fact]
+    public void AnEmptyPass_ClearsEverything()
+    {
+        // Every node going unknown at once is a real state (the feed died); the scrape must then be empty
+        // rather than a full set of frozen values.
+        var g = NewGauge("test_flow_c");
+        g.WithLabels("a", "A", "node", "").Set(1);
+
+        PrometheusExportService.Prune(g, new HashSet<string>(System.StringComparer.Ordinal));
+
+        Assert.Empty(g.GetAllLabelValues());
+    }
+
+    [Fact]
+    public void LabelSetsThatDifferOnlyByBoundary_DoNotCollide()
+    {
+        // The key is a join, so a naive separator could make {"a|b","c"} and {"a","b|c"} the same string.
+        var one = PrometheusExportService.LabelKey(new[] { "a|b", "c" });
+        var two = PrometheusExportService.LabelKey(new[] { "a", "b|c" });
+        Assert.NotEqual(one, two);
+    }
+}


### PR DESCRIPTION
The live scrape carried the inverter **twice, in the same response**:

```
rpdu2mqtt_flow_energytoday{node="eg4-flexboss21-inverter",...,tier="Solar (PV)"} 82.63
rpdu2mqtt_flow_energytoday{node="eg4-flexboss21-inverter",...,tier="MPPT_1"}     67.13
```

One of them is a ghost.

A Prometheus gauge remembers every combination of labels it has ever been given and serves each one's last value **forever** — nothing ages out. When the node's `tier` label changed, the old combination stayed behind frozen at whatever it last read, indistinguishable from a live series. The same applies to any reading whose subject disappears: an outlet unplugged, a device renamed, a PDU dropped from config.

Both metric families now forget every label set they weren't given in the pass just finished. A value we can no longer stand behind disappears rather than lingering while it looks current — the rule the rest of the flow already follows, which the exporter was quietly exempt from. Mine, from #313.

The label key joins on a unit separator, which can't occur in a label value, so `{"a|b","c"}` and `{"a","b|c"}` can never collapse into one key and prune each other. Pinned by a test, because that's the kind of thing that works until someone has a pipe in a device name.

535 tests pass.

Refs #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)