### PR TITLE
Find and clear Home Assistant devices for things that no longer exist

### DIFF
--- a/rPDU2MQTT.Core/Flow/FlowExport.cs
+++ b/rPDU2MQTT.Core/Flow/FlowExport.cs
@@ -93,6 +93,61 @@ public static class FlowExport
     /// <summary>The HA unique_id of a battery tier's state-of-charge sensor ("energyflow_&lt;key&gt;_soc").</summary>
     public static string SocUniqueId(string nodeId) => DeviceId(nodeId) + "_soc";
 
+    /// <summary>The discovery-topic prefix every device this exporter publishes is named with.</summary>
+    public const string DeviceIdPrefix = "energyflow_";
+
+    /// <summary>
+    /// Retained Home Assistant discovery configs this exporter published and would no longer publish today —
+    /// the ones to clear.
+    ///
+    /// <para>
+    /// A discovery config is retained, so it outlives the thing it described. An outlet that gains a native
+    /// energy sensor (so the flow export correctly stops publishing a duplicate for it), a node renamed, a
+    /// tier deleted from the hierarchy — each leaves its config sitting on the broker, and Home Assistant
+    /// goes on showing the device as though it were real. Seen on a live system: fifteen orphaned devices,
+    /// several of them a second and third copy of an outlet that already had one.
+    /// </para>
+    /// <para>
+    /// Nothing revisits them on its own. The publish loop only ever walks the nodes that exist <em>now</em>,
+    /// so a config for something that no longer exists is unreachable by construction — it can only be found
+    /// by looking at what is actually retained and subtracting what we mean to publish.
+    /// </para>
+    /// <para>
+    /// Deliberately narrow: only topics under the discovery prefix, only the <c>device</c> component, and only
+    /// ids beginning with <see cref="DeviceIdPrefix"/>. Another integration's discovery — or this project's own
+    /// native PDU discovery, which a different service owns — must never be touched by this.
+    /// </para>
+    /// </summary>
+    /// <param name="retainedTopics">Every retained topic currently on the broker.</param>
+    /// <param name="currentDeviceIds">The device ids the exporter would publish right now.</param>
+    /// <param name="discoveryPrefix">The configured Home Assistant discovery prefix (e.g. "homeassistant").</param>
+    public static IReadOnlyList<string> OrphanedDiscoveryTopics(
+        IEnumerable<string> retainedTopics, IEnumerable<string> currentDeviceIds, string discoveryPrefix)
+    {
+        var keep = new HashSet<string>(currentDeviceIds, StringComparer.OrdinalIgnoreCase);
+        var root = (discoveryPrefix ?? "").Trim().Trim('/');
+        if (root.Length == 0) return Array.Empty<string>();
+
+        var orphans = new List<string>();
+        foreach (var topic in retainedTopics)
+        {
+            if (string.IsNullOrWhiteSpace(topic)) continue;
+            var parts = topic.Split('/');
+            // <root>/device/<id>/config — anything else is not ours to reason about.
+            if (parts.Length != 4) continue;
+            if (!string.Equals(parts[0], root, StringComparison.OrdinalIgnoreCase)) continue;
+            if (!string.Equals(parts[1], "device", StringComparison.OrdinalIgnoreCase)) continue;
+            if (!string.Equals(parts[3], "config", StringComparison.OrdinalIgnoreCase)) continue;
+
+            var id = parts[2];
+            if (!id.StartsWith(DeviceIdPrefix, StringComparison.OrdinalIgnoreCase)) continue;
+            if (keep.Contains(id)) continue;
+
+            orphans.Add(topic);
+        }
+        return orphans;
+    }
+
     /// <summary>
     /// Flow node id -> the unique_id of the native PDU-discovery energy sensor it already has (#177): PDU
     /// tiers (<c>pdu:{name}</c>) and outlets (<c>outlet:{name}:{key}</c>) that carry an energy measurement.

--- a/rPDU2MQTT.Tests/OrphanedDiscoveryTests.cs
+++ b/rPDU2MQTT.Tests/OrphanedDiscoveryTests.cs
@@ -1,0 +1,82 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Retained discovery configs outlive what they describe. Home Assistant kept showing an outlet three times
+/// because two older configs for it were still sitting on the broker with nothing to remove them.
+/// </summary>
+public class OrphanedDiscoveryTests
+{
+    private static readonly string[] Retained =
+    [
+        "homeassistant/device/energyflow_grid/config",              // current tier — keep
+        "homeassistant/device/energyflow_outlet_pdu_1_4/config",    // duplicate of a native outlet — orphan
+        "homeassistant/device/energyflow_pdu_pdu_1/config",         // duplicate of a native PDU — orphan
+        "homeassistant/device/rPDU2MQTT_A0AE_outlets_4/config",     // native discovery — another service owns it
+        "homeassistant/sensor/acurite_attic/config",                // someone else's integration entirely
+        "Rack_PDU/pdu_1/outlets/4/realpower",                       // not discovery at all
+    ];
+
+    [Fact]
+    public void OnlyOurOwnStaleDevicesAreListed()
+    {
+        var orphans = FlowExport.OrphanedDiscoveryTopics(Retained, new[] { "energyflow_grid" }, "homeassistant");
+
+        Assert.Equal(new[]
+        {
+            "homeassistant/device/energyflow_outlet_pdu_1_4/config",
+            "homeassistant/device/energyflow_pdu_pdu_1/config",
+        }, orphans);
+    }
+
+    [Fact]
+    public void AnotherIntegrationIsNeverTouched()
+    {
+        // The failure that would matter most: clearing someone else's retained discovery deletes their
+        // devices from Home Assistant, and nothing here would put them back.
+        var orphans = FlowExport.OrphanedDiscoveryTopics(Retained, System.Array.Empty<string>(), "homeassistant");
+
+        Assert.DoesNotContain(orphans, t => t.Contains("acurite"));
+        Assert.DoesNotContain(orphans, t => t.Contains("rPDU2MQTT_"));
+        Assert.DoesNotContain(orphans, t => t.StartsWith("Rack_PDU/"));
+    }
+
+    [Fact]
+    public void EverythingCurrentSurvives()
+    {
+        var current = new[] { "energyflow_grid", "energyflow_outlet_pdu_1_4", "energyflow_pdu_pdu_1" };
+        Assert.Empty(FlowExport.OrphanedDiscoveryTopics(Retained, current, "homeassistant"));
+    }
+
+    [Fact]
+    public void ACustomDiscoveryPrefixIsHonoured()
+    {
+        var retained = new[] { "ha/device/energyflow_gone/config", "homeassistant/device/energyflow_gone/config" };
+
+        var orphans = FlowExport.OrphanedDiscoveryTopics(retained, System.Array.Empty<string>(), "ha");
+
+        Assert.Equal(new[] { "ha/device/energyflow_gone/config" }, orphans);
+    }
+
+    [Fact]
+    public void ABlankPrefixClearsNothing()
+    {
+        // A misconfigured prefix must not turn into "match everything and delete it".
+        Assert.Empty(FlowExport.OrphanedDiscoveryTopics(Retained, System.Array.Empty<string>(), ""));
+        Assert.Empty(FlowExport.OrphanedDiscoveryTopics(Retained, System.Array.Empty<string>(), "   "));
+    }
+
+    [Fact]
+    public void MalformedTopicsAreIgnoredRatherThanGuessedAt()
+    {
+        var retained = new[]
+        {
+            "homeassistant/device/energyflow_x/config/extra",
+            "homeassistant/device/energyflow_x",
+            "homeassistant/energyflow_x/config",
+        };
+        Assert.Empty(FlowExport.OrphanedDiscoveryTopics(retained, System.Array.Empty<string>(), "homeassistant"));
+    }
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -295,6 +295,41 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     /// connected/stale/waiting, and what colour that is — belong to the components, so this just hands the
     /// board over. One grain call, one cluster-wide answer, whichever replica serves the request.
     /// </summary>
+    /// <summary>
+    /// Retained discovery configs under our own device-id prefix that this build would not publish today.
+    ///
+    /// <para>
+    /// Built by asking the broker what is actually retained and subtracting what the exporter means to
+    /// publish. That subtraction is the only way to find them: the publish loop walks the nodes that exist
+    /// now, so a config for something that no longer exists is unreachable from it by construction.
+    /// </para>
+    /// </summary>
+    private async Task<IReadOnlyList<string>> OrphanedDiscoveryAsync()
+    {
+        var prefix = config.HASS.DiscoveryTopic;
+        if (string.IsNullOrWhiteSpace(prefix)) return Array.Empty<string>();
+
+        var index = grains.GetGrain<Grains.Abstractions.Discovery.ITopicIndexGrain>(0);
+        await index.Renew(prefix.Trim().Trim('/') + "/#");
+        var retained = (await index.Search(null, 5000)).Select(t => t.Topic).ToList();
+
+        // What the exporter would publish right now: every non-synthetic tier that is NOT already covered by
+        // native PDU discovery. Anything else carrying our prefix is a leftover.
+        var merged = new Models.PDU.PduData();
+        foreach (var s in snapshots.All) merged.Devices.AddRange(s.Data.Devices);
+
+        var energyMetric = string.IsNullOrWhiteSpace(config.HASS.EnergyDashboard.EnergyMeasurementType)
+            ? "energy" : config.HASS.EnergyDashboard.EnergyMeasurementType;
+        var graph = Core.Flow.FlowGraphBuilder.Build(merged, config.EnergyFlow, Core.Flow.FlowGraphBuilder.DefaultMetric, live);
+        var native = Core.Flow.FlowExport.NativeEnergyUniqueIds(merged, energyMetric);
+
+        var current = graph.Nodes
+            .Where(n => !n.Synthetic && !native.ContainsKey(n.Id))
+            .Select(n => Core.Flow.FlowExport.DeviceId(n.Id));
+
+        return Core.Flow.FlowExport.OrphanedDiscoveryTopics(retained, current, prefix);
+    }
+
     private async Task<object> BuildBoardAsync()
     {
         try
@@ -1034,6 +1069,48 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         // Browse what's on the broker, for the Nodes editor's topic autocomplete. Asking is what keeps the
         // index alive: the grain leases itself to readers and the subscription only exists while someone is
         // browsing (see ITopicIndexGrain), so this endpoint both queries and renews.
+        // Retained Home Assistant discovery configs this build would no longer publish — and, on POST, the
+        // clearing of them.
+        //
+        // A discovery config is retained, so it outlives whatever it described: an outlet that later gained a
+        // native energy sensor, a tier deleted from the hierarchy, a node renamed. Home Assistant goes on
+        // showing the device, and the publish loop can never find it again because that loop only ever walks
+        // the nodes that exist now. Seen live: fifteen orphans, several of them a second and third copy of an
+        // outlet that already had one.
+        //
+        // Two endpoints on purpose. Deleting devices from someone's Home Assistant is not something to do on
+        // a timer or at startup — GET says exactly what would go, POST does it, and the operator decides.
+        app.MapGet("/api/ha/orphans", async () =>
+        {
+            try
+            {
+                var found = await OrphanedDiscoveryAsync();
+                return Results.Json(new { ok = true, prefix = config.HASS.DiscoveryTopic, topics = found }, ConfigSchema.Json);
+            }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
+        });
+
+        app.MapPost("/api/ha/orphans/clear", async (HttpContext ctx) =>
+        {
+            try
+            {
+                var found = await OrphanedDiscoveryAsync();
+                // An empty retained payload is how MQTT deletes a retained message, and how Home Assistant is
+                // told the device is gone. Same mechanism the exporter already uses for a single duplicate.
+                foreach (var topic in found)
+                    await mqtt.PublishAsync(new MQTT5PublishMessage(topic, QualityOfService.AtLeastOnceDelivery)
+                    {
+                        Payload = Array.Empty<byte>(),
+                        Retain = true,
+                    });
+
+                if (found.Count > 0)
+                    Log.Information($"Cleared {found.Count} orphaned Home Assistant discovery config(s) at the operator's request.");
+                return Results.Json(new { ok = true, cleared = found.Count, topics = found }, ConfigSchema.Json);
+            }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
+        });
+
         app.MapGet("/api/mqtt/topics", async (HttpContext ctx) =>
         {
             try

--- a/rPDU2MQTT.Web/web/src/sections/ha-energy.ts
+++ b/rPDU2MQTT.Web/web/src/sections/ha-energy.ts
@@ -52,5 +52,55 @@ export function addHaEnergySection(nav: any, sections: any) {
     const r = await api('/api/ha-energy/clear', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url.inp.value.trim(), token: token.inp.value }) });
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
   };
+  // Orphaned discovery configs — devices Home Assistant still shows for things that no longer exist.
+  //
+  // A discovery config is retained, so it outlives what it described: an outlet that later gained a native
+  // energy sensor, a tier deleted from the hierarchy, a node renamed. The publish loop can never find them
+  // again because it only walks the nodes that exist now. Two steps on purpose — deleting devices from
+  // someone's Home Assistant is not something to do quietly, so it lists them and waits.
+  sec.appendChild(el('h3', { text: 'Orphaned Home Assistant devices', style: { margin: '18px 0 4px' } }));
+  sec.appendChild(el('div', { class: 'desc' },
+    'Discovery messages are retained, so a device stays in Home Assistant after the thing it described is '
+    + 'gone — an outlet that gained its own energy sensor, a renamed node, a deleted tier. This finds configs '
+    + 'published under this project’s own prefix that the current setup would no longer publish. Nothing '
+    + 'belonging to another integration is ever listed or touched.'));
+
+  const orphanOut = el('div', { class: 'desc' }) as HTMLElement;
+  const orphanFind = btn('Find orphaned devices');
+  const orphanClear = btn('Clear them', 'danger');
+  orphanClear.disabled = true;
+  const orphanBar = el('div', { class: 'sec-actions' }, orphanFind, orphanClear);
+  sec.appendChild(orphanBar);
+  sec.appendChild(orphanOut);
+
+  const showOrphans = (topics: string[]) => {
+    orphanOut.innerHTML = '';
+    if (!topics.length) {
+      orphanOut.textContent = 'Nothing orphaned — every retained discovery config matches something that still exists.';
+      orphanClear.disabled = true;
+      return;
+    }
+    orphanOut.appendChild(el('div', { text: `${topics.length} orphaned config(s) would be cleared:` }));
+    const list = el('ul', { style: { margin: '4px 0 0 18px' } });
+    topics.forEach(t => list.appendChild(el('li', { text: t, style: { fontFamily: 'var(--mono)', fontSize: '11px' } })));
+    orphanOut.appendChild(list);
+    orphanClear.disabled = false;
+  };
+
+  orphanFind.onclick = async () => {
+    orphanOut.textContent = 'Looking…';
+    const r = await api('/api/ha/orphans');
+    if (!r.body?.ok) { orphanOut.textContent = 'Could not check: ' + (r.body?.message || 'unknown error'); return; }
+    showOrphans(r.body.topics || []);
+  };
+
+  orphanClear.onclick = async () => {
+    orphanClear.disabled = true;
+    const r = await api('/api/ha/orphans/clear', 'POST');
+    if (!r.body?.ok) { toast('Could not clear: ' + (r.body?.message || 'unknown error'), false); return; }
+    toast(`Cleared ${r.body.cleared} orphaned device(s). Home Assistant removes them on the next discovery pass.`, true);
+    showOrphans([]);
+  };
+
   link.onclick = () => activate(link, sec);
 }

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -4263,6 +4263,56 @@ function addHaEnergySection(nav     , sections     ) {
     const r = await api('/api/ha-energy/clear', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url: url.inp.value.trim(), token: token.inp.value }) });
     toast(r.body.message || (r.ok ? 'Done.' : 'Failed.'), r.ok && r.body.ok);
   };
+  // Orphaned discovery configs — devices Home Assistant still shows for things that no longer exist.
+  //
+  // A discovery config is retained, so it outlives what it described: an outlet that later gained a native
+  // energy sensor, a tier deleted from the hierarchy, a node renamed. The publish loop can never find them
+  // again because it only walks the nodes that exist now. Two steps on purpose — deleting devices from
+  // someone's Home Assistant is not something to do quietly, so it lists them and waits.
+  sec.appendChild(el('h3', { text: 'Orphaned Home Assistant devices', style: { margin: '18px 0 4px' } }));
+  sec.appendChild(el('div', { class: 'desc' },
+    'Discovery messages are retained, so a device stays in Home Assistant after the thing it described is '
+    + 'gone — an outlet that gained its own energy sensor, a renamed node, a deleted tier. This finds configs '
+    + 'published under this project’s own prefix that the current setup would no longer publish. Nothing '
+    + 'belonging to another integration is ever listed or touched.'));
+
+  const orphanOut = el('div', { class: 'desc' })               ;
+  const orphanFind = btn('Find orphaned devices');
+  const orphanClear = btn('Clear them', 'danger');
+  orphanClear.disabled = true;
+  const orphanBar = el('div', { class: 'sec-actions' }, orphanFind, orphanClear);
+  sec.appendChild(orphanBar);
+  sec.appendChild(orphanOut);
+
+  const showOrphans = (topics          ) => {
+    orphanOut.innerHTML = '';
+    if (!topics.length) {
+      orphanOut.textContent = 'Nothing orphaned — every retained discovery config matches something that still exists.';
+      orphanClear.disabled = true;
+      return;
+    }
+    orphanOut.appendChild(el('div', { text: `${topics.length} orphaned config(s) would be cleared:` }));
+    const list = el('ul', { style: { margin: '4px 0 0 18px' } });
+    topics.forEach(t => list.appendChild(el('li', { text: t, style: { fontFamily: 'var(--mono)', fontSize: '11px' } })));
+    orphanOut.appendChild(list);
+    orphanClear.disabled = false;
+  };
+
+  orphanFind.onclick = async () => {
+    orphanOut.textContent = 'Looking…';
+    const r = await api('/api/ha/orphans');
+    if (!r.body?.ok) { orphanOut.textContent = 'Could not check: ' + (r.body?.message || 'unknown error'); return; }
+    showOrphans(r.body.topics || []);
+  };
+
+  orphanClear.onclick = async () => {
+    orphanClear.disabled = true;
+    const r = await api('/api/ha/orphans/clear', 'POST');
+    if (!r.body?.ok) { toast('Could not clear: ' + (r.body?.message || 'unknown error'), false); return; }
+    toast(`Cleared ${r.body.cleared} orphaned device(s). Home Assistant removes them on the next discovery pass.`, true);
+    showOrphans([]);
+  };
+
   link.onclick = () => activate(link, sec);
 }
 


### PR DESCRIPTION
Home Assistant was showing outlets two and three times over. On the broker:

```
13 × homeassistant/device/energyflow_outlet_*/config   ← duplicates of native outlets
 2 × homeassistant/device/energyflow_pdu_*/config      ← duplicates of native PDUs
 9 × homeassistant/device/energyflow_<tier>/config     ← correct (the synthetic tiers)
33 × homeassistant/device/rPDU2MQTT_*/config           ← correct (native discovery)
```

A discovery config is **retained**, so it outlives what it described. An outlet that later gained a native energy sensor — at which point the flow export correctly *stops* publishing a duplicate for it — leaves the old config sitting on the broker, and HA goes on showing the device as real. Same for a tier deleted from the hierarchy, or a node renamed.

Nothing revisits them, and nothing can: the publish loop walks the nodes that exist *now*, so a config for something that no longer exists is unreachable from it by construction. The only way to find one is to ask the broker what's actually retained and subtract what we mean to publish.

**Two buttons, not one** (HA Energy Mapping page). Deleting devices out of someone's Home Assistant isn't something to do on a timer or quietly at startup — *Find orphaned devices* lists exactly what would go, *Clear them* does it.

**Narrow by construction:** only the configured discovery prefix, only the `device` component, only ids under this exporter's own `energyflow_` prefix. Another integration's discovery — and this project's *native* PDU discovery, which a different service owns — are never listed and never touched. A blank prefix matches nothing rather than everything, which is the failure that would actually hurt; there's a test for it.

537 tests pass; GUI smoke/layout/sankey checks pass.

Refs #292, #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)