### PR TITLE
"Clear discovery" now clears discovery

### DIFF
--- a/rPDU2MQTT.Core/HomeAssistant/HaDiscoveryTopics.cs
+++ b/rPDU2MQTT.Core/HomeAssistant/HaDiscoveryTopics.cs
@@ -1,0 +1,64 @@
+namespace rPDU2MQTT.Core.HomeAssistant;
+
+/// <summary>
+/// Which retained Home Assistant discovery topics on the broker belong to this project.
+///
+/// <para>
+/// "Clear discovery" used to mean "clear what this process published since it started" — a set held in
+/// memory by one service. That is not what anyone reading the button expects, and it cannot be: it has no
+/// knowledge of topics published by a previous version under different ids, by the energy-flow exporter
+/// (a separate service keeping its own set), or by any configuration that has since changed. Everything
+/// outside that set survived the clear and stayed in Home Assistant forever, because the only thing that
+/// could ever have removed it had already forgotten it existed.
+/// </para>
+/// <para>
+/// The set of things to clear therefore has to come from the <b>broker</b>, not from memory: whatever is
+/// actually retained under the discovery prefix, filtered to the ids this project issues.
+/// </para>
+/// </summary>
+public static class HaDiscoveryTopics
+{
+    /// <summary>
+    /// Device/entity id prefixes this project issues. Everything it publishes is named with one of these:
+    /// <c>rPDU2MQTT_</c> for PDU-derived devices and <c>energyflow_</c> for energy-hierarchy tiers.
+    /// </summary>
+    public static readonly string[] OwnedIdPrefixes = ["rPDU2MQTT_", "energyflow_"];
+
+    /// <summary>
+    /// Every retained discovery topic under <paramref name="discoveryPrefix"/> whose id this project owns.
+    ///
+    /// <para>
+    /// Matches both discovery layouts Home Assistant accepts — <c>&lt;prefix&gt;/&lt;component&gt;/&lt;id&gt;/config</c>
+    /// and the node-scoped <c>&lt;prefix&gt;/&lt;component&gt;/&lt;node&gt;/&lt;id&gt;/config</c> — so a config
+    /// written by an older build in the per-entity format is found as readily as today's device-scoped one.
+    /// </para>
+    /// <para>
+    /// Ownership is decided by the id prefix and nothing else. Another integration's discovery must never be
+    /// touched: clearing it deletes someone's devices out of Home Assistant, and nothing here would put them
+    /// back. A blank discovery prefix matches nothing rather than everything, which is the way round that
+    /// fails safely.
+    /// </para>
+    /// </summary>
+    public static IReadOnlyList<string> Owned(IEnumerable<string> retainedTopics, string? discoveryPrefix)
+    {
+        var root = (discoveryPrefix ?? "").Trim().Trim('/');
+        if (root.Length == 0) return Array.Empty<string>();
+
+        var found = new List<string>();
+        foreach (var topic in retainedTopics ?? Enumerable.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(topic)) continue;
+            var parts = topic.Split('/');
+
+            // <root>/<component>/<id>/config, optionally with a node id before the object id.
+            if (parts.Length is not (4 or 5)) continue;
+            if (!string.Equals(parts[0], root, StringComparison.OrdinalIgnoreCase)) continue;
+            if (!string.Equals(parts[^1], "config", StringComparison.OrdinalIgnoreCase)) continue;
+
+            var id = parts[^2];
+            if (OwnedIdPrefixes.Any(p => id.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+                found.Add(topic);
+        }
+        return found;
+    }
+}

--- a/rPDU2MQTT.Tests/HaDiscoveryTopicsTests.cs
+++ b/rPDU2MQTT.Tests/HaDiscoveryTopicsTests.cs
@@ -1,0 +1,78 @@
+using rPDU2MQTT.Core.HomeAssistant;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// "Clear discovery" has to mean the broker is clean. It used to mean "clear what this process published
+/// since it started", which left every config from an earlier version, a changed config, or the energy-flow
+/// exporter's separate bookkeeping in place — and in Home Assistant forever.
+/// </summary>
+public class HaDiscoveryTopicsTests
+{
+    private static readonly string[] Retained =
+    [
+        "homeassistant/device/rPDU2MQTT_A0AE_outlets_4/config",       // ours, device layout
+        "homeassistant/device/energyflow_grid/config",                // ours, flow tier
+        "homeassistant/sensor/rPDU2MQTT_A0AE_energy/config",          // ours, legacy per-entity layout
+        "homeassistant/binary_sensor/energyflow_old_alarm/config",    // ours, legacy, different component
+        "homeassistant/sensor/node1/rPDU2MQTT_A0AE_x/config",         // ours, node-scoped layout
+        "homeassistant/sensor/acurite_attic/config",                  // someone else entirely
+        "homeassistant/device/zigbee_0x00124b/config",                // someone else entirely
+        "Rack_PDU/pdu_1/outlets/4/realpower",                         // not discovery
+        "homeassistant/device/energyflow_grid/state",                 // ours, but not a config topic
+    ];
+
+    [Fact]
+    public void EverythingOfOursIsFound_WhicheverLayoutItWasPublishedIn()
+    {
+        var owned = HaDiscoveryTopics.Owned(Retained, "homeassistant");
+
+        Assert.Equal(new[]
+        {
+            "homeassistant/device/rPDU2MQTT_A0AE_outlets_4/config",
+            "homeassistant/device/energyflow_grid/config",
+            "homeassistant/sensor/rPDU2MQTT_A0AE_energy/config",
+            "homeassistant/binary_sensor/energyflow_old_alarm/config",
+            "homeassistant/sensor/node1/rPDU2MQTT_A0AE_x/config",
+        }, owned);
+    }
+
+    [Fact]
+    public void NobodyElsesDiscoveryIsEverTouched()
+    {
+        // The failure that would matter: clearing another integration's config deletes their devices out of
+        // Home Assistant, and nothing here would put them back.
+        var owned = HaDiscoveryTopics.Owned(Retained, "homeassistant");
+
+        Assert.DoesNotContain(owned, t => t.Contains("acurite"));
+        Assert.DoesNotContain(owned, t => t.Contains("zigbee"));
+    }
+
+    [Fact]
+    public void OnlyConfigTopics_NotStateTopics()
+        => Assert.DoesNotContain(HaDiscoveryTopics.Owned(Retained, "homeassistant"), t => t.EndsWith("/state"));
+
+    [Fact]
+    public void ACustomPrefixIsHonoured()
+    {
+        var retained = new[] { "ha/device/energyflow_x/config", "homeassistant/device/energyflow_x/config" };
+        Assert.Equal(new[] { "ha/device/energyflow_x/config" }, HaDiscoveryTopics.Owned(retained, "ha"));
+    }
+
+    [Fact]
+    public void ABlankPrefixMatchesNothingRatherThanEverything()
+    {
+        Assert.Empty(HaDiscoveryTopics.Owned(Retained, ""));
+        Assert.Empty(HaDiscoveryTopics.Owned(Retained, "  "));
+        Assert.Empty(HaDiscoveryTopics.Owned(Retained, null));
+    }
+
+    [Fact]
+    public void AnIdThatMerelyContainsOurNameIsNotOurs()
+    {
+        // Ownership is a prefix, not a substring — someone else's "solar_rPDU2MQTT_mirror" is not ours to delete.
+        var retained = new[] { "homeassistant/sensor/solar_rPDU2MQTT_mirror/config" };
+        Assert.Empty(HaDiscoveryTopics.Owned(retained, "homeassistant"));
+    }
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1749,8 +1749,47 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             if (!discovery.HasSubscribers)
                 return Results.Json(new { ok = false, message = "Home Assistant discovery is disabled." }, ConfigSchema.Json);
 
+            // First the services' own clear: each forgets and retracts what it published this run.
             await discovery.RequestClearAsync(CancellationToken.None);
-            return Results.Json(new { ok = true, message = "Cleared the retained Home Assistant discovery messages." }, ConfigSchema.Json);
+
+            // Then everything else of ours still retained on the broker. The services only know what THEY
+            // published since starting, which is why this button used to leave devices behind — anything
+            // from an earlier version, from a config that has since changed, or from the energy-flow
+            // exporter's separate bookkeeping, survived every "clear" and stayed in Home Assistant forever.
+            // "Clear discovery" has to mean the broker is clean, so the list comes from the broker.
+            var swept = 0;
+            var message = "Cleared the retained Home Assistant discovery messages.";
+            try
+            {
+                var prefix = config.HASS.DiscoveryTopic;
+                var index = grains.GetGrain<Grains.Abstractions.Discovery.ITopicIndexGrain>(0);
+                await index.Renew((prefix ?? "").Trim().Trim('/') + "/#");
+                var retained = (await index.Search(null, 5000)).Select(t => t.Topic);
+
+                foreach (var topic in Core.HomeAssistant.HaDiscoveryTopics.Owned(retained, prefix))
+                {
+                    await mqtt.PublishAsync(new MQTT5PublishMessage(topic, QualityOfService.AtLeastOnceDelivery)
+                    {
+                        Payload = Array.Empty<byte>(),
+                        Retain = true,
+                    });
+                    swept++;
+                }
+                if (swept > 0)
+                {
+                    Log.Information($"Clear discovery: swept {swept} retained discovery topic(s) from the broker.");
+                    message = $"Cleared the retained Home Assistant discovery messages, including {swept} left over from earlier runs.";
+                }
+            }
+            catch (Exception ex)
+            {
+                // The services' own clear already succeeded; say what did and did not happen rather than
+                // reporting a blanket failure.
+                Log.Warning($"Clear discovery: the broker sweep failed ({ex.Message}); only this run's topics were cleared.");
+                message = "Cleared this run's discovery messages, but could not sweep the broker for older ones: " + ex.Message;
+            }
+
+            return Results.Json(new { ok = true, swept, message }, ConfigSchema.Json);
         });
     }
 

--- a/rPDU2MQTT.Web/web/src/actions.ts
+++ b/rPDU2MQTT.Web/web/src/actions.ts
@@ -33,7 +33,9 @@ export async function deleteEmonCmsFeeds() {
 }
 export async function rediscoverHa() { toast('Requesting discovery…', true); const r = await api('/api/discovery/rediscover', { method: 'POST' }); toast(r.body.message, r.body.ok); }
 export async function clearHa() {
-  if (!confirm('Clear all Home Assistant discovery messages? The entities will disappear from Home Assistant until discovery runs again.')) return;
+  if (!confirm('Clear ALL Home Assistant discovery messages published by rPDU2MQTT — including any left over '
+    + 'from earlier versions or configurations? Every entity disappears from Home Assistant until discovery '
+    + 'runs again. Nothing belonging to another integration is touched.')) return;
   const r = await api('/api/discovery/clear', { method: 'POST' });
   toast(r.body.message, r.body.ok);
 }

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -5017,7 +5017,9 @@ async function deleteEmonCmsFeeds() {
 }
 async function rediscoverHa() { toast('Requesting discovery…', true); const r = await api('/api/discovery/rediscover', { method: 'POST' }); toast(r.body.message, r.body.ok); }
 async function clearHa() {
-  if (!confirm('Clear all Home Assistant discovery messages? The entities will disappear from Home Assistant until discovery runs again.')) return;
+  if (!confirm('Clear ALL Home Assistant discovery messages published by rPDU2MQTT — including any left over '
+    + 'from earlier versions or configurations? Every entity disappears from Home Assistant until discovery '
+    + 'runs again. Nothing belonging to another integration is touched.')) return;
   const r = await api('/api/discovery/clear', { method: 'POST' });
   toast(r.body.message, r.body.ok);
 }


### PR DESCRIPTION
Clicking it left orphaned devices behind. That's not a defensible reading of the button.

## Why

`ClearAllDiscoveries` retracted `publishedDeviceTopics` — **an in-memory set of what that one service published since the process last started.** Nothing else was reachable by it:

- a config written by an earlier version under a different id
- one whose subject has since changed (an outlet that gained a native energy sensor)
- anything from the energy-flow exporter, which keeps its own separate set

All of it survived every "clear" and stayed in Home Assistant indefinitely, because the only thing that could have removed it had already forgotten it existed.

## Fix

The list has to come from the **broker**, not from memory. The button still asks each service to retract what it knows about, then sweeps every retained topic under the discovery prefix whose id carries one of this project's own prefixes — `rPDU2MQTT_` or `energyflow_` — and retracts those too.

Both discovery layouts are matched — `<prefix>/<component>/<id>/config` and the node-scoped five-segment form — so a config left by an older build in the per-entity format is found as readily as today's device-scoped one.

## Safety

Ownership is a **prefix on the id**, nothing else. Another integration's discovery is never touched: clearing it deletes someone's devices out of Home Assistant and nothing here would put them back. Two cases pinned by tests because they're the ones that would actually hurt:

- a blank discovery prefix matches **nothing** rather than everything
- someone else's `solar_rPDU2MQTT_mirror` is **not** ours — substring isn't ownership

If the sweep fails, the services' own clear has already happened, so it reports which part worked rather than a blanket failure.

547 tests pass; GUI smoke/layout/sankey checks pass.

Refs #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)