### PR TITLE
The discovery sweep can now actually see everything it promises to clear

### DIFF
--- a/rPDU2MQTT.Grains.Abstractions/Discovery/ITopicIndexGrain.cs
+++ b/rPDU2MQTT.Grains.Abstractions/Discovery/ITopicIndexGrain.cs
@@ -66,6 +66,20 @@ public interface ITopicIndexGrain : IGrainWithIntegerKey
     /// <summary>Topics matching a query (substring, case-insensitive), shortest first. Renews the lease.</summary>
     Task<List<TopicSample>> Search(string? query, int limit);
 
+    /// <summary>
+    /// Every topic currently held whose name starts with <paramref name="prefix"/> — uncapped, unordered by
+    /// relevance.
+    ///
+    /// <para>
+    /// Separate from <see cref="Search"/> because the two want opposite things. Search is a browse: it caps
+    /// at a couple of hundred and puts the shortest topics first, because a human typing into an autocomplete
+    /// wants the closest match, not a complete inventory. A sweep that has to retract <em>every</em> retained
+    /// discovery message wants exactly the inventory, and quietly receiving the first two hundred by length
+    /// would leave the rest behind — which is the failure the sweep exists to prevent.
+    /// </para>
+    /// </summary>
+    Task<List<string>> TopicsUnder(string prefix);
+
     /// <summary>The last payload seen on one topic, if it's in the index.</summary>
     Task<TopicSample?> Get(string topic);
 }

--- a/rPDU2MQTT.Grains/Discovery/TopicIndexGrain.cs
+++ b/rPDU2MQTT.Grains/Discovery/TopicIndexGrain.cs
@@ -91,6 +91,17 @@ public sealed class TopicIndexGrain : Grain, ITopicIndexGrain
         return Task.FromResult(matches);
     }
 
+
+    public Task<List<string>> TopicsUnder(string prefix)
+    {
+        leaseUntilUtc = DateTime.UtcNow + Lease;   // a sweep is a reader too; don't let the feed lapse mid-scan
+        timer ??= this.RegisterGrainTimer(TickAsync, new GrainTimerCreationOptions(Tick, Tick) { KeepAlive = true });
+
+        var p = prefix ?? "";
+        return Task.FromResult(topics.Keys
+            .Where(t => p.Length == 0 || t.StartsWith(p, StringComparison.OrdinalIgnoreCase))
+            .ToList());
+    }
     public Task<TopicSample?> Get(string topic)
         => Task.FromResult(topics.TryGetValue(topic ?? "", out var sample) ? sample : null);
 

--- a/rPDU2MQTT.Tests/TopicIndexTests.cs
+++ b/rPDU2MQTT.Tests/TopicIndexTests.cs
@@ -221,4 +221,53 @@ public class TopicIndexGrainTests
         }
         finally { await cluster.StopAllSilosAsync(); }
     }
+
+    [Fact]
+    public async Task TopicsUnder_ReturnsEverything_WhereSearchWouldCapAndReorder()
+    {
+        // A sweep that must retract every retained discovery message cannot use Search: it caps at 200 and
+        // orders by topic length for autocomplete relevance, so on a busy broker it would quietly hand back a
+        // subset and the rest would survive the "clear" — the exact failure the sweep exists to prevent.
+        var cluster = await GrainTestCluster.StartAsync();
+        try
+        {
+            var index = cluster.GrainFactory.GetGrain<ITopicIndexGrain>(0);
+            await index.Renew("homeassistant/#");
+
+            var samples = Enumerable.Range(0, 400)
+                .Select(i => new TopicSample { Topic = $"homeassistant/device/rPDU2MQTT_dev{i:000}/config", SeenUtc = DateTime.UtcNow })
+                .Append(new TopicSample { Topic = "other/thing", SeenUtc = DateTime.UtcNow })
+                .ToList();
+            await index.Observe(samples);
+
+            var swept = await index.TopicsUnder("homeassistant/");
+            Assert.Equal(400, swept.Count);
+            Assert.DoesNotContain("other/thing", swept);
+
+            // What the old path would have given the sweep.
+            var browsed = await index.Search(null, 5000);
+            Assert.True(browsed.Count <= 200, $"Search is meant to stay a browse, got {browsed.Count}");
+        }
+        finally { await cluster.StopAllSilosAsync(); }
+    }
+
+    [Fact]
+    public async Task TopicsUnder_MatchesOnPrefix_NotSubstring()
+    {
+        var cluster = await GrainTestCluster.StartAsync();
+        try
+        {
+            var index = cluster.GrainFactory.GetGrain<ITopicIndexGrain>(0);
+            await index.Renew("#");
+            await index.Observe(new List<TopicSample>
+            {
+                new() { Topic = "homeassistant/device/a/config", SeenUtc = DateTime.UtcNow },
+                new() { Topic = "mirror/homeassistant/device/b/config", SeenUtc = DateTime.UtcNow },
+            });
+
+            var found = await index.TopicsUnder("homeassistant/");
+            Assert.Equal(new[] { "homeassistant/device/a/config" }, found);
+        }
+        finally { await cluster.StopAllSilosAsync(); }
+    }
 }

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1762,9 +1762,29 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             try
             {
                 var prefix = config.HASS.DiscoveryTopic;
+                var root = (prefix ?? "").Trim().Trim('/');
                 var index = grains.GetGrain<Grains.Abstractions.Discovery.ITopicIndexGrain>(0);
-                await index.Renew((prefix ?? "").Trim().Trim('/') + "/#");
-                var retained = (await index.Search(null, 5000)).Select(t => t.Topic);
+
+                // The index only fills while someone is reading it, and the subscription it needs is opened by
+                // another process on its own timer. Reading it the instant after asking would sweep whatever
+                // happened to be cached — possibly for a different filter, possibly nothing — and then report
+                // success. Wait for the feed to actually be live, and give the retained backlog a moment to
+                // land, before deciding what exists.
+                var state = await index.Renew(root + "/#");
+                for (var i = 0; i < 30 && !(state.Listening && state.Granted != false); i++)
+                {
+                    await Task.Delay(500);
+                    state = await index.Renew(root + "/#");
+                }
+                if (state.Granted == false)
+                    throw new InvalidOperationException($"the broker refused a subscription to '{root}/#', so what is retained there cannot be read");
+                if (!state.Listening)
+                    throw new InvalidOperationException("no process is feeding the topic index, so what is retained on the broker cannot be read");
+                await Task.Delay(2000);   // retained messages arrive in a burst; let it finish
+
+                // Uncapped on purpose: Search caps at 200 and orders by topic length, which is right for an
+                // autocomplete and wrong for a sweep that must not miss one.
+                var retained = await index.TopicsUnder(root + "/");
 
                 foreach (var topic in Core.HomeAssistant.HaDiscoveryTopics.Owned(retained, prefix))
                 {
@@ -1775,11 +1795,11 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                     });
                     swept++;
                 }
-                if (swept > 0)
-                {
-                    Log.Information($"Clear discovery: swept {swept} retained discovery topic(s) from the broker.");
-                    message = $"Cleared the retained Home Assistant discovery messages, including {swept} left over from earlier runs.";
-                }
+                Log.Information($"Clear discovery: swept {swept} retained discovery topic(s) from the broker "
+                              + $"(index held {retained.Count} under '{root}/').");
+                message = swept > 0
+                    ? $"Cleared every rPDU2MQTT discovery message on the broker — {swept} topic(s), including any left over from earlier versions."
+                    : "Cleared this run's discovery messages; the broker held nothing else of ours.";
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Follow-up to #324 — a flaw in my own fix, found before it bit.

**The sweep asked for 5000 topics; `Search` clamps to 200** and orders by topic *length* (right for an autocomplete, wrong for this). On any broker holding more than 200 discovery topics it would take an arbitrary subset by name length, retract those, and report success — under-clearing exactly the way the button did before, only now with a confident number next to it. This install has 99, so it happens to work here and would have failed silently on a bigger one.

`TopicsUnder(prefix)` returns everything held, uncapped and unordered, documented as the deliberate opposite of `Search` so the next person doesn't reach for the browse call again.

**The other half was worse.** The index only fills while someone reads it, and the broker subscription it needs is opened by a different process on its own timer. Reading immediately after asking swept whatever happened to be cached — possibly for a different filter, possibly nothing at all — and then claimed everything was cleared. It now waits for the feed to be live, lets the retained backlog land, and **refuses outright** if the broker denied the subscription or nothing is feeding the index. Better to say it couldn't look than to claim the broker is clean without having seen it.

549 tests pass, including one pinning `Search` staying a browse — the guard only works while the two calls keep their different jobs.

Refs #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)