### PR TITLE
fix(mqtt): restore Record_Key/Record_Parent on snapshots rebuilt from the wire

### DIFF
--- a/rPDU2MQTT.Core/Core/RawSnapshot.cs
+++ b/rPDU2MQTT.Core/Core/RawSnapshot.cs
@@ -1,4 +1,6 @@
+using rPDU2MQTT.Extensions;
 using rPDU2MQTT.Models.PDU;
+using rPDU2MQTT.Models.PDU.DummyDevices;
 
 namespace rPDU2MQTT.Core.Transport;
 
@@ -51,6 +53,52 @@ public static class RawSnapshotMapper
 
     private static RawMeasurement ToWire(Measurement m) => new(
         m.Key, m.Type, m.Entity_Name, m.Entity_DisplayName, m.Value, m.Units, m.State);
+
+    /// <summary>
+    /// Re-establish the MQTT topic wiring on a rebuilt <see cref="PduData"/>.
+    ///
+    /// <para>
+    /// <c>Record_Key</c> and <c>Record_Parent</c> are <c>[JsonIgnore]</c>, so they do not cross the wire, and
+    /// nothing downstream can reconstruct them from the payload alone. <c>GetTopicPath()</c> walks that
+    /// parent chain upward; with it missing the path collapses to nothing and a measurement publishes to the
+    /// bare topic <c>state</c> at the broker root. That is not a topic anyone subscribes to, so on a live
+    /// system every Home Assistant sensor read "Unavailable" while discovery — which builds its ids by a
+    /// different route — looked perfectly healthy.
+    /// </para>
+    /// <para>
+    /// The wiring below mirrors what the poller does when it first builds the graph, and must keep mirroring
+    /// it: <c>SetParentAndIdentifier</c> also recomputes <c>Entity_Identifier</c>, which is the Home
+    /// Assistant unique_id. Diverging here would not fail loudly — it would silently mint a second device for
+    /// every outlet and leave the originals orphaned, which is a mess that outlives the fix.
+    /// </para>
+    /// </summary>
+    /// <param name="data">The rebuilt graph, straight out of <see cref="ToData"/>.</param>
+    /// <param name="parentTopic">The MQTT parent topic — the root of every path (<c>MQTT.ParentTopic</c>).</param>
+    /// <param name="rootIdentifier">The root's <c>Entity_Identifier</c>, which every child id is built from.</param>
+    public static void Rewire(PduData data, string parentTopic, string rootIdentifier)
+    {
+        // PduData is a container, not a topic node — the poller's root is the OneView document, which does
+        // not survive the wire either. A stand-in carrying the same key and identifier reproduces the same
+        // paths and the same ids, which is all the chain below reads from it.
+        var root = new DummyEntity
+        {
+            Record_Key = parentTopic ?? "",
+            Record_Parent = null,
+            Entity_Identifier = rootIdentifier ?? "",
+        };
+
+        data.Devices.SetParentAndIdentifier(root, o => o.Key);
+        foreach (var device in data.Devices)
+        {
+            device.Entity.SetParentAndIdentifier(BaseEntity.FromDevice(device, MqttPath.Entity), o => o.Key);
+            device.Outlets.SetParentAndIdentifier(BaseEntity.FromDevice(device, MqttPath.Outlets), o => o.Key.ToString());
+
+            foreach (var entity in device.Entity)
+                entity.Measurements.SetParentAndIdentifier(BaseEntity.FromDevice(entity, MqttPath.Measurements), o => o.Type);
+            foreach (var outlet in device.Outlets)
+                outlet.Measurements.SetParentAndIdentifier(BaseEntity.FromDevice(outlet, MqttPath.Measurements), o => o.Type);
+        }
+    }
 
     /// <summary>Consumer side: rebuild a ready-to-render <see cref="PduData"/> (keys + computed names restored).</summary>
     public static PduData ToData(RawSnapshot snapshot)

--- a/rPDU2MQTT.Tests/SnapshotRewireTests.cs
+++ b/rPDU2MQTT.Tests/SnapshotRewireTests.cs
@@ -1,0 +1,117 @@
+using rPDU2MQTT.Core.Transport;
+using rPDU2MQTT.Extensions;
+using rPDU2MQTT.Models.PDU;
+using rPDU2MQTT.Models.PDU.DummyDevices;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// A snapshot that crosses the wire must come back publishable.
+///
+/// <para>
+/// <c>Record_Key</c> and <c>Record_Parent</c> are <c>[JsonIgnore]</c>, so they do not survive, and
+/// <c>GetTopicPath()</c> walks exactly that chain. Without them a measurement published to the bare topic
+/// <c>state</c> — which is why every Home Assistant sensor read "Unavailable" while discovery, which builds
+/// its ids by another route, looked healthy.
+/// </para>
+/// </summary>
+public class SnapshotRewireTests
+{
+    private const string ParentTopic = "Rack_PDU";
+    private const string RootId = "rPDU2MQTT";
+
+    /// <summary>The graph as the poller builds it, wired the way PDU.processOneViewData wires it.</summary>
+    private static (PduData Data, DummyEntity Root) Original()
+    {
+        var m = new Measurement { Key = "realpower", Type = "realpower", Value = "61", Units = "W", State = "state" };
+        var outlet = new Outlet { Key = 3, Name = "Outlet 3", Label = "Kube01", State = "on" };
+        outlet.Measurements.Add(m);
+        var device = new Device { Key = "pdu_1", Name = "Rack-PDU-1", Label = "Rack-PDU-1", State = "on", Type = "rpdu" };
+        device.Outlets.Add(outlet);
+
+        var data = new PduData();
+        data.Devices.Add(device);
+
+        var root = new DummyEntity { Record_Key = ParentTopic, Record_Parent = null, Entity_Identifier = RootId };
+        data.Devices.SetParentAndIdentifier(root, o => o.Key);
+        foreach (var d in data.Devices)
+        {
+            d.Outlets.SetParentAndIdentifier(BaseEntity.FromDevice(d, MqttPath.Outlets), o => o.Key.ToString());
+            foreach (var o in d.Outlets)
+                o.Measurements.SetParentAndIdentifier(BaseEntity.FromDevice(o, MqttPath.Measurements), x => x.Type);
+        }
+        return (data, root);
+    }
+
+    private static Measurement FirstMeasurement(PduData d) => d.Devices[0].Outlets[0].Measurements[0];
+
+    [Fact]
+    public void WithoutRewiring_AMeasurementPublishesToTheBareTopic_state()
+    {
+        // The bug, reproduced. This is the topic the live system was trying to publish to, and the broker
+        // never acknowledged it.
+        var wire = RawSnapshotMapper.ToWire("default", DateTime.UtcNow, Original().Data);
+        var rebuilt = RawSnapshotMapper.ToData(wire);
+
+        var topic = FirstMeasurement(rebuilt).GetTopicPath();
+
+        Assert.DoesNotContain(ParentTopic, topic);
+        Assert.DoesNotContain("outlets", topic);
+    }
+
+    [Fact]
+    public void AfterRewiring_TheTopicIsIdenticalToTheOneThePollerWouldPublish()
+    {
+        var (original, _) = Original();
+        var expected = FirstMeasurement(original).GetTopicPath();
+
+        var rebuilt = RawSnapshotMapper.ToData(RawSnapshotMapper.ToWire("default", DateTime.UtcNow, original));
+        RawSnapshotMapper.Rewire(rebuilt, ParentTopic, RootId);
+
+        Assert.Equal(expected, FirstMeasurement(rebuilt).GetTopicPath());
+        Assert.StartsWith(ParentTopic, FirstMeasurement(rebuilt).GetTopicPath());
+    }
+
+    [Fact]
+    public void AfterRewiring_EveryEntityIdentifierIsUnchanged()
+    {
+        // The one that must not drift. Entity_Identifier is the Home Assistant unique_id: a rewire that
+        // produced different ids would not fail — it would silently mint a second device for every outlet
+        // and orphan the originals, which is a mess that outlives the fix.
+        var (original, _) = Original();
+        var rebuilt = RawSnapshotMapper.ToData(RawSnapshotMapper.ToWire("default", DateTime.UtcNow, original));
+        RawSnapshotMapper.Rewire(rebuilt, ParentTopic, RootId);
+
+        Assert.Equal(original.Devices[0].Entity_Identifier, rebuilt.Devices[0].Entity_Identifier);
+        Assert.Equal(original.Devices[0].Outlets[0].Entity_Identifier, rebuilt.Devices[0].Outlets[0].Entity_Identifier);
+        Assert.Equal(FirstMeasurement(original).Entity_Identifier, FirstMeasurement(rebuilt).Entity_Identifier);
+    }
+
+    [Fact]
+    public void AfterRewiring_TheDeviceAndOutletTopicsAlsoMatch()
+    {
+        var (original, _) = Original();
+        var rebuilt = RawSnapshotMapper.ToData(RawSnapshotMapper.ToWire("default", DateTime.UtcNow, original));
+        RawSnapshotMapper.Rewire(rebuilt, ParentTopic, RootId);
+
+        Assert.Equal(original.Devices[0].GetTopicPath(), rebuilt.Devices[0].GetTopicPath());
+        Assert.Equal(original.Devices[0].Outlets[0].GetTopicPath(), rebuilt.Devices[0].Outlets[0].GetTopicPath());
+    }
+
+    [Fact]
+    public void RewiringIsIdempotent()
+    {
+        // The sync service rebuilds on a timer; running it twice must not compound the path or the id.
+        var (original, _) = Original();
+        var rebuilt = RawSnapshotMapper.ToData(RawSnapshotMapper.ToWire("default", DateTime.UtcNow, original));
+        RawSnapshotMapper.Rewire(rebuilt, ParentTopic, RootId);
+        var once = FirstMeasurement(rebuilt).GetTopicPath();
+        var onceId = FirstMeasurement(rebuilt).Entity_Identifier;
+
+        RawSnapshotMapper.Rewire(rebuilt, ParentTopic, RootId);
+
+        Assert.Equal(once, FirstMeasurement(rebuilt).GetTopicPath());
+        Assert.Equal(onceId, FirstMeasurement(rebuilt).Entity_Identifier);
+    }
+}

--- a/rPDU2MQTT/Hosting/PduSyncService.cs
+++ b/rPDU2MQTT/Hosting/PduSyncService.cs
@@ -18,15 +18,17 @@ public sealed class PduSyncService : BackgroundService
     private readonly PduInstanceRegistry registry;
     private readonly IMessageBus bus;
     private readonly HealthState health;
+    private readonly Config config;
     // The freshest snapshot timestamp seen per instance — a repeat of the same one isn't a new poll.
     private readonly Dictionary<string, DateTime> seen = new(StringComparer.OrdinalIgnoreCase);
 
-    public PduSyncService(IGrainFactory grains, PduInstanceRegistry registry, IMessageBus bus, HealthState health)
+    public PduSyncService(IGrainFactory grains, PduInstanceRegistry registry, IMessageBus bus, HealthState health, Config config)
     {
         this.grains = grains;
         this.registry = registry;
         this.bus = bus;
         this.health = health;
+        this.config = config;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -42,7 +44,17 @@ public sealed class PduSyncService : BackgroundService
                     var wire = await grains.GetGrain<IPduGrain>(id).Latest();
                     if (wire is null) continue;
 
-                    await bus.PublishAsync(new PduSnapshot(wire.InstanceId, wire.TimestampUtc, RawSnapshotMapper.ToData(wire)), stoppingToken);
+                    // Rebuilding from the wire loses Record_Key/Record_Parent — they are [JsonIgnore] and the
+                    // payload has no way to carry them. GetTopicPath() walks exactly that chain, so without
+                    // this the snapshot that lands in the cache publishes every measurement to the bare topic
+                    // `state`, and the good one the local poller put there is overwritten by it. On a live
+                    // system that showed up as every Home Assistant sensor reading "Unavailable" while
+                    // discovery — which builds its ids by another route — looked entirely healthy.
+                    var data = RawSnapshotMapper.ToData(wire);
+                    RawSnapshotMapper.Rewire(data, config.MQTT.ParentTopic,
+                        string.IsNullOrWhiteSpace(config.Overrides?.rPDU2MQTT?.ID) ? "rPDU2MQTT" : config.Overrides!.rPDU2MQTT!.ID!);
+
+                    await bus.PublishAsync(new PduSnapshot(wire.InstanceId, wire.TimestampUtc, data), stoppingToken);
 
                     // Readiness is a per-process signal read by this process's health endpoint, so it has to
                     // be recorded here — the poll itself happens in a grain on whichever silo owns it, and a


### PR DESCRIPTION
Every Home Assistant sensor read **Unavailable** while discovery looked healthy and MQTT was connected.

`Record_Key` and `Record_Parent` are `[JsonIgnore]`, so they don't cross the wire, and `RawSnapshotMapper.ToData` rebuilt the graph without them. `GetTopicPath()` walks exactly that parent chain — with it missing the path collapses to nothing and `JoinPaths(GetTopicPath(), State_Topic)` yields the bare topic **`state`** at the broker root. Nothing subscribes to that, and the broker never acknowledged it.

`PduSyncService` then overwrote the correctly-wired snapshot the local poller had already put in the cache, so even an all-in-one deployment broke itself — and whichever landed last in `byInstance[...]` won, which made it look intermittent and environmental.

Discovery kept working throughout because it builds ids from `Entity_Identifier` rather than by walking the topic chain. So the entities existed and simply never received a value — a shape that argues convincingly for a broker fault and isn't one. I spent hours misreading it as an ACL problem.

## The care that mattered

`SetParentAndIdentifier` also recomputes `Entity_Identifier`, which is the Home Assistant **unique_id**. A rewire producing different ids wouldn't fail loudly — it would mint a second device for every outlet and orphan the originals, on top of the 39 stale ones just cleaned up. There's a test asserting the rebuilt ids are identical to the poller's, one reproducing the bare `state` topic, and one pinning the rewire as idempotent (the sync service runs it every second).

## Verified on the live instance

```
before:   Rack_PDU/#  →  1 message  (just Status)
after:    Rack_PDU/#  →  1,647 messages in 25s

Rack_PDU/1E9E260C851900C3/entity/breaker0/measurements/current
Rack_PDU/1E9E260C851900C3/entity/phase0/identifier
```

554 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)