### PR TITLE
The auto-update notice fires on a moving tag, which is everyone

### DIFF
--- a/rPDU2MQTT.Grains.Abstractions/Operator/IOperatorGrain.cs
+++ b/rPDU2MQTT.Grains.Abstractions/Operator/IOperatorGrain.cs
@@ -34,6 +34,24 @@ public sealed record OperatorReport
     [Id(6)] public string? CheckedAt { get; init; }
     [Id(7)] public string? Message { get; init; }
     [Id(8)] public OperatorSeverity Severity { get; init; }
+
+    /// <summary>
+    /// When the operator last actually rolled the deployment, ISO-8601. Null when it never has.
+    ///
+    /// <para>
+    /// <see cref="Applied"/> alone cannot signal a roll, which is why the GUI's auto-update notice never
+    /// appeared. Anyone tracking a moving tag — <c>unstable</c>, <c>main</c>, <c>edge</c>, the default and
+    /// the common case — gets a new <em>digest</em> under the same tag, so <see cref="Applied"/> reads
+    /// "unstable" before and after and nothing looks like it changed. Only a switch between differently
+    /// named tags was ever visible.
+    /// </para>
+    /// <para>
+    /// A timestamp of the roll itself changes every time, moving-tag or not, and is distinct from
+    /// <see cref="CheckedAt"/> — which advances on every scheduled check and would announce an update once
+    /// an hour whether or not anything happened.
+    /// </para>
+    /// </summary>
+    [Id(9)] public string? AppliedAt { get; init; }
 }
 
 /// <summary>

--- a/rPDU2MQTT.Grains/Operator/OperatorGrain.cs
+++ b/rPDU2MQTT.Grains/Operator/OperatorGrain.cs
@@ -73,7 +73,7 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
         try
         {
             var patched = await SetImageAsync(repository, newImage, newImage, CancellationToken.None);
-            await Report(report with { Available = false, Current = tag, Latest = tag, Applied = tag, CheckedAt = NowIso(), Message = $"Switched to {tag}.", Severity = OperatorSeverity.Ok });
+            await Report(report with { Available = false, Current = tag, Latest = tag, Applied = tag, AppliedAt = NowIso(), CheckedAt = NowIso(), Message = $"Switched to {tag}.", Severity = OperatorSeverity.Ok });
             return $"Switching to {tag}: rolled {(patched.Count > 0 ? string.Join(", ", patched) : "no")} deployment(s).";
         }
         catch (Exception ex) { return $"Switch to {tag} failed: {ex.Message}"; }
@@ -159,6 +159,11 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
                 Policy = cfg.Operator.Policy.ToString(),
                 AutoUpdate = cfg.Operator.AutoUpdate,
                 Applied = appliedChannel,
+                // Only stamped when a roll actually happened, and otherwise carried forward: this is "when
+                // we last rolled", not "when we last looked". On a moving channel the tag is identical
+                // before and after, so this timestamp is the only thing that changes — and it is what the
+                // GUI watches to announce the restart it is about to suffer.
+                AppliedAt = appliedChannel is not null ? NowIso() : report.AppliedAt,
                 CheckedAt = NowIso(),
                 Message = message,
                 Severity = severity,
@@ -183,6 +188,7 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
             Policy = cfg.Operator.Policy.ToString(),
             AutoUpdate = cfg.Operator.AutoUpdate,
             Applied = applied,
+            AppliedAt = applied is not null ? NowIso() : report.AppliedAt,
             CheckedAt = NowIso(),
             Message = check.UpdateAvailable ? (applied is not null ? $"Auto-updated to {applied}." : $"Update available: {latest}.") : "Up to date.",
             Severity = check.UpdateAvailable ? OperatorSeverity.UpdateAvailable : OperatorSeverity.Ok,
@@ -226,7 +232,7 @@ public sealed class OperatorGrain : Grain, IOperatorGrain
         if (source is null) return;
         try
         {
-            await source.PatchStatusAsync(new { update = new { available = r.Available, current = r.Current, latest = r.Latest, policy = r.Policy, autoUpdate = r.AutoUpdate, applied = r.Applied, checkedAt = r.CheckedAt, message = r.Message } }, CancellationToken.None);
+            await source.PatchStatusAsync(new { update = new { available = r.Available, current = r.Current, latest = r.Latest, policy = r.Policy, autoUpdate = r.AutoUpdate, applied = r.Applied, appliedAt = r.AppliedAt, checkedAt = r.CheckedAt, message = r.Message } }, CancellationToken.None);
         }
         catch (Exception ex) { log.LogDebug("Operator: CR status patch failed: {Msg}", ex.Message); }
     }

--- a/rPDU2MQTT.Web/rPDU2MQTT.Web.csproj
+++ b/rPDU2MQTT.Web/rPDU2MQTT.Web.csproj
@@ -39,6 +39,7 @@
 		<GuiSource Include="web\domstub.mjs" />
 		<GuiSource Include="web\layout.check.mjs" />
 		<GuiSource Include="web\sankey.check.mjs" />
+			<GuiSource Include="web\update.check.mjs" />
 		<GuiSource Include="web\schema.fixture.json" />
 	</ItemGroup>
 
@@ -58,6 +59,10 @@
 		     invisible ribbons. Both are asserted on the real bundle's rendered geometry. -->
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/layout.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/sankey.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
+		<!-- The auto-update notice has no click behind it, so its only test is this transition table: #304
+		     shipped one in prose and the case it missed (a moving channel, where the tag never changes) was
+		     exactly the one that broke. -->
+		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/update.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Warning Condition="'$(_NodeExitCode)' != '0'" Text="node not found; using the committed wwwroot/app.js + styles.css. Install Node 22+ to rebuild the GUI from web/src." />
 	</Target>
 

--- a/rPDU2MQTT.Web/web/src/main.ts
+++ b/rPDU2MQTT.Web/web/src/main.ts
@@ -33,20 +33,37 @@ export async function load() {
 // Last-seen operator update report, so "check now" can tell when a fresh result has landed.
 let lastCheckedAt: string | null = null;
 let configWritable = true;
-// The tag the operator last reported having rolled to. null means "we haven't seen a report yet", which
-// is deliberately different from "" — see appliedTagChanged.
+// The last roll the operator reported — its timestamp, and the tag it went to. null means "we haven't seen
+// a report yet", which is deliberately different from "" — see appliedTagChanged.
 let lastApplied: string | null = null;
+let lastAppliedAt: string | null = null;
 
-/// Did the operator just roll the deployment to a different tag?
+/// Did the operator just roll the deployment?
 ///
 /// AutoUpdate rolls on the operator's own schedule, so unlike Switch or Force update there is no click to
 /// hang an expectRestart() on: the page's first and only warning is the stream dying, which shows as a red
-/// "Offline" for something entirely routine. The operator does report the tag it applied, and that arrives
-/// on the status feed before the pod goes down, so a change in it is the signal.
+/// "Offline" for something entirely routine.
+///
+/// Watching the applied *tag* was not enough, and is why this never fired for anyone. Tracking a moving
+/// channel — `unstable`, `main`, `edge`, the default and the common case — means an auto-update swaps the
+/// digest under an unchanged tag, so "unstable" was reported before and after and nothing looked different.
+/// Only a switch between two differently named tags was ever visible. The operator now stamps when it
+/// actually rolled, which changes either way; the tag is still checked so an older operator that reports no
+/// timestamp keeps working as it did.
 ///
 /// Never fires on the first report. On a fresh page load every value is "new", and announcing a restart
 /// that already happened (or never happened) would put the app bar into a state nothing is going to clear.
-export function appliedTagChanged(applied: string | undefined | null): boolean {
+export function appliedTagChanged(applied: string | undefined | null, appliedAt?: string | null): boolean {
+  const at = appliedAt || '';
+  if (at !== '') {
+    // Same rule as the tag below: an absent timestamp is not a new roll, so it must not clear what we know.
+    const rolled = lastAppliedAt !== null && at !== lastAppliedAt;
+    lastAppliedAt = at;
+    // Keep the tag in step so a later report can't read as a change purely because we stopped tracking it.
+    if (applied) lastApplied = applied;
+    return rolled;
+  }
+
   const now = applied || '';
   // No tag in this report is not a change of tag — the operator can simply stop reporting one (restarting,
   // briefly unreachable). Forgetting the last tag here would make the next report of the SAME tag look
@@ -65,7 +82,7 @@ function renderUpdate(u: any) {
   lastCheckedAt = u.checkedAt || null;
   // An update the operator applied by itself: the workload is going away and nobody here asked for it.
   // Same treatment as a manual switch, so the drop that follows reads as "busy", not "broken".
-  if (appliedTagChanged(u.applied)) {
+  if (appliedTagChanged(u.applied, u.appliedAt)) {
     expectRestart(`Auto-updating to ${u.applied}`);
     toast(`Update applied — rolling to ${u.applied}. The bridge is restarting.`, true);
   }

--- a/rPDU2MQTT.Web/web/update.check.mjs
+++ b/rPDU2MQTT.Web/web/update.check.mjs
@@ -1,0 +1,69 @@
+// Regression check for the auto-update notice (#304, #327).
+//
+// AutoUpdate rolls on the operator's own schedule, so there is no click to hang an expectRestart() on: the
+// page's only warning would otherwise be the stream dying, which paints a red "Offline" for something
+// entirely routine.
+//
+// #304 shipped a transition table in its description and no test for it, and the gap that hid in there was
+// the one that mattered: it watched the applied *tag*. Tracking a moving channel — `unstable`, `main`,
+// `edge`, the default and the common case — swaps the digest under an unchanged tag, so the tag reads the
+// same before and after an update and the notice never fired for anyone on a channel. The operator now
+// stamps when it actually rolled; this pins both signals, and the cases where firing would be wrong.
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDom } from './domstub.mjs';
+
+const code = await readFile(new URL('../wwwroot/app.js', import.meta.url), 'utf8');
+// The bundle bootstraps a full page on load; give it the shapes it expects so the run reaches our function
+// rather than dying in build(). We are testing one exported predicate, not the page.
+const schema = JSON.parse(await readFile(new URL('./schema.fixture.json', import.meta.url), 'utf8'))
+  .filter(n => n.key !== '_README');
+const bodies = (url) =>
+  url.includes('/api/schema') ? schema :
+  url.includes('/api/instances') ? { ok: true, instances: [] } :
+  url.includes('/api/config') ? {} :
+  { ok: true };
+
+const { sandbox } = makeDom({ bodies });
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox, { filename: 'app.js' });
+await new Promise(r => setTimeout(r, 30));
+
+const fn = sandbox.appliedTagChanged;
+const fail = (m) => { console.error('update check FAILED: ' + m); process.exit(1); };
+if (typeof fn !== 'function') fail('appliedTagChanged is not reachable from the bundle');
+
+let passed = 0;
+const expect = (want, label, ...args) => {
+  const got = fn(...args);
+  if (got !== want) fail(`${label} — expected ${want}, got ${got}`);
+  passed++;
+};
+
+// --- A moving channel: the tag never changes, only the roll timestamp. This is the case that was broken.
+expect(false, 'first report is never a roll',            'unstable', '2026-08-03T01:00:00Z');
+expect(false, 'same roll reported again is not a roll',  'unstable', '2026-08-03T01:00:00Z');
+expect(true,  'a new roll on the SAME tag fires',        'unstable', '2026-08-03T02:00:00Z');
+expect(false, 'steady after the roll is quiet',          'unstable', '2026-08-03T02:00:00Z');
+// The operator can stop reporting mid-restart; that is not a roll, and must not lose what we know.
+expect(false, 'an absent timestamp is not a roll',       'unstable', null);
+expect(false, 'the prior roll is still remembered',      'unstable', '2026-08-03T02:00:00Z');
+expect(true,  'the next genuine roll still fires',       'unstable', '2026-08-03T03:00:00Z');
+
+// --- An operator too old to send a timestamp: fall back to the tag, exactly as before.
+const { sandbox: s2 } = makeDom({ bodies });
+vm.createContext(s2);
+vm.runInContext(code, s2, { filename: 'app.js' });
+const legacy = s2.appliedTagChanged;
+const expectLegacy = (want, label, ...args) => {
+  const got = legacy(...args);
+  if (got !== want) fail(`${label} — expected ${want}, got ${got}`);
+  passed++;
+};
+expectLegacy(false, 'legacy: first report is quiet',        'unstable');
+expectLegacy(false, 'legacy: same tag is quiet',            'unstable');
+expectLegacy(false, 'legacy: an absent tag is not a change', null);
+expectLegacy(false, 'legacy: the prior tag is remembered',   'unstable');
+expectLegacy(true,  'legacy: a real tag switch fires',       'main');
+
+console.log(`update: auto-update notice fires on a moving channel and stays quiet otherwise (${passed} transitions)`);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -5052,20 +5052,37 @@ async function load() {
 // Last-seen operator update report, so "check now" can tell when a fresh result has landed.
 let lastCheckedAt                = null;
 let configWritable = true;
-// The tag the operator last reported having rolled to. null means "we haven't seen a report yet", which
-// is deliberately different from "" — see appliedTagChanged.
+// The last roll the operator reported — its timestamp, and the tag it went to. null means "we haven't seen
+// a report yet", which is deliberately different from "" — see appliedTagChanged.
 let lastApplied                = null;
+let lastAppliedAt                = null;
 
-/// Did the operator just roll the deployment to a different tag?
+/// Did the operator just roll the deployment?
 ///
 /// AutoUpdate rolls on the operator's own schedule, so unlike Switch or Force update there is no click to
 /// hang an expectRestart() on: the page's first and only warning is the stream dying, which shows as a red
-/// "Offline" for something entirely routine. The operator does report the tag it applied, and that arrives
-/// on the status feed before the pod goes down, so a change in it is the signal.
+/// "Offline" for something entirely routine.
+///
+/// Watching the applied *tag* was not enough, and is why this never fired for anyone. Tracking a moving
+/// channel — `unstable`, `main`, `edge`, the default and the common case — means an auto-update swaps the
+/// digest under an unchanged tag, so "unstable" was reported before and after and nothing looked different.
+/// Only a switch between two differently named tags was ever visible. The operator now stamps when it
+/// actually rolled, which changes either way; the tag is still checked so an older operator that reports no
+/// timestamp keeps working as it did.
 ///
 /// Never fires on the first report. On a fresh page load every value is "new", and announcing a restart
 /// that already happened (or never happened) would put the app bar into a state nothing is going to clear.
-function appliedTagChanged(applied                           )          {
+function appliedTagChanged(applied                           , appliedAt                )          {
+  const at = appliedAt || '';
+  if (at !== '') {
+    // Same rule as the tag below: an absent timestamp is not a new roll, so it must not clear what we know.
+    const rolled = lastAppliedAt !== null && at !== lastAppliedAt;
+    lastAppliedAt = at;
+    // Keep the tag in step so a later report can't read as a change purely because we stopped tracking it.
+    if (applied) lastApplied = applied;
+    return rolled;
+  }
+
   const now = applied || '';
   // No tag in this report is not a change of tag — the operator can simply stop reporting one (restarting,
   // briefly unreachable). Forgetting the last tag here would make the next report of the SAME tag look
@@ -5084,7 +5101,7 @@ function renderUpdate(u     ) {
   lastCheckedAt = u.checkedAt || null;
   // An update the operator applied by itself: the workload is going away and nobody here asked for it.
   // Same treatment as a manual switch, so the drop that follows reads as "busy", not "broken".
-  if (appliedTagChanged(u.applied)) {
+  if (appliedTagChanged(u.applied, u.appliedAt)) {
     expectRestart(`Auto-updating to ${u.applied}`);
     toast(`Update applied — rolling to ${u.applied}. The bridge is restarting.`, true);
   }


### PR DESCRIPTION
#327, item 3. It never appeared for anyone tracking a channel — which is the default.

**Cause:** the notice watched the applied *tag*. On a moving channel (`unstable`, `main`, `edge`) an auto-update swaps the **digest** under an unchanged tag, so the operator reports the same thing before and after. Only a switch between two differently *named* tags was ever visible — the one case almost nobody hits. Straight from the live CR status:

```json
"update": { "applied": "unstable", "current": "unstable", "latest": "unstable", "available": false }
```

`applied` is `"unstable"`, and it always will be.

**Fix:** the operator now stamps `AppliedAt` when it actually rolls the deployment, and the GUI watches that. It changes on every roll, moving-tag or not.

Deliberately **not** `CheckedAt` — that advances on every scheduled check and would announce an update once an hour whether or not anything happened. `AppliedAt` is stamped only on a real roll and otherwise carried forward, so it means *when we last rolled*, not *when we last looked*. The tag check stays as a fallback, so an older operator sending no timestamp behaves exactly as before.

## The test that should have existed

#304 shipped a transition table **in its description** and no test for it — and the gap hiding in there was precisely the case that broke. `update.check.mjs` now runs that table against the real bundle:

```
first report on a channel            -> quiet
same roll reported again             -> quiet
new roll, SAME tag (moving channel)  -> FIRES   ← was broken
steady after the roll                -> quiet
operator reports no timestamp        -> quiet, and remembers the prior roll
next genuine roll                    -> FIRES
legacy operator, real tag switch     -> FIRES
```

Wired into the build alongside the smoke/layout/sankey checks. 549 tests pass, 12 transitions pinned.

Refs #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)