### PR TITLE
fix(flow): the flow animation no longer turns wide ribbons into a venetian blind

### DIFF
--- a/rPDU2MQTT.Web/web/animation.check.mjs
+++ b/rPDU2MQTT.Web/web/animation.check.mjs
@@ -58,12 +58,22 @@ const off = await render(false);
 if (off.length !== 0) fail(`animation is off but ${off.length} stream(s) were drawn`);
 
 // --- On: only the links that carry a known, non-zero value.
+//
+// A ribbon is streamed by several thin lanes rather than one stroke as tall as the band — a dashed stroke
+// draws its gaps across the full stroke width, so one full-height stroke turns every dash into a vertical
+// bar and a wide ribbon reads as a venetian blind. So the assertion is over distinct LINKS, not paths.
 const on = await render(true);
-if (on.length !== 2) fail(`expected 2 streams (grid->inverter, inverter->panel), got ${on.length}`);
-
-const pairs = on.map(p => `${p.attrs['data-src']}->${p.attrs['data-dst']}`).sort();
+const pairs = [...new Set(on.map(p => `${p.attrs['data-src']}->${p.attrs['data-dst']}`))].sort();
+if (pairs.length !== 2) fail(`expected 2 streamed links (grid->inverter, inverter->panel), got ${pairs.length}: ${pairs.join(', ')}`);
+if (on.length < pairs.length) fail('a streamed link produced no lane at all');
 const want = ['grid->inverter', 'inverter->panel'];
 if (JSON.stringify(pairs) !== JSON.stringify(want)) fail(`streamed the wrong links: ${pairs.join(', ')}`);
+
+// Lanes must stay inside the band: a lane wider than its share would merge them back into one bar.
+for (const p of on) {
+  const w = parseFloat(p.attrs['stroke-width']);
+  if (!(w >= 1.5 && w <= 3.5)) fail(`a lane is ${w}px wide — outside the range that reads as a particle`);
+}
 
 // The two that must never move: a measured zero, and a link with no data.
 if (pairs.some(p => p.startsWith('solar->'))) fail('a measured zero was animated — 0 W must not look busy');
@@ -102,4 +112,4 @@ for (const t of texts) {
     fail('a <title> is inside a <text> — its content is painted onto the chart, not shown as a tooltip');
 }
 
-console.log(`animation: ${on.length} streams on known flow, none on unknown or zero, durations clamped; ${titles.length} tooltip(s), none inside <text>`);
+console.log(`animation: ${pairs.length} streamed links (${on.length} lanes) on known flow, none on unknown or zero, durations clamped; ${titles.length} tooltip(s), none inside <text>`);

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1621,21 +1621,37 @@ export function addFlowSection(nav: any, sections: any) {
         clip.appendChild(svgEl('path', { d: ribbonPath }));
         svg.appendChild(clip);
 
-        const stream = svgEl('path', {
-          d: `M${x1},${sTop + h / 2} C${xc},${sTop + h / 2} ${xc},${tTop + h / 2} ${x2},${tTop + h / 2}`,
-          fill: 'none', stroke: color, 'stroke-opacity': '0.5',
-          // Overshoot the band so the clip, not the stroke width, defines the edges — a stroke exactly h
-          // tall leaves hairline gaps where the curve is steep.
-          'stroke-width': h + 2,
-          'stroke-dasharray': '14 26',
-          'clip-path': `url(#${clipId})`,
-          class: 'flow-stream',
-          'data-src': l.source, 'data-dst': l.target,
-        });
+        // Lanes of thin particles, not one stroke as tall as the band.
+        //
+        // A dashed stroke draws its gaps across the whole stroke width, so stroking the centre line at the
+        // ribbon's full height turns every dash into a full-height vertical bar: on a wide ribbon that reads
+        // as a venetian blind rather than as movement. Several thin lanes spread across the band, offset
+        // from one another, read as a current — and they degrade correctly, because a hairline ribbon simply
+        // gets one lane and looks exactly as it did.
+        const lanes = Math.max(1, Math.min(6, Math.round(h / 16)));
+        const laneW = Math.max(1.5, Math.min(3.5, (h / lanes) * 0.4));
         // Faster where the flow is denser, clamped either side so nothing crawls or strobes.
         const intensity = l.value / Math.max(1, maxTotal);
-        stream.style.animationDuration = `${Math.max(0.9, Math.min(6, 3.2 - intensity * 9)).toFixed(2)}s`;
-        svg.appendChild(stream);
+        const duration = Math.max(0.9, Math.min(6, 3.2 - intensity * 9));
+
+        for (let i = 0; i < lanes; i++) {
+          const f = (i + 0.5) / lanes;                       // this lane's position across the band
+          const sY = sTop + h * f, tY = tTop + h * f;
+          const stream = svgEl('path', {
+            d: `M${x1},${sY} C${xc},${sY} ${xc},${tY} ${x2},${tY}`,
+            fill: 'none', stroke: color, 'stroke-opacity': lanes > 1 ? '0.42' : '0.5',
+            'stroke-width': laneW,
+            'stroke-linecap': 'round',
+            'stroke-dasharray': '9 31',
+            'clip-path': `url(#${clipId})`,
+            class: 'flow-stream',
+            'data-src': l.source, 'data-dst': l.target,
+          });
+          stream.style.animationDuration = `${duration.toFixed(2)}s`;
+          // Stagger the lanes so they read as a current rather than as one blinking comb.
+          stream.style.animationDelay = `${(-duration * (i / Math.max(1, lanes))).toFixed(2)}s`;
+          svg.appendChild(stream);
+        }
       }
 
       s.outOff += h; t.inOff += h;

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3048,21 +3048,37 @@ function addFlowSection(nav     , sections     ) {
         clip.appendChild(svgEl('path', { d: ribbonPath }));
         svg.appendChild(clip);
 
-        const stream = svgEl('path', {
-          d: `M${x1},${sTop + h / 2} C${xc},${sTop + h / 2} ${xc},${tTop + h / 2} ${x2},${tTop + h / 2}`,
-          fill: 'none', stroke: color, 'stroke-opacity': '0.5',
-          // Overshoot the band so the clip, not the stroke width, defines the edges — a stroke exactly h
-          // tall leaves hairline gaps where the curve is steep.
-          'stroke-width': h + 2,
-          'stroke-dasharray': '14 26',
-          'clip-path': `url(#${clipId})`,
-          class: 'flow-stream',
-          'data-src': l.source, 'data-dst': l.target,
-        });
+        // Lanes of thin particles, not one stroke as tall as the band.
+        //
+        // A dashed stroke draws its gaps across the whole stroke width, so stroking the centre line at the
+        // ribbon's full height turns every dash into a full-height vertical bar: on a wide ribbon that reads
+        // as a venetian blind rather than as movement. Several thin lanes spread across the band, offset
+        // from one another, read as a current — and they degrade correctly, because a hairline ribbon simply
+        // gets one lane and looks exactly as it did.
+        const lanes = Math.max(1, Math.min(6, Math.round(h / 16)));
+        const laneW = Math.max(1.5, Math.min(3.5, (h / lanes) * 0.4));
         // Faster where the flow is denser, clamped either side so nothing crawls or strobes.
         const intensity = l.value / Math.max(1, maxTotal);
-        stream.style.animationDuration = `${Math.max(0.9, Math.min(6, 3.2 - intensity * 9)).toFixed(2)}s`;
-        svg.appendChild(stream);
+        const duration = Math.max(0.9, Math.min(6, 3.2 - intensity * 9));
+
+        for (let i = 0; i < lanes; i++) {
+          const f = (i + 0.5) / lanes;                       // this lane's position across the band
+          const sY = sTop + h * f, tY = tTop + h * f;
+          const stream = svgEl('path', {
+            d: `M${x1},${sY} C${xc},${sY} ${xc},${tY} ${x2},${tY}`,
+            fill: 'none', stroke: color, 'stroke-opacity': lanes > 1 ? '0.42' : '0.5',
+            'stroke-width': laneW,
+            'stroke-linecap': 'round',
+            'stroke-dasharray': '9 31',
+            'clip-path': `url(#${clipId})`,
+            class: 'flow-stream',
+            'data-src': l.source, 'data-dst': l.target,
+          });
+          stream.style.animationDuration = `${duration.toFixed(2)}s`;
+          // Stagger the lanes so they read as a current rather than as one blinking comb.
+          stream.style.animationDelay = `${(-duration * (i / Math.max(1, lanes))).toFixed(2)}s`;
+          svg.appendChild(stream);
+        }
       }
 
       s.outOff += h; t.inOff += h;


### PR DESCRIPTION
## What was wrong

A dashed stroke draws its gaps across the **whole stroke width**. #333 stroked each ribbon's centre line at the ribbon's full height, so every dash became a full-height vertical bar.

On a hairline ribbon that reads as a moving dash. On a 7.8 kW ribbon a few hundred pixels tall it reads as thick vertical stripes across the band — a venetian blind, not flow.

## What changed

Each ribbon is now streamed by up to six thin lanes spread across the band:

- lane count scales with band height (`h/16`, clamped 1–6), so a hairline ribbon gets exactly one lane and looks unchanged
- lane width is `(h/lanes) * 0.4`, clamped 1.5–3.5px — thin enough to read as a particle at any size
- lanes are staggered in animation phase so they read as a current rather than as one blinking comb
- dash period stays 40 (`9 31`), so the existing `-40` keyframe still loops seamlessly

Everything that made the animation honest is untouched: no stream on an unknown link or a measured zero, speed still comes from intensity, `prefers-reduced-motion` still stops it.

## Checks

`animation.check.mjs` counted stream *paths*, which is no longer the meaningful unit. It now asserts over distinct **links** — still exactly two streamed, still none on the unknown link or the measured zero — and additionally pins lane width, so a lane can never grow back into a full-height bar.

576 tests pass; all six GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)