### PR TITLE
feat(nodes): edit a node in a dialog instead of a form at the bottom of the page

### DIFF
--- a/rPDU2MQTT.Tests/PublishTimeoutTests.cs
+++ b/rPDU2MQTT.Tests/PublishTimeoutTests.cs
@@ -69,12 +69,18 @@ public class PublishTimeoutTests
     {
         // Cancelling on shutdown is not the broker's fault and must not be logged as one — otherwise every
         // restart leaves a misleading "the broker did not acknowledge" in the log.
+        //
+        // The timeout is minutes and the cancellation is immediate, so the wait can only end one way. Racing
+        // the two on the clock (cancel at 50ms, time out at 80ms) is what an earlier version of this test did,
+        // and it failed roughly one run in five: under load the 80ms timer fired before the 50ms cancellation
+        // callback was scheduled, and reporting a timeout there is the correct answer, not a bug.
         var shutdown = new CancellationTokenSource();
         var hang = new TaskCompletionSource();
-        shutdown.CancelAfter(50);
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => PublishTimeout.RunAsync(() => hang.Task, TimeSpan.FromMilliseconds(80), "t", shutdown.Token));
+        var run = PublishTimeout.RunAsync(() => hang.Task, TimeSpan.FromMinutes(5), "t", shutdown.Token);
+        shutdown.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => run);
 
         hang.SetResult();
     }

--- a/rPDU2MQTT.Web/web/animation.check.mjs
+++ b/rPDU2MQTT.Web/web/animation.check.mjs
@@ -58,12 +58,22 @@ const off = await render(false);
 if (off.length !== 0) fail(`animation is off but ${off.length} stream(s) were drawn`);
 
 // --- On: only the links that carry a known, non-zero value.
+//
+// A ribbon is streamed by several thin lanes rather than one stroke as tall as the band — a dashed stroke
+// draws its gaps across the full stroke width, so one full-height stroke turns every dash into a vertical
+// bar and a wide ribbon reads as a venetian blind. So the assertion is over distinct LINKS, not paths.
 const on = await render(true);
-if (on.length !== 2) fail(`expected 2 streams (grid->inverter, inverter->panel), got ${on.length}`);
-
-const pairs = on.map(p => `${p.attrs['data-src']}->${p.attrs['data-dst']}`).sort();
+const pairs = [...new Set(on.map(p => `${p.attrs['data-src']}->${p.attrs['data-dst']}`))].sort();
+if (pairs.length !== 2) fail(`expected 2 streamed links (grid->inverter, inverter->panel), got ${pairs.length}: ${pairs.join(', ')}`);
+if (on.length < pairs.length) fail('a streamed link produced no lane at all');
 const want = ['grid->inverter', 'inverter->panel'];
 if (JSON.stringify(pairs) !== JSON.stringify(want)) fail(`streamed the wrong links: ${pairs.join(', ')}`);
+
+// Lanes must stay inside the band: a lane wider than its share would merge them back into one bar.
+for (const p of on) {
+  const w = parseFloat(p.attrs['stroke-width']);
+  if (!(w >= 1.5 && w <= 3.5)) fail(`a lane is ${w}px wide — outside the range that reads as a particle`);
+}
 
 // The two that must never move: a measured zero, and a link with no data.
 if (pairs.some(p => p.startsWith('solar->'))) fail('a measured zero was animated — 0 W must not look busy');
@@ -102,4 +112,4 @@ for (const t of texts) {
     fail('a <title> is inside a <text> — its content is painted onto the chart, not shown as a tooltip');
 }
 
-console.log(`animation: ${on.length} streams on known flow, none on unknown or zero, durations clamped; ${titles.length} tooltip(s), none inside <text>`);
+console.log(`animation: ${pairs.length} streamed links (${on.length} lanes) on known flow, none on unknown or zero, durations clamped; ${titles.length} tooltip(s), none inside <text>`);

--- a/rPDU2MQTT.Web/web/domstub.mjs
+++ b/rPDU2MQTT.Web/web/domstub.mjs
@@ -56,10 +56,14 @@ export function makeEl(tag = 'div') {
     set textContent(v) { this._text = String(v); this.children = []; },
     set innerHTML(v) { if (!v) this.children = []; },
     get innerHTML() { return ''; },
-    appendChild(c) { if (c && c.tag) this.children.push(c); return c; },
-    append(...cs) { cs.forEach(c => { if (c && c.tag) this.children.push(c); }); },
-    removeChild(c) { this.children = this.children.filter(x => x !== c); },
-    remove() {}, insertBefore(c) { this.children.push(c); return c; },
+    // Parentage is tracked so remove() actually detaches: a panel mounted on <body> and later closed has
+    // to leave the tree, or a test can't tell an open modal from a closed one.
+    parent: null,
+    appendChild(c) { if (c && c.tag) { c.parent = this; this.children.push(c); } return c; },
+    append(...cs) { cs.forEach(c => { if (c && c.tag) { c.parent = this; this.children.push(c); } }); },
+    removeChild(c) { this.children = this.children.filter(x => x !== c); if (c) c.parent = null; },
+    remove() { if (this.parent) this.parent.removeChild(this); },
+    insertBefore(c) { if (c && c.tag) { c.parent = this; this.children.push(c); } return c; },
     // Node.contains(): self or any descendant (used to tell Oidc fields from Basic ones).
     contains(n) { if (n === this) return true; for (const d of descendants(this)) if (d === n) return true; return false; },
     setAttribute(k, v) { this.attrs[k] = String(v); },
@@ -106,6 +110,11 @@ export function makeDom({ bodies }) {
       querySelector: (s) => query(root, s, false),
       querySelectorAll: (s) => query(root, s, true),
       elementFromPoint: () => null,
+      // Document-level listeners are how a modal picks up Escape; record them so a test can fire one.
+      _on: {},
+      addEventListener(type, fn) { (this._on[type] ||= []).push(fn); },
+      removeEventListener(type, fn) { this._on[type] = (this._on[type] || []).filter(f => f !== fn); },
+      dispatch(type, ev) { (this._on[type] || []).slice().forEach(f => f(ev)); },
     },
     window: { addEventListener() { }, removeEventListener() { }, dispatchEvent() { return true; }, prompt: () => null },
     // protocol/hostname are read when building the API docs links (#190).

--- a/rPDU2MQTT.Web/web/smoke.mjs
+++ b/rPDU2MQTT.Web/web/smoke.mjs
@@ -168,13 +168,23 @@ if (!editBtn) fail('the virtual-node manager rendered no Edit button');
 editBtn.click();
 await new Promise(r => setTimeout(r, 20));
 
-const editorText = query(getEl('sections'), '.section', true).map(s => s.textContent).join(' ');
+// The editor opens as a modal on <body>, not inline under the table (#292) — inline put the form at the
+// bottom of a long page, away from the row, and kept the table too wide for a small screen.
+const editor = query(sandbox.document.body, '.node-editor', false);
+if (!editor) fail('opening a node did not open the editor modal');
+if (query(getEl('sections'), '.node-editor', false)) fail('the node editor rendered inline under the table again');
+const editorText = editor.textContent;
 if (!editorText.includes('Live value bindings')) fail('opening a node did not render its bindings editor');
 if (!editorText.includes('Feeders & children')) fail('the node editor did not render the feeders/children wiring');
-if (!query(getEl('sections'), 'input', true).some(i => i.attrs.value === 'solar_assistant/inverter_1/pv_power/state'))
+if (!query(editor, 'input', true).some(i => i.attrs.value === 'solar_assistant/inverter_1/pv_power/state'))
   fail('the node editor did not surface the migrated MQTT binding as an editable topic');
 // The Modbus binding row must render its connection picker, listing the configured connection.
 if (!editorText.includes('Inverter')) fail('the Modbus binding row did not list the configured connection');
+
+// Escape dismisses it, and dismissing it leaves nothing behind on <body>.
+sandbox.document.dispatch('keydown', { key: 'Escape' });
+await new Promise(r => setTimeout(r, 20));
+if (query(sandbox.document.body, '.node-editor', false)) fail('Escape did not close the node editor modal');
 
 // --- Flow node hover card ----------------------------------------------------------------------------
 // The card is only reachable by hovering a Sankey node, so nothing else would notice it breaking.

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1621,21 +1621,37 @@ export function addFlowSection(nav: any, sections: any) {
         clip.appendChild(svgEl('path', { d: ribbonPath }));
         svg.appendChild(clip);
 
-        const stream = svgEl('path', {
-          d: `M${x1},${sTop + h / 2} C${xc},${sTop + h / 2} ${xc},${tTop + h / 2} ${x2},${tTop + h / 2}`,
-          fill: 'none', stroke: color, 'stroke-opacity': '0.5',
-          // Overshoot the band so the clip, not the stroke width, defines the edges — a stroke exactly h
-          // tall leaves hairline gaps where the curve is steep.
-          'stroke-width': h + 2,
-          'stroke-dasharray': '14 26',
-          'clip-path': `url(#${clipId})`,
-          class: 'flow-stream',
-          'data-src': l.source, 'data-dst': l.target,
-        });
+        // Lanes of thin particles, not one stroke as tall as the band.
+        //
+        // A dashed stroke draws its gaps across the whole stroke width, so stroking the centre line at the
+        // ribbon's full height turns every dash into a full-height vertical bar: on a wide ribbon that reads
+        // as a venetian blind rather than as movement. Several thin lanes spread across the band, offset
+        // from one another, read as a current — and they degrade correctly, because a hairline ribbon simply
+        // gets one lane and looks exactly as it did.
+        const lanes = Math.max(1, Math.min(6, Math.round(h / 16)));
+        const laneW = Math.max(1.5, Math.min(3.5, (h / lanes) * 0.4));
         // Faster where the flow is denser, clamped either side so nothing crawls or strobes.
         const intensity = l.value / Math.max(1, maxTotal);
-        stream.style.animationDuration = `${Math.max(0.9, Math.min(6, 3.2 - intensity * 9)).toFixed(2)}s`;
-        svg.appendChild(stream);
+        const duration = Math.max(0.9, Math.min(6, 3.2 - intensity * 9));
+
+        for (let i = 0; i < lanes; i++) {
+          const f = (i + 0.5) / lanes;                       // this lane's position across the band
+          const sY = sTop + h * f, tY = tTop + h * f;
+          const stream = svgEl('path', {
+            d: `M${x1},${sY} C${xc},${sY} ${xc},${tY} ${x2},${tY}`,
+            fill: 'none', stroke: color, 'stroke-opacity': lanes > 1 ? '0.42' : '0.5',
+            'stroke-width': laneW,
+            'stroke-linecap': 'round',
+            'stroke-dasharray': '9 31',
+            'clip-path': `url(#${clipId})`,
+            class: 'flow-stream',
+            'data-src': l.source, 'data-dst': l.target,
+          });
+          stream.style.animationDuration = `${duration.toFixed(2)}s`;
+          // Stagger the lanes so they read as a current rather than as one blinking comb.
+          stream.style.animationDelay = `${(-duration * (i / Math.max(1, lanes))).toFixed(2)}s`;
+          svg.appendChild(stream);
+        }
       }
 
       s.outOff += h; t.inOff += h;

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -88,7 +88,9 @@ const NODE_MODES: [string, string, string][] = [
 let pickerSeq = 0;
 
 /// A modal panel over the page. Returns the body to fill; closes on the button, the backdrop, or Escape.
-function overlay(title: string): { body: any, close: () => void } {
+/// `onClose` fires only on those three — a caller closing the panel itself already knows, and firing it
+/// there would loop when the callback re-renders the surface that owns the panel.
+function overlay(title: string, onClose?: () => void): { body: any, close: () => void } {
   const back = el('div', { style: { position: 'fixed', inset: '0', background: 'rgba(0,0,0,.55)', zIndex: '50', display: 'flex', alignItems: 'center', justifyContent: 'center' } });
   const panel = el('div', { style: { background: 'var(--panel2)', border: '1px solid var(--line)', borderRadius: '8px', padding: '14px', width: 'min(860px, 92vw)', maxHeight: '80vh', overflow: 'auto' } });
   const head = el('div', { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' } });
@@ -101,9 +103,10 @@ function overlay(title: string): { body: any, close: () => void } {
   document.body.appendChild(back);
 
   const close = () => { back.remove(); document.removeEventListener('keydown', onKey); };
-  const onKey = (e: any) => { if (e.key === 'Escape') close(); };
-  x.onclick = close;
-  back.onclick = (e: any) => { if (e.target === back) close(); };
+  const dismiss = () => { close(); if (onClose) onClose(); };
+  const onKey = (e: any) => { if (e.key === 'Escape') dismiss(); };
+  x.onclick = dismiss;
+  back.onclick = (e: any) => { if (e.target === back) dismiss(); };
   document.addEventListener('keydown', onKey);
   return { body, close };
 }
@@ -374,13 +377,9 @@ function field(labelText: string, control: HTMLElement, hint?: string) {
 function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, rerender: (close?: boolean) => void) {
   const meta = kindMeta(node.Kind);
   const allowed = meta[2];
-  const box = el('div', { style: { margin: '10px 0 4px', padding: '14px', border: '1px solid var(--accent, #4f8cff)', borderRadius: '8px', background: 'var(--panel2)' } });
-
-  const header = el('div', { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' } });
-  header.appendChild(el('h4', { text: `Editing ${node.Label || node.Id}`, style: { margin: '0', fontSize: '14px' } }));
-  const close = btn('Close'); close.onclick = () => rerender(true);
-  header.appendChild(close);
-  box.appendChild(header);
+  // No frame and no header of its own: this is rendered into a modal panel that already carries the node's
+  // name and a Close button (#292).
+  const box = el('div', { class: 'node-editor' });
 
   const grid = el('div', { style: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '12px', marginBottom: '12px' } });
 
@@ -910,7 +909,7 @@ function collapseGraph(nodes: any[], links: any[]): { nodes: any[]; links: any[]
     const s = remap(l.source), t = remap(l.target);
     if (s === t) return;                       // a link fully inside one collapsed group
     present.add(s); present.add(t);
-    const k = s + ' ' + t;
+    const k = s + '\u0000' + t;
     if (!merged[k]) merged[k] = { source: s, target: t, value: 0, known: true };
     merged[k].value += (l.value || 0);
     if (l.known === false) merged[k].known = false;
@@ -1115,8 +1114,33 @@ function renderGroupManager(flow: any, cand: Map<string, any>, rerender: () => v
   return box;
 }
 
+// The open node editor, as a modal over the table (#292).
+//
+// It used to render beneath the table, which put the form at the bottom of a long page — nowhere near the
+// row you clicked — and forced the table itself to stay wide enough to host it, which small screens can't
+// give. The panel lives on <body>, so it outlives the re-render of the surface underneath it and is rebuilt
+// in place instead: the node object's identity is what the editor holds, and that survives a re-render.
+let nodeModal: { id: string, body: any, close: () => void } | null = null;
+
+function closeNodeModal() {
+  const m = nodeModal;
+  nodeModal = null;
+  if (m) m.close();
+}
+
+function syncNodeModal(node: any, links: any[], cand: Map<string, any>, editing: { id: string | null }, rerender: () => void) {
+  if (!node) { closeNodeModal(); return; }
+  if (nodeModal && nodeModal.id !== node.Id) closeNodeModal();   // switched rows: a fresh panel, fresh title
+  if (!nodeModal) {
+    const o = overlay(`Edit node — ${node.Label || node.Id}`, () => { nodeModal = null; editing.id = null; rerender(); });
+    nodeModal = { id: node.Id, body: o.body, close: o.close };
+  }
+  nodeModal.body.innerHTML = '';
+  nodeModal.body.appendChild(renderNodeEditor(node, links, cand, (close?: boolean) => { if (close) editing.id = null; rerender(); }));
+}
+
 // Virtual-node manager (#129): the dedicated node-configuration surface (its own Nodes tab). Each row is a
-// node; Edit opens the full editor (name, kind, mode, value, bindings, feeders/children) below the table.
+// node; Edit opens the full editor (name, kind, mode, value, bindings, feeders/children) in a modal.
 // Deleting a node takes its bound sources with it (they live on the node).
 function renderNodeManager(flow: any, customNodes: any[], links: any[], cand: Map<string, any>, editing: { id: string | null }, rerender: (close?: boolean) => void) {
   const box = el('div', { style: { margin: '18px 0' } });
@@ -1124,6 +1148,7 @@ function renderNodeManager(flow: any, customNodes: any[], links: any[], cand: Ma
   box.appendChild(el('div', { class: 'desc', text: 'The custom nodes you’ve added (panels, breakers, batteries, producers, a “Total”). Click Edit to set the name, kind, how it’s valued, and bind live values from your broker.' }));
 
   if (!customNodes.length) {
+    closeNodeModal();
     box.appendChild(el('div', { class: 'desc', text: 'No virtual nodes yet — add one above.' }));
     return box;
   }
@@ -1203,8 +1228,8 @@ function renderNodeManager(flow: any, customNodes: any[], links: any[], cand: Ma
   tbl.appendChild(body);
   box.appendChild(tbl);
 
-  const editingNode = editing.id ? customNodes.find((n: any) => n.Id === editing.id) : null;
-  if (editingNode) box.appendChild(renderNodeEditor(editingNode, links, cand, (close?: boolean) => { if (close) editing.id = null; rerender(); }));
+  // A deleted or renamed-away node leaves editing.id dangling; find() returning nothing closes the panel.
+  syncNodeModal(editing.id ? customNodes.find((n: any) => n.Id === editing.id) : null, links, cand, editing, rerender);
   return box;
 }
 
@@ -2343,8 +2368,6 @@ export function addNodesSection(nav: any, sections: any) {
     };
 
     const cand = flowCandidates(lastGraph, customNodes);
-    // Groups first: the node manager appends the (tall) per-node editor beneath its table when one is open,
-    // which would otherwise bury the Groups section off the bottom of the page.
     ed.appendChild(renderGroupManager(flow, cand, render));
     ed.appendChild(renderNodeManager(flow, customNodes, links, cand, editing, (close?: boolean) => { if (close) editing.id = null; render(); }));
   };
@@ -2357,6 +2380,9 @@ export function addNodesSection(nav: any, sections: any) {
     render();
   };
   link.onclick = () => { activate(link, sec); load(); };
+  // The editor panel is mounted on <body>, so switching pages would otherwise leave it floating over
+  // whatever you switched to.
+  nav.addEventListener('click', (e: any) => { if (nodeModal && !link.contains(e.target)) { editing.id = null; closeNodeModal(); } });
 }
 
 // The Energy overview (#energy-rollup C): an at-a-glance board of where power is flowing right now —

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3048,21 +3048,37 @@ function addFlowSection(nav     , sections     ) {
         clip.appendChild(svgEl('path', { d: ribbonPath }));
         svg.appendChild(clip);
 
-        const stream = svgEl('path', {
-          d: `M${x1},${sTop + h / 2} C${xc},${sTop + h / 2} ${xc},${tTop + h / 2} ${x2},${tTop + h / 2}`,
-          fill: 'none', stroke: color, 'stroke-opacity': '0.5',
-          // Overshoot the band so the clip, not the stroke width, defines the edges — a stroke exactly h
-          // tall leaves hairline gaps where the curve is steep.
-          'stroke-width': h + 2,
-          'stroke-dasharray': '14 26',
-          'clip-path': `url(#${clipId})`,
-          class: 'flow-stream',
-          'data-src': l.source, 'data-dst': l.target,
-        });
+        // Lanes of thin particles, not one stroke as tall as the band.
+        //
+        // A dashed stroke draws its gaps across the whole stroke width, so stroking the centre line at the
+        // ribbon's full height turns every dash into a full-height vertical bar: on a wide ribbon that reads
+        // as a venetian blind rather than as movement. Several thin lanes spread across the band, offset
+        // from one another, read as a current — and they degrade correctly, because a hairline ribbon simply
+        // gets one lane and looks exactly as it did.
+        const lanes = Math.max(1, Math.min(6, Math.round(h / 16)));
+        const laneW = Math.max(1.5, Math.min(3.5, (h / lanes) * 0.4));
         // Faster where the flow is denser, clamped either side so nothing crawls or strobes.
         const intensity = l.value / Math.max(1, maxTotal);
-        stream.style.animationDuration = `${Math.max(0.9, Math.min(6, 3.2 - intensity * 9)).toFixed(2)}s`;
-        svg.appendChild(stream);
+        const duration = Math.max(0.9, Math.min(6, 3.2 - intensity * 9));
+
+        for (let i = 0; i < lanes; i++) {
+          const f = (i + 0.5) / lanes;                       // this lane's position across the band
+          const sY = sTop + h * f, tY = tTop + h * f;
+          const stream = svgEl('path', {
+            d: `M${x1},${sY} C${xc},${sY} ${xc},${tY} ${x2},${tY}`,
+            fill: 'none', stroke: color, 'stroke-opacity': lanes > 1 ? '0.42' : '0.5',
+            'stroke-width': laneW,
+            'stroke-linecap': 'round',
+            'stroke-dasharray': '9 31',
+            'clip-path': `url(#${clipId})`,
+            class: 'flow-stream',
+            'data-src': l.source, 'data-dst': l.target,
+          });
+          stream.style.animationDuration = `${duration.toFixed(2)}s`;
+          // Stagger the lanes so they read as a current rather than as one blinking comb.
+          stream.style.animationDelay = `${(-duration * (i / Math.max(1, lanes))).toFixed(2)}s`;
+          svg.appendChild(stream);
+        }
       }
 
       s.outOff += h; t.inOff += h;

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1516,7 +1516,9 @@ const NODE_MODES                             = [
 let pickerSeq = 0;
 
 /// A modal panel over the page. Returns the body to fill; closes on the button, the backdrop, or Escape.
-function overlay(title        )                                   {
+/// `onClose` fires only on those three — a caller closing the panel itself already knows, and firing it
+/// there would loop when the callback re-renders the surface that owns the panel.
+function overlay(title        , onClose             )                                   {
   const back = el('div', { style: { position: 'fixed', inset: '0', background: 'rgba(0,0,0,.55)', zIndex: '50', display: 'flex', alignItems: 'center', justifyContent: 'center' } });
   const panel = el('div', { style: { background: 'var(--panel2)', border: '1px solid var(--line)', borderRadius: '8px', padding: '14px', width: 'min(860px, 92vw)', maxHeight: '80vh', overflow: 'auto' } });
   const head = el('div', { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' } });
@@ -1529,9 +1531,10 @@ function overlay(title        )                                   {
   document.body.appendChild(back);
 
   const close = () => { back.remove(); document.removeEventListener('keydown', onKey); };
-  const onKey = (e     ) => { if (e.key === 'Escape') close(); };
-  x.onclick = close;
-  back.onclick = (e     ) => { if (e.target === back) close(); };
+  const dismiss = () => { close(); if (onClose) onClose(); };
+  const onKey = (e     ) => { if (e.key === 'Escape') dismiss(); };
+  x.onclick = dismiss;
+  back.onclick = (e     ) => { if (e.target === back) dismiss(); };
   document.addEventListener('keydown', onKey);
   return { body, close };
 }
@@ -1802,13 +1805,9 @@ function field(labelText        , control             , hint         ) {
 function renderNodeEditor(node     , links       , cand                  , rerender                           ) {
   const meta = kindMeta(node.Kind);
   const allowed = meta[2];
-  const box = el('div', { style: { margin: '10px 0 4px', padding: '14px', border: '1px solid var(--accent, #4f8cff)', borderRadius: '8px', background: 'var(--panel2)' } });
-
-  const header = el('div', { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' } });
-  header.appendChild(el('h4', { text: `Editing ${node.Label || node.Id}`, style: { margin: '0', fontSize: '14px' } }));
-  const close = btn('Close'); close.onclick = () => rerender(true);
-  header.appendChild(close);
-  box.appendChild(header);
+  // No frame and no header of its own: this is rendered into a modal panel that already carries the node's
+  // name and a Close button (#292).
+  const box = el('div', { class: 'node-editor' });
 
   const grid = el('div', { style: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '12px', marginBottom: '12px' } });
 
@@ -2338,7 +2337,7 @@ function collapseGraph(nodes       , links       )                              
     const s = remap(l.source), t = remap(l.target);
     if (s === t) return;                       // a link fully inside one collapsed group
     present.add(s); present.add(t);
-    const k = s + ' ' + t;
+    const k = s + '\u0000' + t;
     if (!merged[k]) merged[k] = { source: s, target: t, value: 0, known: true };
     merged[k].value += (l.value || 0);
     if (l.known === false) merged[k].known = false;
@@ -2543,8 +2542,33 @@ function renderGroupManager(flow     , cand                  , rerender         
   return box;
 }
 
+// The open node editor, as a modal over the table (#292).
+//
+// It used to render beneath the table, which put the form at the bottom of a long page — nowhere near the
+// row you clicked — and forced the table itself to stay wide enough to host it, which small screens can't
+// give. The panel lives on <body>, so it outlives the re-render of the surface underneath it and is rebuilt
+// in place instead: the node object's identity is what the editor holds, and that survives a re-render.
+let nodeModal                                                      = null;
+
+function closeNodeModal() {
+  const m = nodeModal;
+  nodeModal = null;
+  if (m) m.close();
+}
+
+function syncNodeModal(node     , links       , cand                  , editing                       , rerender            ) {
+  if (!node) { closeNodeModal(); return; }
+  if (nodeModal && nodeModal.id !== node.Id) closeNodeModal();   // switched rows: a fresh panel, fresh title
+  if (!nodeModal) {
+    const o = overlay(`Edit node — ${node.Label || node.Id}`, () => { nodeModal = null; editing.id = null; rerender(); });
+    nodeModal = { id: node.Id, body: o.body, close: o.close };
+  }
+  nodeModal.body.innerHTML = '';
+  nodeModal.body.appendChild(renderNodeEditor(node, links, cand, (close          ) => { if (close) editing.id = null; rerender(); }));
+}
+
 // Virtual-node manager (#129): the dedicated node-configuration surface (its own Nodes tab). Each row is a
-// node; Edit opens the full editor (name, kind, mode, value, bindings, feeders/children) below the table.
+// node; Edit opens the full editor (name, kind, mode, value, bindings, feeders/children) in a modal.
 // Deleting a node takes its bound sources with it (they live on the node).
 function renderNodeManager(flow     , customNodes       , links       , cand                  , editing                       , rerender                           ) {
   const box = el('div', { style: { margin: '18px 0' } });
@@ -2552,6 +2576,7 @@ function renderNodeManager(flow     , customNodes       , links       , cand    
   box.appendChild(el('div', { class: 'desc', text: 'The custom nodes you’ve added (panels, breakers, batteries, producers, a “Total”). Click Edit to set the name, kind, how it’s valued, and bind live values from your broker.' }));
 
   if (!customNodes.length) {
+    closeNodeModal();
     box.appendChild(el('div', { class: 'desc', text: 'No virtual nodes yet — add one above.' }));
     return box;
   }
@@ -2631,8 +2656,8 @@ function renderNodeManager(flow     , customNodes       , links       , cand    
   tbl.appendChild(body);
   box.appendChild(tbl);
 
-  const editingNode = editing.id ? customNodes.find((n     ) => n.Id === editing.id) : null;
-  if (editingNode) box.appendChild(renderNodeEditor(editingNode, links, cand, (close          ) => { if (close) editing.id = null; rerender(); }));
+  // A deleted or renamed-away node leaves editing.id dangling; find() returning nothing closes the panel.
+  syncNodeModal(editing.id ? customNodes.find((n     ) => n.Id === editing.id) : null, links, cand, editing, rerender);
   return box;
 }
 
@@ -3770,8 +3795,6 @@ function addNodesSection(nav     , sections     ) {
     };
 
     const cand = flowCandidates(lastGraph, customNodes);
-    // Groups first: the node manager appends the (tall) per-node editor beneath its table when one is open,
-    // which would otherwise bury the Groups section off the bottom of the page.
     ed.appendChild(renderGroupManager(flow, cand, render));
     ed.appendChild(renderNodeManager(flow, customNodes, links, cand, editing, (close          ) => { if (close) editing.id = null; render(); }));
   };
@@ -3784,6 +3807,9 @@ function addNodesSection(nav     , sections     ) {
     render();
   };
   link.onclick = () => { activate(link, sec); load(); };
+  // The editor panel is mounted on <body>, so switching pages would otherwise leave it floating over
+  // whatever you switched to.
+  nav.addEventListener('click', (e     ) => { if (nodeModal && !link.contains(e.target)) { editing.id = null; closeNodeModal(); } });
 }
 
 // The Energy overview (#energy-rollup C): an at-a-glance board of where power is flowing right now —


### PR DESCRIPTION
Stacked on #335 — merge that first and this retargets to `main` automatically.

## The change (#292)

> When editing a row, instead of the default/current inline edit… Pop open a dialog model for making the changes. Current status is… not good user experience, where the edit opens at the BOTTOM of the table, rather than where you are editing.

Editing a virtual node now opens a modal over the table.

The panel mounts on `<body>`, so it survives the re-render of the surface underneath and is rebuilt in place rather than recreated — the node object's identity is what the editor holds, and that survives a re-render. Deleting the node being edited, or leaving the Nodes tab, dismisses it. The editor no longer draws its own border and "Editing X" header, since the panel already supplies both.

## Three things found on the way

**A NUL byte in the source.** `flow.ts:913` used a literal NUL as a link-key separator. `file` reports the largest file in the GUI as `data`, and **grep silently returns nothing on it** — no error, just no matches. It is now written as a unicode escape; behaviour identical.

**The DOM stub couldn't see modals.** `remove()` was a no-op and the stub `document` had no `addEventListener`, so nothing mounted on `<body>` was testable and Escape couldn't be fired. Elements now track their parent, `remove()` detaches, and document-level listeners are recorded like element ones.

**A genuinely flaky test.** `PublishTimeoutTests.ShuttingDown_IsNotReportedAsABrokerTimeout` cancelled at 50 ms against an 80 ms timeout and failed **about one run in five**. Under load the 80 ms timer fires before the cancellation callback is scheduled — and reporting a timeout there is the *correct* answer, so this was the test's margins, not `PublishTimeout` itself. It now cancels before the wait against a timeout of minutes, so only one outcome is possible. 8/8 clean runs.

## Checks

`smoke.mjs` asserts the editor renders on `<body>`, asserts it does **not** render inline under the table, and that Escape leaves nothing behind. Putting the inline render back fails it:

```
smoke FAILED: the node editor rendered inline under the table again
```

576 tests pass; all six GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
