### PR TITLE
feat(alarms): publish the per-measurement alarms the PDU reports, and stop dropping severity

### DIFF
--- a/rPDU2MQTT.Core/Core/AlarmPayload.cs
+++ b/rPDU2MQTT.Core/Core/AlarmPayload.cs
@@ -1,0 +1,54 @@
+using rPDU2MQTT.Models.PDU;
+
+namespace rPDU2MQTT.Core;
+
+/// <summary>
+/// What the bridge says about an entity's alarm, as payloads.
+///
+/// <para>
+/// Home Assistant reads the alarm state through <c>{{ 'OFF' if value == 'none' else 'ON' }}</c> — so
+/// <em>anything</em> that isn't exactly "none" is displayed as an active problem. That makes every
+/// odd-shaped payload a fabricated alarm, which is the one thing this project must never produce, and it is
+/// why these rules live in one tested place rather than inline at two call sites.
+/// </para>
+/// </summary>
+public static class AlarmPayload
+{
+    /// <summary>
+    /// The PDU reported an alarm object for this reading, so it is alarm-capable — whether or not one is
+    /// currently active.
+    /// </summary>
+    /// <remarks>
+    /// A clear alarm still counts. An entity that is being watched and is currently fine is worth showing:
+    /// it tells you the threshold exists. What isn't worth showing is a reading the hardware has no alarm
+    /// for at all — surfacing those would put an always-off "problem" on every measurement of every outlet.
+    /// </remarks>
+    public static bool Reported(Alarm? alarm) => alarm is not null;
+
+    /// <summary>
+    /// The alarm state to publish. "none" when there is no alarm, and when the PDU reported the field
+    /// empty.
+    /// </summary>
+    /// <remarks>
+    /// The empty case is the one that matters. A blank state is the PDU declining to say, and because
+    /// Home Assistant treats everything that isn't "none" as a problem, publishing it verbatim would light
+    /// up an alarm nobody raised. Reporting it as clear is the honest reading of "no alarm was stated".
+    /// </remarks>
+    public static string State(Alarm? alarm) =>
+        string.IsNullOrWhiteSpace(alarm?.State) ? "none" : alarm.State.Trim();
+
+    /// <summary>
+    /// The alarm's detail as a JSON object, for the entity's attributes — today the PDU's own severity
+    /// (its alarm-vs-warning distinction), which used to be parsed off the wire and then dropped.
+    /// </summary>
+    /// <remarks>
+    /// An absent severity is reported as absent. Defaulting it to "warning" or "alarm" would state
+    /// something the PDU never said, on the exact field an operator would use to decide whether to care.
+    /// Always a JSON object, never null or empty text: Home Assistant discards an attributes payload it
+    /// cannot parse as one, and would leave the previous value showing.
+    /// </remarks>
+    public static string Attributes(Alarm? alarm) =>
+        string.IsNullOrWhiteSpace(alarm?.Severity)
+            ? "{}"
+            : System.Text.Json.JsonSerializer.Serialize(new Dictionary<string, string> { ["severity"] = alarm.Severity.Trim() });
+}

--- a/rPDU2MQTT.Core/Models/HomeAssistant/baseClasses/baseEntity.cs
+++ b/rPDU2MQTT.Core/Models/HomeAssistant/baseClasses/baseEntity.cs
@@ -94,6 +94,14 @@ public abstract class baseEntity : IBaseDiscovery
     public string? Icon { get; set; }
 
     /// <summary>
+    /// A topic carrying a JSON object of extra attributes for this entity. Used to hang detail off an
+    /// entity that has nowhere else to put it — an alarm's severity, where the entity itself is a
+    /// binary "problem" and can only say yes or no.
+    /// </summary>
+    [JsonPropertyName("json_attributes_topic")]
+    public string? JsonAttributesTopic { get; set; }
+
+    /// <summary>
     /// Flag which defines if the entity should be enabled when first added.
     /// </summary>
     [JsonPropertyName("enabled_by_default")]

--- a/rPDU2MQTT.Core/Models/PDU/MqttPath.cs
+++ b/rPDU2MQTT.Core/Models/PDU/MqttPath.cs
@@ -22,6 +22,14 @@ public enum MqttPath
     [JsonPropertyName("alarm")]
     Alarm,
 
+    /// <summary>
+    /// A JSON object of detail about the alarm — today its severity. Sits beside <see cref="Alarm"/>
+    /// rather than replacing its payload, because the plain state topic is what existing installs already
+    /// read, and changing that payload to JSON would break every one of them.
+    /// </summary>
+    [JsonPropertyName("alarm_attributes")]
+    AlarmAttributes,
+
     [JsonPropertyName("measurements")]
     Measurements,
 

--- a/rPDU2MQTT.Engine/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT.Engine/Services/HomeAssistantDiscoveryService.cs
@@ -224,6 +224,15 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
         {
             if (BuildMeasurement(measurement, parent) is { } sensor)
                 components.Add(sensor);
+
+            // Its threshold alarm, where the PDU has one (#99) — the high/low limits configured per circuit,
+            // phase, outlet or total. Named after the reading so it can be told apart from the outlet's own
+            // alarm on the same device, and only created where the hardware actually reports one, so a PDU
+            // with no alarms configured gains no entities.
+            if (Core.AlarmPayload.Reported(measurement.Alarm))
+            {
+                components.Add(BuildAlarm(measurement, parent, $"{measurement.Entity_DisplayName} Alarm"));
+            }
         }
         else if (entity is GroupMeasurement groupMeasurement)
         {

--- a/rPDU2MQTT.Engine/Services/baseTypes/baseDiscoveryService.cs
+++ b/rPDU2MQTT.Engine/Services/baseTypes/baseDiscoveryService.cs
@@ -169,13 +169,23 @@ public abstract class baseDiscoveryService : baseMQTTService
     /// <summary>
     /// Build a "problem" binary sensor reflecting an entity's alarm state.
     /// </summary>
-    public BinarySensorDiscovery BuildAlarm(NamedEntity item, DiscoveryDevice Parent)
+    /// <param name="displayName">
+    /// What to call it on the device. Defaults to "Alarm", which is right for the one alarm a device or an
+    /// outlet has — but a measurement's alarm sits on the same HA device as its outlet's, and two entities
+    /// both called "Alarm" cannot be told apart.
+    /// </param>
+    public BinarySensorDiscovery BuildAlarm(NamedEntity item, DiscoveryDevice Parent, string displayName = "Alarm")
     {
         return new BinarySensorDiscovery
         {
             ID = item.Entity_Identifier + "_alarm",
             Name = item.Entity_Name + "_alarm",
-            DisplayName = "Alarm",
+            DisplayName = displayName,
+
+            // Severity (the PDU's own alarm-vs-warning distinction) rides along as an attribute: the entity
+            // is a binary "problem" and can only say yes or no, and a second entity per alarm point to carry
+            // one word would double the count for very little.
+            JsonAttributesTopic = MQTTHelper.JoinPaths(item.GetTopicPath(), MqttPath.AlarmAttributes.ToJsonString()),
 
             Device = Parent,
             EntityType = Models.HomeAssistant.Enums.EntityType.BinarySensor,

--- a/rPDU2MQTT.Engine/Services/baseTypes/basePublishingService.cs
+++ b/rPDU2MQTT.Engine/Services/baseTypes/basePublishingService.cs
@@ -28,6 +28,16 @@ public abstract class basePublishingService : baseMQTTService
             // #205: in Payload mode the reading is published as {"value": …, "timestamp": …}; otherwise it
             // stays the bare value it has always been.
             await PublishString(topic, Core.MessageTimestamps.Payload(measurement.Value, DataTimestampUtc, cfg.MQTT.MessageTimestamp), cancellationToken);
+
+            // The per-measurement alarm (#99). These are the thresholds the PDU actually lets you configure
+            // — high/low current on a circuit or phase, and the outlet's informational fields — and they
+            // were parsed off the wire and then thrown away.
+            //
+            // Only where the PDU reports one: publishing "none" for every measurement on every pass would
+            // double the topic count of the whole bridge to say nothing, and would invent an alarm-capable
+            // reading where the hardware has none.
+            if (Core.AlarmPayload.Reported(measurement.Alarm))
+                await PublishAlarm(measurement, measurement.Alarm, cancellationToken);
         }
     }
 
@@ -92,13 +102,21 @@ public abstract class basePublishingService : baseMQTTService
     }
 
     /// <summary>
-    /// Publish an entity's alarm state ("none" when there is no active alarm).
+    /// Publish an entity's alarm state ("none" when there is no active alarm), plus a small JSON object of
+    /// detail beside it.
     /// </summary>
+    /// <remarks>
+    /// The severity — the PDU's own distinction between an alarm and a warning — used to be parsed and then
+    /// dropped on the floor. It goes to a sibling topic rather than into the state payload: the plain state
+    /// is what existing installs already subscribe to, and turning it into JSON would break all of them.
+    /// It is published on every pass alongside the state, so the two can never disagree.
+    /// </remarks>
     protected async Task PublishAlarm<T>(T Entity, Alarm? alarm, CancellationToken cancellationToken)
         where T : IMQTTKey
     {
-        var topic = MQTTHelper.JoinPaths(Entity.GetTopicPath(), MqttPath.Alarm.ToJsonString());
-        await PublishString(topic, alarm?.State ?? "none", cancellationToken);
+        var path = Entity.GetTopicPath();
+        await PublishString(MQTTHelper.JoinPaths(path, MqttPath.Alarm.ToJsonString()), Core.AlarmPayload.State(alarm), cancellationToken);
+        await PublishString(MQTTHelper.JoinPaths(path, MqttPath.AlarmAttributes.ToJsonString()), Core.AlarmPayload.Attributes(alarm), cancellationToken);
     }
 
     /// <summary>

--- a/rPDU2MQTT.Tests/AlarmPayloadTests.cs
+++ b/rPDU2MQTT.Tests/AlarmPayloadTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using rPDU2MQTT.Core;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Home Assistant reads the alarm state through <c>{{ 'OFF' if value == 'none' else 'ON' }}</c>, so
+/// anything that isn't exactly "none" shows as an active problem. Every payload shape below is therefore a
+/// question of whether the bridge raises an alarm nobody raised.
+/// </summary>
+public class AlarmPayloadTests
+{
+    private static Alarm A(string? state = null, string? severity = null) =>
+        new() { State = state!, Severity = severity! };
+
+    [Fact]
+    public void NoAlarmObject_IsClear()
+        => Assert.Equal("none", AlarmPayload.State(null));
+
+    [Fact]
+    public void AnEmptyState_IsClear_NotAProblem()
+    {
+        // The one that would bite: publishing "" verbatim makes HA's template say ON, so a PDU that
+        // declines to fill the field lights up an alarm on a perfectly healthy outlet.
+        Assert.Equal("none", AlarmPayload.State(A(state: "")));
+        Assert.Equal("none", AlarmPayload.State(A(state: "   ")));
+    }
+
+    [Fact]
+    public void ARealState_IsPassedThroughAsThePduStatedIt()
+    {
+        Assert.Equal("alarm", AlarmPayload.State(A(state: "alarm")));
+        Assert.Equal("none", AlarmPayload.State(A(state: "none")));
+        // Surrounding whitespace would otherwise make "none " read as an active alarm.
+        Assert.Equal("none", AlarmPayload.State(A(state: " none ")));
+    }
+
+    [Fact]
+    public void SeverityIsNeverInvented()
+    {
+        // The field an operator uses to decide whether to care. Defaulting it to either value states
+        // something the PDU never said.
+        Assert.Equal("{}", AlarmPayload.Attributes(null));
+        Assert.Equal("{}", AlarmPayload.Attributes(A(state: "alarm")));
+        Assert.Equal("{}", AlarmPayload.Attributes(A(state: "alarm", severity: "  ")));
+    }
+
+    [Fact]
+    public void SeverityIsCarried_WhenTheDeviceStatesIt()
+    {
+        var json = AlarmPayload.Attributes(A(state: "alarm", severity: "warning"));
+        Assert.Equal("warning", JsonDocument.Parse(json).RootElement.GetProperty("severity").GetString());
+    }
+
+    [Fact]
+    public void AttributesAreAlwaysAParseableObject()
+    {
+        // HA discards an attributes payload it cannot read as an object — and leaves the previous value
+        // showing, which is how a cleared alarm keeps a stale severity beside it.
+        foreach (var alarm in new Alarm?[] { null, A(), A(state: "alarm"), A(state: "alarm", severity: "alarm") })
+            Assert.Equal(JsonValueKind.Object, JsonDocument.Parse(AlarmPayload.Attributes(alarm)).RootElement.ValueKind);
+    }
+
+    [Fact]
+    public void AClearAlarmIsStillReported_BecauseTheThresholdExists()
+    {
+        // A measurement the PDU watches and is currently happy with is worth an entity: it says the limit
+        // is configured. A measurement with no alarm object at all is not — that would put an always-off
+        // "problem" on every reading of every outlet.
+        Assert.True(AlarmPayload.Reported(A(state: "none")));
+        Assert.True(AlarmPayload.Reported(A()));
+        Assert.False(AlarmPayload.Reported(null));
+    }
+}


### PR DESCRIPTION
The **read side** of #99. Creating and editing alarms on the PDU is not included — this is the data the PDU already returns and we were throwing away.

## Per-measurement alarms

Device-level and outlet-level alarms have always published. The `alarm` object carried on each *measurement* never did — it was deserialized and dropped.

Those are exactly the ones your screenshots configure: high/low current on a circuit or phase, the outlet's informational fields, the totals. So the alarms most likely to be set up were the ones nothing surfaced.

They now publish to `<measurement>/alarm`, and get a Home Assistant `problem` entity named after the reading — so an outlet's own alarm and its current alarm can be told apart on the same device.

**Only where the PDU reports an alarm object.** A reading the hardware has no alarm for gains nothing; otherwise every measurement of every outlet grows an always-off "problem" entity. A reported-but-*clear* alarm does get one — that says the threshold exists and is being watched.

## Severity

The PDU's alarm-vs-warning distinction was parsed and discarded. It now rides along as an entity attribute via `json_attributes_topic`, published to a sibling topic (`<entity>/alarm_attributes`).

Deliberately *not* folded into the alarm state payload: the plain state topic is what existing installs already subscribe to, and turning it into JSON would break all of them.

## A fabrication bug found on the way

HA reads the alarm state through:

```jinja
{{ 'OFF' if value == 'none' else 'ON' }}
```

So **anything that isn't exactly `none` displays as an active problem**. An alarm whose state came back empty or padded — `""`, `" none "` — was published verbatim and lit up a problem on a perfectly healthy outlet. Both now resolve to `none`.

That's why the payload rules moved into `Core.AlarmPayload` instead of staying inline at two call sites: every odd-shaped payload here is a fabricated alarm, and that deserves tests rather than a `??`.

Absent severity stays absent — defaulting it to either value states something the PDU never said, on the exact field you'd use to decide whether to care.

## Coverage

`AlarmPayloadTests` pins the payload rules: empty/whitespace state is clear, a real state passes through, severity is never invented, attributes always parse as a JSON object (HA silently discards one that doesn't and keeps showing the previous value), and clear-but-reported still counts as reported.

The discovery wiring itself isn't unit-tested — the service needs live MQTT/PDU dependencies to construct — so the `alarm is not null` decision is exercised only through the shared `AlarmPayload.Reported`. Worth a look on your hardware: I have no PDU here, so I can't confirm what your unit actually puts in the `alarm` field of a measurement.

595 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
