### PR TITLE
fix(flow): stop publishing a counter as "today" when it never resets

### DIFF
--- a/rPDU2MQTT.Core/Flow/PeriodCounterAudit.cs
+++ b/rPDU2MQTT.Core/Flow/PeriodCounterAudit.cs
@@ -1,0 +1,75 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// Checks a source that <em>claims</em> to be a daily counter against what it actually does.
+///
+/// <para>
+/// Declaring <c>Accumulation: period</c> means "the device zeroes this every day, so the reading already
+/// <b>is</b> today's total" — and the bridge then publishes that number straight out as the day's energy,
+/// with no arithmetic in between. There is nothing wrong with that shortcut except that nothing was
+/// checking the claim. Point it at a cumulative counter by mistake and the lifetime total is displayed,
+/// verbatim and with total confidence, as "today".
+/// </para>
+/// <para>
+/// Seen live: a PV source wired to Solar Assistant's <c>total/pv_energy</c> read 129.9 kWh at 00:20 on a
+/// system that makes about 70 kWh on its best day — every sibling source on the same install was declared
+/// <c>lifetime</c> and was correct. The daily accumulator had the right answer stored the whole time (zero,
+/// because the sun was down); the raw reading simply overrode it.
+/// </para>
+/// <para>
+/// The test is the definition: a counter that resets each period must be <b>lower</b> at the start of the
+/// next period than it was at the end of the last one. If it is not, then whatever that number is, it is
+/// not today's — either it is cumulative, or the device has not reported since the day rolled and the value
+/// is yesterday's. Both cases mean the same thing for what may be displayed, so both are treated the same.
+/// </para>
+/// </summary>
+public static class PeriodCounterAudit
+{
+    /// <summary>What one period-declared source has done so far.</summary>
+    /// <param name="PeriodKey">The period the last reading fell in.</param>
+    /// <param name="HighWater">The largest value seen in that period — what a reset has to fall below.</param>
+    /// <param name="Contradicted">The source failed to reset across a boundary, so its reading is not "today".</param>
+    public sealed record State(string PeriodKey, double HighWater, bool Contradicted);
+
+    /// <summary>
+    /// A counter sitting at zero says nothing about whether it resets, so a period that ended at (or near)
+    /// zero is never used to judge the next one. Without this, a night with no production would convict a
+    /// perfectly honest daily counter of being cumulative.
+    /// </summary>
+    private const double Meaningful = 0.05;
+
+    /// <summary>
+    /// Fold one reading in, and say whether the source may still be treated as a daily total.
+    /// </summary>
+    /// <remarks>
+    /// The verdict can clear itself. A source that starts reporting properly — or a config that gets
+    /// corrected — produces a genuine reset at the next boundary and is trusted again from that moment,
+    /// with no restart and nothing to acknowledge.
+    /// </remarks>
+    public static State Observe(State? prior, double value, string periodKey)
+    {
+        if (prior is null || !string.Equals(prior.PeriodKey, periodKey, StringComparison.Ordinal))
+        {
+            // First sight of this source, or the first reading of a new period — the moment of truth.
+            var judgeable = prior is not null && prior.HighWater > Meaningful;
+            var didNotReset = judgeable && value >= prior!.HighWater - Meaningful;
+            return new State(periodKey, value, didNotReset);
+        }
+
+        // Same period: track the high-water mark. Max rather than last, because a counter that dips and
+        // recovers mid-period (a device restart, a re-publish) must still have to fall below the real peak
+        // to count as having reset.
+        return prior with { HighWater = Math.Max(prior.HighWater, value) };
+    }
+
+    /// <summary>
+    /// How to explain a contradicted source to whoever has to fix it — naming the topic, the reading, and
+    /// what to change. A warning nobody can act on is only noise.
+    /// </summary>
+    public static string Explain(string nodeId, string source, double value, string periodKey) =>
+        $"Energy-flow: '{source}' on node '{nodeId}' is configured as a daily (period) counter, but it did not "
+      + $"reset when the day rolled over to {periodKey} — it still reads {value:0.###}. That is not today's "
+      + "total, so it is being withheld rather than displayed as one. Either the counter is cumulative (set "
+      + "its Accumulation to 'lifetime' and the daily figure will be derived from it), or the device has not "
+      + "reported since the rollover.";
+}

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -36,6 +36,10 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     private readonly ISnapshotSink<MeasurementSnapshot>? sink;
     private long version;
     private long received;
+    // Per (node, topic, direction): whether a source claiming to be a daily counter has actually behaved
+    // like one. In memory only — a restart makes it unproven again until the next rollover, which errs
+    // towards showing the device's number rather than withholding one we haven't yet caught out.
+    private readonly Dictionary<string, PeriodCounterAudit.State> periodAudit = new(StringComparer.Ordinal);
 
     public EnergyFlowMqttSourceService(MQTTServiceDependencies deps, ISnapshotSink<MeasurementSnapshot>? sink = null)
     {
@@ -175,6 +179,13 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
         return true;
     }
 
+    /// <summary>The period a reading now belongs to, on the same boundary the daily accumulator uses.</summary>
+    private string CurrentPeriodKey(DateTime nowUtc)
+    {
+        var agg = cfg.EnergyFlow.Aggregation;
+        return EnergyPeriod.KeyFor(nowUtc, EnergyPeriod.Resolve(agg.PeriodTimeZone), agg.PeriodStartHour);
+    }
+
     private void OnMessageReceived(object? sender, OnMessageReceivedEventArgs e)
     {
         var now = DateTime.UtcNow;
@@ -185,7 +196,8 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             readings is null ? null : (node, metric, value, stale) =>
             {
                 if (Metrics.TryParse(metric, out var m)) readings.Add(new MeasurementReading(node, m, value, stale));
-            });
+            },
+            periodAudit, CurrentPeriodKey(now), m => Log.Warning(m));
 
         if (sink is not null && readings is { Count: > 0 })
         {
@@ -226,7 +238,10 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     internal static void Apply(
         IReadOnlyDictionary<string, List<(string NodeId, EnergyFlowSource Source)>> bindings,
         FlowValueCache cache, string? topic, string? payload, DateTime nowUtc,
-        Action<string, string, double, int>? onReading = null)
+        Action<string, string, double, int>? onReading = null,
+        IDictionary<string, PeriodCounterAudit.State>? periodAudit = null,
+        string? periodKey = null,
+        Action<string>? warn = null)
     {
         if (topic is null || !bindings.TryGetValue(topic, out var list) || string.IsNullOrWhiteSpace(payload))
             return;
@@ -248,12 +263,48 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             // A 'period' energy counter is reset by the device each day, so it already IS the daily total —
             // store it under the daily metric rather than pretending it is cumulative and measuring its
             // "rise", which loses the whole day every time the device rolls it over.
+            // A source declared 'period' is published as the day's total with no arithmetic in between, so
+            // the claim has to be checked rather than trusted: a counter that resets daily must be lower at
+            // the start of a period than it was at the end of the last one. When it isn't, the number is not
+            // today's — it is a cumulative total, or a value the device stopped updating before the rollover
+            // — and it is dropped rather than stated. The node then reports "no data" for today, which is
+            // the truth, instead of a confident wrong figure.
+            if (periodAudit is not null && periodKey is not null && IsPeriodEnergy(src)
+                && !AllowPeriodReading(periodAudit, periodKey, nodeId, topic, src, value, warn))
+                continue;
+
             foreach (var (key, v) in FlowMetricKey.Fan(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction, value))
             {
                 cache.Set(nodeId, key, v, src.StaleAfterSeconds, nowUtc);
                 onReading?.Invoke(nodeId, key, v, src.StaleAfterSeconds);
             }
         }
+    }
+
+    /// <summary>A source whose reading is claimed to already be the daily energy total.</summary>
+    private static bool IsPeriodEnergy(EnergyFlowSource src) =>
+        FlowMetricKey.IsPeriod(src.Accumulation) && string.Equals(src.Metric, "energy", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Fold the reading into the audit and say whether it may be published as today's total. Warns once per
+    /// transition — a message on every sample would bury the one that matters.
+    /// </summary>
+    private static bool AllowPeriodReading(
+        IDictionary<string, PeriodCounterAudit.State> audit, string periodKey,
+        string nodeId, string topic, EnergyFlowSource src, double value, Action<string>? warn)
+    {
+        var auditKey = $"{nodeId}|{topic}|{src.Direction}";
+        audit.TryGetValue(auditKey, out var prior);
+        var next = PeriodCounterAudit.Observe(prior, value, periodKey);
+        audit[auditKey] = next;
+
+        if (next.Contradicted && prior?.Contradicted != true)
+            warn?.Invoke(PeriodCounterAudit.Explain(nodeId, topic, value, periodKey));
+        else if (!next.Contradicted && prior?.Contradicted == true)
+            warn?.Invoke($"Energy-flow: '{topic}' on node '{nodeId}' reset properly for {periodKey}; it is being "
+                       + "treated as a daily counter again.");
+
+        return !next.Contradicted;
     }
 
     private static string Truncate(string s) => s.Length <= 80 ? s : s[..80] + "…";

--- a/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
+++ b/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
@@ -282,6 +282,75 @@ public class EnergyFlowMqttSourceTests
     }
 
     [Fact]
+    public void Apply_WithholdsAPeriodCounterThatNeverResets()
+    {
+        // The live failure (#292-era): a cumulative PV counter declared as a daily one was published verbatim
+        // as "today", reading 129.9 kWh at 00:20 with the sun down. The pure rule is covered in
+        // PeriodCounterAuditTests; this pins that the ingest actually acts on the verdict, because a rule
+        // nothing consults changes nothing.
+        var nodes = new[] { NodeWith("solar", new EnergyFlowSource { Topic = "sa/pv_energy", Metric = "energy", Accumulation = "period" }) };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+        var cache = new FlowValueCache();
+        var audit = new Dictionary<string, PeriodCounterAudit.State>();
+        var warnings = new List<string>();
+        var now = DateTime.UtcNow;
+
+        // Day one: no evidence yet, so it is trusted and published as the day's total.
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "129.9", now, null, audit, "2026-08-04", warnings.Add);
+        Assert.True(cache.TryGetValue("solar", EnergyPeriod.Metric, out var dayOne) && dayOne == 129.9);
+
+        // The rollover, with the counter carrying straight on. That is not today's total, and it must not be
+        // stated as one — the cache keeps no new value, so the node reports no data rather than 129.9 kWh.
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "130.4", now, null, audit, "2026-08-05", warnings.Add);
+        Assert.True(cache.TryGetValue("solar", EnergyPeriod.Metric, out var afterRoll) && afterRoll == 129.9,
+            "the stale reading was overwritten with a value that is not today's total");
+        Assert.Single(warnings);
+        Assert.Contains("did not reset", warnings[0]);
+
+        // Still withheld on every later sample, and the operator is told once, not once per message.
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "131.0", now, null, audit, "2026-08-05", warnings.Add);
+        Assert.Single(warnings);
+    }
+
+    [Fact]
+    public void Apply_LeavesAnHonestDailyCounterAlone()
+    {
+        var nodes = new[] { NodeWith("solar", new EnergyFlowSource { Topic = "sa/pv_energy", Metric = "energy", Accumulation = "period" }) };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+        var cache = new FlowValueCache();
+        var audit = new Dictionary<string, PeriodCounterAudit.State>();
+        var warnings = new List<string>();
+        var now = DateTime.UtcNow;
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "69.4", now, null, audit, "2026-08-04", warnings.Add);
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "0.2", now, null, audit, "2026-08-05", warnings.Add);
+
+        Assert.True(cache.TryGetValue("solar", EnergyPeriod.Metric, out var today) && today == 0.2);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
+    public void Apply_NeverWithholdsALifetimeCounter()
+    {
+        // The audit exists to check a claim only 'period' sources make. A lifetime counter is *supposed* to
+        // keep climbing across midnight, and the daily figure is derived from it — auditing it would break
+        // every correctly configured install.
+        var nodes = new[] { NodeWith("grid", new EnergyFlowSource { Topic = "sa/grid_energy", Metric = "energy", Accumulation = "lifetime" }) };
+        var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
+        var cache = new FlowValueCache();
+        var audit = new Dictionary<string, PeriodCounterAudit.State>();
+        var warnings = new List<string>();
+        var now = DateTime.UtcNow;
+
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/grid_energy", "1306.3", now, null, audit, "2026-08-04", warnings.Add);
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/grid_energy", "1308.4", now, null, audit, "2026-08-05", warnings.Add);
+
+        Assert.True(cache.TryGetValue("grid", "energy", out var v) && v == 1308.4);
+        Assert.Empty(warnings);
+        Assert.Empty(audit);
+    }
+
+    [Fact]
     public void Apply_ConvertsTheSourceUnitToCanonicalBeforeCaching()
     {
         // Solar Assistant publishing kW must land in the cache as W, so it lines up with the PDU's watts.

--- a/rPDU2MQTT.Tests/PeriodCounterAuditTests.cs
+++ b/rPDU2MQTT.Tests/PeriodCounterAuditTests.cs
@@ -1,0 +1,117 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// A source declared <c>Accumulation: period</c> is published as the day's energy total with no arithmetic
+/// in between, so the claim has to be checked rather than trusted.
+///
+/// <para>
+/// The failure these pin, seen live: a PV source wired to Solar Assistant's cumulative
+/// <c>total/pv_energy</c> but declared as a daily counter read <b>129.9 kWh at 00:20</b>, on a system whose
+/// best day is about 70 kWh, with the sun down and every MPPT reporting zero. The daily accumulator had the
+/// right answer stored the whole time; the raw reading simply overrode it, and nothing anywhere compared
+/// the two.
+/// </para>
+/// </summary>
+public class PeriodCounterAuditTests
+{
+    private static PeriodCounterAudit.State Feed(PeriodCounterAudit.State? state, string day, params double[] values)
+    {
+        foreach (var v in values) state = PeriodCounterAudit.Observe(state, v, day);
+        return state!;
+    }
+
+    [Fact]
+    public void ACumulativeCounter_IsCaughtAtTheFirstRollover()
+    {
+        // Yesterday it climbed to 129.9. Today it opens at 129.9 and keeps climbing — the defining
+        // behaviour of a counter that does not reset.
+        var state = Feed(null, "2026-08-04", 60.0, 95.5, 129.9);
+        Assert.False(state.Contradicted);
+
+        state = PeriodCounterAudit.Observe(state, 129.9, "2026-08-05");
+        Assert.True(state.Contradicted);
+    }
+
+    [Fact]
+    public void AGenuineDailyCounter_IsLeftAlone()
+    {
+        var state = Feed(null, "2026-08-04", 12.0, 48.0, 69.4);
+        state = PeriodCounterAudit.Observe(state, 0.0, "2026-08-05");
+        Assert.False(state.Contradicted);
+
+        // And it keeps being trusted as it climbs through the new day.
+        state = Feed(state, "2026-08-05", 0.3, 11.2);
+        Assert.False(state.Contradicted);
+    }
+
+    [Fact]
+    public void ANightWithNoProduction_ConvictsNobody()
+    {
+        // The false positive that would matter most: a day that legitimately ended at zero says nothing
+        // about whether the counter resets, so the next day must not be judged on it. Without this, every
+        // honest daily counter on a cloudy winter system would be withheld.
+        var state = Feed(null, "2026-08-04", 0.0, 0.0);
+        state = PeriodCounterAudit.Observe(state, 0.0, "2026-08-05");
+        Assert.False(state.Contradicted);
+    }
+
+    [Fact]
+    public void ADeviceThatStoppedReportingBeforeTheRollover_IsAlsoWithheld()
+    {
+        // Same evidence, different cause: the value is unchanged across the boundary because nothing new
+        // arrived. It is yesterday's total either way, and displaying it as today's is equally wrong — so
+        // there is deliberately no attempt to tell the two apart.
+        var state = Feed(null, "2026-08-04", 70.0);
+        state = PeriodCounterAudit.Observe(state, 70.0, "2026-08-05");
+        Assert.True(state.Contradicted);
+    }
+
+    [Fact]
+    public void TheVerdictClearsItself_WhenTheSourceStartsBehaving()
+    {
+        // Correcting the config (or the device) must not need a restart or an acknowledgement — the next
+        // genuine reset is the evidence, and it is accepted the moment it arrives.
+        var state = Feed(null, "2026-08-04", 129.9);
+        state = PeriodCounterAudit.Observe(state, 129.9, "2026-08-05");
+        Assert.True(state.Contradicted);
+
+        state = Feed(state, "2026-08-05", 140.0);
+        state = PeriodCounterAudit.Observe(state, 0.0, "2026-08-06");
+        Assert.False(state.Contradicted);
+    }
+
+    [Fact]
+    public void AMidPeriodDip_DoesNotCountAsAReset()
+    {
+        // A device restart or a re-publish can make the counter fall inside a period. The high-water mark
+        // is what a reset has to beat, so the dip alone doesn't make a cumulative source look honest.
+        var state = Feed(null, "2026-08-04", 100.0, 3.0, 120.0);
+        Assert.Equal(120.0, state.HighWater);
+
+        state = PeriodCounterAudit.Observe(state, 120.0, "2026-08-05");
+        Assert.True(state.Contradicted);
+    }
+
+    [Fact]
+    public void TheFirstReadingEverIsTrusted()
+    {
+        // Nothing has been observed across a boundary yet, so there is no evidence either way. Withholding
+        // on suspicion would blank out every correctly configured install for its first day.
+        var state = PeriodCounterAudit.Observe(null, 129.9, "2026-08-05");
+        Assert.False(state.Contradicted);
+    }
+
+    [Fact]
+    public void TheExplanationNamesTheSourceAndTheFix()
+    {
+        // A warning nobody can act on is noise. This one has to identify which binding, and say what to change.
+        var msg = PeriodCounterAudit.Explain("eg4-flexboss21-solar", "solar_assistant/total/pv_energy/state", 129.9, "2026-08-05");
+        Assert.Contains("eg4-flexboss21-solar", msg);
+        Assert.Contains("solar_assistant/total/pv_energy/state", msg);
+        Assert.Contains("129.9", msg);
+        Assert.Contains("lifetime", msg);
+    }
+}


### PR DESCRIPTION
## What happened

Solar PV read **129.9 kWh at 00:20**, with the sun down and every MPPT reporting zero, on a system whose best day is about 70 kWh.

The solar node's energy source was declared `Accumulation: period` while pointing at Solar Assistant's **cumulative** `total/pv_energy`. Every sibling source on the same install was declared `lifetime` and was correct:

```
solar    energy | accum=period   | solar_assistant/total/pv_energy       <- 129.9 shown verbatim as "today"
inverter energy | accum=lifetime | solar_assistant/total/load_energy      <- correct
grid     energy | accum=lifetime | solar_assistant/total/grid_energy_in   <- correct
grid     energy | accum=lifetime | solar_assistant/total/grid_energy_out  <- correct
```

`period` means "the device zeroes this daily, so the reading already **is** today's total", so the raw number is published as the day's energy with no arithmetic in between. The daily accumulator had the right answer stored the entire time — Valkey held `PeriodKWh: 0` for that node — and the raw reading simply overrode it.

Nothing anywhere compared the two, and nothing checked the claim.

## The fix

The claim is now tested against behaviour, using its own definition: **a counter that resets each period must be lower at the start of a period than it was at the end of the last one.**

When it isn't, the reading is dropped instead of published. The node reports *no data* for today rather than a confident wrong number, and the log names the node, the topic, the value and the fix.

A cumulative counter and a device that went quiet before the rollover are deliberately **not** told apart — both leave the value unchanged across the boundary, and in both cases it is yesterday's number, equally wrong to show as today's.

### What it won't do

- **Judge a period that ended at ~zero.** A night with no production is no evidence, and without this every honest daily counter on a cloudy system gets withheld.
- **Touch a lifetime counter.** Those are *supposed* to climb across midnight.
- **Withhold before any rollover has been seen** — that would blank a correctly configured install on its first day.

The verdict clears itself the moment a genuine reset arrives: no restart, nothing to acknowledge. State is in-memory, so a restart makes a source unproven again until the next rollover — erring towards showing the device's number rather than withholding one we haven't caught out yet.

## Your live system

Already fixed, before this PR:

- flipped that source to `Accumulation: lifetime` in the CRD, matching its three siblings
- dropped the stale solar entry from Valkey so the period baseline rebuilt from the real counter (a straight flip would have booked a bogus ~99 kWh spike today, since the stored `LastCounterKWh` was 30.79 against a live counter of 129.9)
- scaled to 0 for ~30s across the change so the running process couldn't re-persist the old state

Now reading: solar today **0**, inverter/grid/main panel **3.16** — consistent. Backups of the CRD and the energy hash are kept.

One side effect worth knowing: solar's **lifetime** total restarted from zero, because that state had to be dropped. Today's figures and every other node are unaffected.

## Checks

`PeriodCounterAuditTests` covers the rule; `EnergyFlowMqttSourceTests` covers the ingest acting on it — a rule nothing consults changes nothing. 606 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
