### PR TITLE
fix(flow): apply the period-counter check to Modbus sources as well as MQTT

### DIFF
--- a/rPDU2MQTT.Core/Flow/PeriodCounterAudit.cs
+++ b/rPDU2MQTT.Core/Flow/PeriodCounterAudit.cs
@@ -63,7 +63,41 @@ public static class PeriodCounterAudit
     }
 
     /// <summary>
-    /// How to explain a contradicted source to whoever has to fix it — naming the topic, the reading, and
+    /// Whether this source makes the claim at all. Only an energy source declared <c>period</c> does — a
+    /// lifetime counter is supposed to climb across midnight, and the daily figure is derived from it.
+    /// </summary>
+    public static bool Applies(Models.Config.EnergyFlowSource src) =>
+        FlowMetricKey.IsPeriod(src.Accumulation)
+        && string.Equals(src.Metric, "energy", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Fold a reading in and say whether it may be published as today's total, warning once per change of
+    /// verdict. Shared by every ingest: a rule that only one transport applies is a rule with a hole in it,
+    /// and the hole is wherever the user happened to wire the counter.
+    /// </summary>
+    /// <param name="audit">Per-source state, keyed by <paramref name="nodeId"/>/<paramref name="source"/>/direction.</param>
+    /// <param name="source">How to name this binding to whoever has to fix it — a topic, or a register.</param>
+    public static bool Allow(
+        IDictionary<string, State> audit, string periodKey,
+        string nodeId, string source, string? direction, double value, Action<string>? warn)
+    {
+        var key = $"{nodeId}|{source}|{direction}";
+        audit.TryGetValue(key, out var prior);
+        var next = Observe(prior, value, periodKey);
+        audit[key] = next;
+
+        // Once per transition, not per sample: a message on every reading buries the one that matters.
+        if (next.Contradicted && prior?.Contradicted != true)
+            warn?.Invoke(Explain(nodeId, source, value, periodKey));
+        else if (!next.Contradicted && prior?.Contradicted == true)
+            warn?.Invoke($"Energy-flow: '{source}' on node '{nodeId}' reset properly for {periodKey}; it is being "
+                       + "treated as a daily counter again.");
+
+        return !next.Contradicted;
+    }
+
+    /// <summary>
+    /// How to explain a contradicted source to whoever has to fix it — naming the source, the reading, and
     /// what to change. A warning nobody can act on is only noise.
     /// </summary>
     public static string Explain(string nodeId, string source, double value, string periodKey) =>

--- a/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
@@ -48,6 +48,18 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         catch (OperationCanceledException) { /* shutting down */ }
     }
 
+    // Per (node, register, direction): whether a source claiming to be a daily counter has behaved like one.
+    // In memory only, as on the MQTT side — a restart makes it unproven until the next rollover, erring
+    // towards showing the device's number rather than withholding one we have not yet caught out.
+    private readonly Dictionary<string, PeriodCounterAudit.State> periodAudit = new(StringComparer.Ordinal);
+
+    /// <summary>The period a reading belongs to, on the same boundary the daily accumulator uses.</summary>
+    private string CurrentPeriodKey(DateTime nowUtc)
+    {
+        var agg = cfg.EnergyFlow.Aggregation;
+        return EnergyPeriod.KeyFor(nowUtc, EnergyPeriod.Resolve(agg.PeriodTimeZone), agg.PeriodStartHour);
+    }
+
     /// <summary>Poll each due connection, and drop cached readings whose binding has gone away.</summary>
     private void Reconcile(DateTime nowUtc)
     {
@@ -82,8 +94,23 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         // poll on a device that only speaks RTU-over-TCP.
         var framing = resolvedFraming.TryGetValue(conn.Id, out var cached) ? cached : conn.Framing;
 
+        var periodKey = CurrentPeriodKey(nowUtc);
+
         ReadBatch(conn.Host, conn.Port, conn.UnitId, framing, conn.TimeoutMs, forConn.Select(f => f.Source).ToList(),
-            onValue: (src, value) => { foreach (var (key, v) in FlowMetricKey.Fan(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction, value)) latest.Set(nodeOf[src], key, v, src.StaleAfterSeconds, nowUtc); },
+            onValue: (src, value) =>
+            {
+                // Same check the MQTT ingest applies (#340): a register declared as a daily counter has to
+                // actually reset at the boundary, or whatever it holds is not today's total. A rule only one
+                // transport enforces is a rule with a hole in it, and the hole is wherever the counter
+                // happened to be wired.
+                if (PeriodCounterAudit.Applies(src)
+                    && !PeriodCounterAudit.Allow(periodAudit, periodKey, nodeOf[src],
+                                                 $"register {src.Register} on {conn.Id}", src.Direction, value, m => Log.Warning(m)))
+                    return;
+
+                foreach (var (key, v) in FlowMetricKey.Fan(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction, value))
+                    latest.Set(nodeOf[src], key, v, src.StaleAfterSeconds, nowUtc);
+            },
             onError: (src, msg) => Log.Debug($"Energy-flow Modbus: node '{nodeOf[src]}' register {src.Register} on {conn.Id} — {msg}"),
             onResolved: f => resolvedFraming[conn.Id] = f);
     }

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -269,8 +269,8 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             // today's — it is a cumulative total, or a value the device stopped updating before the rollover
             // — and it is dropped rather than stated. The node then reports "no data" for today, which is
             // the truth, instead of a confident wrong figure.
-            if (periodAudit is not null && periodKey is not null && IsPeriodEnergy(src)
-                && !AllowPeriodReading(periodAudit, periodKey, nodeId, topic, src, value, warn))
+            if (periodAudit is not null && periodKey is not null && PeriodCounterAudit.Applies(src)
+                && !PeriodCounterAudit.Allow(periodAudit, periodKey, nodeId, topic, src.Direction, value, warn))
                 continue;
 
             foreach (var (key, v) in FlowMetricKey.Fan(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction, value))
@@ -279,32 +279,6 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
                 onReading?.Invoke(nodeId, key, v, src.StaleAfterSeconds);
             }
         }
-    }
-
-    /// <summary>A source whose reading is claimed to already be the daily energy total.</summary>
-    private static bool IsPeriodEnergy(EnergyFlowSource src) =>
-        FlowMetricKey.IsPeriod(src.Accumulation) && string.Equals(src.Metric, "energy", StringComparison.OrdinalIgnoreCase);
-
-    /// <summary>
-    /// Fold the reading into the audit and say whether it may be published as today's total. Warns once per
-    /// transition — a message on every sample would bury the one that matters.
-    /// </summary>
-    private static bool AllowPeriodReading(
-        IDictionary<string, PeriodCounterAudit.State> audit, string periodKey,
-        string nodeId, string topic, EnergyFlowSource src, double value, Action<string>? warn)
-    {
-        var auditKey = $"{nodeId}|{topic}|{src.Direction}";
-        audit.TryGetValue(auditKey, out var prior);
-        var next = PeriodCounterAudit.Observe(prior, value, periodKey);
-        audit[auditKey] = next;
-
-        if (next.Contradicted && prior?.Contradicted != true)
-            warn?.Invoke(PeriodCounterAudit.Explain(nodeId, topic, value, periodKey));
-        else if (!next.Contradicted && prior?.Contradicted == true)
-            warn?.Invoke($"Energy-flow: '{topic}' on node '{nodeId}' reset properly for {periodKey}; it is being "
-                       + "treated as a daily counter again.");
-
-        return !next.Contradicted;
     }
 
     private static string Truncate(string s) => s.Length <= 80 ? s : s[..80] + "…";

--- a/rPDU2MQTT.Tests/PeriodCounterAuditTests.cs
+++ b/rPDU2MQTT.Tests/PeriodCounterAuditTests.cs
@@ -105,6 +105,72 @@ public class PeriodCounterAuditTests
     }
 
     [Fact]
+    public void Allow_WithholdsAfterTheMissedReset_AndWarnsOnlyOnTheTransition()
+    {
+        // The shared entry point both ingests call. Warning on every sample would bury the one that
+        // matters under a poll-rate stream of identical lines.
+        var audit = new Dictionary<string, PeriodCounterAudit.State>();
+        var warnings = new List<string>();
+        bool Allow(double v, string day) =>
+            PeriodCounterAudit.Allow(audit, day, "solar", "register 40 on inv1", "out", v, warnings.Add);
+
+        Assert.True(Allow(129.9, "2026-08-04"));
+        Assert.Empty(warnings);
+
+        Assert.False(Allow(130.4, "2026-08-05"));
+        Assert.False(Allow(131.0, "2026-08-05"));
+        Assert.False(Allow(131.6, "2026-08-05"));
+        Assert.Single(warnings);
+        Assert.Contains("register 40 on inv1", warnings[0]);
+    }
+
+    [Fact]
+    public void Allow_SaysSoWhenASourceStartsBehavingAgain()
+    {
+        var audit = new Dictionary<string, PeriodCounterAudit.State>();
+        var warnings = new List<string>();
+        bool Allow(double v, string day) =>
+            PeriodCounterAudit.Allow(audit, day, "solar", "sa/pv_energy", "out", v, warnings.Add);
+
+        Allow(129.9, "2026-08-04");
+        Assert.False(Allow(130.4, "2026-08-05"));
+        Allow(140.0, "2026-08-05");
+        Assert.True(Allow(0.0, "2026-08-06"));
+
+        Assert.Equal(2, warnings.Count);
+        Assert.Contains("did not reset", warnings[0]);
+        Assert.Contains("reset properly", warnings[1]);
+    }
+
+    [Fact]
+    public void Allow_JudgesEachBindingSeparately()
+    {
+        // A node's in and out legs are different quantities on the same register, and two nodes can be fed
+        // by one topic. Sharing a verdict between them would convict a counter for its neighbour's sins.
+        var audit = new Dictionary<string, PeriodCounterAudit.State>();
+        bool Allow(string node, string src, string dir, double v, string day) =>
+            PeriodCounterAudit.Allow(audit, day, node, src, dir, v, null);
+
+        Allow("grid", "sa/energy", "out", 50.0, "2026-08-04");
+        Allow("grid", "sa/energy", "in", 20.0, "2026-08-04");
+        Allow("solar", "sa/energy", "out", 80.0, "2026-08-04");
+
+        // Only the out leg fails to reset.
+        Assert.False(Allow("grid", "sa/energy", "out", 51.0, "2026-08-05"));
+        Assert.True(Allow("grid", "sa/energy", "in", 0.0, "2026-08-05"));
+        Assert.True(Allow("solar", "sa/energy", "out", 0.4, "2026-08-05"));
+    }
+
+    [Theory]
+    [InlineData("period", "energy", true)]
+    [InlineData("lifetime", "energy", false)]     // supposed to climb; the daily figure is derived from it
+    [InlineData("period", "realpower", false)]    // instantaneous — nothing accumulates, nothing resets
+    [InlineData(null, "energy", false)]
+    public void Applies_OnlyToAnEnergySourceDeclaredAsADailyCounter(string? accumulation, string metric, bool expected)
+        => Assert.Equal(expected, PeriodCounterAudit.Applies(
+            new rPDU2MQTT.Models.Config.EnergyFlowSource { Metric = metric, Accumulation = accumulation! }));
+
+    [Fact]
     public void TheExplanationNamesTheSourceAndTheFix()
     {
         // A warning nobody can act on is noise. This one has to identify which binding, and say what to change.


### PR DESCRIPTION
#340 checked that a source declared as a daily counter actually resets at the period boundary — but wired the check into the **MQTT ingest only**.

A register bound over Modbus and declared `period` was still published verbatim as today's total, with nothing verifying the claim. Same defect as the solar bug, reachable through the other transport.

## What changed

- the check now runs in both ingests
- the fold-and-warn step moved out of a private helper in `EnergyFlowMqttSourceService` into `PeriodCounterAudit.Allow`, so there is one implementation rather than two that drift apart

Verdicts are keyed per `(node, source, direction)`. A node's in and out legs are different quantities on the same register, and one topic can feed several nodes, so a missed reset on one must not convict its neighbours. Warnings still fire once per change of verdict, not once per reading.

## Coverage

New tests on the shared entry point: withholds after a missed reset and warns exactly once; says so when a source starts behaving again; judges each binding separately; and `Applies` is true only for an energy source declared `period` — never a lifetime counter (supposed to climb across midnight) and never an instantaneous metric.

The Modbus wiring itself is the same two-line call and isn't separately covered — `Poll` needs a live device to exercise.

613 tests pass; GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
