### PR TITLE
fix(flow): do not raise the contradiction banner on lifetime energy

### DIFF
--- a/rPDU2MQTT.Web/web/contradiction.check.mjs
+++ b/rPDU2MQTT.Web/web/contradiction.check.mjs
@@ -21,8 +21,8 @@ const cfg = { EnergyFlow: { Nodes: [], Links: [] } };
 
 // `imbalance` is what the server reports as unaccounted for. inverter is the live case (a reading of 2.1
 // with 129.9 passing through it); panel is 4% out, which is ordinary.
-const graph = (inverterImbalance) => ({
-  ok: true, metric: 'energytoday', units: 'kWh',
+const graph = (inverterImbalance, metric = 'energytoday') => ({
+  ok: true, metric, units: 'kWh',
   nodes: [
     { id: 'solar', label: 'Solar (PV)', kind: 'solar', value: 129.9, derivation: 'measured', imbalance: null },
     { id: 'inverter', label: 'EG4 FlexBoss 21', kind: 'inverter', value: 2.1, derivation: 'measured', imbalance: inverterImbalance },
@@ -34,14 +34,14 @@ const graph = (inverterImbalance) => ({
   ],
 });
 
-async function render(inverterImbalance) {
+async function render(inverterImbalance, metric) {
   const { sandbox, getEl } = makeDom({
     bodies: (url) =>
       url.includes('/api/schema') ? schema :
       url.includes('/api/instances') ? { ok: true, instances: [] } :
       url.includes('/api/config') ? cfg :
       url.includes('/api/flow/live') ? { ok: true, values: [] } :
-      url.includes('/api/flow') ? graph(inverterImbalance) :
+      url.includes('/api/flow') ? graph(inverterImbalance, metric) :
       { ok: true },
   });
   vm.createContext(sandbox);
@@ -83,5 +83,16 @@ sections = await render(0.12);   // 5% of a 2.22 throughput
 const quiet = query(sections, 'div', true).filter(d => cn(d).includes('flow-contradiction'));
 if (quiet.length) fail(`a ${'5%'} gap raised a contradiction banner — the threshold is not being applied`);
 
+// --- Lifetime energy: the same enormous gap, and deliberately silent.
+//
+// Those counters started whenever each device or binding was first seen — a PDU's outlet totals have been
+// running for years, an inverter's for weeks — so the two sides of a node describe different spans and a
+// large gap is the expected result. Checked against the live system: a main panel read 96% "unaccounted"
+// for exactly that reason. Banner-ing it would be the crying wolf this threshold exists to avoid, and the
+// ⚠ tooltip already explains it and points at "Energy today".
+sections = await render(129.9, 'energy');
+const lifetime = query(sections, 'div', true).filter(d => cn(d).includes('flow-contradiction'));
+if (lifetime.length) fail('a lifetime-energy gap raised a contradiction banner — those counters start at different times');
+
 console.log('contradiction: a node whose flows contradict it is named above the chart and marked on it; '
-  + 'ordinary gaps stay quiet');
+  + 'ordinary gaps and lifetime-counter gaps stay quiet');

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1437,6 +1437,9 @@ export function addFlowSection(nav: any, sections: any) {
     if (!links.length) { wrap.innerHTML = '<div class="desc" style="color:var(--muted)">No measured power flow to display. Define an EnergyFlow hierarchy, or check that outlets report power.</div>'; count.textContent = ''; return; }
 
     const units = graph.units || '';
+    // Which metric is actually on screen, taken from the graph rather than the selector: the two disagree
+    // while a fetch is in flight, and a live push repaints without the selector being touched at all.
+    const lifetimeEnergy = String(graph.metric || metricSel.value || '').toLowerCase() === 'energy';
     const incoming: any = {}, outgoing: any = {};
     nodes.forEach((n: any) => { incoming[n.id] = []; outgoing[n.id] = []; });
     links.forEach((l: any) => { (outgoing[l.source] = outgoing[l.source] || []).push(l); (incoming[l.target] = incoming[l.target] || []).push(l); });
@@ -1798,7 +1801,13 @@ export function addFlowSection(nav: any, sections: any) {
         // Past the line, the label stops looking like every other figure on the chart and the node is
         // named in a banner above it. The number is still shown — hiding a reading the hardware actually
         // gave would be its own kind of lying — but it is no longer presented as settled.
-        const share = contradictionShare(n, reading);
+        // Not on lifetime energy. Those counters started whenever each device or binding was first seen —
+        // a PDU's outlet totals have been running for years, an inverter's for weeks, a derived one since
+        // the last restart — so the two sides of a node are answering about different spans and a large
+        // gap is the expected result, not a fault. Checked live: a main panel read 96% "unaccounted" purely
+        // because its outlets have been counting far longer than its feeder. The ⚠ and its tooltip still
+        // say so, and the tooltip already points at "Energy today", where every figure covers one window.
+        const share = lifetimeEnergy ? null : contradictionShare(n, reading);
         if (share != null && share >= CONTRADICTION_SHARE) {
           lab.setAttribute('fill', 'var(--warn, #d08700)');
           lab.setAttribute('class', 'flow-contradicted');

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2865,6 +2865,9 @@ function addFlowSection(nav     , sections     ) {
     if (!links.length) { wrap.innerHTML = '<div class="desc" style="color:var(--muted)">No measured power flow to display. Define an EnergyFlow hierarchy, or check that outlets report power.</div>'; count.textContent = ''; return; }
 
     const units = graph.units || '';
+    // Which metric is actually on screen, taken from the graph rather than the selector: the two disagree
+    // while a fetch is in flight, and a live push repaints without the selector being touched at all.
+    const lifetimeEnergy = String(graph.metric || metricSel.value || '').toLowerCase() === 'energy';
     const incoming      = {}, outgoing      = {};
     nodes.forEach((n     ) => { incoming[n.id] = []; outgoing[n.id] = []; });
     links.forEach((l     ) => { (outgoing[l.source] = outgoing[l.source] || []).push(l); (incoming[l.target] = incoming[l.target] || []).push(l); });
@@ -3225,7 +3228,13 @@ function addFlowSection(nav     , sections     ) {
         // Past the line, the label stops looking like every other figure on the chart and the node is
         // named in a banner above it. The number is still shown — hiding a reading the hardware actually
         // gave would be its own kind of lying — but it is no longer presented as settled.
-        const share = contradictionShare(n, reading);
+        // Not on lifetime energy. Those counters started whenever each device or binding was first seen —
+        // a PDU's outlet totals have been running for years, an inverter's for weeks, a derived one since
+        // the last restart — so the two sides of a node are answering about different spans and a large
+        // gap is the expected result, not a fault. Checked live: a main panel read 96% "unaccounted" purely
+        // because its outlets have been counting far longer than its feeder. The ⚠ and its tooltip still
+        // say so, and the tooltip already points at "Energy today", where every figure covers one window.
+        const share = lifetimeEnergy ? null : contradictionShare(n, reading);
         if (share != null && share >= CONTRADICTION_SHARE) {
           lab.setAttribute('fill', 'var(--warn, #d08700)');
           lab.setAttribute('class', 'flow-contradicted');


### PR DESCRIPTION
Found by running #341's rule against the live install rather than a fixture.

#341 raises a banner when more than a quarter of a node's throughput is unaccounted for. On the **lifetime** energy metric that condition is normal: those counters start whenever each device or binding was first seen, so a PDU's outlet totals may have been running for years while the inverter feeding them has counted for weeks. The two sides of a node are answering about different spans.

Live, on lifetime energy:

```
main_panel  value=8412   imbalance=8068   95.9%
solar       value=193.2  imbalance=140.4  42.1%
```

Both entirely expected, and both would have been named in the banner — the crying wolf the threshold exists to avoid.

## What changed

- banner and warning-colour label suppressed on the lifetime `energy` metric
- the `⚠` marker and its tooltip are unchanged; that tooltip already explains the cause and points at "Energy today", where every figure covers one window
- power and daily energy are unaffected

The metric is now read from the graph being drawn rather than from the selector — they disagree while a fetch is in flight, and a live push repaints without the selector being touched at all. That's also what made the first attempt at this fix fail its own check.

## Checks

`contradiction.check.mjs` renders the same large gap on the lifetime metric and asserts no banner appears. Removing the guard fails it:

```
without the gate -> contradiction check FAILED: a lifetime-energy gap raised a contradiction banner
```

613 tests pass; all seven GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
