### PR TITLE
feat(flow): show which sources are being withheld, and why, on the diagram

### DIFF
--- a/rPDU2MQTT.Core/Flow/CompositeFlowValueSource.cs
+++ b/rPDU2MQTT.Core/Flow/CompositeFlowValueSource.cs
@@ -5,7 +5,7 @@ namespace rPDU2MQTT.Core.Flow;
 /// (node, metric) wins. Lets the graph draw live values from more than one ingest at once — MQTT and Modbus
 /// TCP today — without <see cref="FlowGraphBuilder"/> or any exporter knowing there's more than one source.
 /// </summary>
-public sealed class CompositeFlowValueSource : IFlowValueSource
+public sealed class CompositeFlowValueSource : IFlowValueSource, IWithheldSources
 {
     private readonly IReadOnlyList<IFlowValueSource> sources;
 
@@ -19,4 +19,12 @@ public sealed class CompositeFlowValueSource : IFlowValueSource
         value = 0;
         return false;
     }
+
+    /// <summary>
+    /// What every ingest behind this one is refusing to publish. Merged here so the GUI asks once and no
+    /// caller has to know which transport a binding happens to use — the reason a number is missing is the
+    /// same question whichever wire it was meant to arrive on.
+    /// </summary>
+    public IReadOnlyCollection<WithheldSource> Withheld =>
+        sources.OfType<IWithheldSources>().SelectMany(s => s.Withheld).ToList();
 }

--- a/rPDU2MQTT.Core/Flow/IWithheldSources.cs
+++ b/rPDU2MQTT.Core/Flow/IWithheldSources.cs
@@ -1,0 +1,28 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>A binding whose readings are being dropped, and why.</summary>
+/// <param name="Node">The node it is bound to.</param>
+/// <param name="Source">How to find it in the config — an MQTT topic, or a register on a connection.</param>
+/// <param name="Metric">The metric it would have fed.</param>
+/// <param name="Reason">Plain text, addressed to whoever has to fix it.</param>
+public readonly record struct WithheldSource(string Node, string Source, string Metric, string Reason);
+
+/// <summary>
+/// Reports readings the bridge is deliberately refusing to publish.
+///
+/// <para>
+/// Withholding is the right call when a reading can be shown to be wrong — a counter declared as a daily
+/// total that never resets is not today's figure, whatever else it is. But a value that quietly vanishes is
+/// its own kind of dishonesty: the node reads "no data", which is indistinguishable from a binding nobody
+/// ever configured, and the reason lives only in a log line nobody is watching.
+/// </para>
+/// <para>
+/// So the decision has to be visible in the same place the missing number is. This is what the GUI reads to
+/// say so.
+/// </para>
+/// </summary>
+public interface IWithheldSources
+{
+    /// <summary>Every binding currently being withheld. Empty when everything is being believed.</summary>
+    IReadOnlyCollection<WithheldSource> Withheld { get; }
+}

--- a/rPDU2MQTT.Core/Flow/PeriodCounterAudit.cs
+++ b/rPDU2MQTT.Core/Flow/PeriodCounterAudit.cs
@@ -29,7 +29,12 @@ public static class PeriodCounterAudit
     /// <param name="PeriodKey">The period the last reading fell in.</param>
     /// <param name="HighWater">The largest value seen in that period — what a reset has to fall below.</param>
     /// <param name="Contradicted">The source failed to reset across a boundary, so its reading is not "today".</param>
-    public sealed record State(string PeriodKey, double HighWater, bool Contradicted);
+    /// <param name="Reason">
+    /// Why, in the words shown to whoever has to fix it. Kept on the state rather than only logged, so the
+    /// GUI can say it where the missing number is — a value that vanishes with its explanation in a log file
+    /// is indistinguishable from a binding nobody configured.
+    /// </param>
+    public sealed record State(string PeriodKey, double HighWater, bool Contradicted, string? Reason = null);
 
     /// <summary>
     /// A counter sitting at zero says nothing about whether it resets, so a period that ended at (or near)
@@ -53,7 +58,7 @@ public static class PeriodCounterAudit
             // First sight of this source, or the first reading of a new period — the moment of truth.
             var judgeable = prior is not null && prior.HighWater > Meaningful;
             var didNotReset = judgeable && value >= prior!.HighWater - Meaningful;
-            return new State(periodKey, value, didNotReset);
+            return new State(periodKey, value, didNotReset);   // the caller attaches the wording, which needs its name
         }
 
         // Same period: track the high-water mark. Max rather than last, because a counter that dips and
@@ -84,16 +89,35 @@ public static class PeriodCounterAudit
         var key = $"{nodeId}|{source}|{direction}";
         audit.TryGetValue(key, out var prior);
         var next = Observe(prior, value, periodKey);
+        if (next.Contradicted) next = next with { Reason = Explain(nodeId, source, value, periodKey) };
         audit[key] = next;
 
         // Once per transition, not per sample: a message on every reading buries the one that matters.
         if (next.Contradicted && prior?.Contradicted != true)
-            warn?.Invoke(Explain(nodeId, source, value, periodKey));
+            warn?.Invoke(next.Reason!);
         else if (!next.Contradicted && prior?.Contradicted == true)
             warn?.Invoke($"Energy-flow: '{source}' on node '{nodeId}' reset properly for {periodKey}; it is being "
                        + "treated as a daily counter again.");
 
         return !next.Contradicted;
+    }
+
+    /// <summary>Every binding this audit is currently withholding, for the GUI to show.</summary>
+    public static IReadOnlyCollection<WithheldSource> WithheldIn(IReadOnlyDictionary<string, State> audit)
+    {
+        var outp = new List<WithheldSource>();
+        foreach (var (key, state) in audit)
+        {
+            if (!state.Contradicted) continue;
+            // The key is node|source|direction, and a source name may itself contain '|' — split off the
+            // ends rather than the middle.
+            var first = key.IndexOf('|');
+            var last = key.LastIndexOf('|');
+            if (first < 0 || last <= first) continue;
+            outp.Add(new WithheldSource(key[..first], key[(first + 1)..last], EnergyPeriod.Metric,
+                                        state.Reason ?? "Declared as a daily counter, but it did not reset when the day rolled over."));
+        }
+        return outp;
     }
 
     /// <summary>

--- a/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
@@ -18,7 +18,7 @@ namespace rPDU2MQTT.Services;
 /// them in the GUI takes effect without a restart. A device is opened per poll (connect → read → close),
 /// which is simplest and robust for the seconds-scale cadence energy monitoring needs.
 /// </summary>
-public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValueSource
+public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValueSource, IWithheldSources
 {
     private readonly Config cfg;
     private readonly FlowValueCache latest = new();
@@ -52,6 +52,9 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
     // In memory only, as on the MQTT side — a restart makes it unproven until the next rollover, erring
     // towards showing the device's number rather than withholding one we have not yet caught out.
     private readonly Dictionary<string, PeriodCounterAudit.State> periodAudit = new(StringComparer.Ordinal);
+
+    /// <summary>Bindings whose readings are being dropped, so the GUI can say so where the number is missing.</summary>
+    public IReadOnlyCollection<WithheldSource> Withheld => PeriodCounterAudit.WithheldIn(periodAudit);
 
     /// <summary>The period a reading belongs to, on the same boundary the daily accumulator uses.</summary>
     private string CurrentPeriodKey(DateTime nowUtc)

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -22,7 +22,7 @@ namespace rPDU2MQTT.Services;
 /// Subscriptions are reconciled on a timer rather than only at startup, so binding a topic in the GUI
 /// takes effect without a restart (matching the rest of the app's live-reload behaviour).
 /// </summary>
-public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueSource, IFlowValueDiagnostics
+public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueSource, IFlowValueDiagnostics, IWithheldSources
 {
     private readonly HiveMQClient mqtt;
     private readonly Config cfg;
@@ -40,6 +40,9 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     // like one. In memory only — a restart makes it unproven again until the next rollover, which errs
     // towards showing the device's number rather than withholding one we haven't yet caught out.
     private readonly Dictionary<string, PeriodCounterAudit.State> periodAudit = new(StringComparer.Ordinal);
+
+    /// <summary>Bindings whose readings are being dropped, so the GUI can say so where the number is missing.</summary>
+    public IReadOnlyCollection<WithheldSource> Withheld => PeriodCounterAudit.WithheldIn(periodAudit);
 
     public EnergyFlowMqttSourceService(MQTTServiceDependencies deps, ISnapshotSink<MeasurementSnapshot>? sink = null)
     {

--- a/rPDU2MQTT.Tests/PeriodCounterAuditTests.cs
+++ b/rPDU2MQTT.Tests/PeriodCounterAuditTests.cs
@@ -171,6 +171,37 @@ public class PeriodCounterAuditTests
             new rPDU2MQTT.Models.Config.EnergyFlowSource { Metric = metric, Accumulation = accumulation! }));
 
     [Fact]
+    public void WithheldIn_ReportsOnlyTheContradictedBindings_WithTheirReason()
+    {
+        // What the GUI reads to explain a missing number. A withheld value whose reason lives only in a log
+        // line leaves the node reading "no data", indistinguishable from a binding nobody ever configured.
+        var audit = new Dictionary<string, PeriodCounterAudit.State>();
+        PeriodCounterAudit.Allow(audit, "2026-08-04", "solar", "sa/pv_energy", "out", 129.9, null);
+        PeriodCounterAudit.Allow(audit, "2026-08-04", "grid", "sa/grid_energy", "out", 50.0, null);
+        PeriodCounterAudit.Allow(audit, "2026-08-05", "solar", "sa/pv_energy", "out", 130.4, null);   // no reset
+        PeriodCounterAudit.Allow(audit, "2026-08-05", "grid", "sa/grid_energy", "out", 0.0, null);    // reset
+
+        var withheld = PeriodCounterAudit.WithheldIn(audit);
+        var one = Assert.Single(withheld);
+        Assert.Equal("solar", one.Node);
+        Assert.Equal("sa/pv_energy", one.Source);
+        Assert.Contains("did not reset", one.Reason);
+    }
+
+    [Fact]
+    public void WithheldIn_KeepsASourceNameThatContainsASeparator()
+    {
+        // MQTT topics are slash-delimited, but nothing stops a register label or a future source name from
+        // carrying the '|' the key is built with. Splitting on the wrong one silently renames the binding
+        // in the very message meant to help someone find it.
+        var audit = new Dictionary<string, PeriodCounterAudit.State>();
+        PeriodCounterAudit.Allow(audit, "2026-08-04", "solar", "odd|name", "out", 129.9, null);
+        PeriodCounterAudit.Allow(audit, "2026-08-05", "solar", "odd|name", "out", 130.4, null);
+
+        Assert.Equal("odd|name", Assert.Single(PeriodCounterAudit.WithheldIn(audit)).Source);
+    }
+
+    [Fact]
     public void TheExplanationNamesTheSourceAndTheFix()
     {
         // A warning nobody can act on is noise. This one has to identify which binding, and say what to change.

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1608,6 +1608,19 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             return Results.Json(await BuildFlowAsync(ctx.Request.Query["instance"], ctx.Request.Query["metric"].ToString(), ctx.RequestAborted), ConfigSchema.Json);
         });
 
+        // Readings the bridge is deliberately dropping, and why. Withholding a value that can be shown to be
+        // wrong is the right call; doing it silently is not, because the node then reads "no data" and looks
+        // exactly like a binding nobody ever configured. This is what the diagram reads to say so.
+        app.MapGet("/api/flow/withheld", (HttpContext ctx) =>
+        {
+            var withheld = (live as Core.Flow.IWithheldSources)?.Withheld ?? Array.Empty<Core.Flow.WithheldSource>();
+            return Results.Json(new
+            {
+                ok = true,
+                sources = withheld.Select(w => new { node = w.Node, source = w.Source, metric = w.Metric, reason = w.Reason }),
+            }, ConfigSchema.Json);
+        });
+
         // Preview the generated paths with the posted (unsaved) config applied, so the Overrides
         // editor can show how edits change the HA/Prometheus/EmonCMS paths. Runs the real processing
         // pipeline against a transient PDU so the result matches what would actually be published.

--- a/rPDU2MQTT.Web/web/contradiction.check.mjs
+++ b/rPDU2MQTT.Web/web/contradiction.check.mjs
@@ -34,13 +34,14 @@ const graph = (inverterImbalance, metric = 'energytoday') => ({
   ],
 });
 
-async function render(inverterImbalance, metric) {
+async function render(inverterImbalance, metric, withheld = []) {
   const { sandbox, getEl } = makeDom({
     bodies: (url) =>
       url.includes('/api/schema') ? schema :
       url.includes('/api/instances') ? { ok: true, instances: [] } :
       url.includes('/api/config') ? cfg :
       url.includes('/api/flow/live') ? { ok: true, values: [] } :
+      url.includes('/api/flow/withheld') ? { ok: true, sources: withheld } :
       url.includes('/api/flow') ? graph(inverterImbalance, metric) :
       { ok: true },
   });
@@ -94,5 +95,27 @@ sections = await render(129.9, 'energy');
 const lifetime = query(sections, 'div', true).filter(d => cn(d).includes('flow-contradiction'));
 if (lifetime.length) fail('a lifetime-energy gap raised a contradiction banner — those counters start at different times');
 
-console.log('contradiction: a node whose flows contradict it is named above the chart and marked on it; '
-  + 'ordinary gaps and lifetime-counter gaps stay quiet');
+// --- A withheld source is announced, not silently absent.
+//
+// The bridge drops readings it can show to be wrong — a counter declared daily that never resets. Doing it
+// silently leaves the node reading "no data", which is indistinguishable from a binding nobody configured,
+// and sends the operator hunting for a fault in the wrong place entirely.
+sections = await render(0.12, 'energytoday', [{
+  node: 'solar',
+  source: 'solar_assistant/total/pv_energy/state',
+  metric: 'energytoday',
+  reason: 'Configured as a daily (period) counter, but it did not reset when the day rolled over.',
+}]);
+const notices = query(sections, 'div', true).filter(d => cn(d).includes('flow-contradiction'));
+if (!notices.length) fail('a withheld source was dropped without saying so anywhere on the page');
+const notice = notices.map(n => n.textContent).join(' ');
+if (!notice.includes('solar_assistant/total/pv_energy/state')) fail('the notice does not name the withheld binding');
+if (!notice.includes('did not reset')) fail('the notice does not say why the binding is withheld');
+
+// And nothing is announced when nothing is being withheld.
+sections = await render(0.12, 'energytoday', []);
+if (query(sections, 'div', true).filter(d => cn(d).includes('flow-contradiction')).length)
+  fail('a notice appeared with nothing withheld and no contradiction');
+
+console.log('contradiction: contradicted nodes are named above the chart and marked on it; withheld sources '
+  + 'are announced with their reason; ordinary and lifetime-counter gaps stay quiet');

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -935,6 +935,32 @@ function collapseGraph(nodes: any[], links: any[]): { nodes: any[]; links: any[]
 // believed for a week.
 const CONTRADICTION_SHARE = 0.25;
 
+/// The banner naming every binding the bridge is dropping, and why. Separate from the contradiction banner
+/// because it is a different statement: that one says a number on the chart disagrees with the chart, this
+/// one says a number is absent on purpose. A node reading "no data" is otherwise indistinguishable from one
+/// nobody ever bound a source to, and the two need completely different fixes.
+function withheldBanner(sources: any[]): HTMLElement {
+  const box = el('div', { class: 'flow-contradiction' });
+  box.appendChild(el('strong', {
+    text: sources.length === 1
+      ? '1 source is being withheld'
+      : `${sources.length} sources are being withheld`,
+  }));
+  box.appendChild(el('div', {
+    class: 'desc',
+    style: { margin: '2px 0 6px' },
+    text: 'These bindings are reporting, but what they report can be shown to be wrong, so it is not being '
+        + 'used. The nodes below show no data for them rather than a figure that is not what it claims.',
+  }));
+  sources.forEach((w: any) => {
+    const row = el('div', { class: 'nh-warn', style: { margin: '3px 0' } });
+    row.appendChild(el('strong', { text: `${w.node} · ${w.source}: ` }));
+    row.appendChild(el('span', { text: w.reason || '' }));
+    box.appendChild(row);
+  });
+  return box;
+}
+
 /// The banner naming every node whose figure its own flows contradict. Above the chart, not inside it: the
 /// point is to be read before the numbers are, by someone who came to the page to read the numbers.
 function contradictionBanner(items: { id: string, label: string, share: number }[], onFocus: (id: string) => void): HTMLElement {
@@ -1351,6 +1377,9 @@ export function addFlowSection(nav: any, sections: any) {
   const treePanel = document.createElement('div'); treePanel.style.margin = '16px 0 4px'; sec.appendChild(treePanel);
   const ed: any = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
   let lastGraph: any = null;
+  // Bindings the server is dropping on purpose. Fetched beside the graph rather than folded into it: it
+  // describes the ingest, not the drawing, and it must still be reported when the graph itself is empty.
+  let withheldSources: any[] = [];
 
   // Collapsing/expanding a group must move both graphs together (they share the collapse state).
   const redrawBoth = () => { if (lastGraph) draw(lastGraph); renderTree(); };
@@ -1919,6 +1948,7 @@ export function addFlowSection(nav: any, sections: any) {
     count.title = unknownCount
       ? 'Nothing measures these nodes, and no single path determines them. Bind a source, or mark a feeder "residual" to say where the remainder comes from — values are never invented for them.'
       : '';
+    if (withheldSources.length) wrap.appendChild(withheldBanner(withheldSources));
     if (contradicted.length) wrap.appendChild(contradictionBanner(contradicted, (id) => focusPath(svg, incoming, id)));
 
     const scroll = el('div', { style: { overflow: 'auto', maxHeight: '74vh', border: '1px solid var(--line)', borderRadius: '6px' } });
@@ -2216,7 +2246,8 @@ export function addFlowSection(nav: any, sections: any) {
   const load = async () => {
     let path = withInstance('/api/flow', instSel);
     if (metricSel.value && metricSel.value !== 'realpower') path += (path.includes('?') ? '&' : '?') + 'metric=' + metricSel.value;
-    const r = await api(path);
+    const [r, w] = await Promise.all([api(path), api('/api/flow/withheld')]);
+    withheldSources = (w.body && w.body.ok && w.body.sources) || [];
     if (!r.body.ok) { wrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load flow data.') + '</div>'; count.textContent = ''; lastGraph = null; renderEditor(); return; }
     lastGraph = r.body;
     draw(r.body);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -2363,6 +2363,32 @@ function collapseGraph(nodes       , links       )                              
 // believed for a week.
 const CONTRADICTION_SHARE = 0.25;
 
+/// The banner naming every binding the bridge is dropping, and why. Separate from the contradiction banner
+/// because it is a different statement: that one says a number on the chart disagrees with the chart, this
+/// one says a number is absent on purpose. A node reading "no data" is otherwise indistinguishable from one
+/// nobody ever bound a source to, and the two need completely different fixes.
+function withheldBanner(sources       )              {
+  const box = el('div', { class: 'flow-contradiction' });
+  box.appendChild(el('strong', {
+    text: sources.length === 1
+      ? '1 source is being withheld'
+      : `${sources.length} sources are being withheld`,
+  }));
+  box.appendChild(el('div', {
+    class: 'desc',
+    style: { margin: '2px 0 6px' },
+    text: 'These bindings are reporting, but what they report can be shown to be wrong, so it is not being '
+        + 'used. The nodes below show no data for them rather than a figure that is not what it claims.',
+  }));
+  sources.forEach((w     ) => {
+    const row = el('div', { class: 'nh-warn', style: { margin: '3px 0' } });
+    row.appendChild(el('strong', { text: `${w.node} · ${w.source}: ` }));
+    row.appendChild(el('span', { text: w.reason || '' }));
+    box.appendChild(row);
+  });
+  return box;
+}
+
 /// The banner naming every node whose figure its own flows contradict. Above the chart, not inside it: the
 /// point is to be read before the numbers are, by someone who came to the page to read the numbers.
 function contradictionBanner(items                                                , onFocus                      )              {
@@ -2779,6 +2805,9 @@ function addFlowSection(nav     , sections     ) {
   const treePanel = document.createElement('div'); treePanel.style.margin = '16px 0 4px'; sec.appendChild(treePanel);
   const ed      = document.createElement('div'); ed.style.marginTop = '18px'; sec.appendChild(ed);
   let lastGraph      = null;
+  // Bindings the server is dropping on purpose. Fetched beside the graph rather than folded into it: it
+  // describes the ingest, not the drawing, and it must still be reported when the graph itself is empty.
+  let withheldSources        = [];
 
   // Collapsing/expanding a group must move both graphs together (they share the collapse state).
   const redrawBoth = () => { if (lastGraph) draw(lastGraph); renderTree(); };
@@ -3346,6 +3375,7 @@ function addFlowSection(nav     , sections     ) {
     count.title = unknownCount
       ? 'Nothing measures these nodes, and no single path determines them. Bind a source, or mark a feeder "residual" to say where the remainder comes from — values are never invented for them.'
       : '';
+    if (withheldSources.length) wrap.appendChild(withheldBanner(withheldSources));
     if (contradicted.length) wrap.appendChild(contradictionBanner(contradicted, (id) => focusPath(svg, incoming, id)));
 
     const scroll = el('div', { style: { overflow: 'auto', maxHeight: '74vh', border: '1px solid var(--line)', borderRadius: '6px' } });
@@ -3643,7 +3673,8 @@ function addFlowSection(nav     , sections     ) {
   const load = async () => {
     let path = withInstance('/api/flow', instSel);
     if (metricSel.value && metricSel.value !== 'realpower') path += (path.includes('?') ? '&' : '?') + 'metric=' + metricSel.value;
-    const r = await api(path);
+    const [r, w] = await Promise.all([api(path), api('/api/flow/withheld')]);
+    withheldSources = (w.body && w.body.ok && w.body.sources) || [];
     if (!r.body.ok) { wrap.innerHTML = '<div class="desc" style="color:var(--bad)">' + (r.body.message || 'Could not load flow data.') + '</div>'; count.textContent = ''; lastGraph = null; renderEditor(); return; }
     lastGraph = r.body;
     draw(r.body);


### PR DESCRIPTION
#340 and #343 drop a reading that can be shown to be wrong — a counter declared as a daily total that never resets is not today's figure, whatever else it is.

Dropping it was right. Dropping it **silently** was not: the node then reads "no data", which is exactly what a node with no binding at all reads, and the reason lived only in a log line nobody is tailing. That is the mystery-function failure mode, just inverted — instead of an unexplained number, an unexplained absence.

## What changed

- `GET /api/flow/withheld` reports the bindings currently being dropped
- the Flow page lists them above the diagram, each with the sentence saying what is wrong and what to change
- nothing is shown when nothing is being withheld

Plumbing: the audit now keeps its wording on the state rather than only handing it to the log; both ingests expose it via `IWithheldSources`; and `CompositeFlowValueSource` merges across transports, so the GUI asks once and needs to know nothing about which wire a binding uses.

## Checks

`contradiction.check.mjs` asserts the notice names the binding and gives the reason, and that nothing appears when nothing is withheld. Removing the banner fails it:

```
banner removed -> contradiction check FAILED: a withheld source was dropped without saying so anywhere on the page
```

Two unit tests cover the aggregation — including a source name containing the `|` the audit key is built from, since splitting on the wrong separator would silently rename the binding in the very message meant to help someone find it.

615 tests pass; all seven GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
