### PR TITLE
fix(pdu): include alarm state in the RawSnapshot wire contract

### DIFF
--- a/rPDU2MQTT.Core/Core/RawSnapshot.cs
+++ b/rPDU2MQTT.Core/Core/RawSnapshot.cs
@@ -14,24 +14,30 @@ namespace rPDU2MQTT.Core.Transport;
 // (non-idempotent) transform.
 //
 // Scope: devices -> outlets/entities -> measurements. OneView groups are a follow-up.
+//
+// Every field a consumer needs must be listed here explicitly. An omitted field is lost without error: the
+// consumer receives the type default and cannot distinguish it from a real value. Two have been missed so
+// far — Record_Key/Record_Parent (see Rewire below), and `alarm`, which the PDU reports on the device, on
+// each outlet and on each measurement.
 
 public sealed record RawSnapshot(string InstanceId, DateTime TimestampUtc, List<RawDevice> Devices);
 
 public sealed record RawDevice(
     string? Key, string? Name, string? Label, string? EntityName, string? DisplayName,
     string? Make, string? Model, string? State, string? Type,
-    List<RawOutlet> Outlets, List<RawEntity> Entities);
+    List<RawOutlet> Outlets, List<RawEntity> Entities, Alarm? Alarm = null);
 
 public sealed record RawOutlet(
     int Key, string? Name, string? Label, string? EntityName, string? DisplayName,
-    string? Make, string? Model, string? State, List<RawMeasurement> Measurements);
+    string? Make, string? Model, string? State, List<RawMeasurement> Measurements, Alarm? Alarm = null);
 
 public sealed record RawEntity(
     string? Key, string? Name, string? Label, string? EntityName, string? DisplayName,
     List<RawMeasurement> Measurements);
 
 public sealed record RawMeasurement(
-    string? Key, string? Type, string? EntityName, string? DisplayName, string? Value, string? Units, string? State);
+    string? Key, string? Type, string? EntityName, string? DisplayName, string? Value, string? Units, string? State,
+    Alarm? Alarm = null);
 
 /// <summary>Maps between the live <see cref="PduData"/> model and the <see cref="RawSnapshot"/> wire form.</summary>
 public static class RawSnapshotMapper
@@ -42,17 +48,17 @@ public static class RawSnapshotMapper
 
     private static RawDevice ToWire(Device d) => new(
         d.Key, d.Name, d.Label, d.Entity_Name, d.Entity_DisplayName, d.Entity_Make, d.Entity_Model, d.State, d.Type,
-        d.Outlets.Select(ToWire).ToList(), d.Entity.Select(ToWire).ToList());
+        d.Outlets.Select(ToWire).ToList(), d.Entity.Select(ToWire).ToList(), d.Alarm);
 
     private static RawOutlet ToWire(Outlet o) => new(
         o.Key, o.Name, o.Label, o.Entity_Name, o.Entity_DisplayName, o.Entity_Make, o.Entity_Model, o.State,
-        o.Measurements.Select(ToWire).ToList());
+        o.Measurements.Select(ToWire).ToList(), o.Alarm);
 
     private static RawEntity ToWire(Entity e) => new(
         e.Key, e.Name, e.Label, e.Entity_Name, e.Entity_DisplayName, e.Measurements.Select(ToWire).ToList());
 
     private static RawMeasurement ToWire(Measurement m) => new(
-        m.Key, m.Type, m.Entity_Name, m.Entity_DisplayName, m.Value, m.Units, m.State);
+        m.Key, m.Type, m.Entity_Name, m.Entity_DisplayName, m.Value, m.Units, m.State, m.Alarm);
 
     /// <summary>
     /// Re-establish the MQTT topic wiring on a rebuilt <see cref="PduData"/>.
@@ -110,6 +116,7 @@ public static class RawSnapshotMapper
             {
                 Key = d.Key!, Name = d.Name!, Label = d.Label!, State = d.State!, Type = d.Type!,
                 Entity_Name = d.EntityName!, Entity_DisplayName = d.DisplayName!, Entity_Make = d.Make, Entity_Model = d.Model,
+                Alarm = d.Alarm!,
             };
             foreach (var o in d.Outlets)
                 device.Outlets.Add(ToOutlet(o));
@@ -126,6 +133,7 @@ public static class RawSnapshotMapper
         {
             Key = o.Key, Name = o.Name!, Label = o.Label!, State = o.State!,
             Entity_Name = o.EntityName!, Entity_DisplayName = o.DisplayName!, Entity_Make = o.Make, Entity_Model = o.Model,
+            Alarm = o.Alarm!,
         };
         foreach (var m in o.Measurements)
             outlet.Measurements.Add(ToMeasurement(m));
@@ -148,5 +156,6 @@ public static class RawSnapshotMapper
     {
         Key = m.Key!, Type = m.Type!, Value = m.Value!, Units = m.Units!, State = m.State!,
         Entity_Name = m.EntityName!, Entity_DisplayName = m.DisplayName!,
+        Alarm = m.Alarm!,
     };
 }

--- a/rPDU2MQTT.Tests/SnapshotRewireTests.cs
+++ b/rPDU2MQTT.Tests/SnapshotRewireTests.cs
@@ -47,6 +47,43 @@ public class SnapshotRewireTests
     private static Measurement FirstMeasurement(PduData d) => d.Devices[0].Outlets[0].Measurements[0];
 
     [Fact]
+    public void AnActiveAlarmSurvivesTheWire_OnTheDeviceOutletAndMeasurement()
+    {
+        // The publisher emits "none" when the alarm object is absent, so an alarm lost in transit is
+        // published as a no-problem state rather than as an error. The wire contract lists fields
+        // explicitly, so an omitted one is dropped without any diagnostic.
+        var (data, _) = Original();
+        var device = data.Devices[0];
+        var outlet = device.Outlets[0];
+        var measurement = outlet.Measurements[0];
+        device.Alarm = new Alarm { State = "active", Severity = "alarm" };
+        outlet.Alarm = new Alarm { State = "active", Severity = "warning" };
+        measurement.Alarm = new Alarm { State = "active", Severity = "alarm" };
+
+        var rebuilt = RawSnapshotMapper.ToData(RawSnapshotMapper.ToWire("default", DateTime.UtcNow, data));
+
+        Assert.Equal("active", rebuilt.Devices[0].Alarm?.State);
+        Assert.Equal("alarm", rebuilt.Devices[0].Alarm?.Severity);
+        Assert.Equal("active", rebuilt.Devices[0].Outlets[0].Alarm?.State);
+        Assert.Equal("warning", rebuilt.Devices[0].Outlets[0].Alarm?.Severity);
+        Assert.Equal("active", FirstMeasurement(rebuilt).Alarm?.State);
+        Assert.Equal("alarm", FirstMeasurement(rebuilt).Alarm?.Severity);
+    }
+
+    [Fact]
+    public void NoAlarmStaysNoAlarm_RatherThanBecomingAnEmptyOne()
+    {
+        // A missing alarm object must stay missing. A blank one would create an always-off "problem"
+        // entity for every measurement of every outlet.
+        var (data, _) = Original();
+        var rebuilt = RawSnapshotMapper.ToData(RawSnapshotMapper.ToWire("default", DateTime.UtcNow, data));
+
+        Assert.Null(rebuilt.Devices[0].Alarm);
+        Assert.Null(rebuilt.Devices[0].Outlets[0].Alarm);
+        Assert.Null(FirstMeasurement(rebuilt).Alarm);
+    }
+
+    [Fact]
     public void WithoutRewiring_AMeasurementPublishesToTheBareTopic_state()
     {
         // The bug, reproduced. This is the topic the live system was trying to publish to, and the broker


### PR DESCRIPTION
Found while verifying #339 against the PDU.

## Cause

The PDU reports an alarm object on the device, on each outlet and on each measurement:

```
/data/A0AE.../alarm                         = {"severity": "", "state": "none"}
/data/A0AE.../outlet/10/alarm               = {"severity": "", "state": "none"}
/data/A0AE.../outlet/10/measurement/4/alarm = {"severity": "", "state": "none"}   (current)
```

`RawSnapshot` lists the fields a consumer needs explicitly and did not include `alarm`. `ToWire` dropped it, `ToData` rebuilt without it, and every consumer received `null`.

The publisher emits `"none"` when the alarm object is absent, so an alarm raised by the hardware was published as a no-problem state, with no error or log entry.

This also explains why the per-measurement alarms in #339 did not appear: that publish is conditional on the PDU having reported an alarm object, and none was present by the time the publisher ran. Device and outlet alarms publish unconditionally, so they emitted `"none"` and the broker looked correct:

```
Rack_PDU/A0AE.../alarm            = none
Rack_PDU/A0AE.../outlets/0/alarm  = none
(no measurements/*/alarm topics)
```

## Change

The wire contract carries the alarm at device, outlet and measurement level. The header note records why every field must be listed there; this is the second omission, after `Record_Key`/`Record_Parent`.

## Tests

- an active alarm survives the round trip at all three levels, with its severity
- an absent alarm stays absent rather than becoming a blank object, which would create an always-off "problem" entity per measurement

Removing the field again fails them:

```
measurement alarm dropped again -> Failed!  - Failed: 1, Passed: 6
restored                        -> Passed!  - Failed: 0, Passed: 7
```

617 tests pass.

All alarms on the PDU currently read `state: none, severity: ""`, so no visible value changes; the effect is that a future alarm is delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
