### PR TITLE
fix(pdu): include outlet configuration and device layout in the wire contract

### DIFF
--- a/rPDU2MQTT.Core/Core/RawSnapshot.cs
+++ b/rPDU2MQTT.Core/Core/RawSnapshot.cs
@@ -17,19 +17,26 @@ namespace rPDU2MQTT.Core.Transport;
 //
 // Every field a consumer needs must be listed here explicitly. An omitted field is lost without error: the
 // consumer receives the type default and cannot distinguish it from a real value. Two have been missed so
-// far — Record_Key/Record_Parent (see Rewire below), and `alarm`, which the PDU reports on the device, on
-// each outlet and on each measurement.
+// far — Record_Key/Record_Parent (see Rewire below), `alarm`, which the PDU reports on the device, on each
+// outlet and on each measurement, and the outlet configuration (onDelay/offDelay/rebootDelay/poaAction),
+// which published as 0 and "" instead of the values the outlet was set to, and the device layout, which
+// Home Assistant discovery reads to find the root entity.
 
 public sealed record RawSnapshot(string InstanceId, DateTime TimestampUtc, List<RawDevice> Devices);
 
 public sealed record RawDevice(
     string? Key, string? Name, string? Label, string? EntityName, string? DisplayName,
     string? Make, string? Model, string? State, string? Type,
-    List<RawOutlet> Outlets, List<RawEntity> Entities, Alarm? Alarm = null);
+    List<RawOutlet> Outlets, List<RawEntity> Entities, Alarm? Alarm = null,
+    // Home Assistant discovery reads layout[0] to pick the device's root entity; without it that entity's
+    // measurements are published to the broker but get no sensors.
+    Dictionary<int, string[]>? Layout = null);
 
 public sealed record RawOutlet(
     int Key, string? Name, string? Label, string? EntityName, string? DisplayName,
-    string? Make, string? Model, string? State, List<RawMeasurement> Measurements, Alarm? Alarm = null);
+    string? Make, string? Model, string? State, List<RawMeasurement> Measurements, Alarm? Alarm = null,
+    // Published by PublishOutletConfig and backing the writable delay/power-on entities in Home Assistant.
+    long OnDelay = 0, long OffDelay = 0, long RebootDelay = 0, string? PoaAction = null);
 
 public sealed record RawEntity(
     string? Key, string? Name, string? Label, string? EntityName, string? DisplayName,
@@ -48,11 +55,12 @@ public static class RawSnapshotMapper
 
     private static RawDevice ToWire(Device d) => new(
         d.Key, d.Name, d.Label, d.Entity_Name, d.Entity_DisplayName, d.Entity_Make, d.Entity_Model, d.State, d.Type,
-        d.Outlets.Select(ToWire).ToList(), d.Entity.Select(ToWire).ToList(), d.Alarm);
+        d.Outlets.Select(ToWire).ToList(), d.Entity.Select(ToWire).ToList(), d.Alarm, d.Layout);
 
     private static RawOutlet ToWire(Outlet o) => new(
         o.Key, o.Name, o.Label, o.Entity_Name, o.Entity_DisplayName, o.Entity_Make, o.Entity_Model, o.State,
-        o.Measurements.Select(ToWire).ToList(), o.Alarm);
+        o.Measurements.Select(ToWire).ToList(), o.Alarm,
+        o.OnDelay, o.OffDelay, o.RebootDelay, o.PoaAction);
 
     private static RawEntity ToWire(Entity e) => new(
         e.Key, e.Name, e.Label, e.Entity_Name, e.Entity_DisplayName, e.Measurements.Select(ToWire).ToList());
@@ -116,7 +124,7 @@ public static class RawSnapshotMapper
             {
                 Key = d.Key!, Name = d.Name!, Label = d.Label!, State = d.State!, Type = d.Type!,
                 Entity_Name = d.EntityName!, Entity_DisplayName = d.DisplayName!, Entity_Make = d.Make, Entity_Model = d.Model,
-                Alarm = d.Alarm!,
+                Alarm = d.Alarm!, Layout = d.Layout!,
             };
             foreach (var o in d.Outlets)
                 device.Outlets.Add(ToOutlet(o));
@@ -134,6 +142,7 @@ public static class RawSnapshotMapper
             Key = o.Key, Name = o.Name!, Label = o.Label!, State = o.State!,
             Entity_Name = o.EntityName!, Entity_DisplayName = o.DisplayName!, Entity_Make = o.Make, Entity_Model = o.Model,
             Alarm = o.Alarm!,
+            OnDelay = o.OnDelay, OffDelay = o.OffDelay, RebootDelay = o.RebootDelay, PoaAction = o.PoaAction!,
         };
         foreach (var m in o.Measurements)
             outlet.Measurements.Add(ToMeasurement(m));

--- a/rPDU2MQTT.Tests/SnapshotRewireTests.cs
+++ b/rPDU2MQTT.Tests/SnapshotRewireTests.cs
@@ -25,9 +25,17 @@ public class SnapshotRewireTests
     private static (PduData Data, DummyEntity Root) Original()
     {
         var m = new Measurement { Key = "realpower", Type = "realpower", Value = "61", Units = "W", State = "state" };
-        var outlet = new Outlet { Key = 3, Name = "Outlet 3", Label = "Kube01", State = "on" };
+        var outlet = new Outlet
+        {
+            Key = 3, Name = "Outlet 3", Label = "Kube01", State = "on",
+            OnDelay = 5, OffDelay = 5, RebootDelay = 5, PoaAction = "last",
+        };
         outlet.Measurements.Add(m);
-        var device = new Device { Key = "pdu_1", Name = "Rack-PDU-1", Label = "Rack-PDU-1", State = "on", Type = "rpdu" };
+        var device = new Device
+        {
+            Key = "pdu_1", Name = "Rack-PDU-1", Label = "Rack-PDU-1", State = "on", Type = "rpdu",
+            Layout = new Dictionary<int, string[]> { [0] = ["entity/phase0"], [2] = ["outlet/3"] },
+        };
         device.Outlets.Add(outlet);
 
         var data = new PduData();
@@ -81,6 +89,38 @@ public class SnapshotRewireTests
         Assert.Null(rebuilt.Devices[0].Alarm);
         Assert.Null(rebuilt.Devices[0].Outlets[0].Alarm);
         Assert.Null(FirstMeasurement(rebuilt).Alarm);
+    }
+
+    [Fact]
+    public void TheOutletConfigurationSurvivesTheWire()
+    {
+        // These back the writable delay and power-on-action entities in Home Assistant. Dropped from the
+        // contract, they arrived as 0 and "", so the entities reported defaults rather than what the outlet
+        // was actually set to; on the live PDU the outlet held onDelay/offDelay/rebootDelay of 5 and a
+        // poaAction of "last", and the broker carried 0, 0, 0 and empty.
+        var (data, _) = Original();
+
+        var rebuilt = RawSnapshotMapper.ToData(RawSnapshotMapper.ToWire("default", DateTime.UtcNow, data));
+        var outlet = rebuilt.Devices[0].Outlets[0];
+
+        Assert.Equal(5, outlet.OnDelay);
+        Assert.Equal(5, outlet.OffDelay);
+        Assert.Equal(5, outlet.RebootDelay);
+        Assert.Equal("last", outlet.PoaAction);
+    }
+
+    [Fact]
+    public void TheDeviceLayoutSurvivesTheWire()
+    {
+        // Home Assistant discovery reads layout[0] to identify the device's root entity and discover its
+        // measurements. Without the layout that step is skipped: the readings still reach the broker, but
+        // no sensor is created for them.
+        var (data, _) = Original();
+
+        var rebuilt = RawSnapshotMapper.ToData(RawSnapshotMapper.ToWire("default", DateTime.UtcNow, data));
+
+        Assert.NotNull(rebuilt.Devices[0].Layout);
+        Assert.Equal(["entity/phase0"], rebuilt.Devices[0].Layout[0]);
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #346. I compared every model property the publishing and discovery services read against what `RawSnapshot` carries, and found two more omissions.

## Outlet configuration

`onDelay`, `offDelay`, `rebootDelay`, `poaAction`. `PublishOutletConfig` publishes these, and they back the writable delay and power-on-action entities in Home Assistant. Dropped from the contract, they arrive as `0` and `""`.

Live comparison:

```
PDU:     poaAction=last  onDelay=5  offDelay=5  rebootDelay=5
broker:  poaAction=      onDelay=0  offDelay=0  rebootDelay=0
```

So those HA entities show defaults rather than what the outlet is set to.

## Device layout

Discovery reads `layout[0]` to identify the device's root entity and discover its measurements. Without it the step is skipped: the root entity's readings reach the broker (`entity/phase0/measurements/energy = 7791.605`) with no sensor created for them.

## Tests

One per field; removing either from `ToWire` fails them:

```
config dropped -> Failed!  - Failed: 1, Passed: 7
restored       -> Passed!  - Failed: 0, Passed: 8
```

619 tests pass.

## Method

The audit was mechanical — extract `device.X` / `outlet.X` / `measurement.X` property reads from the Engine services, subtract the names the contract carries. Worth repeating when the contract changes; it is how `alarm` in #346 was found too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
