### PR TITLE
fix(chart): satisfy the restricted Pod Security Standard by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
-USER app
+# Numeric, not the "app" name: with a non-numeric USER, kubelet cannot verify the container is non-root and
+# a pod requesting runAsNonRoot fails to start. Same identity either way — $APP_UID is 1654 in the .NET
+# base images, which is the uid "app" resolves to.
+USER $APP_UID
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build

--- a/charts/rpdu2mqtt/templates/valkey.yaml
+++ b/charts/rpdu2mqtt/templates/valkey.yaml
@@ -36,10 +36,18 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: valkey
     spec:
+      {{- with .Values.valkey.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: valkey
           image: "{{ .Values.valkey.image.repository }}:{{ .Values.valkey.image.tag }}"
           imagePullPolicy: {{ .Values.valkey.image.pullPolicy }}
+          {{- with .Values.valkey.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             {{- if .Values.valkey.persistence.enabled }}
             # Append-only file: the totals are small and written every pass, and losing the last few

--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -282,8 +282,22 @@ healthProbes:
 
 resources: {}
 podAnnotations: {}
-podSecurityContext: {}
-securityContext: {}
+
+# Defaults that satisfy the Pod Security Standards "restricted" profile, so the chart installs without
+# warnings into a namespace that enforces it. The image already runs as uid 1654 (non-root), so these
+# describe what the container does rather than constraining it further.
+#
+# readOnlyRootFilesystem is deliberately not set: the file-backed energy store writes its running kWh
+# totals to disk, and a read-only root would silently lose them on a deployment that is not using Valkey.
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 nodeSelector: {}
 tolerations: []
 affinity: {}
@@ -295,6 +309,12 @@ affinity: {}
 # Enabling this only deploys the instance; the bridge uses it when config.Cache.Enabled is true. Point
 # config.Cache.Connection at your own instance and leave this disabled to share an existing one.
 valkey:
+  # Left empty by default rather than set to the "restricted" profile like the bridge's own pod above.
+  # The valkey image starts as root, and an existing installation's PVC holds data owned by root: adding
+  # runAsNonRoot to a running deployment would leave valkey unable to read its own append-only file, and
+  # that file is the energy accumulator. Set these on a fresh install, or after chowning the volume.
+  podSecurityContext: {}
+  securityContext: {}
   enabled: true
   image:
     repository: valkey/valkey


### PR DESCRIPTION
Noticed while patching a live deployment — every apply into a namespace enforcing `restricted` prints:

```
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false,
unrestricted capabilities, runAsNonRoot != true, seccompProfile
```

The chart already had `podSecurityContext` and `securityContext` hooks. Both defaulted to `{}`.

## Bridge pod

Defaults to `runAsNonRoot`, `RuntimeDefault` seccomp, `allowPrivilegeEscalation: false`, and dropping all capabilities. The image already runs as uid 1654, so these describe what the container does rather than restricting it further.

`readOnlyRootFilesystem` is **not** set — the file-backed energy store writes its running kWh totals to disk.

## Dockerfile

`USER app` → `USER $APP_UID`.

With a non-numeric user, kubelet cannot verify the container is non-root, and a pod requesting `runAsNonRoot` fails to start with `CreateContainerConfigError`. `$APP_UID` is 1654 in the .NET base images, which is what `app` already resolves to:

```
$ kubectl exec deploy/rpdu2mqtt -- id
uid=1654(app) gid=1654(app) groups=1654(app)
```

So the runtime identity is unchanged; only kubelet's ability to check it changes.

## Valkey — hooks added, defaults left empty

Its template had no `securityContext` hook at all, so there was no way to set one. It now has both, still defaulting to `{}`.

Not defaulted to the profile on purpose: the valkey image starts as **root**, and an existing installation's PVC holds root-owned data. Applying the profile to a running deployment would leave valkey unable to read the append-only file that holds the energy accumulator. The values comment records that, and when it is safe to turn on.

619 tests pass; CI runs `helm lint` and `helm template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
