### PR TITLE
fix(chart): set runAsUser alongside runAsNonRoot so the pod starts on any image

### DIFF
--- a/charts/rpdu2mqtt/values.yaml
+++ b/charts/rpdu2mqtt/values.yaml
@@ -284,13 +284,25 @@ resources: {}
 podAnnotations: {}
 
 # Defaults that satisfy the Pod Security Standards "restricted" profile, so the chart installs without
-# warnings into a namespace that enforces it. The image already runs as uid 1654 (non-root), so these
-# describe what the container does rather than constraining it further.
+# warnings into a namespace that enforces it. The image runs as uid 1654 (non-root), so these describe what
+# the container does rather than constraining it further.
+#
+# runAsUser is set explicitly and must stay that way (#349). runAsNonRoot on its own makes kubelet verify
+# the image's own USER, which it can only do when that USER is numeric. Against an image whose USER is a
+# name, the container does not start:
+#
+#   Error: container has runAsNonRoot and image has non-numeric user (app), cannot verify user is non-root
+#
+# The image was given a numeric USER in the same change that added this default, which is precisely the
+# problem: a chart upgrade reaches a cluster before the new image does, and a pinned or mirrored older
+# image keeps failing afterwards. Naming the uid here removes the dependency on the image.
 #
 # readOnlyRootFilesystem is deliberately not set: the file-backed energy store writes its running kWh
 # totals to disk, and a read-only root would silently lose them on a deployment that is not using Valkey.
 podSecurityContext:
   runAsNonRoot: true
+  runAsUser: 1654
+  runAsGroup: 1654
   seccompProfile:
     type: RuntimeDefault
 securityContext:

--- a/rPDU2MQTT.Tests/ChartSecurityContextTests.cs
+++ b/rPDU2MQTT.Tests/ChartSecurityContextTests.cs
@@ -1,0 +1,61 @@
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// The chart's pod security defaults must not depend on what the image's USER directive happens to say.
+///
+/// <para>
+/// #349: setting <c>runAsNonRoot</c> without <c>runAsUser</c> makes kubelet verify the image's own USER,
+/// which it can only do when that USER is numeric. Against an image whose USER is a name the container does
+/// not start at all — "container has runAsNonRoot and image has non-numeric user (app), cannot verify user
+/// is non-root". The image and the chart were changed together, so the chart reached a cluster before the
+/// image did and every pod there failed.
+/// </para>
+/// </summary>
+public class ChartSecurityContextTests
+{
+    private static string Values()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "rPDU2MQTT.sln"))) dir = dir.Parent;
+        Assert.NotNull(dir);
+        var path = Path.Combine(dir!.FullName, "charts", "rpdu2mqtt", "values.yaml");
+        Assert.True(File.Exists(path), $"{path} is missing.");
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>The block starting at a top-level key, up to the next top-level key or comment.</summary>
+    private static string Block(string yaml, string key)
+    {
+        var lines = yaml.Split('\n');
+        var start = Array.FindIndex(lines, l => l.StartsWith(key + ":", StringComparison.Ordinal));
+        Assert.True(start >= 0, $"no top-level '{key}:' in values.yaml");
+        var end = start + 1;
+        while (end < lines.Length && (lines[end].Length == 0 || lines[end][0] is ' ' or '\t')) end++;
+        return string.Join('\n', lines[start..end]);
+    }
+
+    [Fact]
+    public void RunAsNonRoot_IsAlwaysPairedWithAnExplicitRunAsUser()
+    {
+        var block = Block(Values(), "podSecurityContext");
+        if (!block.Contains("runAsNonRoot: true")) return;   // not requesting it; nothing to pair
+
+        Assert.Contains("runAsUser:", block);
+    }
+
+    [Fact]
+    public void TheDockerfileUsesANumericUser()
+    {
+        // Belt and braces for the same failure: even with runAsUser set, a named USER leaves anyone who
+        // overrides podSecurityContext with runAsNonRoot alone in the broken state.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "rPDU2MQTT.sln"))) dir = dir.Parent;
+        var dockerfile = File.ReadAllText(Path.Combine(dir!.FullName, "Dockerfile"));
+
+        var user = dockerfile.Split('\n').Last(l => l.TrimStart().StartsWith("USER ", StringComparison.Ordinal)).Trim();
+        Assert.True(user is "USER $APP_UID" || user.Length > 5 && char.IsDigit(user[5]),
+            $"the image's USER must be numeric or $APP_UID so kubelet can verify runAsNonRoot; found '{user}'");
+    }
+}


### PR DESCRIPTION
Fixes #349, caused by #348.

## What broke

#348 added `runAsNonRoot: true` to the chart's default `podSecurityContext`, and made the image's `USER` numeric in the same change.

`runAsNonRoot` on its own makes kubelet verify the image's own `USER`, and it can only do that when that USER is numeric. So the chart depended on an image that had not been pulled yet:

```
Error: container has runAsNonRoot and image has non-numeric user (app), cannot verify user is non-root
```

The chart upgrade reached the cluster before the new image did, and every pod failed to start. Worse, any pinned, mirrored or air-gapped older image would have kept failing indefinitely.

I described this exact failure mode in #348's description and then shipped the dependency anyway.

## Fix

`podSecurityContext` now sets `runAsUser: 1654` and `runAsGroup: 1654` — the uid and gid the image already runs as:

```
$ kubectl exec deploy/rpdu2mqtt -- id
uid=1654(app) gid=1654(app) groups=1654(app)
```

Kubelet no longer introspects the image, so the default works against any build, old or new.

## Tests

- `runAsNonRoot` in the chart defaults must be paired with an explicit `runAsUser`
- the Dockerfile's `USER` must be numeric or `$APP_UID`

Reverting either change fails them:

```
runAsUser removed    -> Failed!  - Failed: 1, Passed: 1
named USER restored  -> Failed!  - Failed: 1, Passed: 1
both correct         -> Passed!  - Failed: 0, Passed: 621
```

## Your cluster

The current `:unstable` (`sha256:ddfe6a60…`) has `User = "1654"`, so it works with the #348 defaults as-is. Restoring the `runAsNonRoot` line you removed will be safe once you are on that image, and safe regardless of image once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
