### PR TITLE
feat(flow): tag nodes and highlight them on the diagram

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -756,6 +756,11 @@ spec:
                         Max:
                           type: number
                           description: Full-scale value for this node's gauge, in the metric's canonical unit (W for power). For example a PV array's peak output. Leave blank to show the plain reading instead — no ceiling is ever guessed.
+                        Tags:
+                          type: array
+                          items:
+                            type: string
+                          description: Free-form tags for filtering the diagram and the energy views — e.g. 'critical', 'rack-1', 'upstairs'. A tag never changes a reading, only what a view shows.
                         StorageKwh:
                           type: number
                           description: 'For a battery node: usable storage capacity in kWh (display metadata; optional).'

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -756,6 +756,11 @@ spec:
                         Max:
                           type: number
                           description: Full-scale value for this node's gauge, in the metric's canonical unit (W for power). For example a PV array's peak output. Leave blank to show the plain reading instead — no ceiling is ever guessed.
+                        Tags:
+                          type: array
+                          items:
+                            type: string
+                          description: Free-form tags for filtering the diagram and the energy views — e.g. 'critical', 'rack-1', 'upstairs'. A tag never changes a reading, only what a view shows.
                         StorageKwh:
                           type: number
                           description: 'For a battery node: usable storage capacity in kWh (display metadata; optional).'

--- a/rPDU2MQTT.Core/Flow/FlowGraph.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraph.cs
@@ -54,7 +54,7 @@ public static class FlowDerivation
 /// </param>
 public sealed record FlowNode(
     string Id, string Label, string Kind, double? Value = null, double? Imbalance = null,
-    string Derivation = FlowDerivation.Unknown)
+    string Derivation = FlowDerivation.Unknown, IReadOnlyList<string>? Tags = null)
 {
     /// <summary>
     /// A node the builder invented for the diagram, rather than one the operator configured: a

--- a/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
+++ b/rPDU2MQTT.Core/Flow/FlowGraphBuilder.cs
@@ -87,6 +87,7 @@ public static class FlowGraphBuilder
         flow ??= new EnergyFlowConfig();
         var label = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var kind = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var tags = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         var leaf = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);   // outlet id -> measured value
         var outgoing = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         var units = "";
@@ -180,6 +181,15 @@ public static class FlowGraphBuilder
                 // The node's declared kind (battery, inverter, panel, …) styles the diagram; fall back to
                 // the generic "node" when unset. Don't override an auto id that already resolved to pdu/outlet.
                 if (!kind.ContainsKey(n.Id)) kind[n.Id] = string.IsNullOrWhiteSpace(n.Kind) ? "node" : n.Kind.Trim().ToLowerInvariant();
+                // Tags travel with the node so a view can filter on them (#342). Trimmed, blanks dropped and
+                // de-duplicated case-insensitively, because they are hand-typed and "Rack 1" arriving twice
+                // as two chips is just noise. They never take part in any calculation.
+                var tagged = (n.Tags ?? [])
+                    .Select(t => t?.Trim() ?? "")
+                    .Where(t => t.Length > 0)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                if (tagged.Count > 0) tags[n.Id] = tagged;
                 if (live is not null && live.TryGetValue(n.Id, metric, out var liveValue))
                 {
                     // A live reading is authoritative even at 0: solar at night generates nothing, and the
@@ -581,7 +591,8 @@ public static class FlowGraphBuilder
         var nodes = label.Keys
             .Where(id => wired.Contains(id) || leaf.ContainsKey(id))
             .Select(id => new FlowNode(id, label[id], kind.TryGetValue(id, out var k) ? k : "node",
-                                       ValueOf(id), ImbalanceOf(id), DerivationOf(id)))
+                                       ValueOf(id), ImbalanceOf(id), DerivationOf(id),
+                                       tags.TryGetValue(id, out var t) ? t : null))
             .OrderBy(n => n.Id, StringComparer.OrdinalIgnoreCase)
             .ToList();
 

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -153,6 +153,18 @@ public class EnergyFlowNode
     [Description("Full-scale value for this node's gauge, in the metric's canonical unit (W for power). For example a PV array's peak output. Leave blank to show the plain reading instead — no ceiling is ever guessed.")]
     public double? Max { get; set; }
 
+    /// <summary>
+    /// Free-form labels for grouping nodes across the hierarchy (#342) — "upstairs", "critical", "rack-1".
+    ///
+    /// <para>
+    /// Deliberately unvalidated and with no fixed vocabulary: the useful groupings cut across the wiring
+    /// (everything on a UPS, everything in one room) and nobody can guess them in advance. A tag never
+    /// affects a value or a roll-up; it only decides what a view shows.
+    /// </para>
+    /// </summary>
+    [Description("Free-form tags for filtering the diagram and the energy views — e.g. 'critical', 'rack-1', 'upstairs'. A tag never changes a reading, only what a view shows.")]
+    public List<string> Tags { get; set; } = new();
+
     /// <summary>For <see cref="Kind"/> <c>battery</c>: usable storage capacity in kWh. Metadata for the
     /// diagram/state-of-charge display; does not affect the power roll-up.</summary>
     [Description("For a battery node: usable storage capacity in kWh (display metadata; optional).")]

--- a/rPDU2MQTT.Tests/NodeTagTests.cs
+++ b/rPDU2MQTT.Tests/NodeTagTests.cs
@@ -1,0 +1,75 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using rPDU2MQTT.Models.PDU;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Tags group nodes across the hierarchy (#342). They decide what a view emphasises and nothing else — no
+/// tag may change a value, a link, or which nodes exist.
+/// </summary>
+public class NodeTagTests
+{
+    private static EnergyFlowConfig Flow(params EnergyFlowNode[] nodes)
+    {
+        var f = new EnergyFlowConfig();
+        foreach (var n in nodes) f.Nodes.Add(n);
+        f.Links.Add(new EnergyFlowLink { From = "solar", To = "inverter" });
+        return f;
+    }
+
+    private static FlowNode Node(FlowGraph g, string id) => g.Nodes.Single(n => n.Id == id);
+
+    [Fact]
+    public void TagsReachTheGraph()
+    {
+        var graph = FlowGraphBuilder.Build(new PduData(), Flow(
+            new EnergyFlowNode { Id = "solar", Mode = "static", Value = 100, Tags = ["roof", "critical"] },
+            new EnergyFlowNode { Id = "inverter" }));
+
+        Assert.Equal(["roof", "critical"], Node(graph, "solar").Tags);
+    }
+
+    [Fact]
+    public void TagsAreTrimmedAndDeduplicated()
+    {
+        // Hand-typed and comma-split, so blanks and repeats arrive routinely. Two chips reading "Rack 1"
+        // is noise, and a tag of " " would render as an unclickable empty chip.
+        var graph = FlowGraphBuilder.Build(new PduData(), Flow(
+            new EnergyFlowNode { Id = "solar", Mode = "static", Value = 100, Tags = [" roof ", "", "  ", "ROOF", "roof"] },
+            new EnergyFlowNode { Id = "inverter" }));
+
+        Assert.Equal(["roof"], Node(graph, "solar").Tags);
+    }
+
+    [Fact]
+    public void AnUntaggedNodeCarriesNoTagList()
+    {
+        var graph = FlowGraphBuilder.Build(new PduData(), Flow(
+            new EnergyFlowNode { Id = "solar", Mode = "static", Value = 100 },
+            new EnergyFlowNode { Id = "inverter" }));
+
+        Assert.Null(Node(graph, "solar").Tags);
+    }
+
+    [Fact]
+    public void TaggingChangesNoValueLinkOrNode()
+    {
+        // The property that matters: a tag is metadata. Adding one must produce a byte-identical roll-up,
+        // or "filter by tag" becomes a way to change the numbers being read.
+        var plain = FlowGraphBuilder.Build(new PduData(), Flow(
+            new EnergyFlowNode { Id = "solar", Mode = "static", Value = 100 },
+            new EnergyFlowNode { Id = "inverter" }));
+
+        var tagged = FlowGraphBuilder.Build(new PduData(), Flow(
+            new EnergyFlowNode { Id = "solar", Mode = "static", Value = 100, Tags = ["roof"] },
+            new EnergyFlowNode { Id = "inverter", Tags = ["critical"] }));
+
+        Assert.Equal(plain.Nodes.Select(n => n.Id), tagged.Nodes.Select(n => n.Id));
+        Assert.Equal(plain.Nodes.Select(n => n.Value), tagged.Nodes.Select(n => n.Value));
+        Assert.Equal(plain.Nodes.Select(n => n.Derivation), tagged.Nodes.Select(n => n.Derivation));
+        Assert.Equal(plain.Links.Select(l => (l.Source, l.Target, l.Value, l.Known)),
+                     tagged.Links.Select(l => (l.Source, l.Target, l.Value, l.Known)));
+    }
+}

--- a/rPDU2MQTT.Web/rPDU2MQTT.Web.csproj
+++ b/rPDU2MQTT.Web/rPDU2MQTT.Web.csproj
@@ -44,6 +44,7 @@
 			<GuiSource Include="web\animation.check.mjs" />
 			<GuiSource Include="web\gauge.check.mjs" />
 			<GuiSource Include="web\contradiction.check.mjs" />
+			<GuiSource Include="web\tags.check.mjs" />
 		<GuiSource Include="web\schema.fixture.json" />
 	</ItemGroup>
 
@@ -73,6 +74,7 @@
 		<!-- A gauge is only as honest as the ceiling it is drawn against, so it must never invent one. -->
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/gauge.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/contradiction.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
+		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/tags.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Warning Condition="'$(_NodeExitCode)' != '0'" Text="node not found; using the committed wwwroot/app.js + styles.css. Install Node 22+ to rebuild the GUI from web/src." />
 	</Target>
 

--- a/rPDU2MQTT.Web/web/domstub.mjs
+++ b/rPDU2MQTT.Web/web/domstub.mjs
@@ -63,6 +63,16 @@ export function makeEl(tag = 'div') {
     append(...cs) { cs.forEach(c => { if (c && c.tag) { c.parent = this; this.children.push(c); } }); },
     removeChild(c) { this.children = this.children.filter(x => x !== c); if (c) c.parent = null; },
     remove() { if (this.parent) this.parent.removeChild(this); },
+    // Swap this node for another in the parent's child list, keeping its position — used where a toolbar
+    // rebuilds itself in place.
+    replaceWith(next) {
+      const p = this.parent;
+      if (!p) return;
+      const i = p.children.indexOf(this);
+      if (i < 0) return;
+      if (next && next.tag) { next.parent = p; p.children[i] = next; } else p.children.splice(i, 1);
+      this.parent = null;
+    },
     insertBefore(c) { if (c && c.tag) { c.parent = this; this.children.push(c); } return c; },
     // Node.contains(): self or any descendant (used to tell Oidc fields from Basic ones).
     contains(n) { if (n === this) return true; for (const d of descendants(this)) if (d === n) return true; return false; },

--- a/rPDU2MQTT.Web/web/schema.fixture.json
+++ b/rPDU2MQTT.Web/web/schema.fixture.json
@@ -2033,6 +2033,19 @@
               "required": false
             },
             {
+              "key": "Tags",
+              "label": "Tags",
+              "description": "Free-form tags for filtering the diagram and the energy views \u2014 e.g. 'critical', 'rack-1', 'upstairs'. A tag never changes a reading, only what a view shows.",
+              "type": "list",
+              "required": false,
+              "valueSchema": {
+                "key": "",
+                "label": "",
+                "type": "string",
+                "required": false
+              }
+            },
+            {
               "key": "StorageKwh",
               "label": "StorageKwh",
               "description": "For a battery node: usable storage capacity in kWh (display metadata; optional).",

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -414,6 +414,20 @@ function renderNodeEditor(node: any, links: any[], cand: Map<string, any>, reren
   // kind: a dial belongs on something with a rating (an array's peak, an inverter, a main breaker), and
   // offering it everywhere invites a number that means nothing.
   if (['solar', 'battery', 'grid', 'load', 'inverter'].includes(node.Kind || 'node')) {
+    // Tags (#342): free text, comma-separated. No fixed vocabulary and no validation — the groupings worth
+    // having cut across the wiring ("everything on the UPS", "upstairs") and nobody can guess them up front.
+    const tagsIn = el('input', { type: 'text', value: (node.Tags || []).join(', '), placeholder: 'critical, rack-1' });
+    tagsIn.onchange = () => {
+      const list = tagsIn.value.split(',').map((t: string) => t.trim()).filter((t: string) => t);
+      // De-duplicated case-insensitively: they are hand-typed, and the same tag twice is two identical chips.
+      const seen = new Set<string>();
+      node.Tags = list.filter((t: string) => { const k = t.toLowerCase(); return seen.has(k) ? false : (seen.add(k), true); });
+      if (!node.Tags.length) node.Tags = undefined;
+      rerender();
+    };
+    grid.appendChild(field('Tags', tagsIn,
+      'Comma-separated labels for filtering the Energy page and highlighting the diagram. A tag never changes a reading.'));
+
     const maxIn = el('input', { type: 'number', step: 'any', min: '0', value: node.Max ?? '', placeholder: '—' });
     maxIn.onchange = () => { const v = +maxIn.value; node.Max = (maxIn.value !== '' && !isNaN(v) && v > 0) ? v : undefined; };
     grid.appendChild(field('Gauge max (W)', maxIn,
@@ -1056,6 +1070,39 @@ function animateToggle(onToggle: () => void): HTMLElement {
   return lbl;
 }
 
+// The tag selected on the diagram, kept across redraws: the Sankey repaints on every live push, and a
+// highlight that cleared itself every few seconds would be unusable.
+let activeTag: string | null = null;
+
+/// Chips for every tag in use, highlighting the nodes carrying it (#342).
+function tagToggles(nodes: any[], svg: any, apply: (tag: string | null) => void): HTMLElement | null {
+  const all = new Map<string, string>();   // lower-case key -> first spelling seen
+  nodes.forEach(n => (n.tags || []).forEach((t: string) => {
+    const k = t.toLowerCase();
+    if (!all.has(k)) all.set(k, t);
+  }));
+  if (!all.size) return null;   // nothing tagged: an empty row of controls is just clutter
+
+  const row = el('div', { class: 'ld-toolbar', style: { flexWrap: 'wrap', gap: '6px', margin: '0 0 8px' } });
+  row.appendChild(el('span', { class: 'desc', style: { margin: '0' }, text: 'Tags:' }));
+  [...all.values()].sort((a, b) => a.localeCompare(b)).forEach(tag => {
+    const on = activeTag != null && activeTag.toLowerCase() === tag.toLowerCase();
+    const chip = btn(tag, on ? 'primary' : undefined);
+    chip.title = on
+      ? 'Showing every node with this tag; click to clear.'
+      : `Highlight the nodes tagged “${tag}”. Nothing is hidden and no figure changes — the rest are dimmed.`;
+    // Read the state at click time, not the value captured when the chip was built: the row is rebuilt on
+    // every toggle, but a chip that outlives its rebuild would keep re-selecting the tag it already has.
+    chip.onclick = () => {
+      const selected = activeTag != null && activeTag.toLowerCase() === tag.toLowerCase();
+      activeTag = selected ? null : tag;
+      apply(activeTag);
+    };
+    row.appendChild(chip);
+  });
+  return row;
+}
+
 function groupToggles(onToggle: () => void): HTMLElement | null {
   const groups = flowGroups();
   const row = el('div', { class: 'ld-toolbar', style: { flexWrap: 'wrap', gap: '6px', margin: '0 0 8px' } });
@@ -1235,8 +1282,9 @@ function renderNodeManager(flow: any, customNodes: any[], links: any[], cand: Ma
 
   const tbl = el('table', { class: 'ld' });
   const head = el('tr');
-  ['Id', 'Label', 'Kind', 'Mode', 'Value', 'Max', 'Bindings', ''].forEach(h => {
+  ['Id', 'Label', 'Kind', 'Mode', 'Value', 'Max', 'Tags', 'Bindings', ''].forEach(h => {
     const th = el('th', { text: h });
+    if (h === 'Tags') th.title = 'Free-form labels for filtering the views. A tag never changes a reading.';
     if (h === 'Max') th.title = 'Full-scale value for this node’s gauge on the Energy page — a PV array’s peak output, an inverter’s rating, a breaker’s size. Blank shows the plain reading instead; no ceiling is ever guessed.';
     if (h === 'Bindings') th.title = 'Live source bindings. ⚠ = bound, but no energy (kWh) metric — the node won’t appear on Home Assistant’s Energy Dashboard until you add an Energy source.';
     head.appendChild(th);
@@ -1252,6 +1300,7 @@ function renderNodeManager(flow: any, customNodes: any[], links: any[], cand: Ma
     tr.appendChild(el('td', { text: n.Mode || 'auto' }));
     tr.appendChild(el('td', { class: 'num', text: n.Value ?? '—' }));
     tr.appendChild(el('td', { class: 'num', text: n.Max ?? '—' }));
+    tr.appendChild(el('td', { text: (n.Tags || []).join(', ') || '—' }));
     // Flag a node that's measured but has no energy (kWh) source — it can't feed HA's Energy Dashboard (#262).
     const srcs = [...(n.Sources || []), ...(n.Mqtt || [])];
     const nb = srcs.length;
@@ -1948,6 +1997,20 @@ export function addFlowSection(nav: any, sections: any) {
     count.title = unknownCount
       ? 'Nothing measures these nodes, and no single path determines them. Bind a source, or mark a feeder "residual" to say where the remainder comes from — values are never invented for them.'
       : '';
+    // Tag chips, above the banners: they change what is emphasised, not what is being reported.
+    const taggedById = new Map<string, any>(nodes.map((n: any) => [n.id, n]));
+    const applyTag = (tag: string | null) => {
+      if (tag) focusTag(svg, taggedById, tag); else clearFocus(svg);
+      const fresh = tagToggles(nodes, svg, applyTag);
+      if (fresh && tagRow.parentNode) { tagRow.replaceWith(fresh); tagRow = fresh; }
+    };
+    let tagRow = tagToggles(nodes, svg, applyTag) as any;
+    if (tagRow) {
+      wrap.appendChild(tagRow);
+      // Re-apply across the live repaint, so the selection survives a push.
+      if (activeTag) focusTag(svg, taggedById, activeTag);
+    }
+
     if (withheldSources.length) wrap.appendChild(withheldBanner(withheldSources));
     if (contradicted.length) wrap.appendChild(contradictionBanner(contradicted, (id) => focusPath(svg, incoming, id)));
 
@@ -2298,6 +2361,26 @@ function focusPath(svg: any, incoming: any, id: string) {
     e.classList[onPath.has(e.getAttribute('data-node')) ? 'add' : 'remove']('on-path'));
   svg.querySelectorAll('[data-src]').forEach((e: any) =>
     e.classList[links.has(e.getAttribute('data-src') + '' + e.getAttribute('data-dst')) ? 'add' : 'remove']('on-path'));
+  svg.classList.add('flow-focus');
+}
+
+/// Highlight every node carrying `tag`, dimming the rest (#342).
+///
+/// A highlight and not a filter: removing nodes from a Sankey removes the ribbons into them too, so a
+/// node whose feeders were hidden would read as unsourced and the totals along the remaining chain would
+/// no longer add up. Dimming answers "which of these are tagged X" without changing a single figure.
+function focusTag(svg: any, nodesById: Map<string, any>, tag: string) {
+  const tagged = new Set<string>();
+  nodesById.forEach((n, id) => {
+    if ((n.tags || []).some((t: string) => t.toLowerCase() === tag.toLowerCase())) tagged.add(id);
+  });
+
+  focusedNode = null;
+  svg.querySelectorAll('[data-node]').forEach((e: any) =>
+    e.classList[tagged.has(e.getAttribute('data-node')) ? 'add' : 'remove']('on-path'));
+  // Ribbons stay dim throughout: a link is not tagged, and lighting one because an end happens to be
+  // would say the flow itself is part of the selection.
+  svg.querySelectorAll('[data-src]').forEach((e: any) => e.classList.remove('on-path'));
   svg.classList.add('flow-focus');
 }
 

--- a/rPDU2MQTT.Web/web/tags.check.mjs
+++ b/rPDU2MQTT.Web/web/tags.check.mjs
@@ -1,0 +1,79 @@
+// Tag chips on the diagram (#342).
+//
+// The chips highlight; they do not filter. Removing nodes from a Sankey removes the ribbons into them too,
+// so a node whose feeders were hidden reads as unsourced and the totals along the remaining chain stop
+// adding up. Dimming answers "which of these are tagged X" without altering a single figure — this pins
+// that every node is still drawn, and still shows its own value, while a tag is active.
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDom, query } from './domstub.mjs';
+
+const code = await readFile(new URL('../wwwroot/app.js', import.meta.url), 'utf8');
+const schema = JSON.parse(await readFile(new URL('./schema.fixture.json', import.meta.url), 'utf8'))
+  .filter(n => n.key !== '_README');
+const fail = (m) => { console.error('tags check FAILED: ' + m); process.exit(1); };
+const cn = (e) => String((e && (e.className || (e.attrs && e.attrs.class))) || '');
+
+const cfg = { EnergyFlow: { Nodes: [], Links: [] } };
+const graph = {
+  ok: true, metric: 'realpower', units: 'W',
+  nodes: [
+    { id: 'solar', label: 'Solar', kind: 'solar', value: 800, derivation: 'measured', tags: ['roof', 'critical'] },
+    { id: 'inverter', label: 'Inverter', kind: 'inverter', value: 800, derivation: 'measured', tags: ['critical'] },
+    { id: 'panel', label: 'Panel', kind: 'panel', value: 800, derivation: 'measured' },
+  ],
+  links: [
+    { source: 'solar', target: 'inverter', value: 800 },
+    { source: 'inverter', target: 'panel', value: 800 },
+  ],
+};
+
+const { sandbox, getEl } = makeDom({
+  bodies: (url) =>
+    url.includes('/api/schema') ? schema :
+    url.includes('/api/instances') ? { ok: true, instances: [] } :
+    url.includes('/api/config') ? cfg :
+    url.includes('/api/flow/live') ? { ok: true, values: [] } :
+    url.includes('/api/flow/withheld') ? { ok: true, sources: [] } :
+    url.includes('/api/flow') ? graph :
+    { ok: true },
+});
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox, { filename: 'app.js' });
+await new Promise(r => setTimeout(r, 50));
+const link = query(getEl('nav'), 'a', true).find(a => a.dataset.label === 'Flow');
+if (!link) fail('no Flow tab');
+link.click();
+await new Promise(r => setTimeout(r, 400));
+
+const sections = getEl('sections');
+const buttons = () => query(sections, 'button', true);
+
+// One chip per distinct tag, and none for the untagged node.
+const chips = buttons().filter(b => ['roof', 'critical'].includes(b.textContent));
+if (chips.length !== 2) fail(`expected chips for 'roof' and 'critical', got ${chips.map(b => b.textContent).join(', ')}`);
+
+const nodesDrawn = () => query(sections, 'rect', true).filter(r => r.attrs['data-node']);
+const before = nodesDrawn().length;
+if (before < 3) fail(`expected the three nodes to be drawn, got ${before}`);
+
+// Activate 'roof': only solar carries it.
+chips.find(b => b.textContent === 'roof').click();
+await new Promise(r => setTimeout(r, 50));
+
+const lit = nodesDrawn().filter(r => cn(r).includes('on-path')).map(r => r.attrs['data-node']);
+if (JSON.stringify(lit) !== JSON.stringify(['solar'])) fail(`expected only solar highlighted, got ${lit.join(', ') || '(none)'}`);
+
+// Nothing is removed, and nothing loses its reading — the whole point of dimming rather than filtering.
+if (nodesDrawn().length !== before) fail('activating a tag removed nodes from the diagram');
+const labels = query(sections, 'text', true).map(t => t.textContent).join(' ');
+for (const want of ['Solar', 'Inverter', 'Panel'])
+  if (!labels.includes(want)) fail(`'${want}' disappeared while a tag was active`);
+if (!labels.includes('800')) fail('a dimmed node stopped showing its reading');
+
+// Clicking the active chip clears the highlight.
+buttons().find(b => b.textContent === 'roof').click();
+await new Promise(r => setTimeout(r, 50));
+if (nodesDrawn().some(r => cn(r).includes('on-path'))) fail('clicking the active tag did not clear the highlight');
+
+console.log(`tags: ${chips.length} chips from the graph; highlighting dims without removing any node or reading`);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -1842,6 +1842,20 @@ function renderNodeEditor(node     , links       , cand                  , reren
   // kind: a dial belongs on something with a rating (an array's peak, an inverter, a main breaker), and
   // offering it everywhere invites a number that means nothing.
   if (['solar', 'battery', 'grid', 'load', 'inverter'].includes(node.Kind || 'node')) {
+    // Tags (#342): free text, comma-separated. No fixed vocabulary and no validation — the groupings worth
+    // having cut across the wiring ("everything on the UPS", "upstairs") and nobody can guess them up front.
+    const tagsIn = el('input', { type: 'text', value: (node.Tags || []).join(', '), placeholder: 'critical, rack-1' });
+    tagsIn.onchange = () => {
+      const list = tagsIn.value.split(',').map((t        ) => t.trim()).filter((t        ) => t);
+      // De-duplicated case-insensitively: they are hand-typed, and the same tag twice is two identical chips.
+      const seen = new Set        ();
+      node.Tags = list.filter((t        ) => { const k = t.toLowerCase(); return seen.has(k) ? false : (seen.add(k), true); });
+      if (!node.Tags.length) node.Tags = undefined;
+      rerender();
+    };
+    grid.appendChild(field('Tags', tagsIn,
+      'Comma-separated labels for filtering the Energy page and highlighting the diagram. A tag never changes a reading.'));
+
     const maxIn = el('input', { type: 'number', step: 'any', min: '0', value: node.Max ?? '', placeholder: '—' });
     maxIn.onchange = () => { const v = +maxIn.value; node.Max = (maxIn.value !== '' && !isNaN(v) && v > 0) ? v : undefined; };
     grid.appendChild(field('Gauge max (W)', maxIn,
@@ -2484,6 +2498,39 @@ function animateToggle(onToggle            )              {
   return lbl;
 }
 
+// The tag selected on the diagram, kept across redraws: the Sankey repaints on every live push, and a
+// highlight that cleared itself every few seconds would be unusable.
+let activeTag                = null;
+
+/// Chips for every tag in use, highlighting the nodes carrying it (#342).
+function tagToggles(nodes       , svg     , apply                              )                     {
+  const all = new Map                ();   // lower-case key -> first spelling seen
+  nodes.forEach(n => (n.tags || []).forEach((t        ) => {
+    const k = t.toLowerCase();
+    if (!all.has(k)) all.set(k, t);
+  }));
+  if (!all.size) return null;   // nothing tagged: an empty row of controls is just clutter
+
+  const row = el('div', { class: 'ld-toolbar', style: { flexWrap: 'wrap', gap: '6px', margin: '0 0 8px' } });
+  row.appendChild(el('span', { class: 'desc', style: { margin: '0' }, text: 'Tags:' }));
+  [...all.values()].sort((a, b) => a.localeCompare(b)).forEach(tag => {
+    const on = activeTag != null && activeTag.toLowerCase() === tag.toLowerCase();
+    const chip = btn(tag, on ? 'primary' : undefined);
+    chip.title = on
+      ? 'Showing every node with this tag; click to clear.'
+      : `Highlight the nodes tagged “${tag}”. Nothing is hidden and no figure changes — the rest are dimmed.`;
+    // Read the state at click time, not the value captured when the chip was built: the row is rebuilt on
+    // every toggle, but a chip that outlives its rebuild would keep re-selecting the tag it already has.
+    chip.onclick = () => {
+      const selected = activeTag != null && activeTag.toLowerCase() === tag.toLowerCase();
+      activeTag = selected ? null : tag;
+      apply(activeTag);
+    };
+    row.appendChild(chip);
+  });
+  return row;
+}
+
 function groupToggles(onToggle            )                     {
   const groups = flowGroups();
   const row = el('div', { class: 'ld-toolbar', style: { flexWrap: 'wrap', gap: '6px', margin: '0 0 8px' } });
@@ -2663,8 +2710,9 @@ function renderNodeManager(flow     , customNodes       , links       , cand    
 
   const tbl = el('table', { class: 'ld' });
   const head = el('tr');
-  ['Id', 'Label', 'Kind', 'Mode', 'Value', 'Max', 'Bindings', ''].forEach(h => {
+  ['Id', 'Label', 'Kind', 'Mode', 'Value', 'Max', 'Tags', 'Bindings', ''].forEach(h => {
     const th = el('th', { text: h });
+    if (h === 'Tags') th.title = 'Free-form labels for filtering the views. A tag never changes a reading.';
     if (h === 'Max') th.title = 'Full-scale value for this node’s gauge on the Energy page — a PV array’s peak output, an inverter’s rating, a breaker’s size. Blank shows the plain reading instead; no ceiling is ever guessed.';
     if (h === 'Bindings') th.title = 'Live source bindings. ⚠ = bound, but no energy (kWh) metric — the node won’t appear on Home Assistant’s Energy Dashboard until you add an Energy source.';
     head.appendChild(th);
@@ -2680,6 +2728,7 @@ function renderNodeManager(flow     , customNodes       , links       , cand    
     tr.appendChild(el('td', { text: n.Mode || 'auto' }));
     tr.appendChild(el('td', { class: 'num', text: n.Value ?? '—' }));
     tr.appendChild(el('td', { class: 'num', text: n.Max ?? '—' }));
+    tr.appendChild(el('td', { text: (n.Tags || []).join(', ') || '—' }));
     // Flag a node that's measured but has no energy (kWh) source — it can't feed HA's Energy Dashboard (#262).
     const srcs = [...(n.Sources || []), ...(n.Mqtt || [])];
     const nb = srcs.length;
@@ -3375,6 +3424,20 @@ function addFlowSection(nav     , sections     ) {
     count.title = unknownCount
       ? 'Nothing measures these nodes, and no single path determines them. Bind a source, or mark a feeder "residual" to say where the remainder comes from — values are never invented for them.'
       : '';
+    // Tag chips, above the banners: they change what is emphasised, not what is being reported.
+    const taggedById = new Map             (nodes.map((n     ) => [n.id, n]));
+    const applyTag = (tag               ) => {
+      if (tag) focusTag(svg, taggedById, tag); else clearFocus(svg);
+      const fresh = tagToggles(nodes, svg, applyTag);
+      if (fresh && tagRow.parentNode) { tagRow.replaceWith(fresh); tagRow = fresh; }
+    };
+    let tagRow = tagToggles(nodes, svg, applyTag)       ;
+    if (tagRow) {
+      wrap.appendChild(tagRow);
+      // Re-apply across the live repaint, so the selection survives a push.
+      if (activeTag) focusTag(svg, taggedById, activeTag);
+    }
+
     if (withheldSources.length) wrap.appendChild(withheldBanner(withheldSources));
     if (contradicted.length) wrap.appendChild(contradictionBanner(contradicted, (id) => focusPath(svg, incoming, id)));
 
@@ -3725,6 +3788,26 @@ function focusPath(svg     , incoming     , id        ) {
     e.classList[onPath.has(e.getAttribute('data-node')) ? 'add' : 'remove']('on-path'));
   svg.querySelectorAll('[data-src]').forEach((e     ) =>
     e.classList[links.has(e.getAttribute('data-src') + '' + e.getAttribute('data-dst')) ? 'add' : 'remove']('on-path'));
+  svg.classList.add('flow-focus');
+}
+
+/// Highlight every node carrying `tag`, dimming the rest (#342).
+///
+/// A highlight and not a filter: removing nodes from a Sankey removes the ribbons into them too, so a
+/// node whose feeders were hidden would read as unsourced and the totals along the remaining chain would
+/// no longer add up. Dimming answers "which of these are tagged X" without changing a single figure.
+function focusTag(svg     , nodesById                  , tag        ) {
+  const tagged = new Set        ();
+  nodesById.forEach((n, id) => {
+    if ((n.tags || []).some((t        ) => t.toLowerCase() === tag.toLowerCase())) tagged.add(id);
+  });
+
+  focusedNode = null;
+  svg.querySelectorAll('[data-node]').forEach((e     ) =>
+    e.classList[tagged.has(e.getAttribute('data-node')) ? 'add' : 'remove']('on-path'));
+  // Ribbons stay dim throughout: a link is not tagged, and lighting one because an end happens to be
+  // would say the flow itself is part of the selection.
+  svg.querySelectorAll('[data-src]').forEach((e     ) => e.classList.remove('on-path'));
   svg.classList.add('flow-focus');
 }
 


### PR DESCRIPTION
Implements the filtering half of #342.

## Tags

A free-form `Tags` list on energy-flow nodes — no fixed vocabulary, because the groupings worth having cut across the wiring ("everything on the UPS", "upstairs") and cannot be enumerated in advance.

- edited on the node editor as a comma-separated field
- shown as a column on the Nodes table
- carried through the flow graph to `/api/flow`
- trimmed, blanks dropped, de-duplicated case-insensitively (they are hand-typed)

## Highlight, not filter

Each tag in use becomes a chip above the diagram. Selecting one highlights the nodes carrying it and dims the rest; the selection survives the live repaint.

Deliberately not a filter. Removing nodes from a Sankey removes the ribbons into them too, so a node whose feeders were hidden reads as unsourced and the totals along the remaining chain stop adding up. Dimming answers "which of these carry tag X" without altering a single figure.

## A tag never changes a number

One test builds the same graph with and without tags and asserts the node ids, values, derivations and links are byte-identical. Without that, "filter by tag" becomes a way to change the figures being read.

`tags.check.mjs` asserts the chips come from the graph, that only the tagged node lights up, that **no node is removed and no reading disappears** while a tag is active, and that clicking the active chip clears it. Making it filter instead of dim fails it:

```
filter instead of dim -> tags check FAILED: expected only solar highlighted, got (none)
```

## Not included

Gating exports by tag — the other use in the issue. That changes what Home Assistant and EmonCMS record, so it wants its own change with explicit per-exporter configuration rather than being folded in here.

625 tests pass; eight GUI checks green. CRD manifests regenerated for the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
