### PR TITLE
feat(flow): gate each destination's exports by node tag

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -203,6 +203,21 @@ spec:
                       Enabled:
                         type: boolean
                         description: Sync the energy-flow hierarchy into HA's Energy Dashboard via its API. Requires Url + a long-lived access token.
+                      NodeTags:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          Include:
+                            type: array
+                            items:
+                              type: string
+                            description: Only send nodes carrying at least one of these tags. Empty sends every node.
+                          Exclude:
+                            type: array
+                            items:
+                              type: string
+                            description: Never send nodes carrying any of these tags. Takes precedence over Include.
+                        description: Limit the Energy Dashboard sync to nodes with particular tags. Empty syncs every node. Filtering changes only what is sent — never a value, and never any other destination.
                       Url:
                         type: string
                         description: Home Assistant base URL, e.g. http://homeassistant.local:8123 .
@@ -382,6 +397,21 @@ spec:
                   Exporter:
                     type: boolean
                     description: Expose a /metrics endpoint for Prometheus to scrape.
+                  NodeTags:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      Include:
+                        type: array
+                        items:
+                          type: string
+                        description: Only send nodes carrying at least one of these tags. Empty sends every node.
+                      Exclude:
+                        type: array
+                        items:
+                          type: string
+                        description: Never send nodes carrying any of these tags. Takes precedence over Include.
+                    description: Limit the energy-flow metrics to nodes with particular tags. Empty exposes every node. Filtering changes only what is scraped — never a value, and never any other destination.
                   Port:
                     type: integer
                     description: Port the /metrics endpoint listens on (Exporter).
@@ -1008,6 +1038,21 @@ spec:
                   MqttExport:
                     type: boolean
                     description: Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.
+                  MqttExportTags:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      Include:
+                        type: array
+                        items:
+                          type: string
+                        description: Only send nodes carrying at least one of these tags. Empty sends every node.
+                      Exclude:
+                        type: array
+                        items:
+                          type: string
+                        description: Never send nodes carrying any of these tags. Takes precedence over Include.
+                    description: Limit the MQTT export to nodes with particular tags. Empty exports every node. Filtering changes only what is sent — never a value, and never any other destination.
                   MqttTopicTemplate:
                     type: string
                     description: "Template for each tier's MQTT topic. Placeholders: {parent} (MQTT parent topic), {id}, {label}, {kind}, {metric}, {units}. e.g. '{parent}/energyflow/{id}'."

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -203,6 +203,21 @@ spec:
                       Enabled:
                         type: boolean
                         description: Sync the energy-flow hierarchy into HA's Energy Dashboard via its API. Requires Url + a long-lived access token.
+                      NodeTags:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                        properties:
+                          Include:
+                            type: array
+                            items:
+                              type: string
+                            description: Only send nodes carrying at least one of these tags. Empty sends every node.
+                          Exclude:
+                            type: array
+                            items:
+                              type: string
+                            description: Never send nodes carrying any of these tags. Takes precedence over Include.
+                        description: Limit the Energy Dashboard sync to nodes with particular tags. Empty syncs every node. Filtering changes only what is sent — never a value, and never any other destination.
                       Url:
                         type: string
                         description: Home Assistant base URL, e.g. http://homeassistant.local:8123 .
@@ -382,6 +397,21 @@ spec:
                   Exporter:
                     type: boolean
                     description: Expose a /metrics endpoint for Prometheus to scrape.
+                  NodeTags:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      Include:
+                        type: array
+                        items:
+                          type: string
+                        description: Only send nodes carrying at least one of these tags. Empty sends every node.
+                      Exclude:
+                        type: array
+                        items:
+                          type: string
+                        description: Never send nodes carrying any of these tags. Takes precedence over Include.
+                    description: Limit the energy-flow metrics to nodes with particular tags. Empty exposes every node. Filtering changes only what is scraped — never a value, and never any other destination.
                   Port:
                     type: integer
                     description: Port the /metrics endpoint listens on (Exporter).
@@ -1008,6 +1038,21 @@ spec:
                   MqttExport:
                     type: boolean
                     description: Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.
+                  MqttExportTags:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    properties:
+                      Include:
+                        type: array
+                        items:
+                          type: string
+                        description: Only send nodes carrying at least one of these tags. Empty sends every node.
+                      Exclude:
+                        type: array
+                        items:
+                          type: string
+                        description: Never send nodes carrying any of these tags. Takes precedence over Include.
+                    description: Limit the MQTT export to nodes with particular tags. Empty exports every node. Filtering changes only what is sent — never a value, and never any other destination.
                   MqttTopicTemplate:
                     type: string
                     description: "Template for each tier's MQTT topic. Placeholders: {parent} (MQTT parent topic), {id}, {label}, {kind}, {metric}, {units}. e.g. '{parent}/energyflow/{id}'."

--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -32,8 +32,14 @@ public enum EnergyDirection
 /// </summary>
 public static class EnergyDashboardSync
 {
+    /// <param name="include">
+    /// Optional per-node gate — the caller's tag filter (#342). Applied here rather than by handing in a
+    /// pruned graph, so parent lookups still see the whole hierarchy: a filtered-out feeder must not turn
+    /// its children into orphans.
+    /// </param>
     public static List<HaDeviceConsumption> BuildDeviceConsumption(FlowGraph graph, Func<string, string?> statFor,
-        IReadOnlyCollection<string>? excludeKinds = null, Func<string, string?>? powerFor = null)
+        IReadOnlyCollection<string>? excludeKinds = null, Func<string, string?>? powerFor = null,
+        Func<FlowNode, bool>? include = null)
     {
         var excluded = excludeKinds is { Count: > 0 }
             ? new HashSet<string>(excludeKinds, StringComparer.OrdinalIgnoreCase)
@@ -42,6 +48,7 @@ public static class EnergyDashboardSync
         // Diagram-only nodes are not devices — see FlowNode.Synthetic.
         foreach (var node in graph.Nodes.Where(n => !n.Synthetic))
         {
+            if (include is not null && !include(node)) continue;
             // Sources/storage/pass-through (grid, solar, battery, inverter) aren't "device consumption" — they
             // clutter the list and double-count against the dashboard's own grid/solar/battery buckets.
             if (excluded is not null && excluded.Contains(node.Kind ?? "node"))
@@ -70,13 +77,16 @@ public static class EnergyDashboardSync
     /// appears with whichever flow directions resolve.
     /// </para>
     /// </summary>
+    /// <param name="include">Optional per-node gate — the caller's tag filter (#342).</param>
     public static List<JsonObject> BuildEnergySources(FlowGraph graph, Func<string, EnergyDirection, string?> statFor,
-        Func<string, string?>? powerFor = null, Func<string, string?>? socFor = null)
+        Func<string, string?>? powerFor = null, Func<string, string?>? socFor = null,
+        Func<FlowNode, bool>? include = null)
     {
         var sources = new List<JsonObject>();
         // …and they are not energy sources either.
         foreach (var node in graph.Nodes.Where(n => !n.Synthetic))
         {
+            if (include is not null && !include(node)) continue;
             var outStat = statFor(node.Id, EnergyDirection.Out);
             var inStat = statFor(node.Id, EnergyDirection.In);
             var power = powerFor?.Invoke(node.Id);   // signed power sensor (positive supplying); optional

--- a/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/EnergyFlowConfig.cs
@@ -71,6 +71,10 @@ public class EnergyFlowConfig
     [Description("Publish each energy-hierarchy tier's rolled-up value to MQTT every poll.")]
     public bool MqttExport { get; set; }
 
+    /// <summary>Which nodes the MQTT export (and the Home Assistant discovery built from it) receives (#342).</summary>
+    [Description("Limit the MQTT export to nodes with particular tags. Empty exports every node. Filtering changes only what is sent — never a value, and never any other destination.")]
+    public NodeTagFilter MqttExportTags { get; set; } = new();
+
     /// <summary>Template for the per-node MQTT topic. Placeholders: {parent} {id} {label} {kind} {metric} {units}.</summary>
     [DefaultValue("{parent}/energyflow/{id}")]
     [Description("Template for each tier's MQTT topic. Placeholders: {parent} (MQTT parent topic), {id}, {label}, {kind}, {metric}, {units}. e.g. '{parent}/energyflow/{id}'.")]

--- a/rPDU2MQTT.Core/Models/Config/HomeAssistantConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/HomeAssistantConfig.cs
@@ -76,6 +76,10 @@ public class HomeAssistantEnergyDashboardConfig
     [Description("Sync the energy-flow hierarchy into HA's Energy Dashboard via its API. Requires Url + a long-lived access token.")]
     public bool Enabled { get; set; }
 
+    /// <summary>Which energy-flow nodes are synced into the Energy Dashboard (#342).</summary>
+    [Description("Limit the Energy Dashboard sync to nodes with particular tags. Empty syncs every node. Filtering changes only what is sent — never a value, and never any other destination.")]
+    public NodeTagFilter NodeTags { get; set; } = new();
+
     [Description("Home Assistant base URL, e.g. http://homeassistant.local:8123 .")]
     public string? Url { get; set; }
 

--- a/rPDU2MQTT.Core/Models/Config/NodeTagFilter.cs
+++ b/rPDU2MQTT.Core/Models/Config/NodeTagFilter.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel;
+
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>
+/// Which energy-flow nodes a destination receives, chosen by their tags (#342).
+///
+/// <para>
+/// Empty means everything, so an existing install is unaffected until something is entered here. The
+/// filter decides what is <em>sent</em>; it never changes a value. A node excluded from Prometheus still
+/// reports normally on the diagram, still contributes to whatever aggregates from it, and still goes to
+/// every other destination.
+/// </para>
+/// <para>
+/// Exclude wins over include. Tag a handful of nodes "noisy", exclude that one tag, and the rule reads the
+/// same whether or not the include list is also in use — the alternative (include winning) makes a node
+/// that matches both silently reappear, which is the opposite of what someone typing an exclusion expects.
+/// </para>
+/// </summary>
+public class NodeTagFilter
+{
+    [Description("Only send nodes carrying at least one of these tags. Empty sends every node.")]
+    public List<string> Include { get; set; } = new();
+
+    [Description("Never send nodes carrying any of these tags. Takes precedence over Include.")]
+    public List<string> Exclude { get; set; } = new();
+
+    /// <summary>Whether this filter is doing anything at all.</summary>
+    public bool IsEmpty => Include.Count == 0 && Exclude.Count == 0;
+
+    /// <summary>
+    /// Whether a node with <paramref name="tags"/> may be sent.
+    /// </summary>
+    /// <remarks>
+    /// An untagged node passes an empty include list and fails a populated one. That follows from what
+    /// "only send nodes tagged X" means, and it is the reading that cannot lose data by surprise: naming a
+    /// tag is a deliberate narrowing, whereas treating untagged nodes as always-included would make the
+    /// include list do nothing on the install where nothing is tagged yet.
+    /// </remarks>
+    public bool Allows(IReadOnlyList<string>? tags)
+    {
+        if (IsEmpty) return true;
+
+        var has = tags ?? [];
+        if (Exclude.Count > 0 && Exclude.Any(x => has.Any(t => string.Equals(t, x?.Trim(), StringComparison.OrdinalIgnoreCase))))
+            return false;
+
+        return Include.Count == 0
+            || Include.Any(i => has.Any(t => string.Equals(t, i?.Trim(), StringComparison.OrdinalIgnoreCase)));
+    }
+}

--- a/rPDU2MQTT.Core/Models/Config/PrometheusConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/PrometheusConfig.cs
@@ -15,6 +15,10 @@ public class PrometheusConfig
     [FeatureToggle]
     public bool Exporter { get; set; }
 
+    /// <summary>Which energy-flow nodes appear as metrics (#342).</summary>
+    [Description("Limit the energy-flow metrics to nodes with particular tags. Empty exposes every node. Filtering changes only what is scraped — never a value, and never any other destination.")]
+    public NodeTagFilter NodeTags { get; set; } = new();
+
     /// <summary>Port the /metrics endpoint listens on (Exporter).</summary>
     [DefaultValue(9184)]
     [Description("Port the /metrics endpoint listens on (Exporter).")]

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -77,8 +77,13 @@ public class EnergyFlowMqttExportService : baseMQTTService
 
         // Synthetic nodes are for the diagram only — see FlowNode.Synthetic. Publishing one would put a
         // '#' in the topic, which is the MQTT wildcard and not legal in a publish topic.
+        var tagFilter = cfg.EnergyFlow.MqttExportTags;
         foreach (var node in graph.Nodes.Where(n => !n.Synthetic))
         {
+            // Tag filter (#342): what this destination receives. It never changes a value — the node still
+            // reports on the diagram and still goes to every other destination.
+            if (!tagFilter.Allows(node.Tags)) continue;
+
             // Nothing determines this tier's power — no measurement, and no single path that conservation
             // pins down. Publishing it would put a fabricated 0 W into Home Assistant's history, which is
             // worse than the sensor going unavailable: one is a gap, the other is a lie that gets recorded.
@@ -87,7 +92,13 @@ public class EnergyFlowMqttExportService : baseMQTTService
 
             var topic = FlowExport.Topic(node, graph, cfg.MQTT.ParentTopic, flow);
             var energy = FlowExport.NodeValue(energyGraph, node.Id);   // 0 when this tier has no energy sensor
-            var parents = FlowExport.Parents(graph, node.Id);          // the tiers that feed this one
+            // Only feeders that are themselves being exported. A via_device pointing at a device this
+            // destination never receives would leave Home Assistant with a dangling parent for every node
+            // whose feeder the tag filter removed.
+            var parents = FlowExport.Parents(graph, node.Id)
+                .Where(pid => graph.Nodes.FirstOrDefault(n => string.Equals(n.Id, pid, StringComparison.OrdinalIgnoreCase)) is not { } pn
+                              || tagFilter.Allows(pn.Tags))
+                .ToList();
 
             // The in-direction (charge/export) energy, when this node declares one and a fresh value exists —
             // null otherwise, so HA's energy_in sensor reads unavailable rather than a fabricated 0.

--- a/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
+++ b/rPDU2MQTT.Engine/Services/HaEnergyDashboardSync.cs
@@ -61,7 +61,7 @@ public sealed class HaEnergyDashboardSync
         };
         // Optional real-time power sensor: the outlet/PDU's native power entity, else the energyflow power sensor.
         Func<string, string?> powerFor = id => PowerStat(id, nativePower, entityByUniqueId);
-        return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver, excludeKinds, powerFor);
+        return EnergyDashboardSync.BuildDeviceConsumption(graph, resolver, excludeKinds, powerFor, IncludeNode);
     }
 
     /// <summary>Resolve a node's power sensor entity — a native (PDU/outlet) power sensor if it has one, else
@@ -126,8 +126,12 @@ public sealed class HaEnergyDashboardSync
                 ? Resolve(native.TryGetValue(id, out var nativeUid) ? nativeUid : FlowExport.EnergyUniqueId(id))
                 : Resolve(FlowExport.EnergyInUniqueId(id)),
             powerFor: id => PowerStat(id, nativePower, entityByUniqueId),   // grid/battery real-time power
-            socFor: id => Resolve(FlowExport.SocUniqueId(id)));             // battery state of charge
+            socFor: id => Resolve(FlowExport.SocUniqueId(id)),              // battery state of charge
+            include: IncludeNode);
     }
+
+    /// <summary>The tag filter for this destination (#342). Decides what is synced, never what a node reads.</summary>
+    private bool IncludeNode(Core.Flow.FlowNode node) => config.HASS.EnergyDashboard.NodeTags.Allows(node.Tags);
 
     /// <summary>Merge our hierarchy devices into HA's energy prefs (preserving the user's own). Returns the count synced.</summary>
     public async Task<int> SyncAsync(string url, string token, CancellationToken ct)

--- a/rPDU2MQTT.Engine/Services/PrometheusExportService.cs
+++ b/rPDU2MQTT.Engine/Services/PrometheusExportService.cs
@@ -142,6 +142,8 @@ public class PrometheusExportService : baseMQTTService
                     // Synthetic nodes (…#in, …#unmeasured) describe an arithmetic result, not a device — the
                     // same rule the MQTT export applies, and for the same reason.
                     if (node.Synthetic) continue;
+                    // Tag filter (#342): which nodes this scrape carries. Never changes a value.
+                    if (!cfg.Prometheus.NodeTags.Allows(node.Tags)) continue;
                     // Unknown is not zero. A tier nothing determines must be absent from the scrape, so a
                     // dashboard shows a gap rather than recording a confident 0 that was never measured.
                     if (node.Value is not { } v) continue;

--- a/rPDU2MQTT.Tests/NodeTagFilterTests.cs
+++ b/rPDU2MQTT.Tests/NodeTagFilterTests.cs
@@ -1,0 +1,86 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Which nodes a destination receives, chosen by tag (#342). The filter decides what is sent and nothing
+/// else — a node excluded from one destination still reports on the diagram, still contributes to whatever
+/// aggregates from it, and still reaches every other destination.
+/// </summary>
+public class NodeTagFilterTests
+{
+    private static NodeTagFilter Filter(string[]? include = null, string[]? exclude = null) =>
+        new() { Include = [.. include ?? []], Exclude = [.. exclude ?? []] };
+
+    [Fact]
+    public void AnEmptyFilterSendsEverything()
+    {
+        // The default on every existing install: adding the field must change nothing until it is used.
+        var f = Filter();
+        Assert.True(f.IsEmpty);
+        Assert.True(f.Allows(["anything"]));
+        Assert.True(f.Allows(null));
+        Assert.True(f.Allows([]));
+    }
+
+    [Fact]
+    public void IncludeSendsOnlyTaggedNodes()
+    {
+        var f = Filter(include: ["critical"]);
+        Assert.True(f.Allows(["critical"]));
+        Assert.True(f.Allows(["roof", "critical"]));
+        Assert.False(f.Allows(["roof"]));
+        // An untagged node fails a populated include list — that is what "only send nodes tagged X" means.
+        Assert.False(f.Allows(null));
+    }
+
+    [Fact]
+    public void ExcludeBeatsInclude()
+    {
+        // A node matching both must be dropped. The other reading makes a node silently reappear despite an
+        // explicit exclusion, which is the opposite of what someone typing one expects.
+        var f = Filter(include: ["critical"], exclude: ["noisy"]);
+        Assert.True(f.Allows(["critical"]));
+        Assert.False(f.Allows(["critical", "noisy"]));
+    }
+
+    [Fact]
+    public void ExcludeAloneSendsEverythingElse_IncludingUntaggedNodes()
+    {
+        var f = Filter(exclude: ["noisy"]);
+        Assert.False(f.Allows(["noisy"]));
+        Assert.True(f.Allows(["roof"]));
+        Assert.True(f.Allows(null));
+    }
+
+    [Fact]
+    public void MatchingIgnoresCaseAndSurroundingSpace()
+    {
+        // Tags are hand-typed in one place and the filter in another; they will not agree on either.
+        var f = Filter(include: [" Critical "]);
+        Assert.True(f.Allows(["critical"]));
+        Assert.True(f.Allows(["CRITICAL"]));
+    }
+
+    [Fact]
+    public void FilteringADestinationDoesNotChangeTheGraph()
+    {
+        // The property the whole feature rests on. Excluding a node from an export must leave the roll-up
+        // untouched, or a display filter becomes a way to alter the figures every other consumer reads.
+        var flow = new EnergyFlowConfig();
+        flow.Nodes.Add(new EnergyFlowNode { Id = "solar", Mode = "static", Value = 100, Tags = ["noisy"] });
+        flow.Nodes.Add(new EnergyFlowNode { Id = "inverter" });
+        flow.Links.Add(new EnergyFlowLink { From = "solar", To = "inverter" });
+
+        var graph = FlowGraphBuilder.Build(new rPDU2MQTT.Models.PDU.PduData(), flow);
+        var excluded = Filter(exclude: ["noisy"]);
+
+        // The node is still in the graph with its value; only the destination declines to send it.
+        var solar = graph.Nodes.Single(n => n.Id == "solar");
+        Assert.Equal(100, solar.Value);
+        Assert.False(excluded.Allows(solar.Tags));
+        Assert.True(excluded.Allows(graph.Nodes.Single(n => n.Id == "inverter").Tags));
+    }
+}

--- a/rPDU2MQTT.Web/web/schema.fixture.json
+++ b/rPDU2MQTT.Web/web/schema.fixture.json
@@ -362,6 +362,41 @@
             "default": false
           },
           {
+            "key": "NodeTags",
+            "label": "NodeTags",
+            "description": "Limit the Energy Dashboard sync to nodes with particular tags. Empty syncs every node. Filtering changes only what is sent \u2014 never a value, and never any other destination.",
+            "type": "object",
+            "required": false,
+            "properties": [
+              {
+                "key": "Include",
+                "label": "Include",
+                "description": "Only send nodes carrying at least one of these tags. Empty sends every node.",
+                "type": "list",
+                "required": false,
+                "valueSchema": {
+                  "key": "",
+                  "label": "",
+                  "type": "string",
+                  "required": false
+                }
+              },
+              {
+                "key": "Exclude",
+                "label": "Exclude",
+                "description": "Never send nodes carrying any of these tags. Takes precedence over Include.",
+                "type": "list",
+                "required": false,
+                "valueSchema": {
+                  "key": "",
+                  "label": "",
+                  "type": "string",
+                  "required": false
+                }
+              }
+            ]
+          },
+          {
             "key": "Url",
             "label": "Url",
             "description": "Home Assistant base URL, e.g. http://homeassistant.local:8123 .",
@@ -757,6 +792,41 @@
         "required": false,
         "default": false,
         "isFeatureToggle": true
+      },
+      {
+        "key": "NodeTags",
+        "label": "NodeTags",
+        "description": "Limit the energy-flow metrics to nodes with particular tags. Empty exposes every node. Filtering changes only what is scraped \u2014 never a value, and never any other destination.",
+        "type": "object",
+        "required": false,
+        "properties": [
+          {
+            "key": "Include",
+            "label": "Include",
+            "description": "Only send nodes carrying at least one of these tags. Empty sends every node.",
+            "type": "list",
+            "required": false,
+            "valueSchema": {
+              "key": "",
+              "label": "",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "key": "Exclude",
+            "label": "Exclude",
+            "description": "Never send nodes carrying any of these tags. Takes precedence over Include.",
+            "type": "list",
+            "required": false,
+            "valueSchema": {
+              "key": "",
+              "label": "",
+              "type": "string",
+              "required": false
+            }
+          }
+        ]
       },
       {
         "key": "Port",
@@ -2527,6 +2597,41 @@
         "type": "bool",
         "required": false,
         "default": false
+      },
+      {
+        "key": "MqttExportTags",
+        "label": "MqttExportTags",
+        "description": "Limit the MQTT export to nodes with particular tags. Empty exports every node. Filtering changes only what is sent \u2014 never a value, and never any other destination.",
+        "type": "object",
+        "required": false,
+        "properties": [
+          {
+            "key": "Include",
+            "label": "Include",
+            "description": "Only send nodes carrying at least one of these tags. Empty sends every node.",
+            "type": "list",
+            "required": false,
+            "valueSchema": {
+              "key": "",
+              "label": "",
+              "type": "string",
+              "required": false
+            }
+          },
+          {
+            "key": "Exclude",
+            "label": "Exclude",
+            "description": "Never send nodes carrying any of these tags. Takes precedence over Include.",
+            "type": "list",
+            "required": false,
+            "valueSchema": {
+              "key": "",
+              "label": "",
+              "type": "string",
+              "required": false
+            }
+          }
+        ]
       },
       {
         "key": "MqttTopicTemplate",


### PR DESCRIPTION
Completes #342 — the second use in the issue:

> Or, could potentially also be used to gate what gets exported to where.

#352 made tags filter the diagram. This makes them decide which nodes each destination receives.

## Where

A `NodeTagFilter` (`Include` / `Exclude`) on three destinations:

| Setting | Governs |
|---|---|
| `EnergyFlow.MqttExportTags` | the per-node MQTT export, and the HA discovery built from it |
| `Prometheus.NodeTags` | the energy-flow gauges |
| `HomeAssistant.EnergyDashboard.NodeTags` | the Energy Dashboard sync |

EmonCMS is not listed because it exports PDU measurements, not flow nodes.

## Semantics

- **Empty means everything**, so an existing install is unaffected until something is entered
- **Exclude beats Include** — a node matching both is dropped. The other reading makes a node reappear despite an explicit exclusion
- an untagged node fails a populated `Include` (that is what "only send nodes tagged X" means) and passes `Exclude` alone
- matching ignores case and surrounding space; the tags and the filter are typed in different places and will not agree on either

## Filtering never changes a number

A node excluded from Prometheus still reports on the diagram, still contributes to whatever aggregates from it, and still reaches the other destinations. A test builds a graph with an excluded node and asserts its value is unchanged in the graph — otherwise a display filter becomes a way to alter what every other consumer reads.

Two details worth calling out:

- the MQTT export drops `via_device` when the parent tier is filtered out, instead of leaving HA with a dangling parent for every child of a hidden feeder
- the Energy Dashboard builders take the gate as a **predicate** rather than a pruned graph, so parent lookups still see the whole hierarchy

631 tests pass; GUI checks green. CRD manifests and the schema fixture regenerated for the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
