### PR TITLE
fix(ha): include native PDU devices in the orphaned-discovery scan

### DIFF
--- a/rPDU2MQTT.Core/Flow/FlowExport.cs
+++ b/rPDU2MQTT.Core/Flow/FlowExport.cs
@@ -123,7 +123,22 @@ public static class FlowExport
     /// <param name="discoveryPrefix">The configured Home Assistant discovery prefix (e.g. "homeassistant").</param>
     public static IReadOnlyList<string> OrphanedDiscoveryTopics(
         IEnumerable<string> retainedTopics, IEnumerable<string> currentDeviceIds, string discoveryPrefix)
+        => OrphanedDiscoveryTopics(retainedTopics, currentDeviceIds, discoveryPrefix, DeviceIdPrefix);
+
+    /// <summary>
+    /// The same scan for a different family of device ids — native PDU discovery uses the configured root
+    /// identifier rather than <see cref="DeviceIdPrefix"/>.
+    /// </summary>
+    /// <param name="deviceIdPrefix">
+    /// Only ids starting with this are considered. It is the entire safety boundary: everything else on the
+    /// broker belongs to another integration, and clearing one of those deletes someone's devices out of
+    /// Home Assistant with nothing to put them back.
+    /// </param>
+    public static IReadOnlyList<string> OrphanedDiscoveryTopics(
+        IEnumerable<string> retainedTopics, IEnumerable<string> currentDeviceIds, string discoveryPrefix,
+        string deviceIdPrefix)
     {
+        if (string.IsNullOrWhiteSpace(deviceIdPrefix)) return Array.Empty<string>();
         var keep = new HashSet<string>(currentDeviceIds, StringComparer.OrdinalIgnoreCase);
         var root = (discoveryPrefix ?? "").Trim().Trim('/');
         if (root.Length == 0) return Array.Empty<string>();
@@ -140,7 +155,7 @@ public static class FlowExport
             if (!string.Equals(parts[3], "config", StringComparison.OrdinalIgnoreCase)) continue;
 
             var id = parts[2];
-            if (!id.StartsWith(DeviceIdPrefix, StringComparison.OrdinalIgnoreCase)) continue;
+            if (!id.StartsWith(deviceIdPrefix, StringComparison.OrdinalIgnoreCase)) continue;
             if (keep.Contains(id)) continue;
 
             orphans.Add(topic);

--- a/rPDU2MQTT.Engine/Classes/DiscoveryCoordinator.cs
+++ b/rPDU2MQTT.Engine/Classes/DiscoveryCoordinator.cs
@@ -19,6 +19,17 @@ public sealed class DiscoveryCoordinator
         this.pdu = pdu;
     }
 
+    /// <summary>
+    /// What native discovery published on its last pass, set by the discovery service.
+    ///
+    /// <para>
+    /// Null, or a false <c>HasPublished</c>, means "no opinion" and callers must not conclude anything is
+    /// stale: before the first pass nothing has been published, so every retained config on the broker
+    /// would look orphaned and clearing them would delete every device out of Home Assistant.
+    /// </para>
+    /// </summary>
+    public Func<(bool HasPublished, IReadOnlyCollection<string> Ids)>? PublishedDevices { get; set; }
+
     /// <summary>Invoked when a rediscovery is requested. The discovery service subscribes to this.</summary>
     public event Func<CancellationToken, Task>? RediscoverRequested;
 

--- a/rPDU2MQTT.Engine/Services/HomeAssistantDiscoveryService.cs
+++ b/rPDU2MQTT.Engine/Services/HomeAssistantDiscoveryService.cs
@@ -25,6 +25,7 @@ public class HomeAssistantDiscoveryService : baseDiscoveryService
     public HomeAssistantDiscoveryService(MQTTServiceDependencies deps, DiscoveryCoordinator coordinator) : base(deps)
     {
         // Allow the "Rediscover" diagnostic button to trigger an on-demand republish.
+        coordinator.PublishedDevices = () => (HasPublished, PublishedDeviceIds);
         coordinator.RediscoverRequested += Execute;
         // Allow the "Clear discovery" action (GUI) to remove the retained discovery messages.
         coordinator.ClearRequested += ClearDiscoveries;

--- a/rPDU2MQTT.Engine/Services/baseTypes/baseDiscoveryService.cs
+++ b/rPDU2MQTT.Engine/Services/baseTypes/baseDiscoveryService.cs
@@ -270,6 +270,22 @@ public abstract class baseDiscoveryService : baseMQTTService
     private readonly HashSet<string> publishedDeviceTopics = new();
 
     /// <summary>
+    /// The device ids this service published on its last pass, and whether it has completed one.
+    ///
+    /// <para>
+    /// Observed rather than recomputed on purpose. Deciding a retained config is stale means deleting a
+    /// device out of Home Assistant, so the comparison has to be against what this process actually
+    /// published — not against what a second reconstruction thinks it would have published. Before the
+    /// first pass the set is empty and <c>HasPublished</c> is false, which callers must treat as "no
+    /// opinion": at that moment everything on the broker looks orphaned.
+    /// </para>
+    /// </summary>
+    public bool HasPublished { get; private set; }
+
+    public IReadOnlyCollection<string> PublishedDeviceIds =>
+        publishedDeviceTopics.Select(t => t.Split('/') is { Length: 4 } p ? p[2] : "").Where(id => id.Length > 0).ToList();
+
+    /// <summary>
     /// Publish device-based discovery: one retained message per device containing all of its
     /// entities as components. Devices that were published previously but are no longer present
     /// have their retained discovery message cleared so they don't linger in Home Assistant.
@@ -298,6 +314,7 @@ public abstract class baseDiscoveryService : baseMQTTService
 
         publishedDeviceTopics.Clear();
         publishedDeviceTopics.UnionWith(currentTopics);
+        HasPublished = true;
     }
 
     /// <summary>

--- a/rPDU2MQTT.Tests/OrphanedDiscoveryTests.cs
+++ b/rPDU2MQTT.Tests/OrphanedDiscoveryTests.cs
@@ -20,6 +20,43 @@ public class OrphanedDiscoveryTests
     ];
 
     [Fact]
+    public void NativeDeviceIdsAreScannedUnderTheirOwnPrefix()
+    {
+        // Seen live: a PDU stopped exposing its OneView groups and left fourteen entities in Home Assistant
+        // that could never receive a value again. The energyflow sweep does not cover that family of ids, so
+        // nothing but "clear all discovery" could remove them.
+        string[] retained =
+        [
+            "homeassistant/device/rPDU2MQTT_A0AE_outlets_4/config",              // still published — keep
+            "homeassistant/device/rPDU2MQTT_Groups_0_measurements_energy/config", // group is gone — orphan
+            "homeassistant/device/rPDU2MQTT_Groups_total/config",                 // group is gone — orphan
+            "homeassistant/device/energyflow_grid/config",                        // other family, not this scan
+            "homeassistant/sensor/acurite_attic/config",                          // someone else entirely
+        ];
+
+        var orphans = FlowExport.OrphanedDiscoveryTopics(
+            retained, new[] { "rPDU2MQTT_A0AE_outlets_4" }, "homeassistant", "rPDU2MQTT_");
+
+        Assert.Equal(new[]
+        {
+            "homeassistant/device/rPDU2MQTT_Groups_0_measurements_energy/config",
+            "homeassistant/device/rPDU2MQTT_Groups_total/config",
+        }, orphans);
+    }
+
+    [Fact]
+    public void AnEmptyIdPrefixMatchesNothing()
+    {
+        // The prefix is the entire safety boundary. If it ever arrives blank — an unset override, a
+        // trimmed-to-nothing config — the scan must return nothing rather than treat every retained config
+        // on the broker as ours to delete.
+        string[] retained = ["homeassistant/device/anything_at_all/config", "homeassistant/device/acurite/config"];
+
+        Assert.Empty(FlowExport.OrphanedDiscoveryTopics(retained, Array.Empty<string>(), "homeassistant", ""));
+        Assert.Empty(FlowExport.OrphanedDiscoveryTopics(retained, Array.Empty<string>(), "homeassistant", "   "));
+    }
+
+    [Fact]
     public void OnlyOurOwnStaleDevicesAreListed()
     {
         var orphans = FlowExport.OrphanedDiscoveryTopics(Retained, new[] { "energyflow_grid" }, "homeassistant");

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -396,7 +396,24 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             .Where(n => !n.Synthetic && !native.ContainsKey(n.Id))
             .Select(n => Core.Flow.FlowExport.DeviceId(n.Id));
 
-        return Core.Flow.FlowExport.OrphanedDiscoveryTopics(retained, current, prefix);
+        var orphans = Core.Flow.FlowExport.OrphanedDiscoveryTopics(retained, current, prefix).ToList();
+
+        // Native PDU discovery too (#: a PDU that stopped exposing OneView groups left fourteen entities in
+        // Home Assistant that could never receive a value again, and the energyflow sweep deliberately does
+        // not touch that family of ids).
+        //
+        // The "current" set is what the discovery service actually published, not a second reconstruction of
+        // it: this decides whether to delete a device out of Home Assistant, and a reconstruction that
+        // disagreed with the publisher by one id would delete a live device. If it has not completed a pass,
+        // it has no opinion and nothing native is reported.
+        var published = discovery.PublishedDevices?.Invoke();
+        if (published is { HasPublished: true, Ids.Count: > 0 })
+        {
+            var rootId = string.IsNullOrWhiteSpace(config.Overrides?.rPDU2MQTT?.ID) ? "rPDU2MQTT" : config.Overrides!.rPDU2MQTT!.ID!;
+            orphans.AddRange(Core.Flow.FlowExport.OrphanedDiscoveryTopics(retained, published.Value.Ids, prefix, rootId + "_"));
+        }
+
+        return orphans;
     }
 
     private async Task<object> BuildBoardAsync()


### PR DESCRIPTION
Found by auditing the live broker: for every HA entity we publish, does its `state_topic` ever actually arrive?

615 entities, and 14 of ours never receive a value:

```
Rack_PDU/Groups/{0,1,2,3,4,total,unassigned}/measurements/{energy,realPower}
```

Those are OneView group devices the PDU no longer exposes. Their retained discovery configs are still on the broker, so Home Assistant still shows the entities — permanently unavailable.

## Why nothing cleaned them up

Two mechanisms exist and neither covers this:

- `publishedDeviceTopics` clears devices that disappear **during a process run**. These vanished before startup.
- the orphan scan behind the GUI's cleanup button only considers `energyflow_*` ids — native PDU discovery is deliberately excluded from it.

So the only remedy was "clear all discovery", which removes everything and republishes.

## Change

`OrphanedDiscoveryTopics` takes the device-id prefix to scan, and the GUI runs it a second time for native ids under the configured root identifier.

The "currently published" set for that pass comes from **the discovery service itself**, not a second reconstruction of what it would publish. This decides whether to delete a device out of Home Assistant; a reconstruction disagreeing with the publisher by one id would delete a live one. Before the service has completed a pass it reports no opinion and nothing native is listed — otherwise every retained config looks orphaned at startup.

The id prefix is the entire safety boundary between our devices and every other integration on the broker, so a blank one now matches **nothing** rather than everything.

## Tests

Native ids are found under their own prefix while `energyflow_*` and other integrations are left alone; a blank prefix matches nothing. Removing that guard fails it:

```
safety boundary removed -> Failed!  - Failed: 1, Passed: 7
restored                -> Passed!  - Failed: 0, Passed: 633
```

633 tests pass; GUI checks green.

Your 14 will appear in the existing Home Assistant → orphaned-discovery list once this is deployed, to clear or not as you prefer. Nothing is removed automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
