### PR TITLE
feat(flow): import power and energy readings from other integrations' MQTT discovery

### DIFF
--- a/rPDU2MQTT.Core/Flow/MqttDiscoveryImport.cs
+++ b/rPDU2MQTT.Core/Flow/MqttDiscoveryImport.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>One importable reading found in someone else's Home Assistant MQTT discovery.</summary>
+/// <param name="UniqueId">The publisher's unique_id, used to avoid importing the same entity twice.</param>
+/// <param name="Label">What to call the node — the device name where there is one, else the entity name.</param>
+/// <param name="Device">The device the entity belongs to, for grouping in the picker.</param>
+/// <param name="StateTopic">The topic carrying the value.</param>
+/// <param name="Metric">Our metric name: <c>realpower</c> or <c>energy</c>.</param>
+/// <param name="Unit">The unit the publisher states (W, kW, Wh, kWh), converted on ingest.</param>
+/// <param name="JsonField">Field to read from a JSON payload, or null when the payload is the bare value.</param>
+/// <param name="Unsupported">Why this one cannot be bound automatically, or null when it can.</param>
+public readonly record struct DiscoveredReading(
+    string UniqueId, string Label, string Device, string StateTopic,
+    string Metric, string? Unit, string? JsonField, string? Unsupported);
+
+/// <summary>
+/// Finds power and energy readings other integrations publish, by reading the Home Assistant MQTT
+/// discovery they announce.
+///
+/// <para>
+/// Discovery is used rather than per-integration topic patterns because it states the unit, the device
+/// class and the payload shape. ESPHome, Z-Wave JS, Tasmota, Shelly and zigbee2mqtt all publish it. Topic
+/// layouts would require a rule per integration, and each rule would infer a reading's meaning from its
+/// topic name.
+/// </para>
+/// </summary>
+public static class MqttDiscoveryImport
+{
+    /// <summary>Device-class values we can bind, mapped to our metric names.</summary>
+    private static readonly Dictionary<string, string> Metrics = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["power"] = "realpower",
+        ["energy"] = "energy",
+    };
+
+    /// <summary>
+    /// Every importable reading in one retained discovery config. Handles both layouts Home Assistant
+    /// accepts: a single entity per topic, and the newer device bundle with a <c>components</c> map.
+    /// </summary>
+    /// <param name="ourDeviceIdPrefixes">
+    /// Ids belonging to this bridge. Skipped: importing an entity this bridge published and re-exporting
+    /// it duplicates the node in Home Assistant and double-counts it in any roll-up that aggregates it.
+    /// </param>
+    public static IReadOnlyList<DiscoveredReading> Parse(string payload, IReadOnlyCollection<string> ourDeviceIdPrefixes)
+    {
+        JsonNode? root;
+        try { root = JsonNode.Parse(payload); }
+        catch (JsonException) { return []; }
+        if (root is not JsonObject doc) return [];
+
+        var deviceName = (doc["device"] as JsonObject)?["name"]?.GetValue<string>() ?? "";
+        var found = new List<DiscoveredReading>();
+
+        if (doc["components"] is JsonObject components)
+        {
+            foreach (var (_, node) in components)
+                if (node is JsonObject c && One(c, doc, deviceName, ourDeviceIdPrefixes) is { } r)
+                    found.Add(r);
+        }
+        else if (One(doc, doc, deviceName, ourDeviceIdPrefixes) is { } single)
+        {
+            found.Add(single);
+        }
+
+        return found;
+    }
+
+    private static DiscoveredReading? One(JsonObject c, JsonObject doc, string deviceName, IReadOnlyCollection<string> ours)
+    {
+        var deviceClass = c["device_class"]?.GetValue<string>();
+        if (deviceClass is null || !Metrics.TryGetValue(deviceClass, out var metric)) return null;
+
+        var uniqueId = c["unique_id"]?.GetValue<string>() ?? "";
+        if (uniqueId.Length == 0) return null;
+        if (ours.Any(p => p.Length > 0 && uniqueId.StartsWith(p, StringComparison.OrdinalIgnoreCase))) return null;
+
+        // state_topic may sit on the bundle rather than the component.
+        var stateTopic = c["state_topic"]?.GetValue<string>() ?? doc["state_topic"]?.GetValue<string>();
+        if (string.IsNullOrWhiteSpace(stateTopic)) return null;
+
+        var name = c["name"]?.GetValue<string>() ?? uniqueId;
+        var label = deviceName.Length > 0 ? $"{deviceName} {name}".Trim() : name;
+
+        var (field, unsupported) = ReadTemplate(c["value_template"]?.GetValue<string>());
+
+        return new DiscoveredReading(
+            uniqueId, label, deviceName.Length > 0 ? deviceName : name, stateTopic!,
+            metric, c["unit_of_measurement"]?.GetValue<string>(), field, unsupported);
+    }
+
+    /// <summary>
+    /// Turn a discovery value_template into the JSON field our binding reads, or say it cannot be done.
+    /// </summary>
+    /// <remarks>
+    /// Two shapes are accepted: no template (the payload is the value), and a plain
+    /// <c>{{ value_json.a.b }}</c> lookup. Arithmetic, conditionals and filters are reported as
+    /// unsupported: the template transforms the field, so the field is not the published value.
+    /// </remarks>
+    internal static (string? Field, string? Unsupported) ReadTemplate(string? template)
+    {
+        var t = template?.Trim();
+        if (string.IsNullOrEmpty(t)) return (null, null);
+
+        if (!t.StartsWith("{{") || !t.EndsWith("}}"))
+            return (null, "its value template is not a simple field lookup");
+
+        var inner = t[2..^2].Trim();
+        if (inner == "value") return (null, null);                       // the bare payload, spelled out
+
+        const string prefix = "value_json.";
+        if (!inner.StartsWith(prefix, StringComparison.Ordinal))
+            return (null, "its value template is not a simple field lookup");
+
+        var path = inner[prefix.Length..].Trim();
+        // A dotted path is fine (our binding walks it); anything else is arithmetic, a filter or a call.
+        if (path.Length == 0 || path.Any(ch => !char.IsLetterOrDigit(ch) && ch != '_' && ch != '.'))
+            return (null, "its value template does more than read a field");
+
+        return (path, null);
+    }
+
+    /// <summary>
+    /// A node id for an imported reading: lower-case, and safe to use in an MQTT topic and an HA unique_id.
+    /// </summary>
+    public static string NodeId(string uniqueId)
+    {
+        var chars = uniqueId.Trim().ToLowerInvariant()
+            .Select(ch => char.IsLetterOrDigit(ch) ? ch : '_')
+            .ToArray();
+        var id = new string(chars).Trim('_');
+        while (id.Contains("__")) id = id.Replace("__", "_");
+        return id.Length > 0 ? id : "imported";
+    }
+}

--- a/rPDU2MQTT.Tests/MqttDiscoveryImportTests.cs
+++ b/rPDU2MQTT.Tests/MqttDiscoveryImportTests.cs
@@ -1,0 +1,119 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Importing power and energy readings other integrations announce over Home Assistant MQTT discovery.
+/// The import binds a topic to a metric, so a reading whose meaning is not stated is refused.
+/// </summary>
+public class MqttDiscoveryImportTests
+{
+    private static readonly string[] Ours = ["energyflow_", "rPDU2MQTT_"];
+
+    [Fact]
+    public void AnEsphomePowerSensorIsImportable()
+    {
+        // ESPHome: one entity per config topic, bare value on the state topic, no template.
+        const string json = """
+        {"device":{"name":"Garage Meter","identifiers":["esp-garage"]},
+         "name":"Power","unique_id":"esp_garage_power","device_class":"power",
+         "unit_of_measurement":"W","state_topic":"esphome/garage/sensor/power/state"}
+        """;
+
+        var r = Assert.Single(MqttDiscoveryImport.Parse(json, Ours));
+        Assert.Equal("realpower", r.Metric);
+        Assert.Equal("W", r.Unit);
+        Assert.Equal("esphome/garage/sensor/power/state", r.StateTopic);
+        Assert.Equal("Garage Meter Power", r.Label);
+        Assert.Null(r.JsonField);
+        Assert.Null(r.Unsupported);
+    }
+
+    [Fact]
+    public void AZwaveEnergySensorReadingAJsonFieldIsImportable()
+    {
+        const string json = """
+        {"device":{"name":"Dryer Switch"},"name":"Energy","unique_id":"zwavejs_12_energy",
+         "device_class":"energy","unit_of_measurement":"kWh","state_class":"total_increasing",
+         "state_topic":"zwave/dryer/50/0/value/66049","value_template":"{{ value_json.value }}"}
+        """;
+
+        var r = Assert.Single(MqttDiscoveryImport.Parse(json, Ours));
+        Assert.Equal("energy", r.Metric);
+        Assert.Equal("value", r.JsonField);
+        Assert.Null(r.Unsupported);
+    }
+
+    [Fact]
+    public void ADeviceBundleYieldsEveryReadingItContains()
+    {
+        const string json = """
+        {"device":{"name":"Shelly EM"},
+         "components":{
+           "a":{"name":"Power","unique_id":"shelly_em_power","device_class":"power","unit_of_measurement":"W","state_topic":"shelly/em/power"},
+           "b":{"name":"Total","unique_id":"shelly_em_energy","device_class":"energy","unit_of_measurement":"kWh","state_topic":"shelly/em/energy"},
+           "c":{"name":"Temp","unique_id":"shelly_em_temp","device_class":"temperature","unit_of_measurement":"°C","state_topic":"shelly/em/temp"}}}
+        """;
+
+        var found = MqttDiscoveryImport.Parse(json, Ours);
+
+        // Temperature is neither a power nor an energy reading.
+        Assert.Equal(2, found.Count);
+        Assert.Equal(["realpower", "energy"], found.Select(f => f.Metric));
+    }
+
+    [Fact]
+    public void OurOwnPublishedSensorsAreNeverOffered()
+    {
+        // Importing an entity this bridge published and re-exporting it duplicates the node in Home
+        // Assistant and double-counts it in any roll-up that aggregates it.
+        const string json = """
+        {"device":{"name":"Solar (PV)"},"name":"Energy","unique_id":"energyflow_solar_energy",
+         "device_class":"energy","unit_of_measurement":"kWh","state_topic":"energy/solar"}
+        """;
+
+        Assert.Empty(MqttDiscoveryImport.Parse(json, Ours));
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("{{ value }}", null)]
+    [InlineData("{{ value_json.value }}", "value")]
+    [InlineData("{{ value_json.meter.total }}", "meter.total")]
+    public void SimpleTemplatesMapToAField(string? template, string? expected)
+    {
+        var (field, unsupported) = MqttDiscoveryImport.ReadTemplate(template);
+        Assert.Equal(expected, field);
+        Assert.Null(unsupported);
+    }
+
+    [Theory]
+    [InlineData("{{ value_json.power | float * 1000 }}")]
+    [InlineData("{{ (value_json.w / 1000) | round(2) }}")]
+    [InlineData("{% if value_json.on %}{{ value_json.w }}{% else %}0{% endif %}")]
+    [InlineData("{{ value_json['power'] }}")]
+    public void ATemplateThatDoesAnythingElseIsRefused(string template)
+    {
+        // The template transforms the field, so the field is not the published value.
+        var (field, unsupported) = MqttDiscoveryImport.ReadTemplate(template);
+        Assert.Null(field);
+        Assert.False(string.IsNullOrWhiteSpace(unsupported));
+    }
+
+    [Fact]
+    public void AnEntryWithoutTheEssentialsIsSkipped()
+    {
+        // No device class: the reading's quantity is unstated. No state topic: nothing to read.
+        Assert.Empty(MqttDiscoveryImport.Parse("""{"name":"X","unique_id":"x","state_topic":"a/b"}""", Ours));
+        Assert.Empty(MqttDiscoveryImport.Parse("""{"name":"X","unique_id":"x","device_class":"power"}""", Ours));
+        Assert.Empty(MqttDiscoveryImport.Parse("not json at all", Ours));
+    }
+
+    [Theory]
+    [InlineData("esp_garage_power", "esp_garage_power")]
+    [InlineData("Shelly-EM/Power", "shelly_em_power")]
+    [InlineData("  weird   id  ", "weird_id")]
+    public void NodeIdsAreTopicSafe(string uniqueId, string expected)
+        => Assert.Equal(expected, MqttDiscoveryImport.NodeId(uniqueId));
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1206,6 +1206,50 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         //
         // Two endpoints on purpose. Deleting devices from someone's Home Assistant is not something to do on
         // a timer or at startup — GET says exactly what would go, POST does it, and the operator decides.
+        // Power/energy readings other integrations already announce over Home Assistant MQTT discovery
+        // (ESPHome, Z-Wave JS, Tasmota, Shelly, zigbee2mqtt all publish it). Offered for import as
+        // energy-flow nodes; nothing is created until the operator picks from the list.
+        app.MapGet("/api/mqtt/importable", async () =>
+        {
+            try
+            {
+                var prefix = config.HASS.DiscoveryTopic;
+                if (string.IsNullOrWhiteSpace(prefix))
+                    return Results.Json(new { ok = false, message = "No Home Assistant discovery prefix is configured, so there is nothing to scan." }, ConfigSchema.Json);
+
+                var index = grains.GetGrain<Grains.Abstractions.Discovery.ITopicIndexGrain>(0);
+                var filter = prefix.Trim().Trim('/') + "/#";
+                await index.Renew(filter);
+                var retained = await index.Search(null, 5000);
+
+                var rootId = string.IsNullOrWhiteSpace(config.Overrides?.rPDU2MQTT?.ID) ? "rPDU2MQTT" : config.Overrides!.rPDU2MQTT!.ID!;
+                string[] ours = [Core.Flow.FlowExport.DeviceIdPrefix, rootId + "_"];
+
+                var found = retained
+                    .Where(t => t.Topic.EndsWith("/config", StringComparison.OrdinalIgnoreCase))
+                    .SelectMany(t => Core.Flow.MqttDiscoveryImport.Parse(t.Payload ?? "", ours))
+                    .GroupBy(r => r.UniqueId, StringComparer.OrdinalIgnoreCase)
+                    .Select(g => g.First())
+                    .OrderBy(r => r.Device, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(r => r.Label, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                return Results.Json(new
+                {
+                    ok = true,
+                    scanned = retained.Count,
+                    readings = found.Select(r => new
+                    {
+                        id = Core.Flow.MqttDiscoveryImport.NodeId(r.UniqueId),
+                        uniqueId = r.UniqueId, label = r.Label, device = r.Device,
+                        topic = r.StateTopic, metric = r.Metric, unit = r.Unit,
+                        jsonField = r.JsonField, unsupported = r.Unsupported,
+                    }),
+                }, ConfigSchema.Json);
+            }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
+        });
+
         app.MapGet("/api/ha/orphans", async () =>
         {
             try

--- a/rPDU2MQTT.Web/rPDU2MQTT.Web.csproj
+++ b/rPDU2MQTT.Web/rPDU2MQTT.Web.csproj
@@ -45,6 +45,7 @@
 			<GuiSource Include="web\gauge.check.mjs" />
 			<GuiSource Include="web\contradiction.check.mjs" />
 			<GuiSource Include="web\tags.check.mjs" />
+			<GuiSource Include="web\discover.check.mjs" />
 		<GuiSource Include="web\schema.fixture.json" />
 	</ItemGroup>
 
@@ -75,6 +76,7 @@
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/gauge.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/contradiction.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/tags.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
+		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/discover.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Warning Condition="'$(_NodeExitCode)' != '0'" Text="node not found; using the committed wwwroot/app.js + styles.css. Install Node 22+ to rebuild the GUI from web/src." />
 	</Target>
 

--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -1,0 +1,101 @@
+// Importing readings other integrations announce over Home Assistant MQTT discovery.
+//
+// Covers what the panel refuses: an entity whose value template transforms the field cannot be bound, and
+// one already modelled must not be added twice. Both render as disabled rows carrying a reason, rather
+// than being omitted from the list.
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDom, query } from './domstub.mjs';
+
+const code = await readFile(new URL('../wwwroot/app.js', import.meta.url), 'utf8');
+const schema = JSON.parse(await readFile(new URL('./schema.fixture.json', import.meta.url), 'utf8'))
+  .filter(n => n.key !== '_README');
+const fail = (m) => { console.error('discover check FAILED: ' + m); process.exit(1); };
+
+// 'esp_garage_power' is importable; 'shelly_scaled' has a template we cannot read; 'solar' already exists.
+const importable = {
+  ok: true, scanned: 120,
+  readings: [
+    { id: 'esp_garage_power', uniqueId: 'esp_garage_power', label: 'Garage Meter Power', device: 'Garage Meter',
+      topic: 'esphome/garage/sensor/power/state', metric: 'realpower', unit: 'W', jsonField: null, unsupported: null },
+    { id: 'shelly_scaled', uniqueId: 'shelly_scaled', label: 'Shelly Scaled', device: 'Shelly EM',
+      topic: 'shelly/em/power', metric: 'realpower', unit: 'W', jsonField: null,
+      unsupported: 'its value template does more than read a field' },
+    { id: 'solar', uniqueId: 'solar', label: 'Solar', device: 'Inverter',
+      topic: 'sa/pv_power', metric: 'realpower', unit: 'W', jsonField: null, unsupported: null },
+  ],
+};
+
+const cfg = { EnergyFlow: { Nodes: [{ Id: 'solar', Label: 'Solar' }], Links: [] } };
+
+const { sandbox, getEl } = makeDom({
+  bodies: (url) =>
+    url.includes('/api/schema') ? schema :
+    url.includes('/api/instances') ? { ok: true, instances: [] } :
+    url.includes('/api/config') ? cfg :
+    url.includes('/api/mqtt/importable') ? importable :
+    url.includes('/api/flow/live') ? { ok: true, values: [] } :
+    url.includes('/api/flow/withheld') ? { ok: true, sources: [] } :
+    url.includes('/api/flow') ? { ok: true, nodes: [], links: [], metric: 'realpower', units: 'W' } :
+    { ok: true },
+});
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox, { filename: 'app.js' });
+await new Promise(r => setTimeout(r, 50));
+
+const nav = query(getEl('nav'), 'a', true).find(a => a.dataset.label === 'Nodes');
+if (!nav) fail('no Nodes tab');
+nav.click();
+await new Promise(r => setTimeout(r, 200));
+
+const buttons = () => query(getEl('sections'), 'button', true);
+const discover = buttons().find(b => b.textContent === 'Discover from MQTT');
+if (!discover) fail('no "Discover from MQTT" button on the Nodes tab');
+discover.click();
+await new Promise(r => setTimeout(r, 50));
+
+buttons().find(b => b.textContent === 'Scan broker').click();
+await new Promise(r => setTimeout(r, 200));
+
+const rows = query(getEl('sections'), 'tr', true).filter(r => query(r, 'input', true).length);
+if (rows.length !== 3) fail(`expected a row per reading, got ${rows.length}`);
+
+const boxFor = (label) => {
+  const row = rows.find(r => r.textContent.includes(label));
+  if (!row) fail(`no row for ${label}`);
+  return { row, box: query(row, 'input', true)[0] };
+};
+
+// Importable: selectable.
+const good = boxFor('Garage Meter Power');
+if (good.box.disabled) fail('an importable reading was not selectable');
+
+// Unreadable template: shown, disabled, and says why.
+const bad = boxFor('Shelly Scaled');
+if (!bad.box.disabled) fail('a reading whose template cannot be read was offered for import');
+if (!bad.row.textContent.includes('Cannot import')) fail('the refused row does not say why');
+
+// Already modelled: shown, disabled, and says so.
+const dup = boxFor('Solar');
+if (!dup.box.disabled) fail('a reading that is already a node was offered again');
+if (!dup.row.textContent.includes('Already a node')) fail('the duplicate row does not say why');
+
+// Taking the importable one adds a node, tagged, valued only by its own binding.
+good.box.checked = true;
+good.box.onchange({});
+buttons().find(b => b.textContent === 'Add selected').click();
+await new Promise(r => setTimeout(r, 100));
+
+const added = cfg.EnergyFlow.Nodes.find(n => n.Id === 'esp_garage_power');
+if (!added) fail('selecting a reading did not add a node');
+if (JSON.stringify(added.Tags) !== JSON.stringify(['imported'])) fail(`the imported node was not tagged: ${JSON.stringify(added.Tags)}`);
+if (added.Mode !== 'none') fail('an imported node must not be set to aggregate children it does not have');
+const src = (added.Sources || [])[0] || {};
+if (src.Topic !== 'esphome/garage/sensor/power/state') fail('the binding does not point at the discovered topic');
+if (src.Metric !== 'realpower' || src.Unit !== 'W') fail('the binding lost the metric or unit');
+
+// And nothing else was added — in particular not the two refused rows.
+if (cfg.EnergyFlow.Nodes.length !== 2) fail(`expected 2 nodes, got ${cfg.EnergyFlow.Nodes.map(n => n.Id).join(', ')}`);
+
+console.log('discover: importable readings are addable and tagged; unreadable templates and existing nodes '
+  + 'are shown disabled with a reason');

--- a/rPDU2MQTT.Web/web/domstub.mjs
+++ b/rPDU2MQTT.Web/web/domstub.mjs
@@ -43,6 +43,10 @@ function* descendants(node) {
 export function makeEl(tag = 'div') {
   const node = {
     tag, children: [], attrs: {}, style: {}, dataset: {}, _text: '',
+    // Form-control properties a real element always has. el() assigns a prop when `k in e` and falls back
+    // to setAttribute otherwise, so without these an input's value silently became an attribute here while
+    // being a property in the browser — and a test reading either one would disagree with the app.
+    value: '', checked: false, disabled: false,
     classList: {
       _s: new Set(),
       add(...c) { c.forEach(x => x && this._s.add(x)); },

--- a/rPDU2MQTT.Web/web/smoke.mjs
+++ b/rPDU2MQTT.Web/web/smoke.mjs
@@ -176,7 +176,7 @@ if (query(getEl('sections'), '.node-editor', false)) fail('the node editor rende
 const editorText = editor.textContent;
 if (!editorText.includes('Live value bindings')) fail('opening a node did not render its bindings editor');
 if (!editorText.includes('Feeders & children')) fail('the node editor did not render the feeders/children wiring');
-if (!query(editor, 'input', true).some(i => i.attrs.value === 'solar_assistant/inverter_1/pv_power/state'))
+if (!query(editor, 'input', true).some(i => i.value === 'solar_assistant/inverter_1/pv_power/state'))
   fail('the node editor did not surface the migrated MQTT binding as an editable topic');
 // The Modbus binding row must render its connection picker, listing the configured connection.
 if (!editorText.includes('Inverter')) fail('the Modbus binding row did not list the configured connection');

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2462,6 +2462,106 @@ function instantiateTemplate(tpl: any, prefix: string, host: string, unitId: num
 
 // The "Import device template" panel: pick a template, set an id prefix + Modbus host/unit, and drop the
 // pre-wired nodes into the config for review.
+/// Import power/energy readings other integrations announce over Home Assistant MQTT discovery.
+///
+/// Discovery is used rather than per-integration topic patterns because it states the unit, the device
+/// class and the payload shape.
+function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () => void): HTMLElement {
+  const panel = el('div', { class: 'tpl-import' });
+  panel.appendChild(el('div', {
+    class: 'desc',
+    text: 'Power and energy readings other integrations publish to this broker. Pick the ones to add as '
+        + 'nodes; nothing is created until you do, and nothing is saved until you press Save.',
+  }));
+
+  const bar = el('div', { class: 'ld-toolbar' });
+  const tagIn = el('input', { type: 'text', value: 'imported', placeholder: 'tag (optional)' }) as HTMLInputElement;
+  const scan = btn('Scan broker', 'primary');
+  const addBtn = btn('Add selected');
+  bar.append(scan, el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn);
+  const note = el('div', { class: 'desc' });
+  const list = el('div');
+  panel.append(bar, note, list);
+
+  // Tagged on import so the per-destination filters can exclude them. A reading imported from Home
+  // Assistant and re-exported to it arrives back as a second copy.
+  tagIn.title = 'Applied to every node added here. Use it in a destination’s tag filter to avoid '
+              + 'exporting these readings back to where they came from.';
+
+  const picked = new Set<string>();
+
+  const render = (readings: any[]) => {
+    list.innerHTML = '';
+    if (!readings.length) { note.textContent = 'Nothing importable found. Only power and energy entities are offered.'; return; }
+    const tbl = el('table', { class: 'ld' });
+    const head = el('tr');
+    ['', 'Device', 'Reading', 'Metric', 'Topic'].forEach(h => head.appendChild(el('th', { text: h })));
+    tbl.appendChild(el('thead', {}, head));
+    const body = el('tbody');
+    readings.forEach(r => {
+      const tr = el('tr');
+      const cb = el('input', { type: 'checkbox', class: 'switch' }) as HTMLInputElement;
+      const already = existingIds.has(r.id);
+      // Two reasons a row cannot be taken: already modelled, or not bindable from its template.
+      cb.disabled = !!r.unsupported || already;
+      cb.onchange = () => { cb.checked ? picked.add(r.id) : picked.delete(r.id); };
+      tr.appendChild(el('td', {}, cb));
+      tr.appendChild(el('td', { text: r.device || '—' }));
+      tr.appendChild(el('td', { text: r.label }));
+      tr.appendChild(el('td', { text: r.metric + (r.unit ? ` (${r.unit})` : '') }));
+      const topic = el('td');
+      topic.appendChild(el('code', { text: r.topic, style: { color: 'var(--muted)' } }));
+      if (r.unsupported) topic.appendChild(el('div', { class: 'nh-warn', text: `Cannot import: ${r.unsupported}.` }));
+      else if (already) topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'Already a node.' }));
+      tr.appendChild(topic);
+      body.appendChild(tr);
+    });
+    tbl.appendChild(body);
+    list.appendChild(tbl);
+  };
+
+  let found: any[] = [];
+  scan.onclick = async () => {
+    note.textContent = 'Scanning the broker’s retained discovery…';
+    const r = await api('/api/mqtt/importable');
+    if (!r.body || !r.body.ok) { note.textContent = (r.body && r.body.message) || 'Could not scan.'; return; }
+    found = r.body.readings || [];
+    note.textContent = `${found.length} reading(s) from ${r.body.scanned} retained topic(s).`;
+    render(found);
+  };
+
+  addBtn.onclick = () => {
+    const take = found.filter(r => picked.has(r.id) && !r.unsupported && !existingIds.has(r.id));
+    if (!take.length) { toast('Nothing selected.', false); return; }
+    const tag = tagIn.value.trim();
+    const nodes = ensure(flow, 'Nodes', []);
+    take.forEach(r => {
+      const node: any = {
+        Id: r.id,
+        Label: r.label,
+        // 'none': an imported node is valued by its own binding. 'auto' would aggregate children it does
+        // not have.
+        Mode: 'none',
+        Sources: [{
+          Type: 'mqtt', Topic: r.topic, Metric: r.metric,
+          // 'lifetime': the daily figure is derived from it, and a counter that resets is handled by the
+          // reset detection. 'period' declared wrongly publishes a cumulative total as today's.
+          Accumulation: r.metric === 'energy' ? 'lifetime' : undefined,
+          Unit: r.unit || undefined,
+          JsonField: r.jsonField || undefined,
+        }],
+      };
+      if (tag) node.Tags = [tag];
+      nodes.push(node);
+      existingIds.add(r.id);
+    });
+    toast(`Added ${take.length} node(s). Wire their feeders on the Nodes tab, then Save.`, true);
+    rerender();
+  };
+
+  return panel;
+}
+
 function renderImportPanel(flow: any, existingIds: Set<string>, rerender: () => void): HTMLElement {
   const panel = el('div', { class: 'tpl-import' });
   panel.appendChild(el('div', { class: 'desc', text: 'Import a known device to pre-fill its nodes and register bindings. Review and Save afterwards; addresses are community starting points — verify against your firmware.' }));
@@ -2535,6 +2635,7 @@ export function addNodesSection(nav: any, sections: any) {
     NODE_KINDS.forEach(([v, label]) => kindSel.appendChild(el('option', { value: v, text: label })));
     const addBtn = btn('Add node', 'primary');
     const importBtn = btn('Import device template');
+    const discoverBtn = btn('Discover from MQTT');
     const save = btn('Save', 'primary');
     addBtn.onclick = () => {
       const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
@@ -2546,7 +2647,7 @@ export function addNodesSection(nav: any, sections: any) {
       customNodes.push(node); editing.id = id; render();  // open the new node's editor straight away
     };
     save.onclick = () => saveConfig(load);
-    addBar.append(idIn, labIn, kindSel, addBtn, importBtn, save); ed.appendChild(addBar);
+    addBar.append(idIn, labIn, kindSel, addBtn, importBtn, discoverBtn, save); ed.appendChild(addBar);
 
     // Import-device-template panel, toggled by the button (existing ids guard against prefix clashes).
     const existingIds = new Set<string>([...customNodes.map((n: any) => n.Id), ...((lastGraph?.nodes || []).map((n: any) => n.id))]);
@@ -2554,6 +2655,10 @@ export function addNodesSection(nav: any, sections: any) {
     importBtn.onclick = () => {
       if (impWrap.firstChild) { impWrap.innerHTML = ''; return; }   // toggle closed
       impWrap.appendChild(renderImportPanel(flow, existingIds, render));
+    };
+    discoverBtn.onclick = () => {
+      if (impWrap.firstChild) { impWrap.innerHTML = ''; return; }
+      impWrap.appendChild(renderDiscoverPanel(flow, existingIds, render));
     };
 
     const cand = flowCandidates(lastGraph, customNodes);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3889,6 +3889,106 @@ function instantiateTemplate(tpl     , prefix        , host        , unitId     
 
 // The "Import device template" panel: pick a template, set an id prefix + Modbus host/unit, and drop the
 // pre-wired nodes into the config for review.
+/// Import power/energy readings other integrations announce over Home Assistant MQTT discovery.
+///
+/// Discovery is used rather than per-integration topic patterns because it states the unit, the device
+/// class and the payload shape.
+function renderDiscoverPanel(flow     , existingIds             , rerender            )              {
+  const panel = el('div', { class: 'tpl-import' });
+  panel.appendChild(el('div', {
+    class: 'desc',
+    text: 'Power and energy readings other integrations publish to this broker. Pick the ones to add as '
+        + 'nodes; nothing is created until you do, and nothing is saved until you press Save.',
+  }));
+
+  const bar = el('div', { class: 'ld-toolbar' });
+  const tagIn = el('input', { type: 'text', value: 'imported', placeholder: 'tag (optional)' })                    ;
+  const scan = btn('Scan broker', 'primary');
+  const addBtn = btn('Add selected');
+  bar.append(scan, el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn);
+  const note = el('div', { class: 'desc' });
+  const list = el('div');
+  panel.append(bar, note, list);
+
+  // Tagged on import so the per-destination filters can exclude them. A reading imported from Home
+  // Assistant and re-exported to it arrives back as a second copy.
+  tagIn.title = 'Applied to every node added here. Use it in a destination’s tag filter to avoid '
+              + 'exporting these readings back to where they came from.';
+
+  const picked = new Set        ();
+
+  const render = (readings       ) => {
+    list.innerHTML = '';
+    if (!readings.length) { note.textContent = 'Nothing importable found. Only power and energy entities are offered.'; return; }
+    const tbl = el('table', { class: 'ld' });
+    const head = el('tr');
+    ['', 'Device', 'Reading', 'Metric', 'Topic'].forEach(h => head.appendChild(el('th', { text: h })));
+    tbl.appendChild(el('thead', {}, head));
+    const body = el('tbody');
+    readings.forEach(r => {
+      const tr = el('tr');
+      const cb = el('input', { type: 'checkbox', class: 'switch' })                    ;
+      const already = existingIds.has(r.id);
+      // Two reasons a row cannot be taken: already modelled, or not bindable from its template.
+      cb.disabled = !!r.unsupported || already;
+      cb.onchange = () => { cb.checked ? picked.add(r.id) : picked.delete(r.id); };
+      tr.appendChild(el('td', {}, cb));
+      tr.appendChild(el('td', { text: r.device || '—' }));
+      tr.appendChild(el('td', { text: r.label }));
+      tr.appendChild(el('td', { text: r.metric + (r.unit ? ` (${r.unit})` : '') }));
+      const topic = el('td');
+      topic.appendChild(el('code', { text: r.topic, style: { color: 'var(--muted)' } }));
+      if (r.unsupported) topic.appendChild(el('div', { class: 'nh-warn', text: `Cannot import: ${r.unsupported}.` }));
+      else if (already) topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'Already a node.' }));
+      tr.appendChild(topic);
+      body.appendChild(tr);
+    });
+    tbl.appendChild(body);
+    list.appendChild(tbl);
+  };
+
+  let found        = [];
+  scan.onclick = async () => {
+    note.textContent = 'Scanning the broker’s retained discovery…';
+    const r = await api('/api/mqtt/importable');
+    if (!r.body || !r.body.ok) { note.textContent = (r.body && r.body.message) || 'Could not scan.'; return; }
+    found = r.body.readings || [];
+    note.textContent = `${found.length} reading(s) from ${r.body.scanned} retained topic(s).`;
+    render(found);
+  };
+
+  addBtn.onclick = () => {
+    const take = found.filter(r => picked.has(r.id) && !r.unsupported && !existingIds.has(r.id));
+    if (!take.length) { toast('Nothing selected.', false); return; }
+    const tag = tagIn.value.trim();
+    const nodes = ensure(flow, 'Nodes', []);
+    take.forEach(r => {
+      const node      = {
+        Id: r.id,
+        Label: r.label,
+        // 'none': an imported node is valued by its own binding. 'auto' would aggregate children it does
+        // not have.
+        Mode: 'none',
+        Sources: [{
+          Type: 'mqtt', Topic: r.topic, Metric: r.metric,
+          // 'lifetime': the daily figure is derived from it, and a counter that resets is handled by the
+          // reset detection. 'period' declared wrongly publishes a cumulative total as today's.
+          Accumulation: r.metric === 'energy' ? 'lifetime' : undefined,
+          Unit: r.unit || undefined,
+          JsonField: r.jsonField || undefined,
+        }],
+      };
+      if (tag) node.Tags = [tag];
+      nodes.push(node);
+      existingIds.add(r.id);
+    });
+    toast(`Added ${take.length} node(s). Wire their feeders on the Nodes tab, then Save.`, true);
+    rerender();
+  };
+
+  return panel;
+}
+
 function renderImportPanel(flow     , existingIds             , rerender            )              {
   const panel = el('div', { class: 'tpl-import' });
   panel.appendChild(el('div', { class: 'desc', text: 'Import a known device to pre-fill its nodes and register bindings. Review and Save afterwards; addresses are community starting points — verify against your firmware.' }));
@@ -3962,6 +4062,7 @@ function addNodesSection(nav     , sections     ) {
     NODE_KINDS.forEach(([v, label]) => kindSel.appendChild(el('option', { value: v, text: label })));
     const addBtn = btn('Add node', 'primary');
     const importBtn = btn('Import device template');
+    const discoverBtn = btn('Discover from MQTT');
     const save = btn('Save', 'primary');
     addBtn.onclick = () => {
       const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
@@ -3973,7 +4074,7 @@ function addNodesSection(nav     , sections     ) {
       customNodes.push(node); editing.id = id; render();  // open the new node's editor straight away
     };
     save.onclick = () => saveConfig(load);
-    addBar.append(idIn, labIn, kindSel, addBtn, importBtn, save); ed.appendChild(addBar);
+    addBar.append(idIn, labIn, kindSel, addBtn, importBtn, discoverBtn, save); ed.appendChild(addBar);
 
     // Import-device-template panel, toggled by the button (existing ids guard against prefix clashes).
     const existingIds = new Set        ([...customNodes.map((n     ) => n.Id), ...((lastGraph?.nodes || []).map((n     ) => n.id))]);
@@ -3981,6 +4082,10 @@ function addNodesSection(nav     , sections     ) {
     importBtn.onclick = () => {
       if (impWrap.firstChild) { impWrap.innerHTML = ''; return; }   // toggle closed
       impWrap.appendChild(renderImportPanel(flow, existingIds, render));
+    };
+    discoverBtn.onclick = () => {
+      if (impWrap.firstChild) { impWrap.innerHTML = ''; return; }
+      impWrap.appendChild(renderDiscoverPanel(flow, existingIds, render));
     };
 
     const cand = flowCandidates(lastGraph, customNodes);


### PR DESCRIPTION
Adds "Discover from MQTT" on the Nodes tab: scans the broker's retained Home Assistant discovery, lists the power and energy readings other integrations publish, and adds the selected ones as nodes.

## Mechanism

Discovery rather than per-integration topic patterns, because it states the unit, the device class and the payload shape. ESPHome, Z-Wave JS, Tasmota, Shelly and zigbee2mqtt all publish it, so one path covers them without per-integration rules.

## Tagging

Imported nodes are tagged (default `imported`) so the per-destination filters from #353 can exclude them. A reading imported from Home Assistant and re-exported to it arrives back as a second copy. Entities this bridge published are not offered, for the same reason.

## Refused

Rendered as disabled rows carrying the reason, not omitted from the list:

- a `value_template` that transforms the field — `{{ value_json.power | float * 1000 }}`. The field is not the published value. `{{ value }}` and `{{ value_json.a.b }}` are accepted.
- an entity already modelled as a node

Not listed: entities with no device class (the quantity is unstated) or no state topic.

## Defaults for an imported node

- `Mode: none` — valued by its own binding, not aggregating children it does not have
- energy bindings declared `lifetime`; the daily figure is derived from that, and `period` declared wrongly publishes a cumulative total as today's (#340)

## Coverage

16 unit tests on the parser: ESPHome and Z-Wave shapes, device bundles, this bridge's own entities skipped, each template form accepted or refused, topic-safe ids.

`discover.check.mjs` drives the panel and asserts the refusals render and the added node is tagged and bound correctly. Both fail when broken:

```
unsupported made selectable -> discover check FAILED: a reading whose template cannot be read was offered
tag dropped                 -> discover check FAILED: the imported node was not tagged: undefined
```

Also fixed: the DOM stub gave elements no `value`/`checked`/`disabled` properties, so `el()` wrote an input's value as an attribute where a browser sets a property.

647 tests pass; nine GUI checks green.

## Not included

Continuous auto-import. Nodes are created when selected, not as devices appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
