### PR TITLE
feat(flow): import readings by topic shape, for publishers that announce no discovery

### DIFF
--- a/rPDU2MQTT.Core/Flow/MqttTopicProfile.cs
+++ b/rPDU2MQTT.Core/Flow/MqttTopicProfile.cs
@@ -1,0 +1,117 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>One reading matched from a topic pattern.</summary>
+/// <param name="Device">The device segment the pattern captured.</param>
+/// <param name="Measure">The measure segment the pattern captured.</param>
+/// <param name="Topic">The full topic.</param>
+/// <param name="Metric">Our metric name, or null when the measure is not one we roll up.</param>
+/// <param name="JsonField">Field to read from a JSON payload, or null when the payload is the bare value.</param>
+/// <param name="Sample">The last payload seen, so the operator can confirm the unit before importing.</param>
+public readonly record struct PatternMatch(
+    string Device, string Measure, string Topic, string? Metric, string? JsonField, string? Sample);
+
+/// <summary>
+/// Matches readings by topic shape, for publishers that do not announce Home Assistant discovery.
+///
+/// <para>
+/// <see cref="MqttDiscoveryImport"/> is preferred where discovery exists, because it states the unit and
+/// the device class. A raw topic states neither: <c>esphome/devices/fan/sensor/energy_d/state = 113.783</c>
+/// gives no way to tell Wh from kWh. So a pattern match proposes the device, the measure and the metric,
+/// and leaves the unit for the operator to set with the sampled value in front of them.
+/// </para>
+/// </summary>
+public static class MqttTopicProfile
+{
+    /// <summary>A named topic shape, with <c>{device}</c> and <c>{measure}</c> marking the parts to capture.</summary>
+    /// <param name="Id">Stable key used by the API and the GUI.</param>
+    /// <param name="Label">What the picker calls it.</param>
+    /// <param name="Filter">The subscription filter to browse.</param>
+    /// <param name="Pattern">Slash-delimited, with <c>{device}</c>, <c>{measure}</c> and <c>+</c> wildcards.</param>
+    /// <param name="JsonField">Field holding the value, when the payload is JSON.</param>
+    /// <param name="Metrics">Measure -> our metric name. Measures absent from this map are not readings we roll up.</param>
+    public sealed record Profile(
+        string Id, string Label, string Filter, string Pattern, string? JsonField,
+        IReadOnlyDictionary<string, string> Metrics);
+
+    private static readonly Dictionary<string, string> EsphomeMetrics = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["power"] = "realpower",
+        ["energy"] = "energy",
+        ["energy_d"] = "energy",
+        ["daily_energy"] = "energy",
+        ["total_energy"] = "energy",
+        ["current"] = "current",
+        ["voltage"] = "voltage",
+    };
+
+    // Z-Wave meter readings are numbered, not named: command class 50 (Meter), property 66049 = watts and
+    // 65537 = kWh. The numbers are the published vocabulary, so they are what the map keys on.
+    private static readonly Dictionary<string, string> ZwaveMetrics = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["66049"] = "realpower",
+        ["65537"] = "energy",
+        ["66561"] = "current",
+        ["66817"] = "voltage",
+    };
+
+    public static readonly IReadOnlyList<Profile> BuiltIn =
+    [
+        new("esphome", "ESPHome", "esphome/#", "esphome/devices/{device}/sensor/{measure}/state", null, EsphomeMetrics),
+        new("zwavejs", "Z-Wave JS", "zwave/#", "zwave/+/{device}/50/+/value/{measure}", "value", ZwaveMetrics),
+    ];
+
+    public static Profile? ById(string? id) =>
+        BuiltIn.FirstOrDefault(p => string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Match one topic against a pattern. Segment counts must agree exactly — a pattern is a shape, and a
+    /// prefix match would capture a sibling topic whose extra segments change what the value means.
+    /// </summary>
+    public static PatternMatch? Match(string pattern, string topic, string? jsonField,
+                                      IReadOnlyDictionary<string, string>? metrics, string? sample = null)
+    {
+        if (string.IsNullOrWhiteSpace(pattern) || string.IsNullOrWhiteSpace(topic)) return null;
+
+        var pp = pattern.Split('/');
+        var tp = topic.Split('/');
+        if (pp.Length != tp.Length) return null;
+
+        string device = "", measure = "";
+        for (var i = 0; i < pp.Length; i++)
+        {
+            var seg = pp[i];
+            if (seg == "{device}") { device = tp[i]; continue; }
+            if (seg == "{measure}") { measure = tp[i]; continue; }
+            if (seg == "+") continue;
+            if (!string.Equals(seg, tp[i], StringComparison.OrdinalIgnoreCase)) return null;
+        }
+        if (device.Length == 0 || measure.Length == 0) return null;
+
+        string? metric = null;
+        metrics?.TryGetValue(measure, out metric);
+        return new PatternMatch(device, measure, topic, metric, jsonField, sample);
+    }
+
+    /// <summary>
+    /// Every reading a profile finds in <paramref name="topics"/>, ordered by device then measure.
+    /// </summary>
+    /// <param name="rollupOnly">
+    /// Keep only measures that map to a metric. Voltage and current are matched but are not part of the
+    /// energy roll-up, so the picker offers power and energy by default.
+    /// </param>
+    public static IReadOnlyList<PatternMatch> Scan(
+        Profile profile, IEnumerable<(string Topic, string? Payload)> topics, bool rollupOnly = true)
+    {
+        var found = new List<PatternMatch>();
+        foreach (var (topic, payload) in topics)
+        {
+            if (Match(profile.Pattern, topic, profile.JsonField, profile.Metrics, payload) is not { } m) continue;
+            if (rollupOnly && m.Metric is not ("realpower" or "energy")) continue;
+            found.Add(m);
+        }
+        return found
+            .OrderBy(m => m.Device, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(m => m.Measure, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/rPDU2MQTT.Tests/MqttTopicProfileTests.cs
+++ b/rPDU2MQTT.Tests/MqttTopicProfileTests.cs
@@ -1,0 +1,114 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Matching readings by topic shape, for publishers that do not announce Home Assistant discovery.
+/// A raw topic states no unit, so a match proposes the device, measure and metric only.
+/// </summary>
+public class MqttTopicProfileTests
+{
+    private static MqttTopicProfile.Profile Esphome => MqttTopicProfile.ById("esphome")!;
+    private static MqttTopicProfile.Profile Zwave => MqttTopicProfile.ById("zwavejs")!;
+
+    [Fact]
+    public void EsphomeSensorTopicsMatch()
+    {
+        (string, string?)[] topics =
+        [
+            ("esphome/devices/bedroom_fan/sensor/power/state", "101.8"),
+            ("esphome/devices/bedroom_fan/sensor/energy_d/state", "113.783"),
+            ("esphome/devices/bedroom_fan/sensor/wifi_signal/state", "-70"),   // not a roll-up reading
+            ("esphome/devices/bt_proxy/sensor/uptime/state", "1129146"),       // nor this
+        ];
+
+        var found = MqttTopicProfile.Scan(Esphome, topics);
+
+        Assert.Equal(2, found.Count);
+        Assert.Equal(["energy", "realpower"], found.Select(f => f.Metric));
+        Assert.All(found, f => Assert.Equal("bedroom_fan", f.Device));
+        // The payload is carried through so the unit can be judged: 113.783 for a fan is Wh, not kWh, and
+        // nothing in the topic says which.
+        Assert.Contains(found, f => f.Sample == "113.783");
+        Assert.All(found, f => Assert.Null(f.JsonField));
+    }
+
+    [Fact]
+    public void ZwaveMeterTopicsMatchAndReadTheValueField()
+    {
+        (string, string?)[] topics =
+        [
+            ("zwave/Hallway/Hallway_Light/50/0/value/66049", """{"time":1,"value":0.8}"""),
+            ("zwave/Hallway/Hallway_Light/50/0/value/65537", """{"time":1,"value":11.975}"""),
+            ("zwave/Hallway/Thermostat/49/0/Air_temperature", """{"time":1,"value":74}"""),   // not command class 50
+            ("zwave/Hallway/Hallway_Light/lastActive", """{"time":1}"""),
+        ];
+
+        var found = MqttTopicProfile.Scan(Zwave, topics);
+
+        Assert.Equal(2, found.Count);
+        Assert.All(found, f => Assert.Equal("Hallway_Light", f.Device));
+        Assert.All(found, f => Assert.Equal("value", f.JsonField));
+        Assert.Equal(["energy", "realpower"], found.Select(f => f.Metric).Order());
+    }
+
+    [Fact]
+    public void SegmentCountsMustAgreeExactly()
+    {
+        // A prefix match would capture a sibling topic whose extra segments change what the value means —
+        // zwave/../50/0/value/66049 is watts, and anything below it is not.
+        Assert.Null(MqttTopicProfile.Match("esphome/devices/{device}/sensor/{measure}/state",
+                                           "esphome/devices/fan/sensor/power/state/extra", null, null));
+        Assert.Null(MqttTopicProfile.Match("esphome/devices/{device}/sensor/{measure}/state",
+                                           "esphome/devices/fan/sensor/power", null, null));
+    }
+
+    [Fact]
+    public void ALiteralSegmentThatDiffersDoesNotMatch()
+        => Assert.Null(MqttTopicProfile.Match("esphome/devices/{device}/sensor/{measure}/state",
+                                              "esphome/gadgets/fan/sensor/power/state", null, null));
+
+    [Fact]
+    public void AWildcardSegmentMatchesAnythingWithoutCapturing()
+    {
+        var m = MqttTopicProfile.Match("zwave/+/{device}/50/+/value/{measure}",
+                                       "zwave/Kitchen/Kitchen_Light/50/0/value/65537", "value", null);
+        Assert.NotNull(m);
+        Assert.Equal("Kitchen_Light", m!.Value.Device);
+        Assert.Equal("65537", m.Value.Measure);
+    }
+
+    [Fact]
+    public void AnUnknownMeasureMatchesWithNoMetric()
+    {
+        // Matched but unclassified: the picker can show it, and nothing pretends to know what it is.
+        var m = MqttTopicProfile.Match(Esphome.Pattern, "esphome/devices/fan/sensor/lux/state", null, Esphome.Metrics);
+        Assert.NotNull(m);
+        Assert.Null(m!.Value.Metric);
+    }
+
+    [Fact]
+    public void ScanKeepsOnlyRollupMetricsByDefault()
+    {
+        // Voltage and current are matched by the profile but are not part of the energy roll-up.
+        (string, string?)[] topics =
+        [
+            ("esphome/devices/fan/sensor/voltage/state", "122.7"),
+            ("esphome/devices/fan/sensor/current/state", "0.8"),
+            ("esphome/devices/fan/sensor/power/state", "101.8"),
+        ];
+
+        Assert.Equal("realpower", Assert.Single(MqttTopicProfile.Scan(Esphome, topics)).Metric);
+        Assert.Equal(3, MqttTopicProfile.Scan(Esphome, topics, rollupOnly: false).Count);
+    }
+
+    [Fact]
+    public void BuiltInProfilesAreAddressableById()
+    {
+        Assert.Equal("ESPHome", MqttTopicProfile.ById("esphome")!.Label);
+        Assert.Equal("Z-Wave JS", MqttTopicProfile.ById("ZWAVEJS")!.Label);
+        Assert.Null(MqttTopicProfile.ById("nope"));
+        Assert.Null(MqttTopicProfile.ById(null));
+    }
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1250,6 +1250,48 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             catch (Exception ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
         });
 
+        // Readings matched by topic shape, for publishers that do not announce Home Assistant discovery.
+        // A raw topic states no unit, so the sampled payload is returned with each match and the operator
+        // sets the unit before importing.
+        app.MapGet("/api/mqtt/importable/pattern", async (HttpContext ctx) =>
+        {
+            try
+            {
+                var profile = Core.Flow.MqttTopicProfile.ById(ctx.Request.Query["profile"].ToString());
+                if (profile is null)
+                    return Results.Json(new { ok = false, message = "Unknown topic profile." }, ConfigSchema.Json);
+
+                var index = grains.GetGrain<Grains.Abstractions.Discovery.ITopicIndexGrain>(0);
+                await index.Renew(profile.Filter);
+                var samples = await index.Search(null, 5000);
+
+                var matches = Core.Flow.MqttTopicProfile.Scan(
+                    profile, samples.Select(t => (t.Topic, t.Payload)));
+
+                return Results.Json(new
+                {
+                    ok = true,
+                    scanned = samples.Count,
+                    profile = profile.Id,
+                    readings = matches.Select(m => new
+                    {
+                        id = Core.Flow.MqttDiscoveryImport.NodeId($"{profile.Id}_{m.Device}_{m.Measure}"),
+                        label = $"{m.Device} {m.Measure}",
+                        device = m.Device,
+                        topic = m.Topic, metric = m.Metric, unit = (string?)null,
+                        jsonField = m.JsonField, sample = m.Sample, unsupported = (string?)null,
+                    }),
+                }, ConfigSchema.Json);
+            }
+            catch (Exception ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
+        });
+
+        app.MapGet("/api/mqtt/profiles", () => Results.Json(new
+        {
+            ok = true,
+            profiles = Core.Flow.MqttTopicProfile.BuiltIn.Select(p => new { id = p.Id, label = p.Label, pattern = p.Pattern }),
+        }, ConfigSchema.Json));
+
         app.MapGet("/api/ha/orphans", async () =>
         {
             try

--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -26,6 +26,17 @@ const importable = {
   ],
 };
 
+// Topic-matched readings state no unit: esphome/.../energy_d/state = 3063.783 is Wh or kWh depending only
+// on the value. The panel must ask rather than assume.
+const pattern = {
+  ok: true, scanned: 68, profile: 'esphome',
+  readings: [
+    { id: 'esphome_deep_freezer_energy_d', label: 'deep_freezer energy_d', device: 'deep_freezer',
+      topic: 'esphome/devices/deep_freezer/sensor/energy_d/state', metric: 'energy', unit: null,
+      jsonField: null, sample: '3063.783', unsupported: null },
+  ],
+};
+
 const cfg = { EnergyFlow: { Nodes: [{ Id: 'solar', Label: 'Solar' }], Links: [] } };
 
 const { sandbox, getEl } = makeDom({
@@ -33,6 +44,7 @@ const { sandbox, getEl } = makeDom({
     url.includes('/api/schema') ? schema :
     url.includes('/api/instances') ? { ok: true, instances: [] } :
     url.includes('/api/config') ? cfg :
+    url.includes('/api/mqtt/importable/pattern') ? pattern :
     url.includes('/api/mqtt/importable') ? importable :
     url.includes('/api/flow/live') ? { ok: true, values: [] } :
     url.includes('/api/flow/withheld') ? { ok: true, sources: [] } :
@@ -97,5 +109,38 @@ if (src.Metric !== 'realpower' || src.Unit !== 'W') fail('the binding lost the m
 // And nothing else was added — in particular not the two refused rows.
 if (cfg.EnergyFlow.Nodes.length !== 2) fail(`expected 2 nodes, got ${cfg.EnergyFlow.Nodes.map(n => n.Id).join(', ')}`);
 
-console.log('discover: importable readings are addable and tagged; unreadable templates and existing nodes '
-  + 'are shown disabled with a reason');
+// --- The topic-profile path.
+// Adding re-renders the Nodes tab, which closes the panel; reopen it.
+buttons().find(b => b.textContent === 'Discover from MQTT').click();
+await new Promise(r => setTimeout(r, 50));
+
+const sel = query(getEl('sections'), 'select', true)
+  .find(s => (s.children || []).some(o => (o.value || (o.attrs && o.attrs.value)) === 'esphome'));
+if (!sel) fail('no source selector offering the topic profiles');
+sel.value = 'esphome';
+buttons().find(b => b.textContent === 'Scan broker').click();
+await new Promise(r => setTimeout(r, 200));
+
+const patRow = query(getEl('sections'), 'tr', true).find(r => r.textContent.includes('deep_freezer'));
+if (!patRow) fail('the topic-profile scan rendered no row');
+// The sampled value is shown, because it is the only thing that distinguishes Wh from kWh.
+if (!patRow.textContent.includes('3063.783')) fail('the row does not show the sampled value');
+// And the unit is an input, not an assumption.
+const unitBox = query(patRow, 'input', true).find(i => i.attrs?.type === 'text' || i.type === 'text');
+if (!unitBox) fail('a topic-matched reading was offered without asking for its unit');
+
+unitBox.value = 'Wh';
+unitBox.onchange({});
+const patBox = query(patRow, 'input', true)[0];
+patBox.checked = true;
+patBox.onchange({});
+buttons().find(b => b.textContent === 'Add selected').click();
+await new Promise(r => setTimeout(r, 100));
+
+const imported = cfg.EnergyFlow.Nodes.find(n => n.Id === 'esphome_deep_freezer_energy_d');
+if (!imported) fail('the topic-matched reading was not added');
+if ((imported.Sources[0] || {}).Unit !== 'Wh') fail('the unit the operator entered was not carried onto the binding');
+if ((imported.Sources[0] || {}).Accumulation !== 'lifetime') fail('an imported energy counter must default to lifetime');
+
+console.log('discover: discovery and topic-profile scans both import; refusals are shown with a reason; a '
+  + 'topic-matched reading asks for its unit and carries it onto the binding');

--- a/rPDU2MQTT.Web/web/domstub.mjs
+++ b/rPDU2MQTT.Web/web/domstub.mjs
@@ -63,8 +63,18 @@ export function makeEl(tag = 'div') {
     // Parentage is tracked so remove() actually detaches: a panel mounted on <body> and later closed has
     // to leave the tree, or a test can't tell an open modal from a closed one.
     parent: null,
-    appendChild(c) { if (c && c.tag) { c.parent = this; this.children.push(c); } return c; },
-    append(...cs) { cs.forEach(c => { if (c && c.tag) { c.parent = this; this.children.push(c); } }); },
+    appendChild(c) {
+      if (c && c.tag) { c.parent = this; this.children.push(c); this._adoptOption(c); }
+      return c;
+    },
+    // A <select> reports its first option's value until something sets another. Without this a select
+    // built by appending options reads as '' here while a browser reports the first option.
+    _adoptOption(c) {
+      if (this.tag !== 'select' || !c || c.tag !== 'option' || this.value) return;
+      const v = c.value || (c.attrs && c.attrs.value);
+      if (v) this.value = v;
+    },
+    append(...cs) { cs.forEach(c => { if (c && c.tag) { c.parent = this; this.children.push(c); this._adoptOption(c); } }); },
     removeChild(c) { this.children = this.children.filter(x => x !== c); if (c) c.parent = null; },
     remove() { if (this.parent) this.parent.removeChild(this); },
     // Swap this node for another in the parent's child list, keeping its position — used where a toolbar

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2475,10 +2475,16 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
   }));
 
   const bar = el('div', { class: 'ld-toolbar' });
+  // Where to look. Discovery states the unit and device class, so it is the default; the topic profiles
+  // exist for publishers that announce nothing, where the shape of the topic is all there is to go on.
+  const srcSel = el('select', { style: { width: 'auto' } }) as HTMLSelectElement;
+  srcSel.appendChild(el('option', { value: 'discovery', text: 'Home Assistant discovery' }));
+  srcSel.appendChild(el('option', { value: 'esphome', text: 'ESPHome topics' }));
+  srcSel.appendChild(el('option', { value: 'zwavejs', text: 'Z-Wave JS topics' }));
   const tagIn = el('input', { type: 'text', value: 'imported', placeholder: 'tag (optional)' }) as HTMLInputElement;
   const scan = btn('Scan broker', 'primary');
   const addBtn = btn('Add selected');
-  bar.append(scan, el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn);
+  bar.append(srcSel, scan, el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn);
   const note = el('div', { class: 'desc' });
   const list = el('div');
   panel.append(bar, note, list);
@@ -2495,7 +2501,7 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
     if (!readings.length) { note.textContent = 'Nothing importable found. Only power and energy entities are offered.'; return; }
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
-    ['', 'Device', 'Reading', 'Metric', 'Topic'].forEach(h => head.appendChild(el('th', { text: h })));
+    ['', 'Device', 'Reading', 'Metric', 'Unit', 'Topic'].forEach(h => head.appendChild(el('th', { text: h })));
     tbl.appendChild(el('thead', {}, head));
     const body = el('tbody');
     readings.forEach(r => {
@@ -2508,9 +2514,24 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
       tr.appendChild(el('td', {}, cb));
       tr.appendChild(el('td', { text: r.device || '—' }));
       tr.appendChild(el('td', { text: r.label }));
-      tr.appendChild(el('td', { text: r.metric + (r.unit ? ` (${r.unit})` : '') }));
+      tr.appendChild(el('td', { text: r.metric }));
+
+      // A topic-matched reading has no stated unit — esphome/.../energy_d/state = 3063.783 could be Wh or
+      // kWh, and only the value tells you which. Editable, with the sample beside it.
+      const unitCell = el('td');
+      if (r.unit) {
+        unitCell.appendChild(el('span', { text: r.unit }));
+      } else {
+        const unitIn = el('input', { type: 'text', value: '', placeholder: r.metric === 'energy' ? 'kWh / Wh' : 'W / kW', style: { width: '84px' } }) as HTMLInputElement;
+        unitIn.onchange = () => { r.unit = unitIn.value.trim() || undefined; };
+        unitCell.appendChild(unitIn);
+      }
+      tr.appendChild(unitCell);
+
       const topic = el('td');
       topic.appendChild(el('code', { text: r.topic, style: { color: 'var(--muted)' } }));
+      if (r.sample != null && r.sample !== '')
+        topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: `last value: ${String(r.sample).slice(0, 60)}` }));
       if (r.unsupported) topic.appendChild(el('div', { class: 'nh-warn', text: `Cannot import: ${r.unsupported}.` }));
       else if (already) topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'Already a node.' }));
       tr.appendChild(topic);
@@ -2522,8 +2543,11 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
 
   let found: any[] = [];
   scan.onclick = async () => {
-    note.textContent = 'Scanning the broker’s retained discovery…';
-    const r = await api('/api/mqtt/importable');
+    const src = srcSel.value;
+    note.textContent = 'Scanning the broker…';
+    const r = await api(src === 'discovery'
+      ? '/api/mqtt/importable'
+      : '/api/mqtt/importable/pattern?profile=' + encodeURIComponent(src));
     if (!r.body || !r.body.ok) { note.textContent = (r.body && r.body.message) || 'Could not scan.'; return; }
     found = r.body.readings || [];
     note.textContent = `${found.length} reading(s) from ${r.body.scanned} retained topic(s).`;

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3902,10 +3902,16 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
   }));
 
   const bar = el('div', { class: 'ld-toolbar' });
+  // Where to look. Discovery states the unit and device class, so it is the default; the topic profiles
+  // exist for publishers that announce nothing, where the shape of the topic is all there is to go on.
+  const srcSel = el('select', { style: { width: 'auto' } })                     ;
+  srcSel.appendChild(el('option', { value: 'discovery', text: 'Home Assistant discovery' }));
+  srcSel.appendChild(el('option', { value: 'esphome', text: 'ESPHome topics' }));
+  srcSel.appendChild(el('option', { value: 'zwavejs', text: 'Z-Wave JS topics' }));
   const tagIn = el('input', { type: 'text', value: 'imported', placeholder: 'tag (optional)' })                    ;
   const scan = btn('Scan broker', 'primary');
   const addBtn = btn('Add selected');
-  bar.append(scan, el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn);
+  bar.append(srcSel, scan, el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn);
   const note = el('div', { class: 'desc' });
   const list = el('div');
   panel.append(bar, note, list);
@@ -3922,7 +3928,7 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
     if (!readings.length) { note.textContent = 'Nothing importable found. Only power and energy entities are offered.'; return; }
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
-    ['', 'Device', 'Reading', 'Metric', 'Topic'].forEach(h => head.appendChild(el('th', { text: h })));
+    ['', 'Device', 'Reading', 'Metric', 'Unit', 'Topic'].forEach(h => head.appendChild(el('th', { text: h })));
     tbl.appendChild(el('thead', {}, head));
     const body = el('tbody');
     readings.forEach(r => {
@@ -3935,9 +3941,24 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
       tr.appendChild(el('td', {}, cb));
       tr.appendChild(el('td', { text: r.device || '—' }));
       tr.appendChild(el('td', { text: r.label }));
-      tr.appendChild(el('td', { text: r.metric + (r.unit ? ` (${r.unit})` : '') }));
+      tr.appendChild(el('td', { text: r.metric }));
+
+      // A topic-matched reading has no stated unit — esphome/.../energy_d/state = 3063.783 could be Wh or
+      // kWh, and only the value tells you which. Editable, with the sample beside it.
+      const unitCell = el('td');
+      if (r.unit) {
+        unitCell.appendChild(el('span', { text: r.unit }));
+      } else {
+        const unitIn = el('input', { type: 'text', value: '', placeholder: r.metric === 'energy' ? 'kWh / Wh' : 'W / kW', style: { width: '84px' } })                    ;
+        unitIn.onchange = () => { r.unit = unitIn.value.trim() || undefined; };
+        unitCell.appendChild(unitIn);
+      }
+      tr.appendChild(unitCell);
+
       const topic = el('td');
       topic.appendChild(el('code', { text: r.topic, style: { color: 'var(--muted)' } }));
+      if (r.sample != null && r.sample !== '')
+        topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: `last value: ${String(r.sample).slice(0, 60)}` }));
       if (r.unsupported) topic.appendChild(el('div', { class: 'nh-warn', text: `Cannot import: ${r.unsupported}.` }));
       else if (already) topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'Already a node.' }));
       tr.appendChild(topic);
@@ -3949,8 +3970,11 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
 
   let found        = [];
   scan.onclick = async () => {
-    note.textContent = 'Scanning the broker’s retained discovery…';
-    const r = await api('/api/mqtt/importable');
+    const src = srcSel.value;
+    note.textContent = 'Scanning the broker…';
+    const r = await api(src === 'discovery'
+      ? '/api/mqtt/importable'
+      : '/api/mqtt/importable/pattern?profile=' + encodeURIComponent(src));
     if (!r.body || !r.body.ok) { note.textContent = (r.body && r.body.message) || 'Could not scan.'; return; }
     found = r.body.readings || [];
     note.textContent = `${found.length} reading(s) from ${r.body.scanned} retained topic(s).`;


### PR DESCRIPTION
Follow-on to #355, which imports from Home Assistant MQTT discovery.

## Why it was needed

I ran #355's rules against the broker. All 63 power and 53 energy discovery entities belonged to this bridge; the only other publisher was `acurite` (temperature). So the feature found nothing.

The ESPHome and Z-Wave devices publish raw topics with no discovery:

```
esphome/devices/bedroom_fan/sensor/power/state    = 101.8
esphome/devices/bedroom_fan/sensor/energy_d/state = 113.783
zwave/Hallway/Hallway_Light/50/0/value/66049      = {"time":…,"value":0.8}
zwave/Hallway/Hallway_Light/50/0/value/65537      = {"time":…,"value":11.975}
```

## Change

The Discover panel gains a source selector: Home Assistant discovery, ESPHome topics, Z-Wave JS topics.

| Profile | Pattern | Payload |
|---|---|---|
| ESPHome | `esphome/devices/{device}/sensor/{measure}/state` | bare value |
| Z-Wave JS | `zwave/+/{device}/50/+/value/{measure}` | JSON, `value` field |

Command class 50 is Meter; properties `66049` and `65537` are watts and kWh. The numbers are the published vocabulary, so the map keys on them.

Against the live broker the profiles match 10 ESPHome readings (5 devices × power + energy_d) and 8 Z-Wave readings (4 devices × W + kWh).

## The unit is asked for, not assumed

A raw topic states no unit. `energy_d` reads `3063.783` on a freezer drawing 132 W — that is Wh. Nothing in the topic says so.

A topic-matched row therefore shows the last payload and provides a unit field. Discovery-matched rows keep the unit the publisher stated.

## Matching

Segment counts must agree exactly. A prefix match would capture a sibling topic whose extra segments change what the value means — `zwave/…/50/0/value/66049` is watts, and anything below it is not.

## Coverage

8 unit tests on the matcher: both profiles against real topic shapes, non-metering command classes and non-roll-up measures excluded, wildcards, segment-count and literal mismatches, unknown measures matched with no metric.

The GUI check now drives both scan paths and asserts the topic-matched row shows its sample and asks for a unit. Assuming one fails it:

```
unit assumed instead of asked -> discover check FAILED: a topic-matched reading was offered without asking for its unit
```

Two DOM-stub fixes: a `<select>` now reports its first option's value as a browser does, and options adopted on `append` as well as `appendChild`.

655 tests pass; nine GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
