### PR TITLE
fix(nodes): switch between the import panels instead of closing

### DIFF
--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -109,6 +109,20 @@ if (src.Metric !== 'realpower' || src.Unit !== 'W') fail('the binding lost the m
 // And nothing else was added — in particular not the two refused rows.
 if (cfg.EnergyFlow.Nodes.length !== 2) fail(`expected 2 nodes, got ${cfg.EnergyFlow.Nodes.map(n => n.Id).join(', ')}`);
 
+// --- Switching panels, not just closing.
+// Both panels share one container; clicking the other button used to close whatever was open and require
+// a second click to get the panel you asked for.
+buttons().find(b => b.textContent === 'Import device template').click();
+await new Promise(r => setTimeout(r, 50));
+buttons().find(b => b.textContent === 'Discover from MQTT').click();
+await new Promise(r => setTimeout(r, 50));
+if (!buttons().some(b => b.textContent === 'Scan broker'))
+  fail('clicking Discover while the template panel was open closed it instead of switching');
+// And its own button still closes it.
+buttons().find(b => b.textContent === 'Discover from MQTT').click();
+await new Promise(r => setTimeout(r, 50));
+if (buttons().some(b => b.textContent === 'Scan broker')) fail('the panel did not close on its own button');
+
 // --- The topic-profile path.
 // Adding re-renders the Nodes tab, which closes the panel; reopen it.
 buttons().find(b => b.textContent === 'Discover from MQTT').click();

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2676,14 +2676,17 @@ export function addNodesSection(nav: any, sections: any) {
     // Import-device-template panel, toggled by the button (existing ids guard against prefix clashes).
     const existingIds = new Set<string>([...customNodes.map((n: any) => n.Id), ...((lastGraph?.nodes || []).map((n: any) => n.id))]);
     const impWrap = el('div'); ed.appendChild(impWrap);
-    importBtn.onclick = () => {
-      if (impWrap.firstChild) { impWrap.innerHTML = ''; return; }   // toggle closed
-      impWrap.appendChild(renderImportPanel(flow, existingIds, render));
+    // Both panels share one container. Clicking the button of the panel already open closes it; clicking
+    // the other switches to it, rather than closing and requiring a second click.
+    let openPanel: string | null = null;
+    const togglePanel = (which: string, build: () => HTMLElement) => {
+      impWrap.innerHTML = '';
+      if (openPanel === which) { openPanel = null; return; }
+      openPanel = which;
+      impWrap.appendChild(build());
     };
-    discoverBtn.onclick = () => {
-      if (impWrap.firstChild) { impWrap.innerHTML = ''; return; }
-      impWrap.appendChild(renderDiscoverPanel(flow, existingIds, render));
-    };
+    importBtn.onclick = () => togglePanel('template', () => renderImportPanel(flow, existingIds, render));
+    discoverBtn.onclick = () => togglePanel('discover', () => renderDiscoverPanel(flow, existingIds, render));
 
     const cand = flowCandidates(lastGraph, customNodes);
     ed.appendChild(renderGroupManager(flow, cand, render));

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -4103,14 +4103,17 @@ function addNodesSection(nav     , sections     ) {
     // Import-device-template panel, toggled by the button (existing ids guard against prefix clashes).
     const existingIds = new Set        ([...customNodes.map((n     ) => n.Id), ...((lastGraph?.nodes || []).map((n     ) => n.id))]);
     const impWrap = el('div'); ed.appendChild(impWrap);
-    importBtn.onclick = () => {
-      if (impWrap.firstChild) { impWrap.innerHTML = ''; return; }   // toggle closed
-      impWrap.appendChild(renderImportPanel(flow, existingIds, render));
+    // Both panels share one container. Clicking the button of the panel already open closes it; clicking
+    // the other switches to it, rather than closing and requiring a second click.
+    let openPanel                = null;
+    const togglePanel = (which        , build                   ) => {
+      impWrap.innerHTML = '';
+      if (openPanel === which) { openPanel = null; return; }
+      openPanel = which;
+      impWrap.appendChild(build());
     };
-    discoverBtn.onclick = () => {
-      if (impWrap.firstChild) { impWrap.innerHTML = ''; return; }
-      impWrap.appendChild(renderDiscoverPanel(flow, existingIds, render));
-    };
+    importBtn.onclick = () => togglePanel('template', () => renderImportPanel(flow, existingIds, render));
+    discoverBtn.onclick = () => togglePanel('discover', () => renderDiscoverPanel(flow, existingIds, render));
 
     const cand = flowCandidates(lastGraph, customNodes);
     ed.appendChild(renderGroupManager(flow, cand, render));


### PR DESCRIPTION
"Import device template" and "Discover from MQTT" share one container, and each button closed whatever was open before checking which panel had been asked for.

So clicking one while the other was open closed it. Reaching the second panel took two clicks, with nothing to indicate why the first appeared to do nothing.

Each button now closes only its own panel, and switches when the other is open.

The GUI check covers both directions — opening the template panel then clicking Discover leaves the discover panel open, and its own button still closes it. The previous behaviour fails it:

```
old toggle behaviour -> discover check FAILED: the panel did not close on its own button
```

655 tests pass; nine GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
