### PR TITLE
fix(mqtt): wait for the topic index to fill before scanning, and move the import to its own page

### DIFF
--- a/rPDU2MQTT.Core/Flow/TopicIndexScan.cs
+++ b/rPDU2MQTT.Core/Flow/TopicIndexScan.cs
@@ -1,0 +1,51 @@
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// Waits for the browsable topic index to fill before reading it.
+///
+/// <para>
+/// Asking the index for a filter does not subscribe: the process holding the broker connection polls for
+/// the wanted filter on a timer, subscribes, and the retained messages arrive after that. Reading the index
+/// straight after asking therefore returns nothing, every time — which is what a scan of a broker full of
+/// matching topics reported.
+/// </para>
+/// <para>
+/// So: ask, wait, read, and keep reading until the count stops rising. A fixed sleep would have to assume
+/// the worst case on every scan; stopping when the count settles finishes as soon as the broker has
+/// delivered what it has.
+/// </para>
+/// </summary>
+public static class TopicIndexScan
+{
+    /// <summary>
+    /// Poll <paramref name="search"/> until its count repeats or <paramref name="deadline"/> passes,
+    /// renewing the lease each time so it cannot lapse mid-scan.
+    /// </summary>
+    /// <param name="renew">Re-assert the wanted filter (and keep the lease alive).</param>
+    /// <param name="search">Read the index as it stands.</param>
+    /// <param name="delay">Gap between polls.</param>
+    /// <param name="deadline">Give up and return whatever has arrived.</param>
+    public static async Task<IReadOnlyList<T>> SettleAsync<T>(
+        Func<Task> renew, Func<Task<IReadOnlyList<T>>> search,
+        Func<TimeSpan, Task> delay, TimeSpan pollEvery, DateTime deadline, Func<DateTime> now,
+        CancellationToken ct = default)
+    {
+        await renew();
+
+        var previous = -1;
+        IReadOnlyList<T> latest = [];
+        while (now() < deadline && !ct.IsCancellationRequested)
+        {
+            await delay(pollEvery);
+            await renew();
+            latest = await search();
+
+            // Two consecutive equal, non-zero counts: the broker has finished delivering. Zero is not a
+            // settled answer — it is the state the index starts in, and stopping there would reproduce the
+            // bug this exists to fix.
+            if (latest.Count > 0 && latest.Count == previous) break;
+            previous = latest.Count;
+        }
+        return latest;
+    }
+}

--- a/rPDU2MQTT.Tests/TopicIndexScanTests.cs
+++ b/rPDU2MQTT.Tests/TopicIndexScanTests.cs
@@ -1,0 +1,106 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Reading the browsable topic index after asking for a filter.
+///
+/// <para>
+/// Asking does not subscribe: the process holding the broker connection polls for the wanted filter on a
+/// three-second timer, subscribes, and the retained messages arrive after that. A scan that read the index
+/// immediately reported nothing on a broker carrying dozens of matching topics.
+/// </para>
+/// </summary>
+public class TopicIndexScanTests
+{
+    /// <summary>A fake index that stays empty for the first few polls, then fills and stops changing.</summary>
+    private sealed class FakeIndex(int emptyPolls, int finalCount)
+    {
+        public int Renews;
+        public int Searches;
+        public TimeSpan Slept;
+
+        public Task Renew() { Renews++; return Task.CompletedTask; }
+        public Task Delay(TimeSpan d) { Slept += d; return Task.CompletedTask; }
+
+        public Task<IReadOnlyList<string>> Search()
+        {
+            Searches++;
+            var n = Searches <= emptyPolls ? 0 : Math.Min(finalCount, (Searches - emptyPolls) * finalCount);
+            return Task.FromResult<IReadOnlyList<string>>(Enumerable.Range(0, n).Select(i => $"t{i}").ToList());
+        }
+    }
+
+    private static Task<IReadOnlyList<string>> Run(FakeIndex f, int deadlineSeconds = 12)
+    {
+        var start = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var now = start;
+        return TopicIndexScan.SettleAsync<string>(
+            f.Renew,
+            f.Search,
+            d => { now = now.Add(d); return f.Delay(d); },
+            TimeSpan.FromMilliseconds(750),
+            start.AddSeconds(deadlineSeconds),
+            () => now);
+    }
+
+    [Fact]
+    public async Task ItWaitsThroughTheEmptyPollsRatherThanReturningNothing()
+    {
+        // Two polls before the subscription is live, which is the failure: an immediate read returns [].
+        var f = new FakeIndex(emptyPolls: 4, finalCount: 30);
+
+        var found = await Run(f);
+
+        Assert.Equal(30, found.Count);
+        Assert.True(f.Searches > 4, "it gave up before the index had filled");
+    }
+
+    [Fact]
+    public async Task ItStopsAsSoonAsTheCountRepeats()
+    {
+        // Finishing on settle rather than on a fixed sleep: as soon as the broker has delivered what it has.
+        var f = new FakeIndex(emptyPolls: 0, finalCount: 10);
+
+        await Run(f);
+
+        // Poll 1 returns 10, poll 2 returns 10 -> settled. Anything more is waiting for no reason.
+        Assert.Equal(2, f.Searches);
+        Assert.Equal(TimeSpan.FromMilliseconds(1500), f.Slept);
+    }
+
+    [Fact]
+    public async Task AnEmptyIndexIsNeverTreatedAsSettled()
+    {
+        // Zero twice is the state it starts in, not an answer. Accepting it reproduces the original bug.
+        var f = new FakeIndex(emptyPolls: int.MaxValue, finalCount: 0);
+
+        var found = await Run(f, deadlineSeconds: 3);
+
+        Assert.Empty(found);
+        Assert.True(f.Searches >= 4, $"it stopped after {f.Searches} polls on an empty index");
+    }
+
+    [Fact]
+    public async Task TheLeaseIsRenewedOnEveryPoll()
+    {
+        // The lease is short. Waiting a dozen seconds on one renewal would let it lapse mid-scan, and the
+        // subscriber would unsubscribe while we were still reading.
+        var f = new FakeIndex(emptyPolls: 3, finalCount: 5);
+
+        await Run(f);
+
+        Assert.Equal(f.Searches + 1, f.Renews);   // once up front, then once per poll
+    }
+
+    [Fact]
+    public async Task ItGivesUpAtTheDeadline()
+    {
+        var f = new FakeIndex(emptyPolls: int.MaxValue, finalCount: 0);
+
+        await Run(f, deadlineSeconds: 2);
+
+        Assert.InRange(f.Slept.TotalSeconds, 1.5, 3.0);
+    }
+}

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1223,10 +1223,27 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         //
         // Two endpoints on purpose. Deleting devices from someone's Home Assistant is not something to do on
         // a timer or at startup — GET says exactly what would go, POST does it, and the operator decides.
+        // Renew() only *asks* for a subscription: the process holding the broker connection polls for the
+        // wanted filter every few seconds, subscribes, and the retained messages arrive after that. Reading
+        // the index immediately therefore always returns nothing. Wait for it to fill and settle instead —
+        // two consecutive equal counts, or the deadline.
+        async Task<IReadOnlyList<Grains.Abstractions.Discovery.TopicSample>> ScanAsync(string filter, CancellationToken ct)
+        {
+            var index = grains.GetGrain<Grains.Abstractions.Discovery.ITopicIndexGrain>(0);
+            return await Core.Flow.TopicIndexScan.SettleAsync<Grains.Abstractions.Discovery.TopicSample>(
+                renew: () => index.Renew(filter),
+                search: async () => await index.Search(null, 5000),
+                delay: d => Task.Delay(d, ct),
+                pollEvery: TimeSpan.FromMilliseconds(750),
+                deadline: DateTime.UtcNow.AddSeconds(12),
+                now: () => DateTime.UtcNow,
+                ct: ct);
+        }
+
         // Power/energy readings other integrations already announce over Home Assistant MQTT discovery
         // (ESPHome, Z-Wave JS, Tasmota, Shelly, zigbee2mqtt all publish it). Offered for import as
         // energy-flow nodes; nothing is created until the operator picks from the list.
-        app.MapGet("/api/mqtt/importable", async () =>
+        app.MapGet("/api/mqtt/importable", async (HttpContext ctx) =>
         {
             try
             {
@@ -1234,10 +1251,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 if (string.IsNullOrWhiteSpace(prefix))
                     return Results.Json(new { ok = false, message = "No Home Assistant discovery prefix is configured, so there is nothing to scan." }, ConfigSchema.Json);
 
-                var index = grains.GetGrain<Grains.Abstractions.Discovery.ITopicIndexGrain>(0);
-                var filter = prefix.Trim().Trim('/') + "/#";
-                await index.Renew(filter);
-                var retained = await index.Search(null, 5000);
+                var retained = await ScanAsync(prefix.Trim().Trim('/') + "/#", ctx.RequestAborted);
 
                 var rootId = string.IsNullOrWhiteSpace(config.Overrides?.rPDU2MQTT?.ID) ? "rPDU2MQTT" : config.Overrides!.rPDU2MQTT!.ID!;
                 string[] ours = [Core.Flow.FlowExport.DeviceIdPrefix, rootId + "_"];
@@ -1278,9 +1292,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 if (profile is null)
                     return Results.Json(new { ok = false, message = "Unknown topic profile." }, ConfigSchema.Json);
 
-                var index = grains.GetGrain<Grains.Abstractions.Discovery.ITopicIndexGrain>(0);
-                await index.Renew(profile.Filter);
-                var samples = await index.Search(null, 5000);
+                var samples = await ScanAsync(profile.Filter, ctx.RequestAborted);
 
                 var matches = Core.Flow.MqttTopicProfile.Scan(
                     profile, samples.Select(t => (t.Topic, t.Payload)));

--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -55,16 +55,14 @@ vm.createContext(sandbox);
 vm.runInContext(code, sandbox, { filename: 'app.js' });
 await new Promise(r => setTimeout(r, 50));
 
-const nav = query(getEl('nav'), 'a', true).find(a => a.dataset.label === 'Nodes');
-if (!nav) fail('no Nodes tab');
+// Its own page under Integrations, not the node editor's toolbar: it reads the broker rather than the PDU.
+const nav = query(getEl('nav'), 'a', true).find(a => a.dataset.label === 'MQTT Import');
+if (!nav) fail('no MQTT Import page in the nav');
 nav.click();
 await new Promise(r => setTimeout(r, 200));
 
 const buttons = () => query(getEl('sections'), 'button', true);
-const discover = buttons().find(b => b.textContent === 'Discover from MQTT');
-if (!discover) fail('no "Discover from MQTT" button on the Nodes tab');
-discover.click();
-await new Promise(r => setTimeout(r, 50));
+if (!buttons().some(b => b.textContent === 'Scan broker')) fail('the MQTT Import page rendered no scan control');
 
 buttons().find(b => b.textContent === 'Scan broker').click();
 await new Promise(r => setTimeout(r, 200));
@@ -109,25 +107,7 @@ if (src.Metric !== 'realpower' || src.Unit !== 'W') fail('the binding lost the m
 // And nothing else was added — in particular not the two refused rows.
 if (cfg.EnergyFlow.Nodes.length !== 2) fail(`expected 2 nodes, got ${cfg.EnergyFlow.Nodes.map(n => n.Id).join(', ')}`);
 
-// --- Switching panels, not just closing.
-// Both panels share one container; clicking the other button used to close whatever was open and require
-// a second click to get the panel you asked for.
-buttons().find(b => b.textContent === 'Import device template').click();
-await new Promise(r => setTimeout(r, 50));
-buttons().find(b => b.textContent === 'Discover from MQTT').click();
-await new Promise(r => setTimeout(r, 50));
-if (!buttons().some(b => b.textContent === 'Scan broker'))
-  fail('clicking Discover while the template panel was open closed it instead of switching');
-// And its own button still closes it.
-buttons().find(b => b.textContent === 'Discover from MQTT').click();
-await new Promise(r => setTimeout(r, 50));
-if (buttons().some(b => b.textContent === 'Scan broker')) fail('the panel did not close on its own button');
-
 // --- The topic-profile path.
-// Adding re-renders the Nodes tab, which closes the panel; reopen it.
-buttons().find(b => b.textContent === 'Discover from MQTT').click();
-await new Promise(r => setTimeout(r, 50));
-
 const sel = query(getEl('sections'), 'select', true)
   .find(s => (s.children || []).some(o => (o.value || (o.attrs && o.attrs.value)) === 'esphome'));
 if (!sel) fail('no source selector offering the topic profiles');

--- a/rPDU2MQTT.Web/web/src/config-form.ts
+++ b/rPDU2MQTT.Web/web/src/config-form.ts
@@ -10,7 +10,7 @@ import { addPathsSection } from './sections/paths.js';
 import { addDiagnosticsSection } from './sections/diagnostics.js';
 import { addControlSection } from './sections/control.js';
 import { addLiveDataSection } from './sections/livedata.js';
-import { addFlowSection, addNodesSection, addEnergyOverviewSection } from './sections/flow.js';
+import { addFlowSection, addNodesSection, addEnergyOverviewSection, addMqttImportSection } from './sections/flow.js';
 import { addNodeDataSection } from './sections/nodedata.js';
 import { addExportSection } from './sections/export.js';
 import { addHaEnergySection } from './sections/ha-energy.js';
@@ -209,7 +209,7 @@ const NAV_GROUPS: { title: string; items: NavItem[] }[] = [
   // Sources: the Vertiv rPDU integration is the parent; its PDU-only tabs hang off it as children.
   { title: 'Sources', items: [{ schema: 'Pdus' }, { schema: 'Overrides', child: true }, { tool: addLiveDataSection, child: true }, { tool: addControlSection, child: true }, { tool: addPathsSection, child: true }] },
   { title: 'Energy Flow', items: [{ tool: addEnergyOverviewSection }, { tool: addNodesSection }, { tool: addFlowSection }, { tool: addNodeDataSection }] },
-  { title: 'Integrations', items: [{ schema: 'MQTT' }, { schema: 'Modbus' }] },
+  { title: 'Integrations', items: [{ schema: 'MQTT' }, { tool: addMqttImportSection, child: true }, { schema: 'Modbus' }] },
   { title: 'Destinations', items: [{ schema: 'EmonCMS' }, { schema: 'HomeAssistant' }, { tool: addHaEnergySection, child: true }, { schema: 'Prometheus' }] },
   { title: 'System', items: [{ tool: addFeaturesSection }, { schema: 'Gui' }, { schema: 'Api' }, { schema: 'Health' }, { schema: 'Logging' }, { schema: 'Debug' }, { tool: addExportSection }, { tool: addDiagnosticsSection }] },
 ];

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2586,6 +2586,41 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
   return panel;
 }
 
+/// Its own page under Integrations -> MQTT (#342 follow-on). It reads the broker rather than the PDU and
+/// is used once when wiring something up, so it does not belong on the node editor's toolbar.
+export function addMqttImportSection(nav: any, sections: any) {
+  const link = navLink(nav, 'MQTT Import', '⇤');
+  // Adding nodes edits the shared EnergyFlow document, so this page carries its unsaved-edit count.
+  link.dataset.section = 'EnergyFlow';
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  sec.appendChild(el('h2', { text: 'MQTT Import' }));
+  sec.appendChild(el('div', {
+    class: 'desc',
+    text: 'Add energy-flow nodes from readings other integrations already publish to this broker — by their '
+        + 'Home Assistant discovery where they announce it, or by topic shape where they do not.',
+  }));
+
+  const host = el('div');
+  sec.appendChild(host);
+
+  const render = () => {
+    const flow = ensure(state.data, 'EnergyFlow', {});
+    migrateEnergyFlow(flow);
+    const nodes = ensure(flow, 'Nodes', []);
+    const existingIds = new Set<string>(nodes.map((n: any) => n.Id));
+    host.innerHTML = '';
+    host.appendChild(renderDiscoverPanel(flow, existingIds, render));
+    const bar = el('div', { class: 'ld-toolbar' });
+    const save = btn('Save', 'primary');
+    save.onclick = () => saveConfig(() => render());
+    bar.appendChild(save);
+    host.appendChild(bar);
+  };
+
+  link.onclick = () => { render(); activate(link, sec); };
+  return { link, sec };
+}
+
 function renderImportPanel(flow: any, existingIds: Set<string>, rerender: () => void): HTMLElement {
   const panel = el('div', { class: 'tpl-import' });
   panel.appendChild(el('div', { class: 'desc', text: 'Import a known device to pre-fill its nodes and register bindings. Review and Save afterwards; addresses are community starting points — verify against your firmware.' }));
@@ -2659,7 +2694,6 @@ export function addNodesSection(nav: any, sections: any) {
     NODE_KINDS.forEach(([v, label]) => kindSel.appendChild(el('option', { value: v, text: label })));
     const addBtn = btn('Add node', 'primary');
     const importBtn = btn('Import device template');
-    const discoverBtn = btn('Discover from MQTT');
     const save = btn('Save', 'primary');
     addBtn.onclick = () => {
       const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
@@ -2671,22 +2705,15 @@ export function addNodesSection(nav: any, sections: any) {
       customNodes.push(node); editing.id = id; render();  // open the new node's editor straight away
     };
     save.onclick = () => saveConfig(load);
-    addBar.append(idIn, labIn, kindSel, addBtn, importBtn, discoverBtn, save); ed.appendChild(addBar);
+    addBar.append(idIn, labIn, kindSel, addBtn, importBtn, save); ed.appendChild(addBar);
 
     // Import-device-template panel, toggled by the button (existing ids guard against prefix clashes).
     const existingIds = new Set<string>([...customNodes.map((n: any) => n.Id), ...((lastGraph?.nodes || []).map((n: any) => n.id))]);
     const impWrap = el('div'); ed.appendChild(impWrap);
-    // Both panels share one container. Clicking the button of the panel already open closes it; clicking
-    // the other switches to it, rather than closing and requiring a second click.
-    let openPanel: string | null = null;
-    const togglePanel = (which: string, build: () => HTMLElement) => {
-      impWrap.innerHTML = '';
-      if (openPanel === which) { openPanel = null; return; }
-      openPanel = which;
-      impWrap.appendChild(build());
+    importBtn.onclick = () => {
+      if (impWrap.firstChild) { impWrap.innerHTML = ''; return; }   // toggle closed
+      impWrap.appendChild(renderImportPanel(flow, existingIds, render));
     };
-    importBtn.onclick = () => togglePanel('template', () => renderImportPanel(flow, existingIds, render));
-    discoverBtn.onclick = () => togglePanel('discover', () => renderDiscoverPanel(flow, existingIds, render));
 
     const cand = flowCandidates(lastGraph, customNodes);
     ed.appendChild(renderGroupManager(flow, cand, render));

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -4013,6 +4013,41 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
   return panel;
 }
 
+/// Its own page under Integrations -> MQTT (#342 follow-on). It reads the broker rather than the PDU and
+/// is used once when wiring something up, so it does not belong on the node editor's toolbar.
+function addMqttImportSection(nav     , sections     ) {
+  const link = navLink(nav, 'MQTT Import', '⇤');
+  // Adding nodes edits the shared EnergyFlow document, so this page carries its unsaved-edit count.
+  link.dataset.section = 'EnergyFlow';
+  const sec = document.createElement('div'); sec.className = 'section'; sections.appendChild(sec);
+  sec.appendChild(el('h2', { text: 'MQTT Import' }));
+  sec.appendChild(el('div', {
+    class: 'desc',
+    text: 'Add energy-flow nodes from readings other integrations already publish to this broker — by their '
+        + 'Home Assistant discovery where they announce it, or by topic shape where they do not.',
+  }));
+
+  const host = el('div');
+  sec.appendChild(host);
+
+  const render = () => {
+    const flow = ensure(state.data, 'EnergyFlow', {});
+    migrateEnergyFlow(flow);
+    const nodes = ensure(flow, 'Nodes', []);
+    const existingIds = new Set        (nodes.map((n     ) => n.Id));
+    host.innerHTML = '';
+    host.appendChild(renderDiscoverPanel(flow, existingIds, render));
+    const bar = el('div', { class: 'ld-toolbar' });
+    const save = btn('Save', 'primary');
+    save.onclick = () => saveConfig(() => render());
+    bar.appendChild(save);
+    host.appendChild(bar);
+  };
+
+  link.onclick = () => { render(); activate(link, sec); };
+  return { link, sec };
+}
+
 function renderImportPanel(flow     , existingIds             , rerender            )              {
   const panel = el('div', { class: 'tpl-import' });
   panel.appendChild(el('div', { class: 'desc', text: 'Import a known device to pre-fill its nodes and register bindings. Review and Save afterwards; addresses are community starting points — verify against your firmware.' }));
@@ -4086,7 +4121,6 @@ function addNodesSection(nav     , sections     ) {
     NODE_KINDS.forEach(([v, label]) => kindSel.appendChild(el('option', { value: v, text: label })));
     const addBtn = btn('Add node', 'primary');
     const importBtn = btn('Import device template');
-    const discoverBtn = btn('Discover from MQTT');
     const save = btn('Save', 'primary');
     addBtn.onclick = () => {
       const id = (idIn.value || '').trim(); if (!id) { toast('Node id is required.', false); return; }
@@ -4098,22 +4132,15 @@ function addNodesSection(nav     , sections     ) {
       customNodes.push(node); editing.id = id; render();  // open the new node's editor straight away
     };
     save.onclick = () => saveConfig(load);
-    addBar.append(idIn, labIn, kindSel, addBtn, importBtn, discoverBtn, save); ed.appendChild(addBar);
+    addBar.append(idIn, labIn, kindSel, addBtn, importBtn, save); ed.appendChild(addBar);
 
     // Import-device-template panel, toggled by the button (existing ids guard against prefix clashes).
     const existingIds = new Set        ([...customNodes.map((n     ) => n.Id), ...((lastGraph?.nodes || []).map((n     ) => n.id))]);
     const impWrap = el('div'); ed.appendChild(impWrap);
-    // Both panels share one container. Clicking the button of the panel already open closes it; clicking
-    // the other switches to it, rather than closing and requiring a second click.
-    let openPanel                = null;
-    const togglePanel = (which        , build                   ) => {
-      impWrap.innerHTML = '';
-      if (openPanel === which) { openPanel = null; return; }
-      openPanel = which;
-      impWrap.appendChild(build());
+    importBtn.onclick = () => {
+      if (impWrap.firstChild) { impWrap.innerHTML = ''; return; }   // toggle closed
+      impWrap.appendChild(renderImportPanel(flow, existingIds, render));
     };
-    importBtn.onclick = () => togglePanel('template', () => renderImportPanel(flow, existingIds, render));
-    discoverBtn.onclick = () => togglePanel('discover', () => renderDiscoverPanel(flow, existingIds, render));
 
     const cand = flowCandidates(lastGraph, customNodes);
     ed.appendChild(renderGroupManager(flow, cand, render));
@@ -5310,7 +5337,7 @@ const NAV_GROUPS                                        = [
   // Sources: the Vertiv rPDU integration is the parent; its PDU-only tabs hang off it as children.
   { title: 'Sources', items: [{ schema: 'Pdus' }, { schema: 'Overrides', child: true }, { tool: addLiveDataSection, child: true }, { tool: addControlSection, child: true }, { tool: addPathsSection, child: true }] },
   { title: 'Energy Flow', items: [{ tool: addEnergyOverviewSection }, { tool: addNodesSection }, { tool: addFlowSection }, { tool: addNodeDataSection }] },
-  { title: 'Integrations', items: [{ schema: 'MQTT' }, { schema: 'Modbus' }] },
+  { title: 'Integrations', items: [{ schema: 'MQTT' }, { tool: addMqttImportSection, child: true }, { schema: 'Modbus' }] },
   { title: 'Destinations', items: [{ schema: 'EmonCMS' }, { schema: 'HomeAssistant' }, { tool: addHaEnergySection, child: true }, { schema: 'Prometheus' }] },
   { title: 'System', items: [{ tool: addFeaturesSection }, { schema: 'Gui' }, { schema: 'Api' }, { schema: 'Health' }, { schema: 'Logging' }, { schema: 'Debug' }, { tool: addExportSection }, { tool: addDiagnosticsSection }] },
 ];


### PR DESCRIPTION
Two problems with #355/#356, both reported from use.

## The scan found nothing

"Nothing importable found" on a broker carrying exactly the topics being looked for:

```
esphome/devices/deep_freezer/sensor/power/state    = 131.6
esphome/devices/deep_freezer/sensor/energy_d/state = 3110.986
```

`ITopicIndexGrain.Renew` does not subscribe. It records the wanted filter; the process holding the broker connection polls for it **every three seconds**, subscribes, and the retained messages arrive after that.

Both importable endpoints called `Renew` and then `Search` on the next line, so they read the index before anything could be in it — every time, regardless of what was on the broker.

They now poll until the count repeats or a 12-second deadline passes, renewing the lease each time so it cannot lapse mid-scan. **A zero count is never accepted as settled** — zero is the state the index starts in, and accepting it reproduces the original bug.

## It was on the wrong page

Moved off the Nodes toolbar to its own page: **Integrations → MQTT Import**. It reads the broker rather than the PDU, and is used when wiring something up rather than while editing nodes.

The Nodes tab keeps "Import device template", which is about device register maps.

## Coverage

The settle loop is `Core.Flow.TopicIndexScan` rather than inline in the endpoint, with five tests: waits through the empty polls, stops as soon as the count repeats, never treats an empty index as settled, renews on every poll, gives up at the deadline.

Accepting a settled zero fails two of them:

```
empty treated as settled -> Failed!  - Failed: 2, Passed: 3
restored                 -> Passed!  - Failed: 0, Passed: 662
```

The GUI check drives the new page rather than the Nodes toolbar.

662 tests pass; nine GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
