### PR TITLE
feat(mqtt): offer every metric on import, pick the unit from a list, and allow custom topic profiles

### DIFF
--- a/Examples/Kubernetes/crd/crd.yaml
+++ b/Examples/Kubernetes/crd/crd.yaml
@@ -56,6 +56,31 @@ spec:
                   ClientID:
                     type: string
                     description: The client-id used when connecting to MQTT.
+                  ImportProfiles:
+                    type: array
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        Name:
+                          type: string
+                          description: Name shown in the MQTT Import source list.
+                        Filter:
+                          type: string
+                          description: "Subscription filter to browse, e.g. 'tele/#'. Narrow it: a broker's ACL may refuse '#'."
+                        Pattern:
+                          type: string
+                          description: Topic shape, with {device} and {measure} marking the parts to capture and '+' matching any single segment. e.g. 'tele/{device}/SENSOR/{measure}'.
+                        JsonField:
+                          type: string
+                          description: Field holding the value when the payload is JSON — dotted for nesting. Leave blank when the payload is the bare number.
+                        Metrics:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
+                          description: Captured {measure} -> metric name (realpower, apparentpower, energy, current, voltage, frequency, powerfactor). Measures not listed are ignored.
+                    description: Custom topic shapes for the MQTT Import page, for publishers with no built-in profile.
                   ParentTopic:
                     type: string
                     description: The parent topic for MQTT messages.

--- a/charts/rpdu2mqtt/crds/rpduconfig.yaml
+++ b/charts/rpdu2mqtt/crds/rpduconfig.yaml
@@ -56,6 +56,31 @@ spec:
                   ClientID:
                     type: string
                     description: The client-id used when connecting to MQTT.
+                  ImportProfiles:
+                    type: array
+                    items:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                      properties:
+                        Name:
+                          type: string
+                          description: Name shown in the MQTT Import source list.
+                        Filter:
+                          type: string
+                          description: "Subscription filter to browse, e.g. 'tele/#'. Narrow it: a broker's ACL may refuse '#'."
+                        Pattern:
+                          type: string
+                          description: Topic shape, with {device} and {measure} marking the parts to capture and '+' matching any single segment. e.g. 'tele/{device}/SENSOR/{measure}'.
+                        JsonField:
+                          type: string
+                          description: Field holding the value when the payload is JSON — dotted for nesting. Leave blank when the payload is the bare number.
+                        Metrics:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
+                          description: Captured {measure} -> metric name (realpower, apparentpower, energy, current, voltage, frequency, powerfactor). Measures not listed are ignored.
+                    description: Custom topic shapes for the MQTT Import page, for publishers with no built-in profile.
                   ParentTopic:
                     type: string
                     description: The parent topic for MQTT messages.

--- a/rPDU2MQTT.Core/Flow/MqttDiscoveryImport.cs
+++ b/rPDU2MQTT.Core/Flow/MqttDiscoveryImport.cs
@@ -29,11 +29,16 @@ public readonly record struct DiscoveredReading(
 /// </summary>
 public static class MqttDiscoveryImport
 {
-    /// <summary>Device-class values we can bind, mapped to our metric names.</summary>
+    /// <summary>Home Assistant device classes mapped to the metric vocabulary in <see cref="Abstractions.Flow.Metric"/>.</summary>
     private static readonly Dictionary<string, string> Metrics = new(StringComparer.OrdinalIgnoreCase)
     {
         ["power"] = "realpower",
         ["energy"] = "energy",
+        ["current"] = "current",
+        ["voltage"] = "voltage",
+        ["frequency"] = "frequency",
+        ["apparent_power"] = "apparentpower",
+        ["power_factor"] = "powerfactor",
     };
 
     /// <summary>

--- a/rPDU2MQTT.Core/Flow/MqttTopicProfile.cs
+++ b/rPDU2MQTT.Core/Flow/MqttTopicProfile.cs
@@ -36,12 +36,15 @@ public static class MqttTopicProfile
     private static readonly Dictionary<string, string> EsphomeMetrics = new(StringComparer.OrdinalIgnoreCase)
     {
         ["power"] = "realpower",
+        ["apparent_power"] = "apparentpower",
         ["energy"] = "energy",
         ["energy_d"] = "energy",
         ["daily_energy"] = "energy",
         ["total_energy"] = "energy",
         ["current"] = "current",
         ["voltage"] = "voltage",
+        ["frequency"] = "frequency",
+        ["power_factor"] = "powerfactor",
     };
 
     // Z-Wave meter readings are numbered, not named: command class 50 (Meter), property 66049 = watts and
@@ -62,6 +65,31 @@ public static class MqttTopicProfile
 
     public static Profile? ById(string? id) =>
         BuiltIn.FirstOrDefault(p => string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// A built-in profile, or one defined in <c>MQTT.ImportProfiles</c>. Configured profiles are addressed
+    /// as <c>custom:&lt;name&gt;</c>, keeping them in a separate id space from the built-ins.
+    /// </summary>
+    public static Profile? Resolve(string? id, IEnumerable<Models.Config.MqttImportProfile>? configured)
+    {
+        if (ById(id) is { } builtIn) return builtIn;
+
+        const string prefix = "custom:";
+        if (id is null || !id.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return null;
+
+        var name = id[prefix.Length..];
+        var p = configured?.FirstOrDefault(c => string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase));
+        if (p is null || string.IsNullOrWhiteSpace(p.Pattern)) return null;
+
+        // A blank filter falls back to the pattern's root rather than '#', which some broker ACLs refuse.
+        var filter = string.IsNullOrWhiteSpace(p.Filter)
+            ? p.Pattern.Split('/')[0] + "/#"
+            : p.Filter.Trim();
+
+        return new Profile(id, string.IsNullOrWhiteSpace(p.Name) ? "Custom" : p.Name, filter, p.Pattern.Trim(),
+                           string.IsNullOrWhiteSpace(p.JsonField) ? null : p.JsonField.Trim(),
+                           new Dictionary<string, string>(p.Metrics ?? new(), StringComparer.OrdinalIgnoreCase));
+    }
 
     /// <summary>
     /// Match one topic against a pattern. Segment counts must agree exactly — a pattern is a shape, and a
@@ -95,18 +123,15 @@ public static class MqttTopicProfile
     /// <summary>
     /// Every reading a profile finds in <paramref name="topics"/>, ordered by device then measure.
     /// </summary>
-    /// <param name="rollupOnly">
-    /// Keep only measures that map to a metric. Voltage and current are matched but are not part of the
-    /// energy roll-up, so the picker offers power and energy by default.
-    /// </param>
+    /// <param name="mappedOnly">Keep only measures the profile maps to a metric (drops uptime, wifi signal, and the like).</param>
     public static IReadOnlyList<PatternMatch> Scan(
-        Profile profile, IEnumerable<(string Topic, string? Payload)> topics, bool rollupOnly = true)
+        Profile profile, IEnumerable<(string Topic, string? Payload)> topics, bool mappedOnly = true)
     {
         var found = new List<PatternMatch>();
         foreach (var (topic, payload) in topics)
         {
             if (Match(profile.Pattern, topic, profile.JsonField, profile.Metrics, payload) is not { } m) continue;
-            if (rollupOnly && m.Metric is not ("realpower" or "energy")) continue;
+            if (mappedOnly && m.Metric is null) continue;
             found.Add(m);
         }
         return found

--- a/rPDU2MQTT.Core/Models/Config/MQTTConfig.cs
+++ b/rPDU2MQTT.Core/Models/Config/MQTTConfig.cs
@@ -22,6 +22,12 @@ public class MQTTConfig
     /// <summary>
     /// Gets or sets the parent topic for MQTT messages.
     /// </summary>
+    /// <summary>
+    /// Topic shapes for the MQTT Import page, in addition to the built-in ESPHome and Z-Wave JS profiles.
+    /// </summary>
+    [Description("Custom topic shapes for the MQTT Import page, for publishers with no built-in profile.")]
+    public List<MqttImportProfile> ImportProfiles { get; set; } = new();
+
     [Required(ErrorMessage = "ParentTopic is required.")]
     [Display(Description = "The parent topic for MQTT messages.")]
     [DefaultValue("rPDU2MQTT")]

--- a/rPDU2MQTT.Core/Models/Config/MqttImportProfile.cs
+++ b/rPDU2MQTT.Core/Models/Config/MqttImportProfile.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel;
+
+namespace rPDU2MQTT.Models.Config;
+
+/// <summary>
+/// A user-defined topic shape for the MQTT Import page.
+///
+/// <para>
+/// A topic carries neither unit nor quantity. <see cref="Metrics"/> declares the quantity per captured
+/// measure; the unit is selected at import time, with the sampled payload shown alongside.
+/// </para>
+/// </summary>
+public class MqttImportProfile
+{
+    [Description("Name shown in the MQTT Import source list.")]
+    public string Name { get; set; } = "";
+
+    [Description("Subscription filter to browse, e.g. 'tele/#'. Narrow it: a broker's ACL may refuse '#'.")]
+    public string Filter { get; set; } = "";
+
+    [Description("Topic shape, with {device} and {measure} marking the parts to capture and '+' matching any single segment. e.g. 'tele/{device}/SENSOR/{measure}'.")]
+    public string Pattern { get; set; } = "";
+
+    [Description("Field holding the value when the payload is JSON — dotted for nesting. Leave blank when the payload is the bare number.")]
+    public string? JsonField { get; set; }
+
+    [Description("Captured {measure} -> metric name (realpower, apparentpower, energy, current, voltage, frequency, powerfactor). Measures not listed are ignored.")]
+    public Dictionary<string, string> Metrics { get; set; } = new();
+}

--- a/rPDU2MQTT.Tests/MqttImportProfileTests.cs
+++ b/rPDU2MQTT.Tests/MqttImportProfileTests.cs
@@ -1,0 +1,83 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Models.Config;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// Topic shapes the operator defines, for publishers with no built-in profile.
+/// </summary>
+public class MqttImportProfileTests
+{
+    private static List<MqttImportProfile> Configured(params MqttImportProfile[] p) => [.. p];
+
+    private static MqttImportProfile Tasmota() => new()
+    {
+        Name = "Tasmota",
+        Filter = "tele/#",
+        Pattern = "tele/{device}/SENSOR/{measure}",
+        JsonField = "ENERGY.Power",
+        Metrics = new() { ["Power"] = "realpower", ["Total"] = "energy" },
+    };
+
+    [Fact]
+    public void AConfiguredProfileResolvesAndScans()
+    {
+        var p = MqttTopicProfile.Resolve("custom:Tasmota", Configured(Tasmota()));
+
+        Assert.NotNull(p);
+        Assert.Equal("Tasmota", p!.Label);
+        Assert.Equal("ENERGY.Power", p.JsonField);
+
+        var found = MqttTopicProfile.Scan(p, [("tele/kitchen/SENSOR/Power", "{}"), ("tele/kitchen/STATE", "{}")]);
+        var one = Assert.Single(found);
+        Assert.Equal("kitchen", one.Device);
+        Assert.Equal("realpower", one.Metric);
+    }
+
+    [Fact]
+    public void ResolutionIsCaseInsensitiveOnTheName()
+        => Assert.NotNull(MqttTopicProfile.Resolve("custom:tasmota", Configured(Tasmota())));
+
+    [Fact]
+    public void ABuiltInIdStillWins()
+    {
+        // Built-ins and configured profiles occupy separate id spaces.
+        Assert.Equal("ESPHome", MqttTopicProfile.Resolve("esphome", Configured(Tasmota()))!.Label);
+    }
+
+    [Fact]
+    public void AProfileWithNoPatternDoesNotResolve()
+    {
+        // A half-entered profile matches nothing.
+        var blank = new MqttImportProfile { Name = "Half", Filter = "x/#", Pattern = "  " };
+        Assert.Null(MqttTopicProfile.Resolve("custom:Half", Configured(blank)));
+    }
+
+    [Fact]
+    public void AMissingFilterFallsBackToThePatternsRoot()
+    {
+        // Not "#", which some broker ACLs refuse.
+        var p = new MqttImportProfile { Name = "NoFilter", Pattern = "tele/{device}/SENSOR/{measure}" };
+
+        Assert.Equal("tele/#", MqttTopicProfile.Resolve("custom:NoFilter", Configured(p))!.Filter);
+    }
+
+    [Fact]
+    public void AnUnknownOrAbsentProfileResolvesToNothing()
+    {
+        Assert.Null(MqttTopicProfile.Resolve("custom:Nope", Configured(Tasmota())));
+        Assert.Null(MqttTopicProfile.Resolve("custom:Tasmota", null));
+        Assert.Null(MqttTopicProfile.Resolve(null, Configured(Tasmota())));
+    }
+
+    [Fact]
+    public void MeasureMatchingIgnoresCase()
+    {
+        // The map is written in config; the measure comes off the wire.
+        var p = MqttTopicProfile.Resolve("custom:Tasmota", Configured(Tasmota()))!;
+        var m = MqttTopicProfile.Match(p.Pattern, "tele/kitchen/SENSOR/power", p.JsonField, p.Metrics);
+
+        Assert.Equal("realpower", m!.Value.Metric);
+    }
+}

--- a/rPDU2MQTT.Tests/MqttTopicProfileTests.cs
+++ b/rPDU2MQTT.Tests/MqttTopicProfileTests.cs
@@ -89,18 +89,22 @@ public class MqttTopicProfileTests
     }
 
     [Fact]
-    public void ScanKeepsOnlyRollupMetricsByDefault()
+    public void EveryMappedMetricIsOffered_NotJustPowerAndEnergy()
     {
-        // Voltage and current are matched by the profile but are not part of the energy roll-up.
+        // A node binds any of the seven metrics, not only the two that feed the roll-up.
         (string, string?)[] topics =
         [
             ("esphome/devices/fan/sensor/voltage/state", "122.7"),
             ("esphome/devices/fan/sensor/current/state", "0.8"),
             ("esphome/devices/fan/sensor/power/state", "101.8"),
+            ("esphome/devices/fan/sensor/wifi_signal/state", "-70"),   // no metric for this
         ];
 
-        Assert.Equal("realpower", Assert.Single(MqttTopicProfile.Scan(Esphome, topics)).Metric);
-        Assert.Equal(3, MqttTopicProfile.Scan(Esphome, topics, rollupOnly: false).Count);
+        var found = MqttTopicProfile.Scan(Esphome, topics);
+
+        Assert.Equal(["current", "realpower", "voltage"], found.Select(f => f.Metric).Order());
+        // Unmapped measures are dropped by default.
+        Assert.Equal(4, MqttTopicProfile.Scan(Esphome, topics, mappedOnly: false).Count);
     }
 
     [Fact]

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1274,6 +1274,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                         id = Core.Flow.MqttDiscoveryImport.NodeId(r.UniqueId),
                         uniqueId = r.UniqueId, label = r.Label, device = r.Device,
                         topic = r.StateTopic, metric = r.Metric, unit = r.Unit,
+                        units = Core.Flow.FlowUnits.UnitsFor(r.Metric),
                         jsonField = r.JsonField, unsupported = r.Unsupported,
                     }),
                 }, ConfigSchema.Json);
@@ -1288,7 +1289,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         {
             try
             {
-                var profile = Core.Flow.MqttTopicProfile.ById(ctx.Request.Query["profile"].ToString());
+                var profile = Core.Flow.MqttTopicProfile.Resolve(ctx.Request.Query["profile"].ToString(), config.MQTT.ImportProfiles);
                 if (profile is null)
                     return Results.Json(new { ok = false, message = "Unknown topic profile." }, ConfigSchema.Json);
 
@@ -1308,6 +1309,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                         label = $"{m.Device} {m.Measure}",
                         device = m.Device,
                         topic = m.Topic, metric = m.Metric, unit = (string?)null,
+                        units = Core.Flow.FlowUnits.UnitsFor(m.Metric ?? ""),
                         jsonField = m.JsonField, sample = m.Sample, unsupported = (string?)null,
                     }),
                 }, ConfigSchema.Json);
@@ -1318,7 +1320,11 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
         app.MapGet("/api/mqtt/profiles", () => Results.Json(new
         {
             ok = true,
-            profiles = Core.Flow.MqttTopicProfile.BuiltIn.Select(p => new { id = p.Id, label = p.Label, pattern = p.Pattern }),
+            profiles = Core.Flow.MqttTopicProfile.BuiltIn
+                .Select(p => new { id = p.Id, label = p.Label, pattern = p.Pattern })
+                .Concat((config.MQTT.ImportProfiles ?? new())
+                    .Where(p => !string.IsNullOrWhiteSpace(p.Name) && !string.IsNullOrWhiteSpace(p.Pattern))
+                    .Select(p => new { id = "custom:" + p.Name, label = p.Name, pattern = p.Pattern })),
         }, ConfigSchema.Json));
 
         app.MapGet("/api/ha/orphans", async () =>

--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -33,7 +33,7 @@ const pattern = {
   readings: [
     { id: 'esphome_deep_freezer_energy_d', label: 'deep_freezer energy_d', device: 'deep_freezer',
       topic: 'esphome/devices/deep_freezer/sensor/energy_d/state', metric: 'energy', unit: null,
-      jsonField: null, sample: '3063.783', unsupported: null },
+      units: ['kWh', 'Wh', 'MWh'], jsonField: null, sample: '3063.783', unsupported: null },
   ],
 };
 
@@ -44,6 +44,10 @@ const { sandbox, getEl } = makeDom({
     url.includes('/api/schema') ? schema :
     url.includes('/api/instances') ? { ok: true, instances: [] } :
     url.includes('/api/config') ? cfg :
+    url.includes('/api/mqtt/profiles') ? { ok: true, profiles: [
+      { id: 'esphome', label: 'ESPHome', pattern: 'esphome/devices/{device}/sensor/{measure}/state' },
+      { id: 'custom:Tasmota', label: 'Tasmota', pattern: 'tele/{device}/SENSOR/{measure}' },
+    ] } :
     url.includes('/api/mqtt/importable/pattern') ? pattern :
     url.includes('/api/mqtt/importable') ? importable :
     url.includes('/api/flow/live') ? { ok: true, values: [] } :
@@ -111,6 +115,9 @@ if (cfg.EnergyFlow.Nodes.length !== 2) fail(`expected 2 nodes, got ${cfg.EnergyF
 const sel = query(getEl('sections'), 'select', true)
   .find(s => (s.children || []).some(o => (o.value || (o.attrs && o.attrs.value)) === 'esphome'));
 if (!sel) fail('no source selector offering the topic profiles');
+// Profiles come from the server, so one defined in config appears without a rebuild.
+const opts = (sel.children || []).map(o => o.value || (o.attrs && o.attrs.value));
+if (!opts.includes('custom:Tasmota')) fail(`a configured profile is missing from the source list: ${opts.join(', ')}`);
 sel.value = 'esphome';
 buttons().find(b => b.textContent === 'Scan broker').click();
 await new Promise(r => setTimeout(r, 200));
@@ -119,9 +126,15 @@ const patRow = query(getEl('sections'), 'tr', true).find(r => r.textContent.incl
 if (!patRow) fail('the topic-profile scan rendered no row');
 // The sampled value is shown, because it is the only thing that distinguishes Wh from kWh.
 if (!patRow.textContent.includes('3063.783')) fail('the row does not show the sampled value');
-// And the unit is an input, not an assumption.
-const unitBox = query(patRow, 'input', true).find(i => i.attrs?.type === 'text' || i.type === 'text');
+// The unit is asked for, as a dropdown of what the converter accepts — not free text, where a typo binds
+// a source whose readings are then silently never converted.
+const unitBox = query(patRow, 'select', true)[0];
 if (!unitBox) fail('a topic-matched reading was offered without asking for its unit');
+const unitOpts = (unitBox.children || []).map(o => o.value || (o.attrs && o.attrs.value));
+if (!unitOpts.includes('Wh') || !unitOpts.includes('kWh'))
+  fail(`the unit list does not come from the metric's converter table: ${unitOpts.join(', ')}`);
+// Nothing preselected: the sampled value is the only evidence of which unit applies.
+if (unitBox.value) fail(`a unit was preselected (${unitBox.value}) rather than asked for`);
 
 unitBox.value = 'Wh';
 unitBox.onchange({});

--- a/rPDU2MQTT.Web/web/schema.fixture.json
+++ b/rPDU2MQTT.Web/web/schema.fixture.json
@@ -43,6 +43,63 @@
         "required": false
       },
       {
+        "key": "ImportProfiles",
+        "label": "ImportProfiles",
+        "description": "Custom topic shapes for the MQTT Import page, for publishers with no built-in profile.",
+        "type": "list",
+        "required": false,
+        "valueSchema": {
+          "key": "",
+          "label": "",
+          "type": "object",
+          "required": false,
+          "properties": [
+            {
+              "key": "Name",
+              "label": "Name",
+              "description": "Name shown in the MQTT Import source list.",
+              "type": "string",
+              "required": false
+            },
+            {
+              "key": "Filter",
+              "label": "Filter",
+              "description": "Subscription filter to browse, e.g. 'tele/#'. Narrow it: a broker's ACL may refuse '#'.",
+              "type": "string",
+              "required": false
+            },
+            {
+              "key": "Pattern",
+              "label": "Pattern",
+              "description": "Topic shape, with {device} and {measure} marking the parts to capture and '+' matching any single segment. e.g. 'tele/{device}/SENSOR/{measure}'.",
+              "type": "string",
+              "required": false
+            },
+            {
+              "key": "JsonField",
+              "label": "JsonField",
+              "description": "Field holding the value when the payload is JSON \u2014 dotted for nesting. Leave blank when the payload is the bare number.",
+              "type": "string",
+              "required": false
+            },
+            {
+              "key": "Metrics",
+              "label": "Metrics",
+              "description": "Captured {measure} -> metric name (realpower, apparentpower, energy, current, voltage, frequency, powerfactor). Measures not listed are ignored.",
+              "type": "dictionary",
+              "required": false,
+              "valueSchema": {
+                "key": "",
+                "label": "",
+                "type": "string",
+                "required": false
+              },
+              "keyType": "string"
+            }
+          ]
+        }
+      },
+      {
         "key": "ParentTopic",
         "label": "ParentTopic",
         "description": "The parent topic for MQTT messages.",

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2470,8 +2470,9 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
   const panel = el('div', { class: 'tpl-import' });
   panel.appendChild(el('div', {
     class: 'desc',
-    text: 'Power and energy readings other integrations publish to this broker. Pick the ones to add as '
-        + 'nodes; nothing is created until you do, and nothing is saved until you press Save.',
+    text: 'Readings other integrations publish to this broker — power, energy, current, voltage, frequency. '
+        + 'Pick the ones to add as nodes; nothing is created until you do, and nothing is saved until you '
+        + 'press Save. Add topic shapes for other publishers under MQTT → ImportProfiles.',
   }));
 
   const bar = el('div', { class: 'ld-toolbar' });
@@ -2479,8 +2480,11 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
   // exist for publishers that announce nothing, where the shape of the topic is all there is to go on.
   const srcSel = el('select', { style: { width: 'auto' } }) as HTMLSelectElement;
   srcSel.appendChild(el('option', { value: 'discovery', text: 'Home Assistant discovery' }));
-  srcSel.appendChild(el('option', { value: 'esphome', text: 'ESPHome topics' }));
-  srcSel.appendChild(el('option', { value: 'zwavejs', text: 'Z-Wave JS topics' }));
+  // The rest come from the server: built-in profiles plus MQTT.ImportProfiles.
+  api('/api/mqtt/profiles').then((r: any) => {
+    ((r.body && r.body.profiles) || []).forEach((p: any) =>
+      srcSel.appendChild(el('option', { value: p.id, text: p.label + ' topics' })));
+  });
   const tagIn = el('input', { type: 'text', value: 'imported', placeholder: 'tag (optional)' }) as HTMLInputElement;
   const scan = btn('Scan broker', 'primary');
   const addBtn = btn('Add selected');
@@ -2498,7 +2502,14 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
 
   const render = (readings: any[]) => {
     list.innerHTML = '';
-    if (!readings.length) { note.textContent = 'Nothing importable found. Only power and energy entities are offered.'; return; }
+    if (!readings.length) {
+      note.textContent = srcSel.value === 'discovery'
+        ? 'No importable entities in the broker’s Home Assistant discovery. Publishers that announce nothing '
+          + 'will not appear here — try a topic profile instead.'
+        : 'No topics matched this profile’s shape. Check the pattern against what the publisher actually '
+          + 'sends, or add one under MQTT → ImportProfiles.';
+      return;
+    }
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
     ['', 'Device', 'Reading', 'Metric', 'Unit', 'Topic'].forEach(h => head.appendChild(el('th', { text: h })));
@@ -2516,15 +2527,21 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
       tr.appendChild(el('td', { text: r.label }));
       tr.appendChild(el('td', { text: r.metric }));
 
-      // A topic-matched reading has no stated unit — esphome/.../energy_d/state = 3063.783 could be Wh or
-      // kWh, and only the value tells you which. Editable, with the sample beside it.
+      // A topic-matched reading carries no unit. The choices are the units FlowUnits accepts for this
+      // metric; an unlisted string would not convert.
       const unitCell = el('td');
       if (r.unit) {
         unitCell.appendChild(el('span', { text: r.unit }));
       } else {
-        const unitIn = el('input', { type: 'text', value: '', placeholder: r.metric === 'energy' ? 'kWh / Wh' : 'W / kW', style: { width: '84px' } }) as HTMLInputElement;
-        unitIn.onchange = () => { r.unit = unitIn.value.trim() || undefined; };
-        unitCell.appendChild(unitIn);
+        const choices: string[] = r.units || [];
+        const unitSel = el('select', { style: { width: 'auto' } }) as HTMLSelectElement;
+        // Blank and selected by default; the sampled payload is shown in the topic cell.
+        unitSel.appendChild(el('option', { value: '', text: '— pick —' }));
+        choices.forEach(u => unitSel.appendChild(el('option', { value: u, text: u })));
+        unitSel.value = '';
+        unitSel.onchange = () => { r.unit = unitSel.value || undefined; };
+        unitCell.appendChild(unitSel);
+        if (!choices.length) unitCell.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'no units for this metric' }));
       }
       tr.appendChild(unitCell);
 

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3897,8 +3897,9 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
   const panel = el('div', { class: 'tpl-import' });
   panel.appendChild(el('div', {
     class: 'desc',
-    text: 'Power and energy readings other integrations publish to this broker. Pick the ones to add as '
-        + 'nodes; nothing is created until you do, and nothing is saved until you press Save.',
+    text: 'Readings other integrations publish to this broker — power, energy, current, voltage, frequency. '
+        + 'Pick the ones to add as nodes; nothing is created until you do, and nothing is saved until you '
+        + 'press Save. Add topic shapes for other publishers under MQTT → ImportProfiles.',
   }));
 
   const bar = el('div', { class: 'ld-toolbar' });
@@ -3906,8 +3907,11 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
   // exist for publishers that announce nothing, where the shape of the topic is all there is to go on.
   const srcSel = el('select', { style: { width: 'auto' } })                     ;
   srcSel.appendChild(el('option', { value: 'discovery', text: 'Home Assistant discovery' }));
-  srcSel.appendChild(el('option', { value: 'esphome', text: 'ESPHome topics' }));
-  srcSel.appendChild(el('option', { value: 'zwavejs', text: 'Z-Wave JS topics' }));
+  // The rest come from the server: built-in profiles plus MQTT.ImportProfiles.
+  api('/api/mqtt/profiles').then((r     ) => {
+    ((r.body && r.body.profiles) || []).forEach((p     ) =>
+      srcSel.appendChild(el('option', { value: p.id, text: p.label + ' topics' })));
+  });
   const tagIn = el('input', { type: 'text', value: 'imported', placeholder: 'tag (optional)' })                    ;
   const scan = btn('Scan broker', 'primary');
   const addBtn = btn('Add selected');
@@ -3925,7 +3929,14 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
 
   const render = (readings       ) => {
     list.innerHTML = '';
-    if (!readings.length) { note.textContent = 'Nothing importable found. Only power and energy entities are offered.'; return; }
+    if (!readings.length) {
+      note.textContent = srcSel.value === 'discovery'
+        ? 'No importable entities in the broker’s Home Assistant discovery. Publishers that announce nothing '
+          + 'will not appear here — try a topic profile instead.'
+        : 'No topics matched this profile’s shape. Check the pattern against what the publisher actually '
+          + 'sends, or add one under MQTT → ImportProfiles.';
+      return;
+    }
     const tbl = el('table', { class: 'ld' });
     const head = el('tr');
     ['', 'Device', 'Reading', 'Metric', 'Unit', 'Topic'].forEach(h => head.appendChild(el('th', { text: h })));
@@ -3943,15 +3954,21 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
       tr.appendChild(el('td', { text: r.label }));
       tr.appendChild(el('td', { text: r.metric }));
 
-      // A topic-matched reading has no stated unit — esphome/.../energy_d/state = 3063.783 could be Wh or
-      // kWh, and only the value tells you which. Editable, with the sample beside it.
+      // A topic-matched reading carries no unit. The choices are the units FlowUnits accepts for this
+      // metric; an unlisted string would not convert.
       const unitCell = el('td');
       if (r.unit) {
         unitCell.appendChild(el('span', { text: r.unit }));
       } else {
-        const unitIn = el('input', { type: 'text', value: '', placeholder: r.metric === 'energy' ? 'kWh / Wh' : 'W / kW', style: { width: '84px' } })                    ;
-        unitIn.onchange = () => { r.unit = unitIn.value.trim() || undefined; };
-        unitCell.appendChild(unitIn);
+        const choices           = r.units || [];
+        const unitSel = el('select', { style: { width: 'auto' } })                     ;
+        // Blank and selected by default; the sampled payload is shown in the topic cell.
+        unitSel.appendChild(el('option', { value: '', text: '— pick —' }));
+        choices.forEach(u => unitSel.appendChild(el('option', { value: u, text: u })));
+        unitSel.value = '';
+        unitSel.onchange = () => { r.unit = unitSel.value || undefined; };
+        unitCell.appendChild(unitSel);
+        if (!choices.length) unitCell.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'no units for this metric' }));
       }
       tr.appendChild(unitCell);
 


### PR DESCRIPTION
Three changes to the MQTT import.

## Metrics

Previously only `power` and `energy` were kept. The metric vocabulary has seven entries and a node binds any of them.

- Home Assistant discovery maps all seven device classes
- the built-in topic profiles map the corresponding measure names
- the scan keeps every measure a profile maps

Measures a profile does not map are dropped.

## Units

The unit is selected from the units `FlowUnits` accepts for that metric, replacing a free-text field. No value is preselected. The sampled payload is shown in the topic cell.

## Custom topic profiles

`MQTT.ImportProfiles` holds named profiles:

```yaml
MQTT:
  ImportProfiles:
    - Name: Tasmota
      Filter: tele/#
      Pattern: tele/{device}/SENSOR/{measure}
      JsonField: ENERGY.Power
      Metrics: { Power: realpower, Total: energy }
```

They appear in the source list with the built-ins, addressed as `custom:<name>`.

- a profile with no pattern does not resolve
- a profile with no filter uses the pattern's root; `#` is not used, as some broker ACLs refuse it

## Tests

Seven tests on custom profile resolution: name case, built-in precedence, missing pattern, filter fallback, unknown and absent profiles, measure case.

The GUI check asserts the unit list matches the converter's table, that no unit is preselected, and that a configured profile appears in the source list.

669 tests pass; nine GUI checks green. CRD manifests and the schema fixture regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
