### PR TITLE
feat(mqtt): default the import unit to the metric's canonical unit, and add bulk controls

### DIFF
--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1275,6 +1275,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                         uniqueId = r.UniqueId, label = r.Label, device = r.Device,
                         topic = r.StateTopic, metric = r.Metric, unit = r.Unit,
                         units = Core.Flow.FlowUnits.UnitsFor(r.Metric),
+                        canonicalUnit = Core.Flow.FlowUnits.Canonical(r.Metric),
                         jsonField = r.JsonField, unsupported = r.Unsupported,
                     }),
                 }, ConfigSchema.Json);
@@ -1310,6 +1311,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                         device = m.Device,
                         topic = m.Topic, metric = m.Metric, unit = (string?)null,
                         units = Core.Flow.FlowUnits.UnitsFor(m.Metric ?? ""),
+                        canonicalUnit = Core.Flow.FlowUnits.Canonical(m.Metric ?? ""),
                         jsonField = m.JsonField, sample = m.Sample, unsupported = (string?)null,
                     }),
                 }, ConfigSchema.Json);

--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -33,7 +33,13 @@ const pattern = {
   readings: [
     { id: 'esphome_deep_freezer_energy_d', label: 'deep_freezer energy_d', device: 'deep_freezer',
       topic: 'esphome/devices/deep_freezer/sensor/energy_d/state', metric: 'energy', unit: null,
-      units: ['kWh', 'Wh', 'MWh'], jsonField: null, sample: '3063.783', unsupported: null },
+      units: ['kWh', 'Wh', 'MWh'], canonicalUnit: 'kWh', jsonField: null, sample: '3063.783', unsupported: null },
+    { id: 'esphome_fridge_energy_d', label: 'fridge energy_d', device: 'fridge',
+      topic: 'esphome/devices/fridge/sensor/energy_d/state', metric: 'energy', unit: null,
+      units: ['kWh', 'Wh', 'MWh'], canonicalUnit: 'kWh', jsonField: null, sample: '1365.109', unsupported: null },
+    { id: 'esphome_fridge_power', label: 'fridge power', device: 'fridge',
+      topic: 'esphome/devices/fridge/sensor/power/state', metric: 'realpower', unit: null,
+      units: ['W', 'kW', 'MW'], canonicalUnit: 'W', jsonField: null, sample: '97.6', unsupported: null },
   ],
 };
 
@@ -126,21 +132,40 @@ const patRow = query(getEl('sections'), 'tr', true).find(r => r.textContent.incl
 if (!patRow) fail('the topic-profile scan rendered no row');
 // The sampled value is shown, because it is the only thing that distinguishes Wh from kWh.
 if (!patRow.textContent.includes('3063.783')) fail('the row does not show the sampled value');
-// The unit is asked for, as a dropdown of what the converter accepts — not free text, where a typo binds
-// a source whose readings are then silently never converted.
+// The unit is a dropdown of what the converter accepts, defaulted to the metric's canonical unit.
 const unitBox = query(patRow, 'select', true)[0];
-if (!unitBox) fail('a topic-matched reading was offered without asking for its unit');
+if (!unitBox) fail('a topic-matched reading has no unit control');
 const unitOpts = (unitBox.children || []).map(o => o.value || (o.attrs && o.attrs.value));
 if (!unitOpts.includes('Wh') || !unitOpts.includes('kWh'))
   fail(`the unit list does not come from the metric's converter table: ${unitOpts.join(', ')}`);
-// Nothing preselected: the sampled value is the only evidence of which unit applies.
-if (unitBox.value) fail(`a unit was preselected (${unitBox.value}) rather than asked for`);
+if (unitBox.value !== 'kWh') fail(`expected the canonical unit as the default, got '${unitBox.value}'`);
 
-unitBox.value = 'Wh';
-unitBox.onchange({});
-const patBox = query(patRow, 'input', true)[0];
-patBox.checked = true;
-patBox.onchange({});
+// Select all: one click rather than one per row.
+buttons().find(b => b.textContent === 'Select all').click();
+await new Promise(r => setTimeout(r, 20));
+const allRows = query(getEl('sections'), 'tr', true).filter(r => query(r, 'input', true).length);
+const checkable = allRows.map(r => query(r, 'input', true)[0]).filter(b => !b.disabled);
+if (!checkable.every(b => b.checked)) fail('Select all left rows unchecked');
+
+// Per-metric unit setter: changing it moves every row of that metric, and leaves the others alone.
+const bulkSels = query(getEl('sections'), 'select', true)
+  .filter(sel => (sel.children || []).some(o => (o.value || (o.attrs && o.attrs.value)) === 'Wh'));
+const bulkEnergy = bulkSels[0];
+if (!bulkEnergy) fail('no per-metric unit setter for energy');
+bulkEnergy.value = 'Wh';
+bulkEnergy.onchange({});
+await new Promise(r => setTimeout(r, 20));
+
+const energyRows = allRows.filter(r => r.textContent.includes('energy_d'));
+for (const row of energyRows) {
+  const sel = query(row, 'select', true)[0];
+  if (sel.value !== 'Wh') fail(`the bulk setter missed an energy row: ${sel.value}`);
+}
+const powerRow = allRows.find(r => r.textContent.includes('fridge power'));
+if (query(powerRow, 'select', true)[0].value !== 'W') fail('the energy bulk setter changed a power row');
+
+// Import straight from the bulk setting, without touching the row's own control: the bulk change has to
+// reach the reading, not just the dropdown that displays it.
 buttons().find(b => b.textContent === 'Add selected').click();
 await new Promise(r => setTimeout(r, 100));
 

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2500,8 +2500,13 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
 
   const picked = new Set<string>();
 
+  // Rows and their unit selectors, so the bulk controls can drive them without a re-render.
+  let boxes: { reading: any, box: HTMLInputElement }[] = [];
+  let unitSels: { reading: any, sel: HTMLSelectElement }[] = [];
+
   const render = (readings: any[]) => {
     list.innerHTML = '';
+    boxes = []; unitSels = [];
     if (!readings.length) {
       note.textContent = srcSel.value === 'discovery'
         ? 'No importable entities in the broker’s Home Assistant discovery. Publishers that announce nothing '
@@ -2522,6 +2527,7 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
       // Two reasons a row cannot be taken: already modelled, or not bindable from its template.
       cb.disabled = !!r.unsupported || already;
       cb.onchange = () => { cb.checked ? picked.add(r.id) : picked.delete(r.id); };
+      if (!cb.disabled) boxes.push({ reading: r, box: cb });
       tr.appendChild(el('td', {}, cb));
       tr.appendChild(el('td', { text: r.device || '—' }));
       tr.appendChild(el('td', { text: r.label }));
@@ -2535,12 +2541,15 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
       } else {
         const choices: string[] = r.units || [];
         const unitSel = el('select', { style: { width: 'auto' } }) as HTMLSelectElement;
-        // Blank and selected by default; the sampled payload is shown in the topic cell.
         unitSel.appendChild(el('option', { value: '', text: '— pick —' }));
         choices.forEach(u => unitSel.appendChild(el('option', { value: u, text: u })));
-        unitSel.value = '';
+        // Pre-filled with the metric's canonical unit. It is a form default the operator reviews against
+        // the sampled payload in the topic cell, and the bulk setters above change a whole metric at once.
+        r.unit = r.unit || r.canonicalUnit || '';
+        unitSel.value = r.unit || '';
         unitSel.onchange = () => { r.unit = unitSel.value || undefined; };
         unitCell.appendChild(unitSel);
+        unitSels.push({ reading: r, sel: unitSel });
         if (!choices.length) unitCell.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'no units for this metric' }));
       }
       tr.appendChild(unitCell);
@@ -2555,7 +2564,44 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
       body.appendChild(tr);
     });
     tbl.appendChild(body);
+    list.appendChild(bulkBar(readings));
     list.appendChild(tbl);
+  };
+
+  /// Select-all, and one unit setter per metric present, so twenty rows are not twenty clicks.
+  const bulkBar = (readings: any[]) => {
+    const row = el('div', { class: 'ld-toolbar', style: { flexWrap: 'wrap', gap: '8px', margin: '0 0 6px' } });
+
+    const all = btn('Select all');
+    all.onclick = () => {
+      const turnOn = boxes.some(b => !b.box.checked);
+      boxes.forEach(b => {
+        b.box.checked = turnOn;
+        turnOn ? picked.add(b.reading.id) : picked.delete(b.reading.id);
+      });
+      all.textContent = turnOn ? 'Select none' : 'Select all';
+    };
+    row.appendChild(all);
+
+    // One setter per metric in the results: the answer is usually the same for every row of a metric
+    // (every ESPHome power sensor is W), and differs between metrics.
+    const metrics = [...new Set(readings.filter(r => !r.unit || r.units?.length).map(r => r.metric))].sort();
+    metrics.forEach(metric => {
+      const choices: string[] = (readings.find(r => r.metric === metric) || {}).units || [];
+      if (choices.length < 2) return;   // nothing to choose between
+      const sel = el('select', { style: { width: 'auto' } }) as HTMLSelectElement;
+      choices.forEach(u => sel.appendChild(el('option', { value: u, text: u })));
+      sel.value = (readings.find(r => r.metric === metric) || {}).canonicalUnit || choices[0];
+      sel.onchange = () => {
+        unitSels.filter(u => u.reading.metric === metric).forEach(u => {
+          u.sel.value = sel.value;
+          u.reading.unit = sel.value;
+        });
+      };
+      row.append(el('span', { class: 'desc', style: { margin: '0' }, text: `all ${metric}:` }), sel);
+    });
+
+    return row;
   };
 
   let found: any[] = [];

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3927,8 +3927,13 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
 
   const picked = new Set        ();
 
+  // Rows and their unit selectors, so the bulk controls can drive them without a re-render.
+  let boxes                                            = [];
+  let unitSels                                             = [];
+
   const render = (readings       ) => {
     list.innerHTML = '';
+    boxes = []; unitSels = [];
     if (!readings.length) {
       note.textContent = srcSel.value === 'discovery'
         ? 'No importable entities in the broker’s Home Assistant discovery. Publishers that announce nothing '
@@ -3949,6 +3954,7 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
       // Two reasons a row cannot be taken: already modelled, or not bindable from its template.
       cb.disabled = !!r.unsupported || already;
       cb.onchange = () => { cb.checked ? picked.add(r.id) : picked.delete(r.id); };
+      if (!cb.disabled) boxes.push({ reading: r, box: cb });
       tr.appendChild(el('td', {}, cb));
       tr.appendChild(el('td', { text: r.device || '—' }));
       tr.appendChild(el('td', { text: r.label }));
@@ -3962,12 +3968,15 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
       } else {
         const choices           = r.units || [];
         const unitSel = el('select', { style: { width: 'auto' } })                     ;
-        // Blank and selected by default; the sampled payload is shown in the topic cell.
         unitSel.appendChild(el('option', { value: '', text: '— pick —' }));
         choices.forEach(u => unitSel.appendChild(el('option', { value: u, text: u })));
-        unitSel.value = '';
+        // Pre-filled with the metric's canonical unit. It is a form default the operator reviews against
+        // the sampled payload in the topic cell, and the bulk setters above change a whole metric at once.
+        r.unit = r.unit || r.canonicalUnit || '';
+        unitSel.value = r.unit || '';
         unitSel.onchange = () => { r.unit = unitSel.value || undefined; };
         unitCell.appendChild(unitSel);
+        unitSels.push({ reading: r, sel: unitSel });
         if (!choices.length) unitCell.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'no units for this metric' }));
       }
       tr.appendChild(unitCell);
@@ -3982,7 +3991,44 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
       body.appendChild(tr);
     });
     tbl.appendChild(body);
+    list.appendChild(bulkBar(readings));
     list.appendChild(tbl);
+  };
+
+  /// Select-all, and one unit setter per metric present, so twenty rows are not twenty clicks.
+  const bulkBar = (readings       ) => {
+    const row = el('div', { class: 'ld-toolbar', style: { flexWrap: 'wrap', gap: '8px', margin: '0 0 6px' } });
+
+    const all = btn('Select all');
+    all.onclick = () => {
+      const turnOn = boxes.some(b => !b.box.checked);
+      boxes.forEach(b => {
+        b.box.checked = turnOn;
+        turnOn ? picked.add(b.reading.id) : picked.delete(b.reading.id);
+      });
+      all.textContent = turnOn ? 'Select none' : 'Select all';
+    };
+    row.appendChild(all);
+
+    // One setter per metric in the results: the answer is usually the same for every row of a metric
+    // (every ESPHome power sensor is W), and differs between metrics.
+    const metrics = [...new Set(readings.filter(r => !r.unit || r.units?.length).map(r => r.metric))].sort();
+    metrics.forEach(metric => {
+      const choices           = (readings.find(r => r.metric === metric) || {}).units || [];
+      if (choices.length < 2) return;   // nothing to choose between
+      const sel = el('select', { style: { width: 'auto' } })                     ;
+      choices.forEach(u => sel.appendChild(el('option', { value: u, text: u })));
+      sel.value = (readings.find(r => r.metric === metric) || {}).canonicalUnit || choices[0];
+      sel.onchange = () => {
+        unitSels.filter(u => u.reading.metric === metric).forEach(u => {
+          u.sel.value = sel.value;
+          u.reading.unit = sel.value;
+        });
+      };
+      row.append(el('span', { class: 'desc', style: { margin: '0' }, text: `all ${metric}:` }), sel);
+    });
+
+    return row;
   };
 
   let found        = [];


### PR DESCRIPTION
Every row's unit had to be picked individually — twenty readings, twenty selections.

## Defaults

Each row defaults to the metric's canonical unit: `W` for realpower, `kWh` for energy, `A` for current, `V` for voltage. The dropdown still offers every unit the converter accepts, and the sampled payload stays in the topic cell.

## Bulk controls

Above the table:

- **Select all / Select none**
- one unit setter per metric present, which sets every row of that metric and leaves other metrics unchanged

Metrics with a single accepted unit get no setter.

## Tests

The GUI check asserts the canonical default, that Select all checks every selectable row, that a per-metric setter moves only its own metric's rows, and that importing straight after a bulk change carries that unit onto the binding.

Each fails when its behaviour is removed:

```
canonical-default removed                  -> expected the canonical unit as the default, got ''
select-all removed                         -> Select all left rows unchecked
bulk setter does not record the unit       -> the unit the operator entered was not carried onto the binding
```

The third of those initially passed: the check compared dropdown values, which a bulk setter that updated the display without recording the unit would still satisfy. It now imports straight from the bulk setting instead.

669 tests pass; nine GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
