### PR TITLE
feat(mqtt): wire imported nodes to a feeder, and copy built-in profiles into config

### DIFF
--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1319,6 +1319,18 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             catch (Exception ex) { return Results.Json(new { ok = false, message = ex.Message }, ConfigSchema.Json); }
         });
 
+        // One profile's full definition, for copying a built-in into MQTT.ImportProfiles to edit.
+        app.MapGet("/api/mqtt/profile", (HttpContext ctx) =>
+        {
+            var p = Core.Flow.MqttTopicProfile.Resolve(ctx.Request.Query["id"].ToString(), config.MQTT.ImportProfiles);
+            if (p is null) return Results.Json(new { ok = false, message = "Unknown topic profile." }, ConfigSchema.Json);
+            return Results.Json(new
+            {
+                ok = true,
+                profile = new { id = p.Id, label = p.Label, filter = p.Filter, pattern = p.Pattern, jsonField = p.JsonField, metrics = p.Metrics },
+            }, ConfigSchema.Json);
+        });
+
         app.MapGet("/api/mqtt/profiles", () => Results.Json(new
         {
             ok = true,

--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -43,13 +43,23 @@ const pattern = {
   ],
 };
 
-const cfg = { EnergyFlow: { Nodes: [{ Id: 'solar', Label: 'Solar' }], Links: [] } };
+const cfg = { EnergyFlow: { Nodes: [{ Id: 'solar', Label: 'Solar' }, { Id: 'main_panel', Label: 'Main Panel' }], Links: [] } };
+
+const builtIn = {
+  ok: true,
+  profile: {
+    id: 'esphome', label: 'ESPHome', filter: 'esphome/#',
+    pattern: 'esphome/devices/{device}/sensor/{measure}/state', jsonField: null,
+    metrics: { power: 'realpower', energy_d: 'energy' },
+  },
+};
 
 const { sandbox, getEl } = makeDom({
   bodies: (url) =>
     url.includes('/api/schema') ? schema :
     url.includes('/api/instances') ? { ok: true, instances: [] } :
     url.includes('/api/config') ? cfg :
+    url.includes('/api/mqtt/profile?') ? builtIn :
     url.includes('/api/mqtt/profiles') ? { ok: true, profiles: [
       { id: 'esphome', label: 'ESPHome', pattern: 'esphome/devices/{device}/sensor/{measure}/state' },
       { id: 'custom:Tasmota', label: 'Tasmota', pattern: 'tele/{device}/SENSOR/{measure}' },
@@ -115,7 +125,7 @@ if (src.Topic !== 'esphome/garage/sensor/power/state') fail('the binding does no
 if (src.Metric !== 'realpower' || src.Unit !== 'W') fail('the binding lost the metric or unit');
 
 // And nothing else was added — in particular not the two refused rows.
-if (cfg.EnergyFlow.Nodes.length !== 2) fail(`expected 2 nodes, got ${cfg.EnergyFlow.Nodes.map(n => n.Id).join(', ')}`);
+if (cfg.EnergyFlow.Nodes.length !== 3) fail(`expected the two seeded nodes plus one import, got ${cfg.EnergyFlow.Nodes.map(n => n.Id).join(', ')}`);
 
 // --- The topic-profile path.
 const sel = query(getEl('sections'), 'select', true)
@@ -139,6 +149,13 @@ const unitOpts = (unitBox.children || []).map(o => o.value || (o.attrs && o.attr
 if (!unitOpts.includes('Wh') || !unitOpts.includes('kWh'))
   fail(`the unit list does not come from the metric's converter table: ${unitOpts.join(', ')}`);
 if (unitBox.value !== 'kWh') fail(`expected the canonical unit as the default, got '${unitBox.value}'`);
+
+// Wire the imports into an existing node, so they join the hierarchy rather than sitting apart from it.
+const feeds = query(getEl('sections'), 'select', true)
+  .find(sl => (sl.children || []).some(o => (o.value || (o.attrs && o.attrs.value)) === 'main_panel'));
+if (!feeds) fail('no feeder selector offering the configured nodes');
+if (feeds.value !== '') fail(`the feeder defaulted to '${feeds.value}' rather than leaving nodes unwired`);
+feeds.value = 'main_panel';
 
 // Select all: one click rather than one per row.
 buttons().find(b => b.textContent === 'Select all').click();
@@ -174,5 +191,25 @@ if (!imported) fail('the topic-matched reading was not added');
 if ((imported.Sources[0] || {}).Unit !== 'Wh') fail('the unit the operator entered was not carried onto the binding');
 if ((imported.Sources[0] || {}).Accumulation !== 'lifetime') fail('an imported energy counter must default to lifetime');
 
-console.log('discover: discovery and topic-profile scans both import; refusals are shown with a reason; a '
-  + 'topic-matched reading asks for its unit and carries it onto the binding');
+// Every imported node is wired to the chosen feeder.
+const links = cfg.EnergyFlow.Links || [];
+for (const id of ['esphome_deep_freezer_energy_d', 'esphome_fridge_power']) {
+  const link = links.find(l => l.From === id);
+  if (!link) fail(`${id} was imported with no link, leaving it disconnected on the diagram`);
+  if (link.To !== 'main_panel') fail(`${id} was wired to '${link.To}' rather than the chosen feeder`);
+}
+
+// --- A built-in profile can be copied into config to edit.
+// The add re-rendered the panel, so re-select the source first.
+const srcAgain = query(getEl('sections'), 'select', true)
+  .find(sl => (sl.children || []).some(o => (o.value || (o.attrs && o.attrs.value)) === 'esphome'));
+srcAgain.value = 'esphome';
+buttons().find(b => b.textContent === 'Copy this profile to config').click();
+await new Promise(r => setTimeout(r, 100));
+const copied = ((cfg.MQTT || {}).ImportProfiles || []).find(p => p.Name === 'ESPHome');
+if (!copied) fail('copying a built-in profile put nothing into MQTT.ImportProfiles');
+if (copied.Pattern !== 'esphome/devices/{device}/sensor/{measure}/state') fail('the copied profile lost its pattern');
+if (!copied.Metrics || copied.Metrics.power !== 'realpower') fail('the copied profile lost its metric map');
+
+console.log('discover: both scans import; refusals shown with a reason; units default and set in bulk; '
+  + 'imported nodes are wired to the chosen feeder; a built-in profile copies into config');

--- a/rPDU2MQTT.Web/web/domstub.mjs
+++ b/rPDU2MQTT.Web/web/domstub.mjs
@@ -67,12 +67,12 @@ export function makeEl(tag = 'div') {
       if (c && c.tag) { c.parent = this; this.children.push(c); this._adoptOption(c); }
       return c;
     },
-    // A <select> reports its first option's value until something sets another. Without this a select
-    // built by appending options reads as '' here while a browser reports the first option.
+    // A <select> reports its first option's value until something sets another — including when that
+    // value is the empty string, which is how a leading "— pick —" option works.
     _adoptOption(c) {
-      if (this.tag !== 'select' || !c || c.tag !== 'option' || this.value) return;
-      const v = c.value || (c.attrs && c.attrs.value);
-      if (v) this.value = v;
+      if (this.tag !== 'select' || !c || c.tag !== 'option' || this._adopted) return;
+      this._adopted = true;
+      this.value = c.value || (c.attrs && c.attrs.value) || '';
     },
     append(...cs) { cs.forEach(c => { if (c && c.tag) { c.parent = this; this.children.push(c); this._adoptOption(c); } }); },
     removeChild(c) { this.children = this.children.filter(x => x !== c); if (c) c.parent = null; },

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2486,9 +2486,20 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
       srcSel.appendChild(el('option', { value: p.id, text: p.label + ' topics' })));
   });
   const tagIn = el('input', { type: 'text', value: 'imported', placeholder: 'tag (optional)' }) as HTMLInputElement;
+  // Where the imported nodes hang. Without a feeder a new node is an island on the diagram: it has a value
+  // but nothing carries it, so it sits apart from the hierarchy.
+  const feedSel = el('select', { style: { width: 'auto' } }) as HTMLSelectElement;
+  feedSel.appendChild(el('option', { value: '', text: '— not wired —' }));
+  (flow.Nodes || []).forEach((n: any) =>
+    feedSel.appendChild(el('option', { value: n.Id, text: n.Label || n.Id })));
   const scan = btn('Scan broker', 'primary');
   const addBtn = btn('Add selected');
-  bar.append(srcSel, scan, el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn);
+  const copyBtn = btn('Copy this profile to config');
+  copyBtn.title = 'Write the selected built-in profile into MQTT.ImportProfiles, where its pattern and '
+                + 'metric map can be edited.';
+  bar.append(srcSel, scan,
+    el('span', { class: 'desc', style: { margin: '0' }, text: 'Feeds:' }), feedSel,
+    el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn, copyBtn);
   const note = el('div', { class: 'desc' });
   const list = el('div');
   panel.append(bar, note, list);
@@ -2604,6 +2615,26 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
     return row;
   };
 
+  copyBtn.onclick = async () => {
+    const id = srcSel.value;
+    if (!id || id === 'discovery' || id.startsWith('custom:')) {
+      toast('Pick a built-in topic profile first.', false);
+      return;
+    }
+    const r = await api('/api/mqtt/profile?id=' + encodeURIComponent(id));
+    if (!r.body || !r.body.ok) { toast((r.body && r.body.message) || 'Could not read that profile.', false); return; }
+    const p = r.body.profile;
+    const mqtt = ensure(state.data, 'MQTT', {});
+    const list = ensure(mqtt, 'ImportProfiles', []);
+    if (list.some((x: any) => (x.Name || '').toLowerCase() === (p.label || '').toLowerCase())) {
+      toast(`'${p.label}' is already in ImportProfiles.`, false);
+      return;
+    }
+    list.push({ Name: p.label, Filter: p.filter, Pattern: p.pattern, JsonField: p.jsonField || undefined, Metrics: p.metrics });
+    toast(`Copied '${p.label}' into MQTT → ImportProfiles. Edit it there, then Save.`, true);
+    refreshDirty();
+  };
+
   let found: any[] = [];
   scan.onclick = async () => {
     const src = srcSel.value;
@@ -2641,6 +2672,8 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
       if (tag) node.Tags = [tag];
       nodes.push(node);
       existingIds.add(r.id);
+      // One link per imported node, so it is part of the hierarchy rather than a disconnected node.
+      if (feedSel.value) ensure(flow, 'Links', []).push({ From: r.id, To: feedSel.value });
     });
     toast(`Added ${take.length} node(s). Wire their feeders on the Nodes tab, then Save.`, true);
     rerender();

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3913,9 +3913,20 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
       srcSel.appendChild(el('option', { value: p.id, text: p.label + ' topics' })));
   });
   const tagIn = el('input', { type: 'text', value: 'imported', placeholder: 'tag (optional)' })                    ;
+  // Where the imported nodes hang. Without a feeder a new node is an island on the diagram: it has a value
+  // but nothing carries it, so it sits apart from the hierarchy.
+  const feedSel = el('select', { style: { width: 'auto' } })                     ;
+  feedSel.appendChild(el('option', { value: '', text: '— not wired —' }));
+  (flow.Nodes || []).forEach((n     ) =>
+    feedSel.appendChild(el('option', { value: n.Id, text: n.Label || n.Id })));
   const scan = btn('Scan broker', 'primary');
   const addBtn = btn('Add selected');
-  bar.append(srcSel, scan, el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn);
+  const copyBtn = btn('Copy this profile to config');
+  copyBtn.title = 'Write the selected built-in profile into MQTT.ImportProfiles, where its pattern and '
+                + 'metric map can be edited.';
+  bar.append(srcSel, scan,
+    el('span', { class: 'desc', style: { margin: '0' }, text: 'Feeds:' }), feedSel,
+    el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn, copyBtn);
   const note = el('div', { class: 'desc' });
   const list = el('div');
   panel.append(bar, note, list);
@@ -4031,6 +4042,26 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
     return row;
   };
 
+  copyBtn.onclick = async () => {
+    const id = srcSel.value;
+    if (!id || id === 'discovery' || id.startsWith('custom:')) {
+      toast('Pick a built-in topic profile first.', false);
+      return;
+    }
+    const r = await api('/api/mqtt/profile?id=' + encodeURIComponent(id));
+    if (!r.body || !r.body.ok) { toast((r.body && r.body.message) || 'Could not read that profile.', false); return; }
+    const p = r.body.profile;
+    const mqtt = ensure(state.data, 'MQTT', {});
+    const list = ensure(mqtt, 'ImportProfiles', []);
+    if (list.some((x     ) => (x.Name || '').toLowerCase() === (p.label || '').toLowerCase())) {
+      toast(`'${p.label}' is already in ImportProfiles.`, false);
+      return;
+    }
+    list.push({ Name: p.label, Filter: p.filter, Pattern: p.pattern, JsonField: p.jsonField || undefined, Metrics: p.metrics });
+    toast(`Copied '${p.label}' into MQTT → ImportProfiles. Edit it there, then Save.`, true);
+    refreshDirty();
+  };
+
   let found        = [];
   scan.onclick = async () => {
     const src = srcSel.value;
@@ -4068,6 +4099,8 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
       if (tag) node.Tags = [tag];
       nodes.push(node);
       existingIds.add(r.id);
+      // One link per imported node, so it is part of the hierarchy rather than a disconnected node.
+      if (feedSel.value) ensure(flow, 'Links', []).push({ From: r.id, To: feedSel.value });
     });
     toast(`Added ${take.length} node(s). Wire their feeders on the Nodes tab, then Save.`, true);
     rerender();


### PR DESCRIPTION
Two additions to the MQTT Import page.

## Feeds

A selector listing the configured energy-flow nodes. Each node added takes a link to the chosen node.

Default is "— not wired —", which is the previous behaviour: an imported node with no link stands apart from the rest of the diagram.

## Copy a built-in profile into config

The built-ins existed only in code, so the `MQTT.ImportProfiles` editor started empty with no indication that ESPHome and Z-Wave JS were already available.

"Copy this profile to config" writes the selected built-in into `ImportProfiles` with its filter, pattern, JSON field and metric map, where it can be edited. Served by `GET /api/mqtt/profile?id=`.

## Stub fix

The DOM stub adopted a select's first *non-empty* option value, so a leading blank option was skipped and a select read as its second entry. A browser takes the blank. This is what made the feeder read as `solar` instead of unwired.

## Tests

The GUI check asserts the feeder defaults to unwired, that every imported node takes a link to the chosen feeder, and that copying a built-in lands in `ImportProfiles` with its pattern and metric map intact. Both fail when removed:

```
wiring removed -> esphome_deep_freezer_energy_d was imported with no link
copy removed   -> copying a built-in profile put nothing into MQTT.ImportProfiles
```

669 tests pass; nine GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
