### PR TITLE
fix(mqtt): repeat the import action below the table and show the selected count

### DIFF
--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -95,6 +95,13 @@ nav.click();
 await new Promise(r => setTimeout(r, 200));
 
 const buttons = () => query(getEl('sections'), 'button', true);
+// The label carries the count once rows are ticked, so match on the prefix.
+const addButtons = () => buttons().filter(b => /^Add( \d+)? selected$/.test(b.textContent || ''));
+const addButton = () => {
+  const b = addButtons()[0];
+  if (!b) fail('no "Add selected" control');
+  return b;
+};
 if (!buttons().some(b => b.textContent === 'Scan broker')) fail('the MQTT Import page rendered no scan control');
 
 buttons().find(b => b.textContent === 'Scan broker').click();
@@ -126,7 +133,7 @@ if (!dup.row.textContent.includes('Already bound')) fail('the duplicate row does
 // Taking the importable one adds a node, tagged, valued only by its own binding.
 good.box.checked = true;
 good.box.onchange({});
-buttons().find(b => b.textContent === 'Add selected').click();
+addButton().click();
 await new Promise(r => setTimeout(r, 100));
 
 // The node id comes from the device, not the reading: "Garage Meter" -> garage_meter.
@@ -178,6 +185,13 @@ const allRows = query(getEl('sections'), 'tr', true).filter(r => query(r, 'input
 const checkable = allRows.map(r => query(r, 'input', true)[0]).filter(b => !b.disabled);
 if (!checkable.every(b => b.checked)) fail('Select all left rows unchecked');
 
+// The action is repeated below the table: with twenty rows the toolbar scrolls out of view, leaving the
+// page's Save button as the only visible control.
+if (addButtons().length < 2) fail('the Add action is not repeated below the table');
+// The label counts what is ticked, so the button states what pressing it will do.
+if (!addButtons().some(b => /^Add \d+ selected$/.test(b.textContent)))
+  fail(`the Add button does not show how many rows are ticked: ${addButtons().map(b => b.textContent).join(' | ')}`);
+
 // Per-metric unit setter: changing it moves every row of that metric, and leaves the others alone.
 const bulkSels = query(getEl('sections'), 'select', true)
   .filter(sel => (sel.children || []).some(o => (o.value || (o.attrs && o.attrs.value)) === 'Wh'));
@@ -197,7 +211,7 @@ if (query(powerRow, 'select', true)[0].value !== 'W') fail('the energy bulk sett
 
 // Import straight from the bulk setting, without touching the row's own control: the bulk change has to
 // reach the reading, not just the dropdown that displays it.
-buttons().find(b => b.textContent === 'Add selected').click();
+addButton().click();
 await new Promise(r => setTimeout(r, 100));
 
 const imported = cfg.EnergyFlow.Nodes.find(n => n.Id === 'deep_freezer');

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2543,7 +2543,7 @@ function renderDiscoverPanel(flow: any, rerender: () => void): HTMLElement {
   (flow.Nodes || []).forEach((n: any) =>
     feedSel.appendChild(el('option', { value: n.Id, text: n.Label || n.Id })));
   const scan = btn('Scan broker', 'primary');
-  const addBtn = btn('Add selected');
+  const addBtn = btn('Add selected', 'primary');
   const copyBtn = btn('Copy this profile to config');
   copyBtn.title = 'Write the selected built-in profile into MQTT.ImportProfiles, where its pattern and '
                 + 'metric map can be edited.';
@@ -2596,7 +2596,7 @@ function renderDiscoverPanel(flow: any, rerender: () => void): HTMLElement {
       const already = boundTopics.has(r.topic);
       // Two reasons a row cannot be taken: already modelled, or not bindable from its template.
       cb.disabled = !!r.unsupported || already;
-      cb.onchange = () => { cb.checked ? picked.add(r.id) : picked.delete(r.id); };
+      cb.onchange = () => { cb.checked ? picked.add(r.id) : picked.delete(r.id); syncCount(); };
       if (!cb.disabled) boxes.push({ reading: r, box: cb });
       tr.appendChild(el('td', {}, cb));
       tr.appendChild(el('td', { text: r.device || '—' }));
@@ -2636,6 +2636,23 @@ function renderDiscoverPanel(flow: any, rerender: () => void): HTMLElement {
     tbl.appendChild(body);
     list.appendChild(bulkBar(readings));
     list.appendChild(tbl);
+    // Repeated below the table. With twenty rows the toolbar scrolls off the top, leaving the page's Save
+    // button as the only visible action — and Save without Add writes a config with no imported nodes.
+    const footer = el('div', { class: 'ld-toolbar', style: { marginTop: '6px' } });
+    const addAgain = btn('Add selected', 'primary');
+    addAgain.onclick = () => addBtn.onclick!({} as any);
+    footer.append(addAgain, el('span', { class: 'desc', style: { margin: '0' }, text: 'Adds the ticked rows as nodes. Save writes them to the config.' }));
+    list.appendChild(footer);
+    syncCount();
+  };
+
+  /// Keep both Add buttons showing how many rows are ticked.
+  const syncCount = () => {
+    const n = picked.size;
+    const label = n ? `Add ${n} selected` : 'Add selected';
+    [addBtn, ...Array.from(list.querySelectorAll('button'))].forEach((b: any) => {
+      if (b && /^Add \d* ?selected$/.test(b.textContent || '')) b.textContent = label;
+    });
   };
 
   /// Select-all, and one unit setter per metric present, so twenty rows are not twenty clicks.
@@ -2650,6 +2667,7 @@ function renderDiscoverPanel(flow: any, rerender: () => void): HTMLElement {
         turnOn ? picked.add(b.reading.id) : picked.delete(b.reading.id);
       });
       all.textContent = turnOn ? 'Select none' : 'Select all';
+      syncCount();
     };
     row.appendChild(all);
 

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3970,7 +3970,7 @@ function renderDiscoverPanel(flow     , rerender            )              {
   (flow.Nodes || []).forEach((n     ) =>
     feedSel.appendChild(el('option', { value: n.Id, text: n.Label || n.Id })));
   const scan = btn('Scan broker', 'primary');
-  const addBtn = btn('Add selected');
+  const addBtn = btn('Add selected', 'primary');
   const copyBtn = btn('Copy this profile to config');
   copyBtn.title = 'Write the selected built-in profile into MQTT.ImportProfiles, where its pattern and '
                 + 'metric map can be edited.';
@@ -4023,7 +4023,7 @@ function renderDiscoverPanel(flow     , rerender            )              {
       const already = boundTopics.has(r.topic);
       // Two reasons a row cannot be taken: already modelled, or not bindable from its template.
       cb.disabled = !!r.unsupported || already;
-      cb.onchange = () => { cb.checked ? picked.add(r.id) : picked.delete(r.id); };
+      cb.onchange = () => { cb.checked ? picked.add(r.id) : picked.delete(r.id); syncCount(); };
       if (!cb.disabled) boxes.push({ reading: r, box: cb });
       tr.appendChild(el('td', {}, cb));
       tr.appendChild(el('td', { text: r.device || '—' }));
@@ -4063,6 +4063,23 @@ function renderDiscoverPanel(flow     , rerender            )              {
     tbl.appendChild(body);
     list.appendChild(bulkBar(readings));
     list.appendChild(tbl);
+    // Repeated below the table. With twenty rows the toolbar scrolls off the top, leaving the page's Save
+    // button as the only visible action — and Save without Add writes a config with no imported nodes.
+    const footer = el('div', { class: 'ld-toolbar', style: { marginTop: '6px' } });
+    const addAgain = btn('Add selected', 'primary');
+    addAgain.onclick = () => addBtn.onclick ({}       );
+    footer.append(addAgain, el('span', { class: 'desc', style: { margin: '0' }, text: 'Adds the ticked rows as nodes. Save writes them to the config.' }));
+    list.appendChild(footer);
+    syncCount();
+  };
+
+  /// Keep both Add buttons showing how many rows are ticked.
+  const syncCount = () => {
+    const n = picked.size;
+    const label = n ? `Add ${n} selected` : 'Add selected';
+    [addBtn, ...Array.from(list.querySelectorAll('button'))].forEach((b     ) => {
+      if (b && /^Add \d* ?selected$/.test(b.textContent || '')) b.textContent = label;
+    });
   };
 
   /// Select-all, and one unit setter per metric present, so twenty rows are not twenty clicks.
@@ -4077,6 +4094,7 @@ function renderDiscoverPanel(flow     , rerender            )              {
         turnOn ? picked.add(b.reading.id) : picked.delete(b.reading.id);
       });
       all.textContent = turnOn ? 'Select none' : 'Select all';
+      syncCount();
     };
     row.appendChild(all);
 


### PR DESCRIPTION
Ticking rows and pressing Save wrote a config with no imported nodes.

Ticking a row does not add it — "Add selected" does. With twenty readings that button is scrolled off the top of the table, and the page's Save button is the only action visible at the bottom. Save then persisted a config containing the copied profile and no nodes.

## Change

- the Add action is repeated below the table, beside Save
- both copies count what is ticked: `Add 20 selected` rather than `Add selected`
- the selection clears once the nodes are added

## Tests

The GUI check asserts the action appears twice and that the label carries the count. Each fails when removed:

```
footer removed -> the Add action is not repeated below the table
count removed  -> the Add button does not show how many rows are ticked: Add selected | Add selected
```

669 tests pass; nine GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
