### PR TITLE
fix(mqtt): import one node per device with a source per metric

### DIFF
--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -43,7 +43,16 @@ const pattern = {
   ],
 };
 
-const cfg = { EnergyFlow: { Nodes: [{ Id: 'solar', Label: 'Solar' }, { Id: 'main_panel', Label: 'Main Panel' }], Links: [] } };
+// 'solar' already binds the topic the discovery scan offers, so that row is not importable again.
+const cfg = {
+  EnergyFlow: {
+    Nodes: [
+      { Id: 'solar', Label: 'Solar', Sources: [{ Type: 'mqtt', Topic: 'sa/pv_power', Metric: 'realpower' }] },
+      { Id: 'main_panel', Label: 'Main Panel' },
+    ],
+    Links: [],
+  },
+};
 
 const builtIn = {
   ok: true,
@@ -108,7 +117,7 @@ if (!bad.row.textContent.includes('Cannot import')) fail('the refused row does n
 // Already modelled: shown, disabled, and says so.
 const dup = boxFor('Solar');
 if (!dup.box.disabled) fail('a reading that is already a node was offered again');
-if (!dup.row.textContent.includes('Already a node')) fail('the duplicate row does not say why');
+if (!dup.row.textContent.includes('Already bound')) fail('the duplicate row does not say why');
 
 // Taking the importable one adds a node, tagged, valued only by its own binding.
 good.box.checked = true;
@@ -116,7 +125,8 @@ good.box.onchange({});
 buttons().find(b => b.textContent === 'Add selected').click();
 await new Promise(r => setTimeout(r, 100));
 
-const added = cfg.EnergyFlow.Nodes.find(n => n.Id === 'esp_garage_power');
+// The node id comes from the device, not the reading: "Garage Meter" -> garage_meter.
+const added = cfg.EnergyFlow.Nodes.find(n => n.Id === 'garage_meter');
 if (!added) fail('selecting a reading did not add a node');
 if (JSON.stringify(added.Tags) !== JSON.stringify(['imported'])) fail(`the imported node was not tagged: ${JSON.stringify(added.Tags)}`);
 if (added.Mode !== 'none') fail('an imported node must not be set to aggregate children it does not have');
@@ -125,7 +135,7 @@ if (src.Topic !== 'esphome/garage/sensor/power/state') fail('the binding does no
 if (src.Metric !== 'realpower' || src.Unit !== 'W') fail('the binding lost the metric or unit');
 
 // And nothing else was added — in particular not the two refused rows.
-if (cfg.EnergyFlow.Nodes.length !== 3) fail(`expected the two seeded nodes plus one import, got ${cfg.EnergyFlow.Nodes.map(n => n.Id).join(', ')}`);
+if (cfg.EnergyFlow.Nodes.length !== 3) fail(`expected the two seeded nodes plus one device, got ${cfg.EnergyFlow.Nodes.map(n => n.Id).join(', ')}`);
 
 // --- The topic-profile path.
 const sel = query(getEl('sections'), 'select', true)
@@ -186,14 +196,28 @@ if (query(powerRow, 'select', true)[0].value !== 'W') fail('the energy bulk sett
 buttons().find(b => b.textContent === 'Add selected').click();
 await new Promise(r => setTimeout(r, 100));
 
-const imported = cfg.EnergyFlow.Nodes.find(n => n.Id === 'esphome_deep_freezer_energy_d');
+const imported = cfg.EnergyFlow.Nodes.find(n => n.Id === 'deep_freezer');
 if (!imported) fail('the topic-matched reading was not added');
-if ((imported.Sources[0] || {}).Unit !== 'Wh') fail('the unit the operator entered was not carried onto the binding');
-if ((imported.Sources[0] || {}).Accumulation !== 'lifetime') fail('an imported energy counter must default to lifetime');
+const energySrc = (imported.Sources || []).find(x => x.Metric === 'energy') || {};
+if (energySrc.Unit !== 'Wh') fail('the unit set in bulk was not carried onto the binding');
+if (energySrc.Accumulation !== 'lifetime') fail('an imported energy counter must default to lifetime');
+
+// One node per device with a source per metric, not one node per reading. The fridge publishes two.
+const fridge = cfg.EnergyFlow.Nodes.find(n => n.Id === 'fridge');
+if (!fridge) fail(`no node for the fridge device: ${cfg.EnergyFlow.Nodes.map(n => n.Id).join(', ')}`);
+if (cfg.EnergyFlow.Nodes.filter(n => n.Id.startsWith('fridge')).length !== 1)
+  fail('the fridge device produced more than one node');
+if ((fridge.Sources || []).length !== 2)
+  fail(`fridge should carry one source per selected metric, got ${(fridge.Sources || []).length}`);
+const metrics = fridge.Sources.map(x => x.Metric).sort();
+if (JSON.stringify(metrics) !== JSON.stringify(['energy', 'realpower'])) fail(`wrong metrics on the device node: ${metrics}`);
+// Each source keeps its own unit: the energy one set in bulk, the power one its default.
+if (fridge.Sources.find(x => x.Metric === 'energy').Unit !== 'Wh') fail('the energy source lost its unit');
+if (fridge.Sources.find(x => x.Metric === 'realpower').Unit !== 'W') fail('the power source lost its unit');
 
 // Every imported node is wired to the chosen feeder.
 const links = cfg.EnergyFlow.Links || [];
-for (const id of ['esphome_deep_freezer_energy_d', 'esphome_fridge_power']) {
+for (const id of ['deep_freezer', 'fridge']) {
   const link = links.find(l => l.From === id);
   if (!link) fail(`${id} was imported with no link, leaving it disconnected on the diagram`);
   if (link.To !== 'main_panel') fail(`${id} was wired to '${link.To}' rather than the chosen feeder`);

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2466,7 +2466,7 @@ function instantiateTemplate(tpl: any, prefix: string, host: string, unitId: num
 ///
 /// Discovery is used rather than per-integration topic patterns because it states the unit, the device
 /// class and the payload shape.
-function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () => void): HTMLElement {
+function renderDiscoverPanel(flow: any, rerender: () => void): HTMLElement {
   const panel = el('div', { class: 'tpl-import' });
   panel.appendChild(el('div', {
     class: 'desc',
@@ -2510,6 +2510,15 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
               + 'exporting these readings back to where they came from.';
 
   const picked = new Set<string>();
+  // Topics already bound anywhere in the config: a reading is "already imported" when its topic is bound,
+  // not when some node happens to share its id. That lets a device's remaining metrics be added later.
+  const boundTopics = new Set<string>();
+  (flow.Nodes || []).forEach((n: any) =>
+    (n.Sources || []).forEach((src: any) => { if (src.Topic) boundTopics.add(src.Topic); }));
+
+  /// The node a reading belongs to: its device, not its individual measure.
+  const nodeIdFor = (r: any) =>
+    String(r.device || r.id || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || r.id;
 
   // Rows and their unit selectors, so the bulk controls can drive them without a re-render.
   let boxes: { reading: any, box: HTMLInputElement }[] = [];
@@ -2534,7 +2543,7 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
     readings.forEach(r => {
       const tr = el('tr');
       const cb = el('input', { type: 'checkbox', class: 'switch' }) as HTMLInputElement;
-      const already = existingIds.has(r.id);
+      const already = boundTopics.has(r.topic);
       // Two reasons a row cannot be taken: already modelled, or not bindable from its template.
       cb.disabled = !!r.unsupported || already;
       cb.onchange = () => { cb.checked ? picked.add(r.id) : picked.delete(r.id); };
@@ -2570,7 +2579,7 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
       if (r.sample != null && r.sample !== '')
         topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: `last value: ${String(r.sample).slice(0, 60)}` }));
       if (r.unsupported) topic.appendChild(el('div', { class: 'nh-warn', text: `Cannot import: ${r.unsupported}.` }));
-      else if (already) topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'Already a node.' }));
+      else if (already) topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'Already bound.' }));
       tr.appendChild(topic);
       body.appendChild(tr);
     });
@@ -2649,33 +2658,58 @@ function renderDiscoverPanel(flow: any, existingIds: Set<string>, rerender: () =
   };
 
   addBtn.onclick = () => {
-    const take = found.filter(r => picked.has(r.id) && !r.unsupported && !existingIds.has(r.id));
+    const take = found.filter(r => picked.has(r.id) && !r.unsupported && !boundTopics.has(r.topic));
     if (!take.length) { toast('Nothing selected.', false); return; }
     const tag = tagIn.value.trim();
     const nodes = ensure(flow, 'Nodes', []);
+
+    // One node per device, with a source per metric. A device publishing power, energy, current and
+    // voltage is one thing with four readings, matching how a PDU outlet or an inverter is modelled.
+    const byDevice = new Map<string, any[]>();
     take.forEach(r => {
+      const key = nodeIdFor(r);
+      if (!byDevice.has(key)) byDevice.set(key, []);
+      byDevice.get(key)!.push(r);
+    });
+
+    let added = 0, extended = 0;
+    byDevice.forEach((readings, id) => {
+      const sources = readings.map(r => ({
+        Type: 'mqtt', Topic: r.topic, Metric: r.metric,
+        // 'lifetime': the daily figure is derived from it, and a counter that resets is handled by the
+        // reset detection. 'period' declared wrongly publishes a cumulative total as today's.
+        Accumulation: r.metric === 'energy' ? 'lifetime' : undefined,
+        Unit: r.unit || undefined,
+        JsonField: r.jsonField || undefined,
+      }));
+      readings.forEach(r => boundTopics.add(r.topic));
+
+      // A second pass over the same device adds its remaining readings to the node already there.
+      const existing = nodes.find((n: any) => n.Id === id);
+      if (existing) {
+        ensure(existing, 'Sources', []).push(...sources);
+        extended++;
+        return;
+      }
+
       const node: any = {
-        Id: r.id,
-        Label: r.label,
-        // 'none': an imported node is valued by its own binding. 'auto' would aggregate children it does
+        Id: id,
+        Label: readings[0].device || id,
+        // 'none': an imported node is valued by its own bindings. 'auto' would aggregate children it does
         // not have.
         Mode: 'none',
-        Sources: [{
-          Type: 'mqtt', Topic: r.topic, Metric: r.metric,
-          // 'lifetime': the daily figure is derived from it, and a counter that resets is handled by the
-          // reset detection. 'period' declared wrongly publishes a cumulative total as today's.
-          Accumulation: r.metric === 'energy' ? 'lifetime' : undefined,
-          Unit: r.unit || undefined,
-          JsonField: r.jsonField || undefined,
-        }],
+        Sources: sources,
       };
       if (tag) node.Tags = [tag];
       nodes.push(node);
-      existingIds.add(r.id);
-      // One link per imported node, so it is part of the hierarchy rather than a disconnected node.
-      if (feedSel.value) ensure(flow, 'Links', []).push({ From: r.id, To: feedSel.value });
+      added++;
+      // One link per node, so it is part of the hierarchy rather than standing apart from it.
+      if (feedSel.value) ensure(flow, 'Links', []).push({ From: id, To: feedSel.value });
     });
-    toast(`Added ${take.length} node(s). Wire their feeders on the Nodes tab, then Save.`, true);
+
+    const parts = [added ? `${added} node(s)` : '', extended ? `${extended} extended` : ''].filter(Boolean);
+    toast(`Added ${parts.join(', ')} from ${take.length} reading(s). Press Save to write them to the config.`, true);
+    picked.clear();
     rerender();
   };
 
@@ -2703,9 +2737,8 @@ export function addMqttImportSection(nav: any, sections: any) {
     const flow = ensure(state.data, 'EnergyFlow', {});
     migrateEnergyFlow(flow);
     const nodes = ensure(flow, 'Nodes', []);
-    const existingIds = new Set<string>(nodes.map((n: any) => n.Id));
     host.innerHTML = '';
-    host.appendChild(renderDiscoverPanel(flow, existingIds, render));
+    host.appendChild(renderDiscoverPanel(flow, render));
     const bar = el('div', { class: 'ld-toolbar' });
     const save = btn('Save', 'primary');
     save.onclick = () => saveConfig(() => render());

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3893,7 +3893,7 @@ function instantiateTemplate(tpl     , prefix        , host        , unitId     
 ///
 /// Discovery is used rather than per-integration topic patterns because it states the unit, the device
 /// class and the payload shape.
-function renderDiscoverPanel(flow     , existingIds             , rerender            )              {
+function renderDiscoverPanel(flow     , rerender            )              {
   const panel = el('div', { class: 'tpl-import' });
   panel.appendChild(el('div', {
     class: 'desc',
@@ -3937,6 +3937,15 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
               + 'exporting these readings back to where they came from.';
 
   const picked = new Set        ();
+  // Topics already bound anywhere in the config: a reading is "already imported" when its topic is bound,
+  // not when some node happens to share its id. That lets a device's remaining metrics be added later.
+  const boundTopics = new Set        ();
+  (flow.Nodes || []).forEach((n     ) =>
+    (n.Sources || []).forEach((src     ) => { if (src.Topic) boundTopics.add(src.Topic); }));
+
+  /// The node a reading belongs to: its device, not its individual measure.
+  const nodeIdFor = (r     ) =>
+    String(r.device || r.id || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || r.id;
 
   // Rows and their unit selectors, so the bulk controls can drive them without a re-render.
   let boxes                                            = [];
@@ -3961,7 +3970,7 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
     readings.forEach(r => {
       const tr = el('tr');
       const cb = el('input', { type: 'checkbox', class: 'switch' })                    ;
-      const already = existingIds.has(r.id);
+      const already = boundTopics.has(r.topic);
       // Two reasons a row cannot be taken: already modelled, or not bindable from its template.
       cb.disabled = !!r.unsupported || already;
       cb.onchange = () => { cb.checked ? picked.add(r.id) : picked.delete(r.id); };
@@ -3997,7 +4006,7 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
       if (r.sample != null && r.sample !== '')
         topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: `last value: ${String(r.sample).slice(0, 60)}` }));
       if (r.unsupported) topic.appendChild(el('div', { class: 'nh-warn', text: `Cannot import: ${r.unsupported}.` }));
-      else if (already) topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'Already a node.' }));
+      else if (already) topic.appendChild(el('div', { class: 'desc', style: { margin: '0' }, text: 'Already bound.' }));
       tr.appendChild(topic);
       body.appendChild(tr);
     });
@@ -4076,33 +4085,58 @@ function renderDiscoverPanel(flow     , existingIds             , rerender      
   };
 
   addBtn.onclick = () => {
-    const take = found.filter(r => picked.has(r.id) && !r.unsupported && !existingIds.has(r.id));
+    const take = found.filter(r => picked.has(r.id) && !r.unsupported && !boundTopics.has(r.topic));
     if (!take.length) { toast('Nothing selected.', false); return; }
     const tag = tagIn.value.trim();
     const nodes = ensure(flow, 'Nodes', []);
+
+    // One node per device, with a source per metric. A device publishing power, energy, current and
+    // voltage is one thing with four readings, matching how a PDU outlet or an inverter is modelled.
+    const byDevice = new Map               ();
     take.forEach(r => {
+      const key = nodeIdFor(r);
+      if (!byDevice.has(key)) byDevice.set(key, []);
+      byDevice.get(key) .push(r);
+    });
+
+    let added = 0, extended = 0;
+    byDevice.forEach((readings, id) => {
+      const sources = readings.map(r => ({
+        Type: 'mqtt', Topic: r.topic, Metric: r.metric,
+        // 'lifetime': the daily figure is derived from it, and a counter that resets is handled by the
+        // reset detection. 'period' declared wrongly publishes a cumulative total as today's.
+        Accumulation: r.metric === 'energy' ? 'lifetime' : undefined,
+        Unit: r.unit || undefined,
+        JsonField: r.jsonField || undefined,
+      }));
+      readings.forEach(r => boundTopics.add(r.topic));
+
+      // A second pass over the same device adds its remaining readings to the node already there.
+      const existing = nodes.find((n     ) => n.Id === id);
+      if (existing) {
+        ensure(existing, 'Sources', []).push(...sources);
+        extended++;
+        return;
+      }
+
       const node      = {
-        Id: r.id,
-        Label: r.label,
-        // 'none': an imported node is valued by its own binding. 'auto' would aggregate children it does
+        Id: id,
+        Label: readings[0].device || id,
+        // 'none': an imported node is valued by its own bindings. 'auto' would aggregate children it does
         // not have.
         Mode: 'none',
-        Sources: [{
-          Type: 'mqtt', Topic: r.topic, Metric: r.metric,
-          // 'lifetime': the daily figure is derived from it, and a counter that resets is handled by the
-          // reset detection. 'period' declared wrongly publishes a cumulative total as today's.
-          Accumulation: r.metric === 'energy' ? 'lifetime' : undefined,
-          Unit: r.unit || undefined,
-          JsonField: r.jsonField || undefined,
-        }],
+        Sources: sources,
       };
       if (tag) node.Tags = [tag];
       nodes.push(node);
-      existingIds.add(r.id);
-      // One link per imported node, so it is part of the hierarchy rather than a disconnected node.
-      if (feedSel.value) ensure(flow, 'Links', []).push({ From: r.id, To: feedSel.value });
+      added++;
+      // One link per node, so it is part of the hierarchy rather than standing apart from it.
+      if (feedSel.value) ensure(flow, 'Links', []).push({ From: id, To: feedSel.value });
     });
-    toast(`Added ${take.length} node(s). Wire their feeders on the Nodes tab, then Save.`, true);
+
+    const parts = [added ? `${added} node(s)` : '', extended ? `${extended} extended` : ''].filter(Boolean);
+    toast(`Added ${parts.join(', ')} from ${take.length} reading(s). Press Save to write them to the config.`, true);
+    picked.clear();
     rerender();
   };
 
@@ -4130,9 +4164,8 @@ function addMqttImportSection(nav     , sections     ) {
     const flow = ensure(state.data, 'EnergyFlow', {});
     migrateEnergyFlow(flow);
     const nodes = ensure(flow, 'Nodes', []);
-    const existingIds = new Set        (nodes.map((n     ) => n.Id));
     host.innerHTML = '';
-    host.appendChild(renderDiscoverPanel(flow, existingIds, render));
+    host.appendChild(renderDiscoverPanel(flow, render));
     const bar = el('div', { class: 'ld-toolbar' });
     const save = btn('Save', 'primary');
     save.onclick = () => saveConfig(() => render());


### PR DESCRIPTION
The import created a node per reading:

```
custom_esphome_fridge_current
custom_esphome_fridge_energy_d
custom_esphome_fridge_power
custom_esphome_fridge_voltage
```

Four nodes for one fridge, where every other node in the model is one thing carrying several sources — an inverter has four, the grid has six.

## Change

Selected readings are grouped by device. One node per device, id and label from the device name, with a source per metric:

```
fridge   Sources: [ realpower  esphome/devices/fridge/sensor/power/state
                    energy     esphome/devices/fridge/sensor/energy_d/state
                    current    esphome/devices/fridge/sensor/current/state
                    voltage    esphome/devices/fridge/sensor/voltage/state ]
```

Selecting a device's remaining readings later appends them to the node already there rather than creating a second one.

## Duplicate detection

Moved from the node id to the bound topic. A node whose id matches means nothing; a topic already bound in any node's `Sources` is what makes a reading a duplicate. That is also what allows a device's other metrics to be added in a later pass — previously the whole device was considered done.

## Tests

The GUI check asserts a two-reading device produces one node with two sources, each keeping its own unit, and that the node id comes from the device rather than the reading. Grouping by reading fails it:

```
one node per reading -> selecting a reading did not add a node
```

669 tests pass; nine GUI checks green.

## Your existing config

The nodes already imported are one-per-reading and are not migrated. Deleting them and re-importing produces the grouped form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
