### PR TITLE
fix(mqtt): import appliances as loads, not as feeders

### DIFF
--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -215,12 +215,16 @@ if (JSON.stringify(metrics) !== JSON.stringify(['energy', 'realpower'])) fail(`w
 if (fridge.Sources.find(x => x.Metric === 'energy').Unit !== 'Wh') fail('the energy source lost its unit');
 if (fridge.Sources.find(x => x.Metric === 'realpower').Unit !== 'W') fail('the power source lost its unit');
 
-// Every imported node is wired to the chosen feeder.
+// Every imported node is wired to the chosen node, as a load drawn from it.
+//
+// Direction matters: an appliance monitor draws from the panel. Wiring it as a feeder adds its draw to the
+// panel's total while the appliance is still inside the panel's unmeasured remainder, counting it twice.
 const links = cfg.EnergyFlow.Links || [];
 for (const id of ['deep_freezer', 'fridge']) {
-  const link = links.find(l => l.From === id);
+  const link = links.find(l => l.To === id);
   if (!link) fail(`${id} was imported with no link, leaving it disconnected on the diagram`);
-  if (link.To !== 'main_panel') fail(`${id} was wired to '${link.To}' rather than the chosen feeder`);
+  if (link.From !== 'main_panel') fail(`${id} was wired from '${link.From}' rather than the chosen node`);
+  if (links.some(l => l.From === id)) fail(`${id} was wired as a feeder, inflating what it draws from`);
 }
 
 // --- A built-in profile can be copied into config to edit.

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2527,8 +2527,12 @@ function renderDiscoverPanel(flow: any, rerender: () => void): HTMLElement {
       srcSel.appendChild(el('option', { value: p.id, text: p.label + ' topics' })));
   });
   const tagIn = el('input', { type: 'text', value: 'imported', placeholder: 'tag (optional)' }) as HTMLInputElement;
-  // Where the imported nodes hang. Without a feeder a new node is an island on the diagram: it has a value
-  // but nothing carries it, so it sits apart from the hierarchy.
+  // Where the imported nodes hang, and which way round. An appliance monitor is a load: the panel supplies
+  // the fridge, not the reverse. Wiring it the other way adds its draw to the panel's total and counts it
+  // twice, since the appliance is already inside the panel's unmeasured remainder.
+  const dirSel = el('select', { style: { width: 'auto' } }) as HTMLSelectElement;
+  dirSel.appendChild(el('option', { value: 'load', text: 'drawn from' }));
+  dirSel.appendChild(el('option', { value: 'source', text: 'feeding' }));
   const feedSel = el('select', { style: { width: 'auto' } }) as HTMLSelectElement;
   feedSel.appendChild(el('option', { value: '', text: '— not wired —' }));
   (flow.Nodes || []).forEach((n: any) =>
@@ -2539,7 +2543,7 @@ function renderDiscoverPanel(flow: any, rerender: () => void): HTMLElement {
   copyBtn.title = 'Write the selected built-in profile into MQTT.ImportProfiles, where its pattern and '
                 + 'metric map can be edited.';
   bar.append(srcSel, scan,
-    el('span', { class: 'desc', style: { margin: '0' }, text: 'Feeds:' }), feedSel,
+    el('span', { class: 'desc', style: { margin: '0' }, text: 'Wire as:' }), dirSel, feedSel,
     el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn, copyBtn);
   const note = el('div', { class: 'desc' });
   const list = el('div');
@@ -2744,8 +2748,13 @@ function renderDiscoverPanel(flow: any, rerender: () => void): HTMLElement {
       if (tag) node.Tags = [tag];
       nodes.push(node);
       added++;
-      // One link per node, so it is part of the hierarchy rather than standing apart from it.
-      if (feedSel.value) ensure(flow, 'Links', []).push({ From: id, To: feedSel.value });
+      // One link per node, in the direction chosen. 'drawn from' makes the node a child of the target,
+      // which is what an appliance monitor is.
+      if (feedSel.value) {
+        ensure(flow, 'Links', []).push(dirSel.value === 'source'
+          ? { From: id, To: feedSel.value }
+          : { From: feedSel.value, To: id });
+      }
     });
 
     const parts = [added ? `${added} node(s)` : '', extended ? `${extended} extended` : ''].filter(Boolean);

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3954,8 +3954,12 @@ function renderDiscoverPanel(flow     , rerender            )              {
       srcSel.appendChild(el('option', { value: p.id, text: p.label + ' topics' })));
   });
   const tagIn = el('input', { type: 'text', value: 'imported', placeholder: 'tag (optional)' })                    ;
-  // Where the imported nodes hang. Without a feeder a new node is an island on the diagram: it has a value
-  // but nothing carries it, so it sits apart from the hierarchy.
+  // Where the imported nodes hang, and which way round. An appliance monitor is a load: the panel supplies
+  // the fridge, not the reverse. Wiring it the other way adds its draw to the panel's total and counts it
+  // twice, since the appliance is already inside the panel's unmeasured remainder.
+  const dirSel = el('select', { style: { width: 'auto' } })                     ;
+  dirSel.appendChild(el('option', { value: 'load', text: 'drawn from' }));
+  dirSel.appendChild(el('option', { value: 'source', text: 'feeding' }));
   const feedSel = el('select', { style: { width: 'auto' } })                     ;
   feedSel.appendChild(el('option', { value: '', text: '— not wired —' }));
   (flow.Nodes || []).forEach((n     ) =>
@@ -3966,7 +3970,7 @@ function renderDiscoverPanel(flow     , rerender            )              {
   copyBtn.title = 'Write the selected built-in profile into MQTT.ImportProfiles, where its pattern and '
                 + 'metric map can be edited.';
   bar.append(srcSel, scan,
-    el('span', { class: 'desc', style: { margin: '0' }, text: 'Feeds:' }), feedSel,
+    el('span', { class: 'desc', style: { margin: '0' }, text: 'Wire as:' }), dirSel, feedSel,
     el('span', { class: 'desc', style: { margin: '0' }, text: 'Tag as:' }), tagIn, addBtn, copyBtn);
   const note = el('div', { class: 'desc' });
   const list = el('div');
@@ -4171,8 +4175,13 @@ function renderDiscoverPanel(flow     , rerender            )              {
       if (tag) node.Tags = [tag];
       nodes.push(node);
       added++;
-      // One link per node, so it is part of the hierarchy rather than standing apart from it.
-      if (feedSel.value) ensure(flow, 'Links', []).push({ From: id, To: feedSel.value });
+      // One link per node, in the direction chosen. 'drawn from' makes the node a child of the target,
+      // which is what an appliance monitor is.
+      if (feedSel.value) {
+        ensure(flow, 'Links', []).push(dirSel.value === 'source'
+          ? { From: id, To: feedSel.value }
+          : { From: feedSel.value, To: id });
+      }
     });
 
     const parts = [added ? `${added} node(s)` : '', extended ? `${extended} extended` : ''].filter(Boolean);


### PR DESCRIPTION
The import's wiring control only produced `node -> target` links, making every imported device a **supplier** of the node it was attached to. An appliance monitor is the opposite: the panel supplies the fridge.

## Effect on a live install

Five ESPHome appliances wired to Main Panel:

```
Main Panel   7,185.7 W      <- inverter 6,856 W + 329.7 W of appliance draw
Unmeasured   6,625.7 W      <- still contains those same appliances
```

The panel's inflow was inflated by loads that were already inside its own unmeasured remainder, so they were counted twice.

After flipping the five links:

```
Main Panel   7,080 W        <- matches the inverter exactly
```

## Change

The control takes a direction, defaulting to **drawn from** — the imported node becomes a child of the node chosen. **feeding** produces the previous direction, for a source such as a separately metered supply.

## Tests

The GUI check asserts the link runs from the chosen node to the import, and that no reverse link exists. Producing the old direction fails it:

```
wired as feeder -> deep_freezer was imported with no link
```

669 tests pass; nine GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
