### PR TITLE
fix(flow): draw the unmetered remainder below its measured siblings

### DIFF
--- a/rPDU2MQTT.Web/web/sankey.check.mjs
+++ b/rPDU2MQTT.Web/web/sankey.check.mjs
@@ -61,7 +61,7 @@ await new Promise(r => setTimeout(r, 50));
 const fail = (m) => { console.error('sankey check FAILED: ' + m); process.exit(1); };
 
 /// Render a second graph in a fresh sandbox and return its ribbons.
-async function render(graph) {
+async function render(graph, want = 'path') {
   const { sandbox: sb, getEl: ge } = makeDom({
     bodies: (url) =>
       url.includes('/api/schema') ? schema :
@@ -75,6 +75,7 @@ async function render(graph) {
   await new Promise(r => setTimeout(r, 40));
   query(ge('nav'), 'a', true).find(a => a.dataset.label === 'Flow').click();
   await new Promise(r => setTimeout(r, 50));
+  if (want === 'rect') return query(ge('sections'), 'rect', true).filter(r => r.attrs['data-node']);
   return query(ge('sections'), 'path', true).filter(p => p.attrs['fill-opacity'] !== undefined);
 }
 
@@ -138,5 +139,35 @@ for (const r of flat) {
     fail(`a ribbon whose targets exactly fill its source drops ${dy.toFixed(1)}px — far more than the stacking gaps`);
 }
 
+// --- The unmetered remainder sits below every measured sibling (#366).
+//
+// It is what is left after the metered children are subtracted, and it changes size as they do, so ordering
+// it by magnitude moves it up and down the column between readings.
+const withRemainder = await render({
+  ok: true, metric: 'realpower', units: 'W',
+  nodes: [
+    { id: 'panel', label: 'Main Panel', value: 6722 },
+    { id: 'panel#unmeasured', label: 'Unmeasured load', kind: 'unmeasured', value: 5915 },
+    { id: 'pdu_1', label: 'Rack-PDU-1', value: 500 },
+    { id: 'fridge', label: 'fridge', value: 307 },
+  ],
+  links: [
+    { source: 'panel', target: 'panel#unmeasured', value: 5915 },
+    { source: 'panel', target: 'pdu_1', value: 500 },
+    { source: 'panel', target: 'fridge', value: 307 },
+  ],
+}, 'rect');
+
+const yOf = (id) => {
+  const r = withRemainder.find(x => x.attrs['data-node'] === id);
+  if (!r) fail(`no node drawn for ${id}`);
+  return Number(r.attrs.y);
+};
+const remainderY = yOf('panel#unmeasured');
+for (const id of ['pdu_1', 'fridge']) {
+  if (remainderY < yOf(id))
+    fail(`the unmetered remainder is drawn above ${id} — it is the last figure calculated and belongs below`);
+}
+
 console.log(`sankey: night-time chain holds together (MPPTs within ${Math.round(drift)}px of Solar), `
-  + `${ribbons.length} ribbons all visible`);
+  + `${ribbons.length} ribbons all visible; the unmetered remainder sits below its measured siblings`);

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -1670,10 +1670,15 @@ export function addFlowSection(nav: any, sections: any) {
       return y;
     };
 
+    // The unmetered remainder sits at the bottom of its column, below every measured sibling (#366). It is
+    // what is left after the metered children are subtracted, so reading it above them inverts the order the
+    // figure is arrived at, and it moves up and down the column as the remainder changes size.
+    const remainder = (id: string) => (id || '').includes('#unmeasured') ? 1 : 0;
+
     // Forward: roots stack by size, downstream columns follow their feeders (groups children, avoids crossings).
     cols.forEach((cn, c) => {
-      if (c === 0) cn.sort((a: any, b: any) => nodeValue(b.id) - nodeValue(a.id));
-      else cn.sort((a: any, b: any) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
+      if (c === 0) cn.sort((a: any, b: any) => remainder(a.id) - remainder(b.id) || nodeValue(b.id) - nodeValue(a.id));
+      else cn.sort((a: any, b: any) => remainder(a.id) - remainder(b.id) || (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
       placeColumn(cn, c);
     });
     // Backward: right-to-left, order each column by what it feeds. The forward pass alone can only order a
@@ -1681,7 +1686,7 @@ export function addFlowSection(nav: any, sections: any) {
     // feeder always sank to the bottom, however far that was from the node it powers.
     for (let c = cols.length - 2; c >= 0; c--) {
       if (!cols[c]) continue;
-      cols[c].sort((a: any, b: any) => (obary(a.id) - obary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
+      cols[c].sort((a: any, b: any) => remainder(a.id) - remainder(b.id) || (obary(a.id) - obary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
       placeColumn(cols[c], c);
     }
     // Re-place left-to-right in the settled order so every column shares one top edge and the offsets reset.

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -3097,10 +3097,15 @@ function addFlowSection(nav     , sections     ) {
       return y;
     };
 
+    // The unmetered remainder sits at the bottom of its column, below every measured sibling (#366). It is
+    // what is left after the metered children are subtracted, so reading it above them inverts the order the
+    // figure is arrived at, and it moves up and down the column as the remainder changes size.
+    const remainder = (id        ) => (id || '').includes('#unmeasured') ? 1 : 0;
+
     // Forward: roots stack by size, downstream columns follow their feeders (groups children, avoids crossings).
     cols.forEach((cn, c) => {
-      if (c === 0) cn.sort((a     , b     ) => nodeValue(b.id) - nodeValue(a.id));
-      else cn.sort((a     , b     ) => (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
+      if (c === 0) cn.sort((a     , b     ) => remainder(a.id) - remainder(b.id) || nodeValue(b.id) - nodeValue(a.id));
+      else cn.sort((a     , b     ) => remainder(a.id) - remainder(b.id) || (bary(a.id) - bary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
       placeColumn(cn, c);
     });
     // Backward: right-to-left, order each column by what it feeds. The forward pass alone can only order a
@@ -3108,7 +3113,7 @@ function addFlowSection(nav     , sections     ) {
     // feeder always sank to the bottom, however far that was from the node it powers.
     for (let c = cols.length - 2; c >= 0; c--) {
       if (!cols[c]) continue;
-      cols[c].sort((a     , b     ) => (obary(a.id) - obary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
+      cols[c].sort((a     , b     ) => remainder(a.id) - remainder(b.id) || (obary(a.id) - obary(b.id)) || (nodeValue(b.id) - nodeValue(a.id)));
       placeColumn(cols[c], c);
     }
     // Re-place left-to-right in the settled order so every column shares one top edge and the offsets reset.


### PR DESCRIPTION
Second half of #366:

> unmetered loads should be displayed at the bottom of a given key, always. This should be the last calculation performed.

The remainder was ordered with every other node — by feeder barycenter, then magnitude — so it appeared wherever its size put it, usually above the metered children it is derived from, and moving position as they change.

It now sorts last in its column, in both the forward and backward ordering passes. Ribbon order follows target position, so its band stacks last too.

## The first half

The metered children not subtracting from the remainder was the link-direction bug in #365 — the appliances were wired as feeders of Main Panel rather than loads on it, so they added to its inflow instead of consuming from it. After flipping those links on the live install:

```
main_panel 6722 = unmeasured 5915.6 + pdu_2 311 + pdu_1 274 + freezer 126.3 + fridge 94.5 + ac 0.6
```

Exact. Please reopen if you still see a discrepancy after #365 deploys.

## Tests

The sankey check renders a panel with a remainder and two metered children and asserts the remainder is drawn below both. Removing the ordering fails it:

```
remainder not pinned last -> the unmetered remainder is drawn above pdu_1
```

669 tests pass; nine GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
