### PR TITLE
fix(mqtt): do not merge an imported device into an unrelated node with the same id

### DIFF
--- a/rPDU2MQTT.Web/web/discover.check.mjs
+++ b/rPDU2MQTT.Web/web/discover.check.mjs
@@ -37,9 +37,13 @@ const pattern = {
     { id: 'esphome_fridge_energy_d', label: 'fridge energy_d', device: 'fridge',
       topic: 'esphome/devices/fridge/sensor/energy_d/state', metric: 'energy', unit: null,
       units: ['kWh', 'Wh', 'MWh'], canonicalUnit: 'kWh', jsonField: null, sample: '1365.109', unsupported: null },
-    { id: 'esphome_fridge_power', label: 'fridge power', device: 'fridge',
+      { id: 'esphome_fridge_power', label: 'fridge power', device: 'fridge',
       topic: 'esphome/devices/fridge/sensor/power/state', metric: 'realpower', unit: null,
       units: ['W', 'kW', 'MW'], canonicalUnit: 'W', jsonField: null, sample: '97.6', unsupported: null },
+    // Sanitises to 'main_panel', which is an unrelated node already in the config.
+    { id: 'esphome_main_panel_power', label: 'main panel power', device: 'main panel',
+      topic: 'esphome/devices/main_panel/sensor/power/state', metric: 'realpower', unit: null,
+      units: ['W', 'kW', 'MW'], canonicalUnit: 'W', jsonField: null, sample: '12.0', unsupported: null },
   ],
 };
 
@@ -214,6 +218,13 @@ if (JSON.stringify(metrics) !== JSON.stringify(['energy', 'realpower'])) fail(`w
 // Each source keeps its own unit: the energy one set in bulk, the power one its default.
 if (fridge.Sources.find(x => x.Metric === 'energy').Unit !== 'Wh') fail('the energy source lost its unit');
 if (fridge.Sources.find(x => x.Metric === 'realpower').Unit !== 'W') fail('the power source lost its unit');
+
+// A device whose id collides with an unrelated node is imported beside it, not merged into it. Appending
+// one device's topics to another node would bind the wrong readings to it.
+const panel = cfg.EnergyFlow.Nodes.find(n => n.Id === 'main_panel');
+if ((panel.Sources || []).length) fail('an unrelated node absorbed the imported device\'s sources');
+if (!cfg.EnergyFlow.Nodes.some(n => n.Id === 'main_panel_2')) fail(
+  `the colliding device was not imported under a free id: ${cfg.EnergyFlow.Nodes.map(n => n.Id).join(', ')}`);
 
 // Every imported node is wired to the chosen node, as a load drawn from it.
 //

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2723,7 +2723,8 @@ function renderDiscoverPanel(flow: any, rerender: () => void): HTMLElement {
     });
 
     let added = 0, extended = 0;
-    byDevice.forEach((readings, id) => {
+    byDevice.forEach((readings, deviceId) => {
+      let id = deviceId;
       const sources = readings.map(r => ({
         Type: 'mqtt', Topic: r.topic, Metric: r.metric,
         // 'lifetime': the daily figure is derived from it, and a counter that resets is handled by the
@@ -2734,8 +2735,21 @@ function renderDiscoverPanel(flow: any, rerender: () => void): HTMLElement {
       }));
       readings.forEach(r => boundTopics.add(r.topic));
 
-      // A second pass over the same device adds its remaining readings to the node already there.
-      const existing = nodes.find((n: any) => n.Id === id);
+      // A second pass over the same device adds its remaining readings to the node already there. The node
+      // has to be that device though: an ESPHome device called "grid" sanitises to the id of an existing
+      // grid node, and appending an appliance's topics to it would bind one device's readings onto another.
+      // Sameness is decided by the topics this scan found for the device, which is what an earlier import
+      // of it would have bound.
+      const deviceTopics = new Set(found.filter((f: any) => nodeIdFor(f) === id).map((f: any) => f.topic));
+      let existing = nodes.find((n: any) => n.Id === id);
+      if (existing && !(existing.Sources || []).some((src: any) => deviceTopics.has(src.Topic))) {
+        // Same id, different thing. Take the next free id rather than merging or overwriting.
+        let free = id, i = 2;
+        while (nodes.some((n: any) => n.Id === free)) free = `${id}_${i++}`;
+        toast(`A node named '${id}' already exists and is something else — imported as '${free}'.`, false);
+        id = free;
+        existing = undefined;
+      }
       if (existing) {
         ensure(existing, 'Sources', []).push(...sources);
         extended++;

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -4150,7 +4150,8 @@ function renderDiscoverPanel(flow     , rerender            )              {
     });
 
     let added = 0, extended = 0;
-    byDevice.forEach((readings, id) => {
+    byDevice.forEach((readings, deviceId) => {
+      let id = deviceId;
       const sources = readings.map(r => ({
         Type: 'mqtt', Topic: r.topic, Metric: r.metric,
         // 'lifetime': the daily figure is derived from it, and a counter that resets is handled by the
@@ -4161,8 +4162,21 @@ function renderDiscoverPanel(flow     , rerender            )              {
       }));
       readings.forEach(r => boundTopics.add(r.topic));
 
-      // A second pass over the same device adds its remaining readings to the node already there.
-      const existing = nodes.find((n     ) => n.Id === id);
+      // A second pass over the same device adds its remaining readings to the node already there. The node
+      // has to be that device though: an ESPHome device called "grid" sanitises to the id of an existing
+      // grid node, and appending an appliance's topics to it would bind one device's readings onto another.
+      // Sameness is decided by the topics this scan found for the device, which is what an earlier import
+      // of it would have bound.
+      const deviceTopics = new Set(found.filter((f     ) => nodeIdFor(f) === id).map((f     ) => f.topic));
+      let existing = nodes.find((n     ) => n.Id === id);
+      if (existing && !(existing.Sources || []).some((src     ) => deviceTopics.has(src.Topic))) {
+        // Same id, different thing. Take the next free id rather than merging or overwriting.
+        let free = id, i = 2;
+        while (nodes.some((n     ) => n.Id === free)) free = `${id}_${i++}`;
+        toast(`A node named '${id}' already exists and is something else — imported as '${free}'.`, false);
+        id = free;
+        existing = undefined;
+      }
       if (existing) {
         ensure(existing, 'Sources', []).push(...sources);
         extended++;


### PR DESCRIPTION
Found reviewing the import path rather than from a report.

The import derives a node id from the device name and appends to any existing node with that id, which is how a second pass over a device adds its remaining metrics. The match was on the **id alone**.

An ESPHome device named `main panel`, `grid` or `solar` sanitises to the id of a node already in the hierarchy. Its topics were appended to that node, binding one device's readings onto another — on this install, an appliance's power would have landed on the Grid node and been rolled up as grid import.

## Change

Sameness is decided by topic: the existing node must already bind at least one of the topics this scan found for that device, which is what an earlier import of it would have left behind. A node that binds none of them is a different thing, so the device is imported under the next free id (`grid_2`) and the operator is told.

## Tests

The GUI check imports a device whose id collides with an unrelated existing node, and asserts that node's sources are untouched and the device arrives beside it. Removing the guard fails it:

```
collision guard removed -> an unrelated node absorbed the imported device's sources
```

669 tests pass; nine GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
