### PR TITLE
feat(flow): persist the period-counter audit across restarts

### DIFF
--- a/rPDU2MQTT.Core/Flow/IPeriodAuditStore.cs
+++ b/rPDU2MQTT.Core/Flow/IPeriodAuditStore.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+
+namespace rPDU2MQTT.Core.Flow;
+
+/// <summary>
+/// Where <see cref="PeriodCounterAudit"/>'s verdicts live between restarts.
+///
+/// <para>
+/// The audit decides whether a source declared as a daily counter has behaved like one, and it can only
+/// decide that by comparing a period against the one before it. Held in memory, a restart erases the
+/// previous period: the source is unproven again and its reading is published as today's total until the
+/// next rollover. On a deployment that restarts on every image update that is most of the time.
+/// </para>
+/// <para>
+/// Keyed by node|source|direction, so it is a different shape from <see cref="IEnergyStore"/> and kept
+/// apart from it. The two do sit side by side in the same backing store.
+/// </para>
+/// </summary>
+public interface IPeriodAuditStore
+{
+    /// <summary>Everything known so far. Called once, before the first reading is judged.</summary>
+    IReadOnlyDictionary<string, PeriodCounterAudit.State> Load();
+
+    /// <summary>Persist the whole set. Called when a verdict or a high-water mark changes.</summary>
+    void Save(IReadOnlyDictionary<string, PeriodCounterAudit.State> states);
+}
+
+/// <summary>Keeps the verdicts in memory only — the behaviour this interface exists to replace.</summary>
+public sealed class MemoryPeriodAuditStore : IPeriodAuditStore
+{
+    private IReadOnlyDictionary<string, PeriodCounterAudit.State> held = new Dictionary<string, PeriodCounterAudit.State>();
+    public IReadOnlyDictionary<string, PeriodCounterAudit.State> Load() => held;
+    public void Save(IReadOnlyDictionary<string, PeriodCounterAudit.State> states) => held = states;
+}
+
+/// <summary>
+/// One small JSON file, alongside the energy totals.
+///
+/// <para>
+/// Written via a temp file and moved into place, so a crash mid-write leaves the previous verdicts rather
+/// than a truncated file. A verdict lost this way is not silently wrong — it reverts to unproven, which is
+/// the pre-restart behaviour.
+/// </para>
+/// </summary>
+public sealed class FilePeriodAuditStore(string path, Action<string>? warn = null) : IPeriodAuditStore
+{
+    private static readonly JsonSerializerOptions Json = new() { WriteIndented = true };
+
+    public IReadOnlyDictionary<string, PeriodCounterAudit.State> Load()
+    {
+        try
+        {
+            if (!File.Exists(path)) return new Dictionary<string, PeriodCounterAudit.State>();
+            return JsonSerializer.Deserialize<Dictionary<string, PeriodCounterAudit.State>>(File.ReadAllText(path))
+                   ?? new Dictionary<string, PeriodCounterAudit.State>();
+        }
+        catch (Exception ex)
+        {
+            warn?.Invoke($"Could not read the period-counter audit at {path} ({ex.Message}). Sources declared as "
+                       + "daily counters are unproven until the next rollover.");
+            return new Dictionary<string, PeriodCounterAudit.State>();
+        }
+    }
+
+    public void Save(IReadOnlyDictionary<string, PeriodCounterAudit.State> states)
+    {
+        try
+        {
+            var tmp = path + ".tmp";
+            File.WriteAllText(tmp, JsonSerializer.Serialize(states, Json));
+            File.Move(tmp, path, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            warn?.Invoke($"Could not write the period-counter audit to {path} ({ex.Message}).");
+        }
+    }
+}

--- a/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
@@ -26,7 +26,11 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
     // For 'auto' connections: the framing that actually read, so we don't re-probe both every poll.
     private readonly Dictionary<string, string> resolvedFraming = new(StringComparer.Ordinal);
 
-    public EnergyFlowModbusSourceService(Config cfg) => this.cfg = cfg;
+    public EnergyFlowModbusSourceService(Config cfg, IPeriodAuditStore? auditStore = null)
+    {
+        this.cfg = cfg;
+        this.auditStore = auditStore ?? new MemoryPeriodAuditStore();
+    }
 
     public bool TryGetValue(string nodeId, string metric, out double value)
         => latest.TryGetValue(nodeId, metric, out value);
@@ -49,9 +53,11 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
     }
 
     // Per (node, register, direction): whether a source claiming to be a daily counter has behaved like one.
-    // In memory only, as on the MQTT side — a restart makes it unproven until the next rollover, erring
-    // towards showing the device's number rather than withholding one we have not yet caught out.
+    // Persisted, as on the MQTT side: a restart must not erase the previous period and leave every source
+    // unproven until the next rollover.
     private readonly Dictionary<string, PeriodCounterAudit.State> periodAudit = new(StringComparer.Ordinal);
+    private readonly IPeriodAuditStore auditStore;
+    private bool auditLoaded;
 
     /// <summary>Bindings whose readings are being dropped, so the GUI can say so where the number is missing.</summary>
     public IReadOnlyCollection<WithheldSource> Withheld => PeriodCounterAudit.WithheldIn(periodAudit);
@@ -98,6 +104,12 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         var framing = resolvedFraming.TryGetValue(conn.Id, out var cached) ? cached : conn.Framing;
 
         var periodKey = CurrentPeriodKey(nowUtc);
+        if (!auditLoaded)
+        {
+            auditLoaded = true;
+            foreach (var (k, v) in auditStore.Load()) periodAudit[k] = v;
+        }
+        var auditBefore = periodAudit.Count == 0 ? "" : string.Join('|', periodAudit.Select(kv => $"{kv.Key}={kv.Value.PeriodKey}:{kv.Value.HighWater}:{kv.Value.Contradicted}").OrderBy(x => x, StringComparer.Ordinal));
 
         ReadBatch(conn.Host, conn.Port, conn.UnitId, framing, conn.TimeoutMs, forConn.Select(f => f.Source).ToList(),
             onValue: (src, value) =>
@@ -116,6 +128,10 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
             },
             onError: (src, msg) => Log.Debug($"Energy-flow Modbus: node '{nodeOf[src]}' register {src.Register} on {conn.Id} — {msg}"),
             onResolved: f => resolvedFraming[conn.Id] = f);
+
+        // Only when something moved: a poll that changes nothing must not write the cache.
+        var auditAfter = periodAudit.Count == 0 ? "" : string.Join('|', periodAudit.Select(kv => $"{kv.Key}={kv.Value.PeriodKey}:{kv.Value.HighWater}:{kv.Value.Contradicted}").OrderBy(x => x, StringComparer.Ordinal));
+        if (auditBefore != auditAfter) auditStore.Save(new Dictionary<string, PeriodCounterAudit.State>(periodAudit));
     }
 
     /// <summary>

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -37,20 +37,24 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     private long version;
     private long received;
     // Per (node, topic, direction): whether a source claiming to be a daily counter has actually behaved
-    // like one. In memory only — a restart makes it unproven again until the next rollover, which errs
-    // towards showing the device's number rather than withholding one we haven't yet caught out.
+    // like one. Loaded from the store on first use and written back when a verdict changes, so a restart
+    // does not erase the previous period and leave every source unproven until the next rollover.
     private readonly Dictionary<string, PeriodCounterAudit.State> periodAudit = new(StringComparer.Ordinal);
+    private readonly IPeriodAuditStore auditStore;
+    private bool auditLoaded;
 
     /// <summary>Bindings whose readings are being dropped, so the GUI can say so where the number is missing.</summary>
     public IReadOnlyCollection<WithheldSource> Withheld => PeriodCounterAudit.WithheldIn(periodAudit);
 
-    public EnergyFlowMqttSourceService(MQTTServiceDependencies deps, ISnapshotSink<MeasurementSnapshot>? sink = null)
+    public EnergyFlowMqttSourceService(MQTTServiceDependencies deps, ISnapshotSink<MeasurementSnapshot>? sink = null,
+                                       IPeriodAuditStore? auditStore = null)
     {
         // OnMessageReceived lives on the concrete client, not the interface.
         mqtt = deps.Mqtt as HiveMQClient
             ?? throw new InvalidOperationException("Expected a HiveMQClient instance for energy-flow MQTT sources.");
         cfg = deps.Cfg;
         this.sink = sink;
+        this.auditStore = auditStore ?? new MemoryPeriodAuditStore();
     }
 
     public bool TryGetValue(string nodeId, string metric, out double value)
@@ -182,6 +186,14 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
         return true;
     }
 
+    /// <summary>
+    /// A cheap comparison of the audit's contents, to decide whether it is worth persisting. The
+    /// high-water mark changes on most readings, so the store is written only when something did.
+    /// </summary>
+    private static string Snapshot(Dictionary<string, PeriodCounterAudit.State> audit)
+        => string.Join('\u0001', audit.OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => $"{kv.Key}={kv.Value.PeriodKey}:{kv.Value.HighWater}:{kv.Value.Contradicted}"));
+
     /// <summary>The period a reading now belongs to, on the same boundary the daily accumulator uses.</summary>
     private string CurrentPeriodKey(DateTime nowUtc)
     {
@@ -195,12 +207,24 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
         // Collect the readings this message produced (only if a sink is wired) and push them to the flow grain
         // event-driven — the "subscription manager routes events to the recipient grain" (#v3).
         List<MeasurementReading>? readings = sink is null ? null : new();
+        // Loaded lazily: the store may be a cache that is not up yet when the service starts, and the first
+        // message is the first moment a verdict is needed.
+        if (!auditLoaded)
+        {
+            auditLoaded = true;
+            foreach (var (k, v) in auditStore.Load()) periodAudit[k] = v;
+        }
+
+        var auditBefore = Snapshot(periodAudit);
         Apply(bindings, latest, e.PublishMessage.Topic, e.PublishMessage.PayloadAsString, now,
             readings is null ? null : (node, metric, value, stale) =>
             {
                 if (Metrics.TryParse(metric, out var m)) readings.Add(new MeasurementReading(node, m, value, stale));
             },
             periodAudit, CurrentPeriodKey(now), m => Log.Warning(m));
+        // Only on a change: the high-water mark moves on most readings, and writing the cache per message
+        // would put a round-trip on every publish the broker sends us.
+        if (auditBefore != Snapshot(periodAudit)) auditStore.Save(new Dictionary<string, PeriodCounterAudit.State>(periodAudit));
 
         if (sink is not null && readings is { Count: > 0 })
         {

--- a/rPDU2MQTT.Engine/Services/RedisPeriodAuditStore.cs
+++ b/rPDU2MQTT.Engine/Services/RedisPeriodAuditStore.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using rPDU2MQTT.Core.Flow;
+
+namespace rPDU2MQTT.Services;
+
+/// <summary>
+/// The period-counter audit's verdicts in Redis/Valkey, in a hash beside the energy totals.
+///
+/// <para>
+/// Shared across replicas as well as across restarts: the verdict is about a source, not about a process,
+/// so two replicas reading the same broker should reach the same conclusion rather than each learning it
+/// separately at the next rollover.
+/// </para>
+/// <para>
+/// An unreachable instance reports empty and says so rather than throwing. The caller then treats every
+/// source as unproven, which is the behaviour before this store existed.
+/// </para>
+/// </summary>
+public sealed class RedisPeriodAuditStore : IPeriodAuditStore
+{
+    private readonly ICacheClient cache;
+    private readonly string key;
+    private readonly Action<string>? warn;
+    private bool complained;
+
+    public RedisPeriodAuditStore(ICacheClient cache, string keyPrefix, Action<string>? warn = null)
+    {
+        this.cache = cache;
+        this.key = (keyPrefix ?? "") + "periodaudit";
+        this.warn = warn;
+    }
+
+    public IReadOnlyDictionary<string, PeriodCounterAudit.State> Load()
+    {
+        var states = new Dictionary<string, PeriodCounterAudit.State>();
+        try
+        {
+            foreach (var (source, json) in cache.HashGetAll(key))
+            {
+                // One unreadable field must not discard every other source's verdict.
+                try
+                {
+                    if (JsonSerializer.Deserialize<PeriodCounterAudit.State>(json) is { } s) states[source] = s;
+                }
+                catch (JsonException ex)
+                {
+                    warn?.Invoke($"Period-counter audit for '{source}' in {key} is unreadable ({ex.Message}); "
+                               + "that source is unproven until the next rollover.");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Complain($"Could not read the period-counter audit from the cache ({ex.Message}). Sources declared as "
+                   + "daily counters are unproven for this run.");
+        }
+        return states;
+    }
+
+    public void Save(IReadOnlyDictionary<string, PeriodCounterAudit.State> states)
+    {
+        try
+        {
+            cache.HashSet(key, states.ToDictionary(kv => kv.Key, kv => JsonSerializer.Serialize(kv.Value)));
+            complained = false;
+        }
+        catch (Exception ex)
+        {
+            Complain($"Could not write the period-counter audit to the cache ({ex.Message}). The verdicts hold in "
+                   + "memory, but a restart before it recovers loses them.");
+        }
+    }
+
+    // An unreachable cache fails on every pass; say it once per outage rather than filling the log.
+    private void Complain(string message)
+    {
+        if (complained) return;
+        complained = true;
+        warn?.Invoke(message);
+    }
+}

--- a/rPDU2MQTT.Tests/PeriodAuditStoreTests.cs
+++ b/rPDU2MQTT.Tests/PeriodAuditStoreTests.cs
@@ -1,0 +1,131 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Services;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// The audit compares a period against the one before it, so its verdicts have to outlive the process.
+/// Held in memory, a restart erased the previous period and every source declared as a daily counter was
+/// unproven again — its reading published as today's total until the next rollover.
+/// </summary>
+public class PeriodAuditStoreTests : IDisposable
+{
+    private readonly string path = Path.Combine(Path.GetTempPath(), $"period-audit-{Guid.NewGuid():N}.json");
+
+    public void Dispose()
+    {
+        if (File.Exists(path)) File.Delete(path);
+        if (File.Exists(path + ".tmp")) File.Delete(path + ".tmp");
+    }
+
+    private sealed class FakeCache : ICacheClient
+    {
+        public readonly Dictionary<string, Dictionary<string, string>> Data = new();
+        public bool Down;
+        public IReadOnlyDictionary<string, string> HashGetAll(string key)
+        {
+            if (Down) throw new InvalidOperationException("cache is not connected");
+            return Data.TryGetValue(key, out var h) ? h : new Dictionary<string, string>();
+        }
+        public bool Ping() => !Down;
+        public void HashSet(string key, IReadOnlyDictionary<string, string> fields)
+        {
+            if (Down) throw new InvalidOperationException("cache is not connected");
+            Data[key] = fields.ToDictionary(kv => kv.Key, kv => kv.Value);
+        }
+    }
+
+    private static Dictionary<string, PeriodCounterAudit.State> Contradicted()
+    {
+        var audit = new Dictionary<string, PeriodCounterAudit.State>();
+        PeriodCounterAudit.Allow(audit, "2026-08-04", "solar", "sa/pv_energy", "out", 129.9, null);
+        PeriodCounterAudit.Allow(audit, "2026-08-05", "solar", "sa/pv_energy", "out", 130.4, null);   // no reset
+        Assert.Single(PeriodCounterAudit.WithheldIn(audit));
+        return audit;
+    }
+
+    [Fact]
+    public void AVerdictSurvivesAReload_File()
+    {
+        // The property the store exists for: after a restart the source is still withheld, without waiting
+        // for another rollover to catch it out a second time.
+        new FilePeriodAuditStore(path).Save(Contradicted());
+
+        var reloaded = new Dictionary<string, PeriodCounterAudit.State>(new FilePeriodAuditStore(path).Load());
+
+        var withheld = Assert.Single(PeriodCounterAudit.WithheldIn(reloaded));
+        Assert.Equal("solar", withheld.Node);
+        Assert.Contains("did not reset", withheld.Reason);
+
+        // And the next reading is still refused, rather than the source getting a clean slate.
+        Assert.False(PeriodCounterAudit.Allow(reloaded, "2026-08-05", "solar", "sa/pv_energy", "out", 131.0, null));
+    }
+
+    [Fact]
+    public void AVerdictSurvivesAReload_Cache()
+    {
+        var cache = new FakeCache();
+        new RedisPeriodAuditStore(cache, "rpdu2mqtt:").Save(Contradicted());
+
+        // Beside the energy totals, not mixed into them.
+        Assert.Contains("rpdu2mqtt:periodaudit", cache.Data.Keys);
+        Assert.DoesNotContain("rpdu2mqtt:energy", cache.Data.Keys);
+
+        var reloaded = new Dictionary<string, PeriodCounterAudit.State>(new RedisPeriodAuditStore(cache, "rpdu2mqtt:").Load());
+        Assert.Single(PeriodCounterAudit.WithheldIn(reloaded));
+    }
+
+    [Fact]
+    public void AHighWaterMarkSurvives_SoTheNextRolloverCanStillJudge()
+    {
+        // Restarting mid-period must not lose the peak: without it the next rollover has nothing to compare
+        // against and a cumulative counter passes as honest.
+        var audit = new Dictionary<string, PeriodCounterAudit.State>();
+        PeriodCounterAudit.Allow(audit, "2026-08-04", "solar", "sa/pv_energy", "out", 129.9, null);
+        new FilePeriodAuditStore(path).Save(audit);
+
+        var reloaded = new Dictionary<string, PeriodCounterAudit.State>(new FilePeriodAuditStore(path).Load());
+
+        Assert.False(PeriodCounterAudit.Allow(reloaded, "2026-08-05", "solar", "sa/pv_energy", "out", 130.4, null));
+    }
+
+    [Fact]
+    public void AnUnreadableStoreLeavesEverythingUnproven_RatherThanThrowing()
+    {
+        // Degrading to the previous behaviour is acceptable; taking the ingest down is not.
+        File.WriteAllText(path, "{ this is not json");
+        var warnings = new List<string>();
+
+        var loaded = new FilePeriodAuditStore(path, warnings.Add).Load();
+
+        Assert.Empty(loaded);
+        Assert.Single(warnings);
+    }
+
+    [Fact]
+    public void AnUnreachableCacheLoadsEmptyAndSaysSoOnce()
+    {
+        var cache = new FakeCache { Down = true };
+        var warnings = new List<string>();
+        var store = new RedisPeriodAuditStore(cache, "rpdu2mqtt:", warnings.Add);
+
+        Assert.Empty(store.Load());
+        store.Save(Contradicted());
+        store.Save(Contradicted());
+
+        Assert.Single(warnings);   // one per outage, not one per attempt
+    }
+
+    [Fact]
+    public void OneUnreadableFieldDoesNotDiscardTheRest()
+    {
+        var cache = new FakeCache();
+        new RedisPeriodAuditStore(cache, "p:").Save(Contradicted());
+        cache.Data["p:periodaudit"]["broken|x|out"] = "{{{";
+
+        var loaded = new RedisPeriodAuditStore(cache, "p:").Load();
+
+        Assert.Single(loaded);
+    }
+}

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -356,6 +356,8 @@ public static class ServiceConfiguration
             services.AddSingleton<Services.ICacheClient>(sp => sp.GetRequiredService<Services.RedisCacheClient>());
             services.AddSingleton<Core.Flow.IEnergyStore>(sp => new Services.RedisEnergyStore(
                 sp.GetRequiredService<Services.ICacheClient>(), cfg.Cache.KeyPrefix, m => Log.Warning(m)));
+            services.AddSingleton<Core.Flow.IPeriodAuditStore>(sp => new Services.RedisPeriodAuditStore(
+                sp.GetRequiredService<Services.ICacheClient>(), cfg.Cache.KeyPrefix, m => Log.Warning(m)));
         }
         else
         {
@@ -363,6 +365,8 @@ public static class ServiceConfiguration
             // the property that actually matters. It just can't be shared between replicas.
             services.AddSingleton<Core.Flow.IEnergyStore>(_ => new Core.Flow.FileEnergyStore(
                 Path.Combine(AppContext.BaseDirectory, "energy-totals.json"), m => Log.Warning(m)));
+            services.AddSingleton<Core.Flow.IPeriodAuditStore>(_ => new Core.Flow.FilePeriodAuditStore(
+                Path.Combine(AppContext.BaseDirectory, "period-audit.json"), m => Log.Warning(m)));
         }
     }
 }


### PR DESCRIPTION
The gap I flagged in #340 and deferred three times.

The audit decides whether a source declared as a daily counter behaves like one by comparing a period against the one before it. Held in memory, a restart erased the previous period — every such source became unproven and its reading was published as today's total until the next rollover. On a deployment that restarts on each image update, that is most of the time.

## Change

`IPeriodAuditStore` mirrors `IEnergyStore`:

| Deployment | Store |
|---|---|
| default | `period-audit.json`, beside `energy-totals.json` |
| `Cache.Enabled` | `<prefix>periodaudit` hash, beside `<prefix>energy` |
| neither registered | in-memory (the previous behaviour) |

Shared across replicas as well as restarts: the verdict is about a source, not a process.

Both ingests load on first use and write back **only when a verdict or high-water mark changes**, so a poll that moves nothing costs no round-trip.

Failure degrades rather than escalating: an unreadable file or unreachable cache loads empty and warns once, leaving sources unproven until the next rollover — exactly where they were before this existed.

## Tests

Six: a verdict survives a reload through both stores; a mid-period high-water mark survives, so the next rollover can still judge; the audit hash is separate from the energy one; an unreadable store loads empty and warns; an unreachable cache warns once per outage; one unreadable field does not discard the rest.

Making the file store forget on reload fails three:

```
file store forgets on reload -> Failed!  - Failed: 3, Passed: 3
```

678 tests pass; nine GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
