### PR TITLE
feat(energy): switch the Energy board between power and energy today, and show the grid's net

### DIFF
--- a/rPDU2MQTT.Web/rPDU2MQTT.Web.csproj
+++ b/rPDU2MQTT.Web/rPDU2MQTT.Web.csproj
@@ -46,6 +46,7 @@
 			<GuiSource Include="web\contradiction.check.mjs" />
 			<GuiSource Include="web\tags.check.mjs" />
 			<GuiSource Include="web\discover.check.mjs" />
+			<GuiSource Include="web\energyshow.check.mjs" />
 		<GuiSource Include="web\schema.fixture.json" />
 	</ItemGroup>
 
@@ -77,6 +78,7 @@
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/contradiction.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/tags.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/discover.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
+		<Exec Condition="'$(_NodeExitCode)' == '0'" Command="node web/energyshow.check.mjs" WorkingDirectory="$(MSBuildProjectDirectory)" />
 		<Warning Condition="'$(_NodeExitCode)' != '0'" Text="node not found; using the committed wwwroot/app.js + styles.css. Install Node 22+ to rebuild the GUI from web/src." />
 	</Target>
 

--- a/rPDU2MQTT.Web/web/energyshow.check.mjs
+++ b/rPDU2MQTT.Web/web/energyshow.check.mjs
@@ -1,0 +1,76 @@
+// The Energy board's Show toggle (#371): power now, or energy for the day so far.
+//
+// Two properties matter. A node's Max is a full-scale power figure, so no dial is drawn against a kWh
+// reading. And the grid's day figure is the NET — import minus export, signed — because a magnitude reads
+// the same for a day that imported 5 kWh and one that exported 5.
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+import { makeDom, query } from './domstub.mjs';
+
+const code = await readFile(new URL('../wwwroot/app.js', import.meta.url), 'utf8');
+const schema = JSON.parse(await readFile(new URL('./schema.fixture.json', import.meta.url), 'utf8'))
+  .filter(n => n.key !== '_README');
+const fail = (m) => { console.error('energy-show check FAILED: ' + m); process.exit(1); };
+const cn = (e) => String((e && (e.className || (e.attrs && e.attrs.class))) || '');
+
+const cfg = { EnergyFlow: { Nodes: [{ Id: 'grid', Kind: 'grid', Max: 9000 }, { Id: 'solar', Kind: 'solar', Max: 9000 }], Links: [] } };
+
+const power = {
+  ok: true, metric: 'realpower', units: 'W',
+  nodes: [{ id: 'solar', label: 'Solar', kind: 'solar', value: 4600 }, { id: 'grid', label: 'Grid', kind: 'grid', value: 1200 }],
+  links: [],
+};
+// Exported more than imported today: out 2.0, in 7.5 -> net -5.5 kWh.
+const today = {
+  ok: true, metric: 'energytoday', units: 'kWh',
+  nodes: [{ id: 'solar', label: 'Solar', kind: 'solar', value: 41.2 }, { id: 'grid', label: 'Grid', kind: 'grid', value: 2.0 }],
+  links: [],
+};
+
+const { sandbox, getEl } = makeDom({
+  bodies: (url) =>
+    url.includes('/api/schema') ? schema :
+    url.includes('/api/instances') ? { ok: true, instances: [] } :
+    url.includes('/api/config') ? cfg :
+    url.includes('/api/flow/live') ? { ok: true, values: [{ node: 'grid', metric: 'energytoday#in', value: 7.5 }] } :
+    url.includes('metric=energytoday') ? today :
+    url.includes('/api/flow') ? power :
+    { ok: true },
+});
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox, { filename: 'app.js' });
+await new Promise(r => setTimeout(r, 50));
+query(getEl('nav'), 'a', true).find(a => a.dataset.label === 'Energy').click();
+await new Promise(r => setTimeout(r, 400));
+
+const tiles = () => query(getEl('sections'), 'div', true).filter(d => cn(d).includes('energy-tile'));
+const tileText = (label) => {
+  const t = tiles().find(x => x.textContent.includes(label));
+  if (!t) fail(`no ${label} tile`);
+  return t;
+};
+
+// Power: dials are drawn against the stated Max.
+if (!query(getEl('sections'), 'svg', true).some(g => cn(g).includes('gauge'))) fail('no gauge on the power view');
+
+const show = query(getEl('sections'), 'select', true)
+  .find(s => (s.children || []).some(o => (o.value || (o.attrs && o.attrs.value)) === 'energytoday'));
+if (!show) fail('no Show selector offering energy today');
+show.value = 'energytoday';
+show.onchange({});
+await new Promise(r => setTimeout(r, 400));
+
+const solarTile = tileText('Solar');
+if (!solarTile.textContent.includes('41.2')) fail(`the solar tile did not switch to the day's energy: ${solarTile.textContent}`);
+if (!solarTile.textContent.includes('kWh')) fail('the energy tile does not carry its unit');
+
+// No dial: a Max is a power ceiling and means nothing against kWh.
+if (query(getEl('sections'), 'svg', true).some(g => cn(g).includes('gauge')))
+  fail('a gauge was drawn against a power ceiling while showing energy');
+
+// The grid figure is the signed net: 2.0 out - 7.5 in = -5.5.
+const gridTile = tileText('Grid');
+if (!/-5\.5/.test(gridTile.textContent)) fail(`the grid tile does not show the day's net: ${gridTile.textContent}`);
+
+console.log('energy-show: the board switches between power and energy today; no dial against a power '
+  + 'ceiling on kWh; the grid shows the signed net for the day');

--- a/rPDU2MQTT.Web/web/src/sections/flow.ts
+++ b/rPDU2MQTT.Web/web/src/sections/flow.ts
@@ -2962,9 +2962,16 @@ export function addEnergyOverviewSection(nav: any, sections: any) {
 
   const bar = el('div', { class: 'sec-actions' });
   const refresh = btn('Refresh');
+  // Power now, or energy for the day so far (#371). Two different questions: what the house is doing this
+  // second, and what it has used since the period rolled over.
+  const showSel = el('select', { style: { width: 'auto' } }) as HTMLSelectElement;
+  showSel.appendChild(el('option', { value: 'realpower', text: 'Power (W)' }));
+  showSel.appendChild(el('option', { value: 'energytoday', text: 'Energy today (kWh)' }));
   const instSel = instanceSelector(() => load());
   const status = el('span', { class: 'ld-count' });
-  bar.append(refresh, instSel.wrap, status); sec.appendChild(bar);
+  bar.append(refresh, el('span', { class: 'desc', style: { margin: '0' }, text: 'Show:' }), showSel, instSel.wrap, status);
+  sec.appendChild(bar);
+  showSel.onchange = () => load();
 
   // One column for the whole board, so the diagram and the tiles share an edge and read as a single
   // thing. Left to themselves the diagram centred itself in the page while the tiles bunched up against
@@ -3158,8 +3165,13 @@ export function addEnergyOverviewSection(nav: any, sections: any) {
   };
 
   const loadBoard = async () => {
+    // The whole board reads one metric (#371). Power and energy-today are the same shape — a value per
+    // node plus an in-direction for the bidirectional ones — so the tiles are built once and the metric
+    // decides what they mean.
+    const metric = showSel.value || 'realpower';
+    const isEnergy = metric !== 'realpower';
     let r: any;
-    try { r = await api(withInstance('/api/flow', instSel)); }
+    try { r = await api(withInstance('/api/flow' + (isEnergy ? '?metric=' + encodeURIComponent(metric) : ''), instSel)); }
     catch (e: any) { r = { body: { ok: false, message: 'Could not reach the bridge: ' + (e?.message || 'the request failed') } }; }
     grid.innerHTML = ''; summary.innerHTML = ''; flowWrap.innerHTML = '';
     if (!r.body || !r.body.ok) {
@@ -3191,7 +3203,7 @@ export function addEnergyOverviewSection(nav: any, sections: any) {
     // which are the only way to tell a source that has expired from one that never published at all.
     const liveInfo: Record<string, any> = {};
     const q = [
-      ...[...battIds, ...gridIds].map(id => ({ Node: id, Metric: 'realpower#in' })),
+      ...[...battIds, ...gridIds].map(id => ({ Node: id, Metric: metric + '#in' })),
       ...battIds.map(id => ({ Node: id, Metric: 'soc' })),
     ];
     if (q.length) {
@@ -3203,10 +3215,16 @@ export function addEnergyOverviewSection(nav: any, sections: any) {
         });
       } catch { /* no live cache — these reads just stay absent */ }
     }
-    const sumIn = (ids: string[]) => { let s = 0, known = false; ids.forEach(id => { const k = `${id}|realpower#in`; if (k in liveBy) { s += liveBy[k]; known = true; } }); return known ? s : null; };
+    const sumIn = (ids: string[]) => { let s = 0, known = false; ids.forEach(id => { const k = `${id}|${metric}#in`; if (k in liveBy) { s += liveBy[k]; known = true; } }); return known ? s : null; };
     // Battery SoC: average across battery nodes that report it (a bank reads as one figure).
     const socVals = battIds.map(id => liveBy[`${id}|soc`]).filter((v): v is number => typeof v === 'number');
     const soc = socVals.length ? Math.round(socVals.reduce((a, b) => a + b, 0) / socVals.length) : null;
+
+    // Formatting and gauges follow the metric. A node's Max is a full-scale power figure, so a dial against
+    // it means nothing for kWh — the tile shows the plain reading instead.
+    const units = r.body.units || (isEnergy ? 'kWh' : 'W');
+    const fmt = (v: number | null) => isEnergy ? fmtEnergy(v, units) : fmtPower(v);
+    const dial = (ids: string[], v: number | null) => isEnergy ? undefined : gaugeFor(ids, v, 'W');
 
     const solar = sumKind(nodes, 'solar');
     const batt = sumKind(nodes, 'battery');   // out = discharge
@@ -3268,17 +3286,17 @@ export function addEnergyOverviewSection(nav: any, sections: any) {
 
     // Animated flow diagram — the arms present in this system, each with its live figure and flow direction.
     const arms: any[] = [];
-    if (solar.present) arms.push({ key: 'solar', icon: '☀️', label: 'Solar', text: fmtPower(solar.value), color: 'var(--warn)', flow: solar.value });
-    if (batt.present || battIds.length) arms.push({ key: 'battery', icon: '🔋', label: 'Battery', text: soc != null ? `${soc}%` : fmtPower(battNet == null ? null : Math.abs(battNet)), color: 'var(--good)', flow: battNet });
-    if (gridK.present || gridIds.length) arms.push({ key: 'grid', icon: '⚡', label: 'Grid', text: fmtPower(gridNet == null ? null : Math.abs(gridNet)), color: 'var(--accent)', flow: gridNet });
-    if (home != null || load_.present) arms.push({ key: 'home', icon: '🏠', label: 'Home', text: fmtPower(home), color: 'var(--muted)', flow: home });
+    if (solar.present) arms.push({ key: 'solar', icon: '☀️', label: 'Solar', text: fmt(solar.value), color: 'var(--warn)', flow: solar.value });
+    if (batt.present || battIds.length) arms.push({ key: 'battery', icon: '🔋', label: 'Battery', text: soc != null ? `${soc}%` : fmt(battNet == null ? null : Math.abs(battNet)), color: 'var(--good)', flow: battNet });
+    if (gridK.present || gridIds.length) arms.push({ key: 'grid', icon: '⚡', label: 'Grid', text: fmt(gridNet == null ? null : Math.abs(gridNet)), color: 'var(--accent)', flow: gridNet });
+    if (home != null || load_.present) arms.push({ key: 'home', icon: '🏠', label: 'Home', text: fmt(home), color: 'var(--muted)', flow: home });
     if (arms.length) drawFlow(arms);
 
     // Solar
     if (solar.present)
-      grid.appendChild(tile('solar', '☀️', 'Solar', fmtPower(solar.value),
+      grid.appendChild(tile('solar', '☀️', 'Solar', fmt(solar.value),
         subOrWhy(solar.value, 'solar', solar.value! > 1 ? 'producing' : 'idle'), solar.value && solar.value > 1 ? 'supply' : '',
-        gaugeFor(solarIds, solar.value, 'W')));
+        dial(solarIds, solar.value)));
 
     // Battery — sign tells charge vs discharge; magnitude is what's shown. SoC (when bound) leads the sub-line.
     if (batt.present || battIds.length) {
@@ -3290,8 +3308,8 @@ export function addEnergyOverviewSection(nav: any, sections: any) {
       const socWhy = soc == null ? whyNoSoc(battIds, liveInfo) : null;
       // The dial is the battery's power against its rating; the slim bar below is state of charge. Two
       // different quantities, so they are two different marks rather than one doing double duty.
-      const t = tile('battery', '🔋', 'Battery', fmtPower(battNet == null ? null : Math.abs(battNet)), `${soc == null ? socWhy : soc + '%'} · ${dir}`, cls,
-        gaugeFor(battIds, battNet == null ? null : Math.abs(battNet), 'W'));
+      const t = tile('battery', '🔋', 'Battery', fmt(battNet == null ? null : Math.abs(battNet)), `${soc == null ? socWhy : soc + '%'} · ${dir}`, cls,
+        dial(battIds, battNet == null ? null : Math.abs(battNet)));
       if (socWhy) t.title = `No battery percentage: ${socWhy}. Bind or correct the state-of-charge source on the Nodes tab.`;
       // A slim charge gauge under the tile when SoC is known — the "battery %" at a glance.
       if (soc != null) {
@@ -3305,14 +3323,18 @@ export function addEnergyOverviewSection(nav: any, sections: any) {
     if (gridK.present || gridIds.length) {
       const sub = subOrWhy(gridNet, 'grid', gridNet! > 1 ? 'importing' : gridNet! < -1 ? 'exporting' : 'idle');
       const cls = gridNet == null ? '' : gridNet > 1 ? 'draw' : gridNet < -1 ? 'supply' : '';
-      grid.appendChild(tile('grid', '⚡', 'Grid', fmtPower(gridNet == null ? null : Math.abs(gridNet)), sub, cls,
-        gaugeFor(gridIds, gridNet == null ? null : Math.abs(gridNet), 'W')));
+      // On energy the figure is the day's NET — import minus export, signed (#371). A magnitude would read
+      // the same for a day that imported 5 kWh and one that exported 5 kWh.
+      const gridShown = gridNet == null ? null : isEnergy ? gridNet : Math.abs(gridNet);
+      grid.appendChild(tile('grid', '⚡', 'Grid', fmt(gridShown),
+        isEnergy ? `${sub} · net for the day` : sub, cls,
+        dial(gridIds, gridNet == null ? null : Math.abs(gridNet))));
     }
 
     // Home load (computed above with the flow arms).
     if (home != null || load_.present)
-      grid.appendChild(tile('home', '🏠', 'Home', fmtPower(home), home == null ? whyNoReading('load') : (homeSub || 'consuming'), '',
-        gaugeFor(loadIds, home, 'W')));
+      grid.appendChild(tile('home', '🏠', 'Home', fmt(home), home == null ? whyNoReading('load') : (homeSub || 'consuming'), '',
+        dial(loadIds, home)));
 
     // Self-sufficiency: the share of the home's cumulative ENERGY (kWh) NOT drawn from the grid — a lifetime
     // figure, not this instant's power. Only when the home energy and grid import both resolve and the house

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -4389,9 +4389,16 @@ function addEnergyOverviewSection(nav     , sections     ) {
 
   const bar = el('div', { class: 'sec-actions' });
   const refresh = btn('Refresh');
+  // Power now, or energy for the day so far (#371). Two different questions: what the house is doing this
+  // second, and what it has used since the period rolled over.
+  const showSel = el('select', { style: { width: 'auto' } })                     ;
+  showSel.appendChild(el('option', { value: 'realpower', text: 'Power (W)' }));
+  showSel.appendChild(el('option', { value: 'energytoday', text: 'Energy today (kWh)' }));
   const instSel = instanceSelector(() => load());
   const status = el('span', { class: 'ld-count' });
-  bar.append(refresh, instSel.wrap, status); sec.appendChild(bar);
+  bar.append(refresh, el('span', { class: 'desc', style: { margin: '0' }, text: 'Show:' }), showSel, instSel.wrap, status);
+  sec.appendChild(bar);
+  showSel.onchange = () => load();
 
   // One column for the whole board, so the diagram and the tiles share an edge and read as a single
   // thing. Left to themselves the diagram centred itself in the page while the tiles bunched up against
@@ -4585,8 +4592,13 @@ function addEnergyOverviewSection(nav     , sections     ) {
   };
 
   const loadBoard = async () => {
+    // The whole board reads one metric (#371). Power and energy-today are the same shape — a value per
+    // node plus an in-direction for the bidirectional ones — so the tiles are built once and the metric
+    // decides what they mean.
+    const metric = showSel.value || 'realpower';
+    const isEnergy = metric !== 'realpower';
     let r     ;
-    try { r = await api(withInstance('/api/flow', instSel)); }
+    try { r = await api(withInstance('/api/flow' + (isEnergy ? '?metric=' + encodeURIComponent(metric) : ''), instSel)); }
     catch (e     ) { r = { body: { ok: false, message: 'Could not reach the bridge: ' + (e?.message || 'the request failed') } }; }
     grid.innerHTML = ''; summary.innerHTML = ''; flowWrap.innerHTML = '';
     if (!r.body || !r.body.ok) {
@@ -4618,7 +4630,7 @@ function addEnergyOverviewSection(nav     , sections     ) {
     // which are the only way to tell a source that has expired from one that never published at all.
     const liveInfo                      = {};
     const q = [
-      ...[...battIds, ...gridIds].map(id => ({ Node: id, Metric: 'realpower#in' })),
+      ...[...battIds, ...gridIds].map(id => ({ Node: id, Metric: metric + '#in' })),
       ...battIds.map(id => ({ Node: id, Metric: 'soc' })),
     ];
     if (q.length) {
@@ -4630,10 +4642,16 @@ function addEnergyOverviewSection(nav     , sections     ) {
         });
       } catch { /* no live cache — these reads just stay absent */ }
     }
-    const sumIn = (ids          ) => { let s = 0, known = false; ids.forEach(id => { const k = `${id}|realpower#in`; if (k in liveBy) { s += liveBy[k]; known = true; } }); return known ? s : null; };
+    const sumIn = (ids          ) => { let s = 0, known = false; ids.forEach(id => { const k = `${id}|${metric}#in`; if (k in liveBy) { s += liveBy[k]; known = true; } }); return known ? s : null; };
     // Battery SoC: average across battery nodes that report it (a bank reads as one figure).
     const socVals = battIds.map(id => liveBy[`${id}|soc`]).filter((v)              => typeof v === 'number');
     const soc = socVals.length ? Math.round(socVals.reduce((a, b) => a + b, 0) / socVals.length) : null;
+
+    // Formatting and gauges follow the metric. A node's Max is a full-scale power figure, so a dial against
+    // it means nothing for kWh — the tile shows the plain reading instead.
+    const units = r.body.units || (isEnergy ? 'kWh' : 'W');
+    const fmt = (v               ) => isEnergy ? fmtEnergy(v, units) : fmtPower(v);
+    const dial = (ids          , v               ) => isEnergy ? undefined : gaugeFor(ids, v, 'W');
 
     const solar = sumKind(nodes, 'solar');
     const batt = sumKind(nodes, 'battery');   // out = discharge
@@ -4695,17 +4713,17 @@ function addEnergyOverviewSection(nav     , sections     ) {
 
     // Animated flow diagram — the arms present in this system, each with its live figure and flow direction.
     const arms        = [];
-    if (solar.present) arms.push({ key: 'solar', icon: '☀️', label: 'Solar', text: fmtPower(solar.value), color: 'var(--warn)', flow: solar.value });
-    if (batt.present || battIds.length) arms.push({ key: 'battery', icon: '🔋', label: 'Battery', text: soc != null ? `${soc}%` : fmtPower(battNet == null ? null : Math.abs(battNet)), color: 'var(--good)', flow: battNet });
-    if (gridK.present || gridIds.length) arms.push({ key: 'grid', icon: '⚡', label: 'Grid', text: fmtPower(gridNet == null ? null : Math.abs(gridNet)), color: 'var(--accent)', flow: gridNet });
-    if (home != null || load_.present) arms.push({ key: 'home', icon: '🏠', label: 'Home', text: fmtPower(home), color: 'var(--muted)', flow: home });
+    if (solar.present) arms.push({ key: 'solar', icon: '☀️', label: 'Solar', text: fmt(solar.value), color: 'var(--warn)', flow: solar.value });
+    if (batt.present || battIds.length) arms.push({ key: 'battery', icon: '🔋', label: 'Battery', text: soc != null ? `${soc}%` : fmt(battNet == null ? null : Math.abs(battNet)), color: 'var(--good)', flow: battNet });
+    if (gridK.present || gridIds.length) arms.push({ key: 'grid', icon: '⚡', label: 'Grid', text: fmt(gridNet == null ? null : Math.abs(gridNet)), color: 'var(--accent)', flow: gridNet });
+    if (home != null || load_.present) arms.push({ key: 'home', icon: '🏠', label: 'Home', text: fmt(home), color: 'var(--muted)', flow: home });
     if (arms.length) drawFlow(arms);
 
     // Solar
     if (solar.present)
-      grid.appendChild(tile('solar', '☀️', 'Solar', fmtPower(solar.value),
+      grid.appendChild(tile('solar', '☀️', 'Solar', fmt(solar.value),
         subOrWhy(solar.value, 'solar', solar.value  > 1 ? 'producing' : 'idle'), solar.value && solar.value > 1 ? 'supply' : '',
-        gaugeFor(solarIds, solar.value, 'W')));
+        dial(solarIds, solar.value)));
 
     // Battery — sign tells charge vs discharge; magnitude is what's shown. SoC (when bound) leads the sub-line.
     if (batt.present || battIds.length) {
@@ -4717,8 +4735,8 @@ function addEnergyOverviewSection(nav     , sections     ) {
       const socWhy = soc == null ? whyNoSoc(battIds, liveInfo) : null;
       // The dial is the battery's power against its rating; the slim bar below is state of charge. Two
       // different quantities, so they are two different marks rather than one doing double duty.
-      const t = tile('battery', '🔋', 'Battery', fmtPower(battNet == null ? null : Math.abs(battNet)), `${soc == null ? socWhy : soc + '%'} · ${dir}`, cls,
-        gaugeFor(battIds, battNet == null ? null : Math.abs(battNet), 'W'));
+      const t = tile('battery', '🔋', 'Battery', fmt(battNet == null ? null : Math.abs(battNet)), `${soc == null ? socWhy : soc + '%'} · ${dir}`, cls,
+        dial(battIds, battNet == null ? null : Math.abs(battNet)));
       if (socWhy) t.title = `No battery percentage: ${socWhy}. Bind or correct the state-of-charge source on the Nodes tab.`;
       // A slim charge gauge under the tile when SoC is known — the "battery %" at a glance.
       if (soc != null) {
@@ -4732,14 +4750,18 @@ function addEnergyOverviewSection(nav     , sections     ) {
     if (gridK.present || gridIds.length) {
       const sub = subOrWhy(gridNet, 'grid', gridNet  > 1 ? 'importing' : gridNet  < -1 ? 'exporting' : 'idle');
       const cls = gridNet == null ? '' : gridNet > 1 ? 'draw' : gridNet < -1 ? 'supply' : '';
-      grid.appendChild(tile('grid', '⚡', 'Grid', fmtPower(gridNet == null ? null : Math.abs(gridNet)), sub, cls,
-        gaugeFor(gridIds, gridNet == null ? null : Math.abs(gridNet), 'W')));
+      // On energy the figure is the day's NET — import minus export, signed (#371). A magnitude would read
+      // the same for a day that imported 5 kWh and one that exported 5 kWh.
+      const gridShown = gridNet == null ? null : isEnergy ? gridNet : Math.abs(gridNet);
+      grid.appendChild(tile('grid', '⚡', 'Grid', fmt(gridShown),
+        isEnergy ? `${sub} · net for the day` : sub, cls,
+        dial(gridIds, gridNet == null ? null : Math.abs(gridNet))));
     }
 
     // Home load (computed above with the flow arms).
     if (home != null || load_.present)
-      grid.appendChild(tile('home', '🏠', 'Home', fmtPower(home), home == null ? whyNoReading('load') : (homeSub || 'consuming'), '',
-        gaugeFor(loadIds, home, 'W')));
+      grid.appendChild(tile('home', '🏠', 'Home', fmt(home), home == null ? whyNoReading('load') : (homeSub || 'consuming'), '',
+        dial(loadIds, home)));
 
     // Self-sufficiency: the share of the home's cumulative ENERGY (kWh) NOT drawn from the grid — a lifetime
     // figure, not this instant's power. Only when the home energy and grid import both resolve and the house


### PR DESCRIPTION
Closes #371.

## Show selector

Power (W) or Energy today (kWh). The board reads one metric throughout — the same tiles, flow arms and in-direction reads, with the metric deciding what they mean — so there is one code path rather than a second set of tiles.

## Grid net

On energy the grid tile shows the day's **net**: import minus export, signed.

A magnitude reads the same for a day that imported 5 kWh and one that exported 5, which is the opposite conclusion about the same day.

## No dial on energy

A node's `Max` is a full-scale **power** figure. A needle against it says nothing about kWh, so the tile shows the plain reading instead.

Self-sufficiency is unchanged and still uses lifetime energy — it is a cumulative question, not a daily one.

## Tests

`energyshow.check.mjs` asserts the tiles switch and carry their unit, that no gauge is drawn on energy, and that a day of 2.0 out and 7.5 in shows as **-5.5 kWh**. Both fail when removed:

```
net removed  -> the grid tile does not show the day's net: ⚡Grid 5.5 kWh exporting · net for the day
dial removed -> a gauge was drawn against a power ceiling while showing energy
```

678 tests pass; ten GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
