### PR TITLE
fix(flow): give the period-counter audit one owner, as a grain

### DIFF
--- a/rPDU2MQTT.Core/Flow/IWithheldSources.cs
+++ b/rPDU2MQTT.Core/Flow/IWithheldSources.cs
@@ -26,3 +26,25 @@ public interface IWithheldSources
     /// <summary>Every binding currently being withheld. Empty when everything is being believed.</summary>
     IReadOnlyCollection<WithheldSource> Withheld { get; }
 }
+
+/// <summary>
+/// The port the ingests use to consult the period-counter audit, implemented by whatever owns it.
+///
+/// <para>
+/// Engine talks to this rather than to a grain directly, the same way it takes an
+/// <c>ISnapshotSink</c>: the host decides that the owner is a single-activation grain, and the ingest
+/// neither knows nor needs to.
+/// </para>
+/// <para>
+/// Synchronous because the ingest's message callback is. Only a source declared <c>period</c> reaches it,
+/// so an install with none never calls it and it is not on a per-message path.
+/// </para>
+/// </summary>
+public interface IPeriodAuditor
+{
+    /// <summary>Fold a reading in; false means it may not be published as the day's total.</summary>
+    bool Allow(string nodeId, string source, string? direction, string periodKey, double value);
+
+    /// <summary>Every binding currently withheld.</summary>
+    IReadOnlyCollection<WithheldSource> Withheld { get; }
+}

--- a/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowModbusSourceService.cs
@@ -26,10 +26,10 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
     // For 'auto' connections: the framing that actually read, so we don't re-probe both every poll.
     private readonly Dictionary<string, string> resolvedFraming = new(StringComparer.Ordinal);
 
-    public EnergyFlowModbusSourceService(Config cfg, IPeriodAuditStore? auditStore = null)
+    public EnergyFlowModbusSourceService(Config cfg, IPeriodAuditor? auditor = null)
     {
         this.cfg = cfg;
-        this.auditStore = auditStore ?? new MemoryPeriodAuditStore();
+        this.auditor = auditor;
     }
 
     public bool TryGetValue(string nodeId, string metric, out double value)
@@ -52,15 +52,28 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         catch (OperationCanceledException) { /* shutting down */ }
     }
 
-    // Per (node, register, direction): whether a source claiming to be a daily counter has behaved like one.
-    // Persisted, as on the MQTT side: a restart must not erase the previous period and leave every source
-    // unproven until the next rollover.
-    private readonly Dictionary<string, PeriodCounterAudit.State> periodAudit = new(StringComparer.Ordinal);
-    private readonly IPeriodAuditStore auditStore;
-    private bool auditLoaded;
+    // The verdicts belong to one owner cluster-wide, not to this process — see IPeriodAuditor.
+    private readonly IPeriodAuditor? auditor;
+    private volatile WithheldSource[] withheld = [];
 
     /// <summary>Bindings whose readings are being dropped, so the GUI can say so where the number is missing.</summary>
-    public IReadOnlyCollection<WithheldSource> Withheld => PeriodCounterAudit.WithheldIn(periodAudit);
+    public IReadOnlyCollection<WithheldSource> Withheld => withheld;
+
+    /// <summary>Ask the audit's owner; an unreachable owner leaves the reading published, as before the audit existed.</summary>
+    private bool Audit(string nodeId, string source, string? direction, string periodKey, double value)
+    {
+        try
+        {
+            var allowed = auditor!.Allow(nodeId, source, direction, periodKey, value);
+            withheld = [.. auditor.Withheld];
+            return allowed;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug($"Energy-flow Modbus: could not consult the period audit ({ex.Message}).");
+            return true;
+        }
+    }
 
     /// <summary>The period a reading belongs to, on the same boundary the daily accumulator uses.</summary>
     private string CurrentPeriodKey(DateTime nowUtc)
@@ -104,12 +117,6 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
         var framing = resolvedFraming.TryGetValue(conn.Id, out var cached) ? cached : conn.Framing;
 
         var periodKey = CurrentPeriodKey(nowUtc);
-        if (!auditLoaded)
-        {
-            auditLoaded = true;
-            foreach (var (k, v) in auditStore.Load()) periodAudit[k] = v;
-        }
-        var auditBefore = periodAudit.Count == 0 ? "" : string.Join('|', periodAudit.Select(kv => $"{kv.Key}={kv.Value.PeriodKey}:{kv.Value.HighWater}:{kv.Value.Contradicted}").OrderBy(x => x, StringComparer.Ordinal));
 
         ReadBatch(conn.Host, conn.Port, conn.UnitId, framing, conn.TimeoutMs, forConn.Select(f => f.Source).ToList(),
             onValue: (src, value) =>
@@ -118,9 +125,8 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
                 // actually reset at the boundary, or whatever it holds is not today's total. A rule only one
                 // transport enforces is a rule with a hole in it, and the hole is wherever the counter
                 // happened to be wired.
-                if (PeriodCounterAudit.Applies(src)
-                    && !PeriodCounterAudit.Allow(periodAudit, periodKey, nodeOf[src],
-                                                 $"register {src.Register} on {conn.Id}", src.Direction, value, m => Log.Warning(m)))
+                if (auditor is not null && PeriodCounterAudit.Applies(src)
+                    && !Audit(nodeOf[src], $"register {src.Register} on {conn.Id}", src.Direction, periodKey, value))
                     return;
 
                 foreach (var (key, v) in FlowMetricKey.Fan(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction, value))
@@ -129,9 +135,6 @@ public sealed class EnergyFlowModbusSourceService : BackgroundService, IFlowValu
             onError: (src, msg) => Log.Debug($"Energy-flow Modbus: node '{nodeOf[src]}' register {src.Register} on {conn.Id} — {msg}"),
             onResolved: f => resolvedFraming[conn.Id] = f);
 
-        // Only when something moved: a poll that changes nothing must not write the cache.
-        var auditAfter = periodAudit.Count == 0 ? "" : string.Join('|', periodAudit.Select(kv => $"{kv.Key}={kv.Value.PeriodKey}:{kv.Value.HighWater}:{kv.Value.Contradicted}").OrderBy(x => x, StringComparer.Ordinal));
-        if (auditBefore != auditAfter) auditStore.Save(new Dictionary<string, PeriodCounterAudit.State>(periodAudit));
     }
 
     /// <summary>

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttSourceService.cs
@@ -36,25 +36,24 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     private readonly ISnapshotSink<MeasurementSnapshot>? sink;
     private long version;
     private long received;
-    // Per (node, topic, direction): whether a source claiming to be a daily counter has actually behaved
-    // like one. Loaded from the store on first use and written back when a verdict changes, so a restart
-    // does not erase the previous period and leave every source unproven until the next rollover.
-    private readonly Dictionary<string, PeriodCounterAudit.State> periodAudit = new(StringComparer.Ordinal);
-    private readonly IPeriodAuditStore auditStore;
-    private bool auditLoaded;
+    // The audit's verdicts belong to one owner cluster-wide, so they live in IPeriodAuditGrain rather than
+    // here: two ingests each keeping their own map wrote back over one shared record and erased each other,
+    // and two replicas would have reached the verdict separately.
+    private readonly IPeriodAuditor? auditor;
 
     /// <summary>Bindings whose readings are being dropped, so the GUI can say so where the number is missing.</summary>
-    public IReadOnlyCollection<WithheldSource> Withheld => PeriodCounterAudit.WithheldIn(periodAudit);
+    public IReadOnlyCollection<WithheldSource> Withheld => withheld;
+    private volatile WithheldSource[] withheld = [];
 
     public EnergyFlowMqttSourceService(MQTTServiceDependencies deps, ISnapshotSink<MeasurementSnapshot>? sink = null,
-                                       IPeriodAuditStore? auditStore = null)
+                                       IPeriodAuditor? auditor = null)
     {
         // OnMessageReceived lives on the concrete client, not the interface.
         mqtt = deps.Mqtt as HiveMQClient
             ?? throw new InvalidOperationException("Expected a HiveMQClient instance for energy-flow MQTT sources.");
         cfg = deps.Cfg;
         this.sink = sink;
-        this.auditStore = auditStore ?? new MemoryPeriodAuditStore();
+        this.auditor = auditor;
     }
 
     public bool TryGetValue(string nodeId, string metric, out double value)
@@ -187,12 +186,31 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
     }
 
     /// <summary>
-    /// A cheap comparison of the audit's contents, to decide whether it is worth persisting. The
-    /// high-water mark changes on most readings, so the store is written only when something did.
+    /// Ask the audit's owner whether this reading may be published as the day's total.
+    ///
+    /// <para>
+    /// Only reached for a source declared <c>period</c>, so the grain is not on a per-message path — an
+    /// install with none never calls it. The call is awaited: withholding is a correctness decision, and
+    /// publishing first and asking after would put the figure out before the answer came back.
+    /// </para>
     /// </summary>
-    private static string Snapshot(Dictionary<string, PeriodCounterAudit.State> audit)
-        => string.Join('\u0001', audit.OrderBy(kv => kv.Key, StringComparer.Ordinal)
-            .Select(kv => $"{kv.Key}={kv.Value.PeriodKey}:{kv.Value.HighWater}:{kv.Value.Contradicted}"));
+    private bool Audit(string nodeId, string source, string? direction, string periodKey, double value)
+    {
+        if (auditor is null) return true;   // no owner wired (tests): nothing is withheld
+        try
+        {
+            var allowed = auditor.Allow(nodeId, source, direction, periodKey, value);
+            withheld = [.. auditor.Withheld];
+            return allowed;
+        }
+        catch (Exception ex)
+        {
+            // An unreachable owner must not stop the ingest. Publishing the reading is the pre-audit
+            // behaviour, and the next reading re-asks.
+            Log.Debug($"Energy-flow: could not consult the period audit ({ex.Message}).");
+            return true;
+        }
+    }
 
     /// <summary>The period a reading now belongs to, on the same boundary the daily accumulator uses.</summary>
     private string CurrentPeriodKey(DateTime nowUtc)
@@ -207,24 +225,12 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
         // Collect the readings this message produced (only if a sink is wired) and push them to the flow grain
         // event-driven — the "subscription manager routes events to the recipient grain" (#v3).
         List<MeasurementReading>? readings = sink is null ? null : new();
-        // Loaded lazily: the store may be a cache that is not up yet when the service starts, and the first
-        // message is the first moment a verdict is needed.
-        if (!auditLoaded)
-        {
-            auditLoaded = true;
-            foreach (var (k, v) in auditStore.Load()) periodAudit[k] = v;
-        }
-
-        var auditBefore = Snapshot(periodAudit);
         Apply(bindings, latest, e.PublishMessage.Topic, e.PublishMessage.PayloadAsString, now,
             readings is null ? null : (node, metric, value, stale) =>
             {
                 if (Metrics.TryParse(metric, out var m)) readings.Add(new MeasurementReading(node, m, value, stale));
             },
-            periodAudit, CurrentPeriodKey(now), m => Log.Warning(m));
-        // Only on a change: the high-water mark moves on most readings, and writing the cache per message
-        // would put a round-trip on every publish the broker sends us.
-        if (auditBefore != Snapshot(periodAudit)) auditStore.Save(new Dictionary<string, PeriodCounterAudit.State>(periodAudit));
+            Audit, CurrentPeriodKey(now));
 
         if (sink is not null && readings is { Count: > 0 })
         {
@@ -266,9 +272,8 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
         IReadOnlyDictionary<string, List<(string NodeId, EnergyFlowSource Source)>> bindings,
         FlowValueCache cache, string? topic, string? payload, DateTime nowUtc,
         Action<string, string, double, int>? onReading = null,
-        IDictionary<string, PeriodCounterAudit.State>? periodAudit = null,
-        string? periodKey = null,
-        Action<string>? warn = null)
+        Func<string, string, string?, string, double, bool>? auditor = null,
+        string? periodKey = null)
     {
         if (topic is null || !bindings.TryGetValue(topic, out var list) || string.IsNullOrWhiteSpace(payload))
             return;
@@ -296,8 +301,8 @@ public sealed class EnergyFlowMqttSourceService : BackgroundService, IFlowValueS
             // today's — it is a cumulative total, or a value the device stopped updating before the rollover
             // — and it is dropped rather than stated. The node then reports "no data" for today, which is
             // the truth, instead of a confident wrong figure.
-            if (periodAudit is not null && periodKey is not null && PeriodCounterAudit.Applies(src)
-                && !PeriodCounterAudit.Allow(periodAudit, periodKey, nodeId, topic, src.Direction, value, warn))
+            if (auditor is not null && periodKey is not null && PeriodCounterAudit.Applies(src)
+                && !auditor(nodeId, topic, src.Direction, periodKey, value))
                 continue;
 
             foreach (var (key, v) in FlowMetricKey.Fan(FlowMetricKey.ForAccumulation(src.Metric, src.Accumulation), src.Direction, value))

--- a/rPDU2MQTT.Grains.Abstractions/Flow/IPeriodAuditGrain.cs
+++ b/rPDU2MQTT.Grains.Abstractions/Flow/IPeriodAuditGrain.cs
@@ -1,0 +1,30 @@
+namespace rPDU2MQTT.Grains.Abstractions.Flow;
+
+/// <summary>
+/// One owner, cluster-wide, of whether each source declared as a daily counter has behaved like one
+/// (singleton, key 0).
+///
+/// <para>
+/// The verdict is a property of a source, not of a process. Held per ingest it was reached twice — the MQTT
+/// and Modbus services each kept their own map — and written back over one shared record, so each service's
+/// save erased the other's. Two replicas would have compounded it. Single activation is the answer the rest
+/// of v3 uses for "exactly one of these", and it applies here for the same reason.
+/// </para>
+/// <para>
+/// Only sources that make the claim reach this grain: an energy source declared <c>period</c>. Everything
+/// else is decided in the ingest without a call, which keeps a per-message hot path off the grain.
+/// </para>
+/// </summary>
+public interface IPeriodAuditGrain : IGrainWithIntegerKey
+{
+    /// <summary>
+    /// Fold a reading in and say whether it may be published as the day's total.
+    /// </summary>
+    /// <param name="nodeId">The node the binding feeds.</param>
+    /// <param name="source">The topic or register, as named to whoever has to fix it.</param>
+    /// <param name="direction">out / in — a node's two legs are different quantities on one source.</param>
+    Task<bool> Allow(string nodeId, string source, string? direction, string periodKey, double value);
+
+    /// <summary>Every binding currently withheld, as (node, source, metric, reason).</summary>
+    Task<List<(string Node, string Source, string Metric, string Reason)>> Withheld();
+}

--- a/rPDU2MQTT.Grains/Flow/PeriodAuditGrain.cs
+++ b/rPDU2MQTT.Grains/Flow/PeriodAuditGrain.cs
@@ -1,0 +1,47 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Grains.Abstractions.Flow;
+
+namespace rPDU2MQTT.Grains.Flow;
+
+/// <summary>
+/// The period-counter audit's single owner. Holds every binding's verdict, applies
+/// <see cref="PeriodCounterAudit"/>, and persists through <see cref="IPeriodAuditStore"/>.
+/// </summary>
+public sealed class PeriodAuditGrain : Grain, IPeriodAuditGrain
+{
+    private readonly IPeriodAuditStore store;
+    private readonly Dictionary<string, PeriodCounterAudit.State> audit = new(StringComparer.Ordinal);
+    private readonly Action<string> warn;
+
+    public PeriodAuditGrain(IPeriodAuditStore store)
+    {
+        this.store = store;
+        warn = m => Serilog.Log.Warning(m);
+    }
+
+    public override Task OnActivateAsync(CancellationToken ct)
+    {
+        foreach (var (k, v) in store.Load()) audit[k] = v;
+        return base.OnActivateAsync(ct);
+    }
+
+    public Task<bool> Allow(string nodeId, string source, string? direction, string periodKey, double value)
+    {
+        var key = $"{nodeId}|{source}|{direction}";
+        audit.TryGetValue(key, out var prior);
+        var allowed = PeriodCounterAudit.Allow(audit, periodKey, nodeId, source, direction, value, warn);
+
+        // Only when something moved. The high-water mark changes on most readings, and the store is a file
+        // or a cache round-trip.
+        var next = audit.TryGetValue(key, out var after) ? after : null;
+        if (prior is null || next is null
+            || prior.PeriodKey != next.PeriodKey || prior.HighWater != next.HighWater || prior.Contradicted != next.Contradicted)
+            store.Save(new Dictionary<string, PeriodCounterAudit.State>(audit));
+
+        return Task.FromResult(allowed);
+    }
+
+    public Task<List<(string Node, string Source, string Metric, string Reason)>> Withheld()
+        => Task.FromResult(PeriodCounterAudit.WithheldIn(audit)
+            .Select(w => (w.Node, w.Source, w.Metric, w.Reason)).ToList());
+}

--- a/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
+++ b/rPDU2MQTT.Tests/EnergyFlowMqttSourceTests.cs
@@ -291,25 +291,33 @@ public class EnergyFlowMqttSourceTests
         var nodes = new[] { NodeWith("solar", new EnergyFlowSource { Topic = "sa/pv_energy", Metric = "energy", Accumulation = "period" }) };
         var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
         var cache = new FlowValueCache();
-        var audit = new Dictionary<string, PeriodCounterAudit.State>();
-        var warnings = new List<string>();
+        var owner = new FakeAuditor();
         var now = DateTime.UtcNow;
 
         // Day one: no evidence yet, so it is trusted and published as the day's total.
-        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "129.9", now, null, audit, "2026-08-04", warnings.Add);
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "129.9", now, null, owner.Allow, "2026-08-04");
         Assert.True(cache.TryGetValue("solar", EnergyPeriod.Metric, out var dayOne) && dayOne == 129.9);
 
         // The rollover, with the counter carrying straight on. That is not today's total, and it must not be
         // stated as one — the cache keeps no new value, so the node reports no data rather than 129.9 kWh.
-        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "130.4", now, null, audit, "2026-08-05", warnings.Add);
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "130.4", now, null, owner.Allow, "2026-08-05");
         Assert.True(cache.TryGetValue("solar", EnergyPeriod.Metric, out var afterRoll) && afterRoll == 129.9,
             "the stale reading was overwritten with a value that is not today's total");
-        Assert.Single(warnings);
-        Assert.Contains("did not reset", warnings[0]);
+        Assert.Single(owner.Warnings);
+        Assert.Contains("did not reset", owner.Warnings[0]);
 
         // Still withheld on every later sample, and the operator is told once, not once per message.
-        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "131.0", now, null, audit, "2026-08-05", warnings.Add);
-        Assert.Single(warnings);
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "131.0", now, null, owner.Allow, "2026-08-05");
+        Assert.Single(owner.Warnings);
+    }
+
+    /// <summary>Stands in for the audit's owner — the grain in production.</summary>
+    private sealed class FakeAuditor
+    {
+        private readonly Dictionary<string, PeriodCounterAudit.State> audit = new(StringComparer.Ordinal);
+        public readonly List<string> Warnings = new();
+        public bool Allow(string node, string source, string? direction, string periodKey, double value)
+            => PeriodCounterAudit.Allow(audit, periodKey, node, source, direction, value, Warnings.Add);
     }
 
     [Fact]
@@ -318,15 +326,14 @@ public class EnergyFlowMqttSourceTests
         var nodes = new[] { NodeWith("solar", new EnergyFlowSource { Topic = "sa/pv_energy", Metric = "energy", Accumulation = "period" }) };
         var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
         var cache = new FlowValueCache();
-        var audit = new Dictionary<string, PeriodCounterAudit.State>();
-        var warnings = new List<string>();
+        var owner = new FakeAuditor();
         var now = DateTime.UtcNow;
 
-        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "69.4", now, null, audit, "2026-08-04", warnings.Add);
-        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "0.2", now, null, audit, "2026-08-05", warnings.Add);
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "69.4", now, null, owner.Allow, "2026-08-04");
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/pv_energy", "0.2", now, null, owner.Allow, "2026-08-05");
 
         Assert.True(cache.TryGetValue("solar", EnergyPeriod.Metric, out var today) && today == 0.2);
-        Assert.Empty(warnings);
+        Assert.Empty(owner.Warnings);
     }
 
     [Fact]
@@ -338,16 +345,14 @@ public class EnergyFlowMqttSourceTests
         var nodes = new[] { NodeWith("grid", new EnergyFlowSource { Topic = "sa/grid_energy", Metric = "energy", Accumulation = "lifetime" }) };
         var bindings = EnergyFlowMqttSourceService.BuildBindings(nodes);
         var cache = new FlowValueCache();
-        var audit = new Dictionary<string, PeriodCounterAudit.State>();
-        var warnings = new List<string>();
+        var owner = new FakeAuditor();
         var now = DateTime.UtcNow;
 
-        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/grid_energy", "1306.3", now, null, audit, "2026-08-04", warnings.Add);
-        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/grid_energy", "1308.4", now, null, audit, "2026-08-05", warnings.Add);
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/grid_energy", "1306.3", now, null, owner.Allow, "2026-08-04");
+        EnergyFlowMqttSourceService.Apply(bindings, cache, "sa/grid_energy", "1308.4", now, null, owner.Allow, "2026-08-05");
 
         Assert.True(cache.TryGetValue("grid", "energy", out var v) && v == 1308.4);
-        Assert.Empty(warnings);
-        Assert.Empty(audit);
+        Assert.Empty(owner.Warnings);
     }
 
     [Fact]

--- a/rPDU2MQTT.Tests/PeriodAuditOwnerTests.cs
+++ b/rPDU2MQTT.Tests/PeriodAuditOwnerTests.cs
@@ -1,0 +1,82 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// The audit's verdicts have one owner.
+///
+/// <para>
+/// Held per ingest they were reached twice — the MQTT and Modbus services each kept their own map — and
+/// both wrote the whole record back through one store. Each save replaced the hash wholesale, so whichever
+/// service saved last erased the other's verdicts. Two replicas would have compounded it.
+/// </para>
+/// </summary>
+public class PeriodAuditOwnerTests : IDisposable
+{
+    private readonly string path = Path.Combine(Path.GetTempPath(), $"audit-owner-{Guid.NewGuid():N}.json");
+
+    public void Dispose()
+    {
+        if (File.Exists(path)) File.Delete(path);
+        if (File.Exists(path + ".tmp")) File.Delete(path + ".tmp");
+    }
+
+    /// <summary>Two independent maps sharing one store — what the ingests did before the owner existed.</summary>
+    [Fact]
+    public void TwoMapsSharingOneStore_EraseEachOther()
+    {
+        var store = new FilePeriodAuditStore(path);
+
+        var fromMqtt = new Dictionary<string, PeriodCounterAudit.State>();
+        PeriodCounterAudit.Allow(fromMqtt, "2026-08-04", "solar", "sa/pv_energy", "out", 129.9, null);
+        store.Save(fromMqtt);
+
+        var fromModbus = new Dictionary<string, PeriodCounterAudit.State>();
+        PeriodCounterAudit.Allow(fromModbus, "2026-08-04", "inverter", "register 40 on inv1", "out", 55.0, null);
+        store.Save(fromModbus);
+
+        // The second save replaced the record: the MQTT source's history is gone, so its next rollover has
+        // nothing to compare against and a cumulative counter passes as honest.
+        var reloaded = store.Load();
+        Assert.Single(reloaded);
+        Assert.DoesNotContain(reloaded.Keys, k => k.StartsWith("solar|"));
+    }
+
+    /// <summary>One map behind one owner — both ingests' bindings survive.</summary>
+    [Fact]
+    public void OneOwnerKeepsBothIngestsVerdicts()
+    {
+        var store = new FilePeriodAuditStore(path);
+        var owned = new Dictionary<string, PeriodCounterAudit.State>();
+
+        PeriodCounterAudit.Allow(owned, "2026-08-04", "solar", "sa/pv_energy", "out", 129.9, null);
+        store.Save(owned);
+        PeriodCounterAudit.Allow(owned, "2026-08-04", "inverter", "register 40 on inv1", "out", 55.0, null);
+        store.Save(owned);
+
+        var reloaded = store.Load();
+        Assert.Equal(2, reloaded.Count);
+        Assert.Contains(reloaded.Keys, k => k.StartsWith("solar|"));
+        Assert.Contains(reloaded.Keys, k => k.StartsWith("inverter|"));
+    }
+
+    [Fact]
+    public void TheOwnerJudgesBothIngestsIndependently()
+    {
+        // One map does not mean one verdict: a missed reset on the MQTT binding must not withhold the
+        // Modbus one.
+        var owned = new Dictionary<string, PeriodCounterAudit.State>();
+        bool Allow(string node, string src, double v, string day) =>
+            PeriodCounterAudit.Allow(owned, day, node, src, "out", v, null);
+
+        Allow("solar", "sa/pv_energy", 129.9, "2026-08-04");
+        Allow("inverter", "register 40 on inv1", 55.0, "2026-08-04");
+
+        Assert.False(Allow("solar", "sa/pv_energy", 130.4, "2026-08-05"));   // no reset
+        Assert.True(Allow("inverter", "register 40 on inv1", 0.0, "2026-08-05"));   // reset
+
+        var withheld = Assert.Single(PeriodCounterAudit.WithheldIn(owned));
+        Assert.Equal("solar", withheld.Node);
+    }
+}

--- a/rPDU2MQTT/Hosting/GrainPeriodAuditor.cs
+++ b/rPDU2MQTT/Hosting/GrainPeriodAuditor.cs
@@ -1,0 +1,32 @@
+using rPDU2MQTT.Core.Flow;
+using rPDU2MQTT.Grains.Abstractions.Flow;
+
+namespace rPDU2MQTT.Hosting;
+
+/// <summary>
+/// Points the ingests' audit port at the grain that owns the verdicts.
+///
+/// <para>
+/// The host decides that the owner is a single activation; Engine only knows there is one. That is the
+/// same split as <c>ISnapshotSink</c>, and it is what keeps the grain reference out of the transport
+/// layer.
+/// </para>
+/// </summary>
+public sealed class GrainPeriodAuditor(IGrainFactory grains) : IPeriodAuditor
+{
+    private volatile WithheldSource[] withheld = [];
+
+    public IReadOnlyCollection<WithheldSource> Withheld => withheld;
+
+    public bool Allow(string nodeId, string source, string? direction, string periodKey, double value)
+    {
+        var grain = grains.GetGrain<IPeriodAuditGrain>(0);
+        // Blocking on the grain is acceptable here and nowhere near a per-message path: only a source
+        // declared 'period' reaches this, and withholding is a correctness decision, so the reading cannot
+        // be published while the answer is still outstanding.
+        var allowed = grain.Allow(nodeId, source, direction, periodKey, value).GetAwaiter().GetResult();
+        withheld = [.. grain.Withheld().GetAwaiter().GetResult()
+            .Select(w => new WithheldSource(w.Node, w.Source, w.Metric, w.Reason))];
+        return allowed;
+    }
+}

--- a/rPDU2MQTT/Startup/ServiceConfiguration.cs
+++ b/rPDU2MQTT/Startup/ServiceConfiguration.cs
@@ -346,6 +346,9 @@ public static class ServiceConfiguration
         // Registered whether or not the cache is enabled, so the Status board can say "not configured"
         // rather than the card simply being absent — an absent card looks like a feature that doesn't
         // exist, which is exactly the confusion this is meant to remove.
+        // The audit's verdicts have one owner cluster-wide (a grain); the ingests see only the port.
+        services.AddSingleton<Core.Flow.IPeriodAuditor>(sp => new Hosting.GrainPeriodAuditor(sp.GetRequiredService<IGrainFactory>()));
+
         services.AddSingleton<Core.Flow.CacheHealth>();
         if (cfg.Cache.Enabled)
         {


### PR DESCRIPTION
You were right, and it cost something concrete.

## The bug

#370 kept the audit's verdicts in each ingest and persisted them through a shared store. The MQTT and Modbus services each held their **own** map containing only their own bindings, and `Save` replaces the record wholesale:

```
MQTT   saves { solar|sa/pv_energy|out: … }
Modbus saves { inverter|register 40|out: … }   <- record now holds only this
```

Whichever saved last erased the other's verdicts. A source whose history is wiped has nothing to compare against at the next rollover, so a cumulative counter passes as honest — the exact failure the audit exists to catch. Two replicas would have compounded it, each reaching the verdict separately.

## The fix

The verdict is a property of a source, not of a process. That is what single activation is for, and what the rest of v3 already uses for "exactly one of these, cluster-wide".

`IPeriodAuditGrain` owns the whole map, applies `PeriodCounterAudit`, and persists through `IPeriodAuditStore`.

Engine talks to an `IPeriodAuditor` port rather than to the grain — the same split as `ISnapshotSink`, so the grain reference stays out of the transport layer and the host decides the owner is a grain.

On the hot-path caveat in the migration doc: only a source declared `period` reaches the owner, so an install with none never calls it. An unreachable owner leaves the reading published, which is the behaviour before the audit existed.

## Tests

```
TwoMapsSharingOneStore_EraseEachOther     <- reproduces the bug
OneOwnerKeepsBothIngestsVerdicts
TheOwnerJudgesBothIngestsIndependently    <- one map is not one verdict
```

681 tests pass; eleven GUI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
