### PR TITLE
fix(gui): label intra-day charts in the viewer's clock, not the container's

### DIFF
--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -513,7 +513,7 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
     /// </para>
     /// </summary>
     private async Task<object> BuildSeriesAsync(string? instance, string metric, IReadOnlyList<DateTime> when,
-                                                IReadOnlyList<string> labels, string? partialLabel, CancellationToken ct)
+                                                IReadOnlyList<string>? labels, string? partialLabel, CancellationToken ct)
     {
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         cts.CancelAfter(TimeSpan.FromSeconds(60));
@@ -559,9 +559,11 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 metric,
                 units = FlowUnits.Canonical(metric),
                 source = history.Id,
-                // Labelled by the caller: a day is the period key the counters re-base on, a moment within
-                // one is a clock time.
+                // A day is named by the period key the counters re-base on — a server concept, so the server
+                // names it. A moment within a day is named by the viewer's clock, so only the instant is
+                // sent and the browser formats it.
                 days = labels,
+                at = when.Select(w => DateTime.SpecifyKind(w, DateTimeKind.Utc)).ToList(),
                 // The last bar is a period still in progress. Named so the chart can say so rather than
                 // showing a part-day beside finished ones as though they were the same thing.
                 partial = partialLabel,
@@ -1930,8 +1932,11 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
                 var metricNow = string.IsNullOrWhiteSpace(ctx.Request.Query["metric"]) ? FlowGraphBuilder.DefaultMetric : ctx.Request.Query["metric"].ToString();
                 var steps = new List<DateTime>();
                 for (var t = end - span; t <= end; t = t.AddSeconds(step)) steps.Add(t);
+                // No labels: a moment within a day is named in the viewer's zone, and the server does not
+                // know it. Formatting here stamped every intra-day tick with the container's clock — UTC
+                // unless someone set TZ — so a chart ending at this minute read as ending hours ago.
                 return Results.Json(await BuildSeriesAsync(ctx.Request.Query["instance"], metricNow, steps,
-                    steps.Select(t => t.ToLocalTime().ToString("HH:mm")).ToList(), null, ctx.RequestAborted), ConfigSchema.Json);
+                    null, null, ctx.RequestAborted), ConfigSchema.Json);
             }
 
             var days = int.TryParse(ctx.Request.Query["days"].ToString(), out var d) ? Math.Clamp(d, 2, 92) : 30;

--- a/rPDU2MQTT.Web/web/src/sections/trends.ts
+++ b/rPDU2MQTT.Web/web/src/sections/trends.ts
@@ -342,7 +342,10 @@ export function addTrendsSection(nav: any, sections: any) {
     hideCard();
     if (!body?.ok) return;
 
-    const days: string[] = body.days || [];
+    // A day carries the server's period key; a moment within one is named here, in the viewer's clock.
+    // The server used to format these too, stamping every intra-day tick with the container's timezone.
+    const days: string[] = body.days
+      || (body.at || []).map((iso: string) => new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }));
     const series = shown();
     const units = body.units || 'kWh';
     // The last period has not ended. Every chart fades it, and the totals leave it out — averaging a

--- a/rPDU2MQTT.Web/web/trends.check.mjs
+++ b/rPDU2MQTT.Web/web/trends.check.mjs
@@ -27,9 +27,13 @@ const series = {
 
 // The same window asked about within a day: power every 5 minutes, not a daily total. A cumulative daily
 // counter charted through the day only ever climbs, so this is a different metric, not a finer one.
+// Instants, not labels: a moment within a day is named in the viewer's clock, and the server does not know
+// it. Formatting them server-side stamped every intra-day tick with the container's timezone — UTC unless
+// someone set TZ — so a chart ending at this minute read as ending hours ago.
+const at = ['2026-08-08T18:00:00Z', '2026-08-08T18:05:00Z', '2026-08-08T18:10:00Z', '2026-08-08T18:15:00Z'];
 const power = {
   ok: true, metric: 'realpower', units: 'W', source: 'prometheus', stepSeconds: 300,
-  days: ['13:00', '13:05', '13:10', '13:15'],
+  at,
   series: [
     { node: 'solar', label: 'Solar', kind: 'solar', tags: ['roof'], values: [4200, 4400, null, 3900] },
     { node: 'grid', label: 'Grid', kind: 'grid', values: [0, 0, null, 120] },
@@ -216,11 +220,15 @@ if (!intraRows.some(h => /Energy \(kWh/.test(h))) fail(`no energy column on the 
 const solarIntra = query(sec, 'tr', true).find(r => r.textContent.includes('Solar'));
 if (!solarIntra.textContent.includes('1.042')) fail(`the energy estimate is wrong: ${solarIntra.textContent}`);
 
-// The clock is the axis, and a missing sample is still a gap.
+// The axis is the clock — this browser's clock, whatever the server's is.
+const local = (iso) => new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 const intraCard = query(sec, 'rect', true).filter(r => (r.attrs.class || '') === 'trend-hit');
-intraCard.find(h => h.attrs['data-day'] === '13:05').dispatch('mouseenter', { clientX: 5, clientY: 5 });
+const want = local(at[1]);
+const hit = intraCard.find(h => h.attrs['data-day'] === want);
+if (!hit) fail(`the axis is not in this browser's clock: expected "${want}", got ${intraCard.map(h => h.attrs['data-day']).join(', ')}`);
+hit.dispatch('mouseenter', { clientX: 5, clientY: 5 });
 const intraText = query(sandbox.document.body, '.trend-card').textContent;
-if (!intraText.includes('13:05') || !intraText.includes('4,400')) fail(`the intra-day hover is wrong: "${intraText}"`);
+if (!intraText.includes(want) || !intraText.includes('4,400')) fail(`the intra-day hover is wrong: "${intraText}"`);
 
 // Columns sort. Twelve nodes over ninety days is a table you read by scanning for the biggest number.
 // Every node back on first: a one-row table is sorted whatever the code does, which is no test at all.

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -5649,7 +5649,10 @@ function addTrendsSection(nav     , sections     ) {
     hideCard();
     if (!body?.ok) return;
 
-    const days           = body.days || [];
+    // A day carries the server's period key; a moment within one is named here, in the viewer's clock.
+    // The server used to format these too, stamping every intra-day tick with the container's timezone.
+    const days           = body.days
+      || (body.at || []).map((iso        ) => new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }));
     const series = shown();
     const units = body.units || 'kWh';
     // The last period has not ended. Every chart fades it, and the totals leave it out — averaging a


### PR DESCRIPTION
"Last 24 hours" showed nothing after ~6pm at 9pm.

The data was there. Checked against the live Prometheus first: the query and the slot mapping were correct
— 96 of 97 requested steps had samples, right up to the current minute. So nothing was missing.

The server formatted each sample's time with `ToLocalTime()`, which is the *container's* zone — UTC unless
someone sets TZ. Every intra-day tick was therefore stamped in a clock that is not the reader's, and the
axis appeared to stop hours before now.

Only the instants are sent now; the browser names them. A day keeps its server-side label, because the
period key is the boundary the counters re-base on and that is the server's to define.

The trends check now fixes a timezone and asserts the axis matches the browser's clock — it fails if the
labels are left in UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)