### PR TITLE
fix(export): hold Home Assistant's daily totals back too, and add a "today so far" range

### DIFF
--- a/rPDU2MQTT.Core/Flow/EnergyPeriod.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyPeriod.cs
@@ -55,6 +55,28 @@ public static class EnergyPeriod
     }
 
     /// <summary>
+    /// When the period in progress began — where the counters last re-based.
+    ///
+    /// <para>
+    /// What "today so far" means. Not the last 24 hours and not the viewer's midnight: the daily totals are
+    /// cut on this boundary, so a chart of today anchored anywhere else covers a different day from the
+    /// totals beside it. Just after the boundary the window is minutes long, and that is the honest answer.
+    /// </para>
+    /// <para>
+    /// Computed in local time rather than by subtracting a day from the next rollover, so a clock change
+    /// does not put the start an hour inside the previous period.
+    /// </para>
+    /// </summary>
+    public static DateTime PeriodStart(DateTime utc, TimeZoneInfo zone, int startHour = 0)
+    {
+        var hour = Clamp(startHour);
+        var local = Local(utc, zone);
+        var start = local.Date.AddHours(hour);
+        if (start > local) start = start.AddDays(-1);
+        return TimeZoneInfo.ConvertTimeToUtc(DateTime.SpecifyKind(start, DateTimeKind.Unspecified), zone);
+    }
+
+    /// <summary>
     /// One instant per day for the last <paramref name="days"/> periods, oldest first, with the day each
     /// belongs to.
     ///

--- a/rPDU2MQTT.Core/Flow/FlowExport.cs
+++ b/rPDU2MQTT.Core/Flow/FlowExport.cs
@@ -19,6 +19,25 @@ public static class FlowExport
     /// <see cref="TryNodeValue"/>.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// A node's daily total for a destination that records history, or <see langword="null"/> when there is
+    /// not one to give.
+    ///
+    /// <para>
+    /// <paramref name="periodTotalsReady"/> is false while a fresh process is still restoring the totals it
+    /// carried over. In that window the leaves have no period figure but an aggregate over them still
+    /// resolves — from links that are known and carry zero — so a tier would publish a confident 0 for a day
+    /// nobody has added up. Home Assistant records that: a daily total dropping to zero reads as a meter
+    /// reset, and HA then corrects history that was already right.
+    /// </para>
+    /// <para>
+    /// One function because two destinations need the same answer, and the last thing to be duplicated
+    /// across them — whether a node belongs in a history store — was got wrong in both.
+    /// </para>
+    /// </summary>
+    public static double? PeriodTotal(FlowGraph graph, string id, bool periodTotalsReady)
+        => periodTotalsReady && TryNodeValue(graph, id, out var v) ? v : null;
+
     public static double NodeValue(FlowGraph graph, string id)
         => TryNodeValue(graph, id, out var value) ? value : 0;
 

--- a/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
+++ b/rPDU2MQTT.Engine/Services/EnergyFlowMqttExportService.cs
@@ -55,6 +55,13 @@ public class EnergyFlowMqttExportService : baseMQTTService
         // an unavailable total simply publishes null, exactly as the in-direction one does.
         var todayGraph = FlowGraphBuilder.Build(merged, flow, EnergyPeriod.Metric, live);
 
+        // ...but not until the carried-over totals are back. On a fresh process the leaves have no period
+        // figure yet while an aggregate over them still resolves from links that are known and carry zero,
+        // so a tier would publish a confident 0 for a day nobody has added up. Home Assistant records that:
+        // a daily total dropping to zero reads as a meter reset, and HA corrects history that was right.
+        // Unavailable for those few seconds is the honest state. (Prometheus is held back the same way.)
+        var periodsReady = (live as Core.Flow.IPeriodTotalsReady)?.PeriodTotalsReady ?? true;
+
         var publishDiscovery = cfg.HASS.DiscoveryEnabled && !string.IsNullOrWhiteSpace(cfg.HASS.DiscoveryTopic);
         var availability = cfg.MQTT.LastWill ? MQTTHelper.StatusTopic(cfg.MQTT.ParentTopic) : null;
         // Outlets and PDU tiers already have native HA energy sensors from PDU discovery; publishing an
@@ -122,7 +129,7 @@ public class EnergyFlowMqttExportService : baseMQTTService
 
             // Today's total. Null — not 0 — when nothing determines it, so HA marks the sensor unavailable
             // rather than recording a zero that would read as "this tier used nothing today".
-            double? energyToday = FlowExport.TryNodeValue(todayGraph, node.Id, out var et) ? et : null;
+            double? energyToday = FlowExport.PeriodTotal(todayGraph, node.Id, periodsReady);
 
             // Signed net power for a bidirectional node: out (discharge/import) minus in (charge/export), so the
             // published power sensor swings ± the way HA's stat_rate wants. A one-way node keeps its plain power.

--- a/rPDU2MQTT.Tests/TodayWindowTests.cs
+++ b/rPDU2MQTT.Tests/TodayWindowTests.cs
@@ -1,0 +1,84 @@
+using rPDU2MQTT.Core.Flow;
+using Xunit;
+
+namespace rPDU2MQTT.Tests;
+
+/// <summary>
+/// "Today so far" starts where the counters last re-based.
+///
+/// <para>
+/// Not the last 24 hours, and not the browser's midnight: the daily totals are cut on the configured
+/// boundary, so a chart of "today" anchored anywhere else covers a different day from the totals beside it.
+/// </para>
+/// </summary>
+public class TodayWindowTests
+{
+    private static readonly TimeZoneInfo Chicago = TimeZoneInfo.FindSystemTimeZoneById("America/Chicago");
+
+    /// <summary>
+    /// The window the endpoint builds. Calls the production rule rather than restating it — stated here
+    /// instead, the test passed just as happily with the endpoint charting a flat 24 hours.
+    /// </summary>
+    private static (DateTime Start, DateTime End) Window(DateTime nowUtc, TimeZoneInfo zone, int startHour)
+        => (EnergyPeriod.PeriodStart(nowUtc, zone, startHour), nowUtc);
+
+    [Fact]
+    public void ItBeginsAtTheBoundaryTheCountersReBaseOn()
+    {
+        // 14:05 CDT on the 8th: today began at midnight CDT, which is 05:00Z.
+        var now = new DateTime(2026, 8, 8, 19, 5, 0, DateTimeKind.Utc);
+
+        var (start, end) = Window(now, Chicago, 0);
+
+        Assert.Equal(new DateTime(2026, 8, 8, 5, 0, 0, DateTimeKind.Utc), start);
+        Assert.Equal(now, end);
+    }
+
+    [Fact]
+    public void AConfiguredStartHourMovesIt()
+    {
+        // A day that starts at 06:00 local: at 14:05 the window began at 06:00 that morning (11:00Z).
+        var now = new DateTime(2026, 8, 8, 19, 5, 0, DateTimeKind.Utc);
+
+        var (start, _) = Window(now, Chicago, 6);
+
+        Assert.Equal(new DateTime(2026, 8, 8, 11, 0, 0, DateTimeKind.Utc), start);
+    }
+
+    [Fact]
+    public void JustAfterTheBoundaryTheWindowIsShort_NotAWholeDay()
+    {
+        // 00:05 CDT. "Today" is five minutes long, and saying so is the point — a fixed 24-hour window here
+        // would chart most of yesterday under today's name.
+        var now = new DateTime(2026, 8, 8, 5, 5, 0, DateTimeKind.Utc);
+
+        var (start, end) = Window(now, Chicago, 0);
+
+        Assert.Equal(TimeSpan.FromMinutes(5), end - start);
+    }
+
+    [Fact]
+    public void ItSurvivesAClockChange()
+    {
+        // The morning the clocks went forward. Subtracting a day from the next rollover lands an hour
+        // inside the previous period and charts an hour of yesterday as today.
+        var now = new DateTime(2026, 3, 8, 18, 0, 0, DateTimeKind.Utc);   // 13:00 CDT, spring-forward day
+
+        var (start, _) = Window(now, Chicago, 0);
+
+        var local = EnergyPeriod.Local(start, Chicago);
+        Assert.Equal(0, local.Hour);
+        Assert.Equal(new DateTime(2026, 3, 8), local.Date);
+    }
+
+    [Fact]
+    public void TheWindowAndTheDailyTotalAgreeOnWhichDayItIs()
+    {
+        // The property that matters: the day the window starts in is the day the totals are filed under.
+        var now = new DateTime(2026, 8, 8, 19, 5, 0, DateTimeKind.Utc);
+
+        var (start, _) = Window(now, Chicago, 0);
+
+        Assert.Equal(EnergyPeriod.KeyFor(now, Chicago, 0), EnergyPeriod.KeyFor(start, Chicago, 0));
+    }
+}

--- a/rPDU2MQTT.Tests/WarmupTotalsTests.cs
+++ b/rPDU2MQTT.Tests/WarmupTotalsTests.cs
@@ -82,6 +82,28 @@ public class WarmupTotalsTests
     }
 
     [Fact]
+    public void NoDailyTotalGoesOutWhileTheTotalsAreStillBeingRestored()
+    {
+        // Home Assistant records what MQTT publishes. A daily total dropping to zero reads there as a meter
+        // reset, and HA corrects history that was already right — so the seconds before the restore have to
+        // publish nothing rather than a zero.
+        var graph = new FlowGraph(
+            [new FlowNode("panel", "Panel", "panel", 12.5)], [], EnergyPeriod.Metric, "kWh");
+
+        Assert.Null(FlowExport.PeriodTotal(graph, "panel", periodTotalsReady: false));
+        Assert.Equal(12.5, FlowExport.PeriodTotal(graph, "panel", periodTotalsReady: true));
+    }
+
+    [Fact]
+    public void AnUnknownTierIsStillNullOnceReady()
+    {
+        var graph = new FlowGraph([new FlowNode("panel", "Panel", "panel")], [], EnergyPeriod.Metric, "kWh");
+
+        Assert.Null(FlowExport.PeriodTotal(graph, "panel", periodTotalsReady: true));
+        Assert.Null(FlowExport.PeriodTotal(graph, "missing", periodTotalsReady: true));
+    }
+
+    [Fact]
     public void TheLiveSourceTheExportersAreGivenCanBeAsked()
     {
         // Structural: the exporters hold a composite, so the gate only works if the composite offers it —

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1925,6 +1925,23 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             // Two shapes of question, and they are not the same question. ?days is the daily total, one
             // sample per day. ?minutes is what is happening within a day, sampled every ?step seconds —
             // power, because a cumulative daily counter charted through the day only ever climbs.
+            // "Today" is the period in progress, so it starts where the counters last re-based rather than a
+            // fixed number of hours ago. Anchored to the configured boundary, not the browser's midnight:
+            // it is the same instant the daily totals are cut on, and a chart of today that disagrees with
+            // the day the totals belong to is worse than no chart.
+            if (ctx.Request.Query["today"] == "1")
+            {
+                var dayZone = EnergyPeriod.Resolve(config.EnergyFlow.Aggregation.PeriodTimeZone);
+                var began = EnergyPeriod.PeriodStart(end, dayZone, config.EnergyFlow.Aggregation.PeriodStartHour);
+                var stepToday = int.TryParse(ctx.Request.Query["step"].ToString(), out var ts) ? Math.Clamp(ts, 60, 3600) : 300;
+                var metricToday = string.IsNullOrWhiteSpace(ctx.Request.Query["metric"]) ? FlowGraphBuilder.DefaultMetric : ctx.Request.Query["metric"].ToString();
+                var sinceStart = new List<DateTime>();
+                for (var t = began; t <= end; t = t.AddSeconds(stepToday)) sinceStart.Add(t);
+                if (sinceStart.Count == 0) sinceStart.Add(end);
+                return Results.Json(await BuildSeriesAsync(ctx.Request.Query["instance"], metricToday, sinceStart,
+                    null, null, ctx.RequestAborted), ConfigSchema.Json);
+            }
+
             if (int.TryParse(ctx.Request.Query["minutes"].ToString(), out var mins))
             {
                 var step = int.TryParse(ctx.Request.Query["step"].ToString(), out var st) ? Math.Clamp(st, 60, 3600) : 300;

--- a/rPDU2MQTT.Web/web/src/sections/trends.ts
+++ b/rPDU2MQTT.Web/web/src/sections/trends.ts
@@ -199,6 +199,9 @@ export function addTrendsSection(nav: any, sections: any) {
   // question is power — a daily energy counter charted through the day only ever climbs, which says
   // nothing about when the load was. Across days it is the daily total, the one figure that adds up.
   const RANGES: [string, string, string][] = [
+    // Not "the last 24 hours": today starts where the counters last re-based, on the configured boundary,
+    // so the chart covers the same day the daily totals belong to.
+    ['today=1&step=300', 'today so far', 'power'],
     ['minutes=360&step=300', 'last 6 hours', 'power'],
     ['minutes=1440&step=900', 'last 24 hours', 'power'],
     ['days=7', 'last 7 days', 'energy'],

--- a/rPDU2MQTT.Web/web/trends.check.mjs
+++ b/rPDU2MQTT.Web/web/trends.check.mjs
@@ -43,7 +43,10 @@ const power = {
 const asked = [];
 const { sandbox, getEl } = makeDom({
   bodies: (url) => {
-    if (url.includes('/api/flow/series')) { asked.push(url); return url.includes('minutes=') ? power : series; }
+    if (url.includes('/api/flow/series')) {
+      asked.push(url);
+      return (url.includes('minutes=') || url.includes('today=1')) ? power : series;
+    }
     return url.includes('/api/schema') ? schema
       : url.includes('/api/instances') ? { ok: true, instances: [] }
       : url.includes('/api/config') ? { EnergyFlow: { Nodes: [], Links: [] }, History: { Enabled: true } }
@@ -190,6 +193,20 @@ await new Promise(r => setTimeout(r, 50));
 if (query(sec, 'rect', true).length >= before) fail('taking a node off the chart changed nothing');
 if (query(sec, 'tr', true).some(r => r.textContent.includes('Grid') && r.textContent.includes('of 7')))
   fail('a node taken off the chart is still in the totals');
+
+// "Today so far" starts where the counters last re-based — the configured boundary, not a fixed 24 hours
+// and not the browser's midnight. A chart of today anchored anywhere else covers a different day from the
+// totals beside it.
+const todayOpt = query(sec, 'select', true)
+  .find(x => (x.children || []).some(o => (o.value || '').includes('today=1')));
+if (!todayOpt) fail('no "today so far" range offered');
+todayOpt.value = 'today=1&step=300';
+todayOpt.onchange({});
+await new Promise(r => setTimeout(r, 300));
+if (!/today=1/.test(decodeURIComponent(asked.at(-1)))) fail(`"today" was not asked for as the period: ${asked.at(-1)}`);
+// It is a moment-in-the-day view, so it charts power like the other intra-day ranges.
+if (!query(sec, 'h3', true).map(h => h.textContent).includes('Power by node'))
+  fail('"today so far" is not charted as power');
 
 // --- Within a day: power, sampled, and no self-sufficiency ------------------------------------------
 const rangeSel = query(sec, 'select', true).find(x => (x.children || []).some(o => (o.value || '').includes('minutes=')));

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -5506,6 +5506,9 @@ function addTrendsSection(nav     , sections     ) {
   // question is power — a daily energy counter charted through the day only ever climbs, which says
   // nothing about when the load was. Across days it is the daily total, the one figure that adds up.
   const RANGES                             = [
+    // Not "the last 24 hours": today starts where the counters last re-based, on the configured boundary,
+    // so the chart covers the same day the daily totals belong to.
+    ['today=1&step=300', 'today so far', 'power'],
     ['minutes=360&step=300', 'last 6 hours', 'power'],
     ['minutes=1440&step=900', 'last 24 hours', 'power'],
     ['days=7', 'last 7 days', 'energy'],


### PR DESCRIPTION
Follow-on to #377, which fixed this for Prometheus only.

## Home Assistant had the same hole

Home Assistant records what MQTT publishes, so the warm-up zeros land in its recorder too. The cluster's own
`values.yaml` spells out why that is worse there than in Prometheus:

> Its running kWh totals have to survive a restart: Home Assistant and EmonCMS read a drop as a meter reset
> and correct their already-recorded history for it, so losing the counter corrupts data that was previously
> right.

The tier export now withholds today's total while the carried-over totals are still being restored — the
sensor is unavailable for those seconds rather than reporting that nothing was used.

The rule lives in `FlowExport.PeriodTotal`, called by both destinations. The last thing duplicated across
the two — whether a node belongs in a history store — was got wrong in both independently.

(EmonCMS is unaffected: it posts PDU readings by input name and carries no flow tiers.)

## "Today so far"

A range that starts where the counters last re-based, on the configured boundary — not the last 24 hours,
and not the viewer's midnight. A chart of "today" anchored anywhere else covers a different day from the
totals beside it. Just after the boundary the window is minutes long, and that is the honest answer.

`EnergyPeriod.PeriodStart` does the arithmetic in local time, so a clock change cannot put the start an
hour inside the previous period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)