### PR TITLE
fix: keep generation out of HA's device list; read the intra-day axis as a clock

### DIFF
--- a/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyDashboardSync.cs
@@ -44,20 +44,22 @@ public static class EnergyDashboardSync
         var excluded = excludeKinds is { Count: > 0 }
             ? new HashSet<string>(excludeKinds, StringComparer.OrdinalIgnoreCase)
             : null;
+        // Sources/storage/pass-through (grid, solar, battery, inverter) aren't "device consumption" — they
+        // clutter the list and double-count against the dashboard's own grid/solar/battery buckets. Neither
+        // are the tiers feeding them: an MPPT is generation, and listing it counts production as load (#382).
+        var notDevices = NotDevices(graph, excluded);
         var entries = new List<HaDeviceConsumption>();
         // Diagram-only nodes are not devices — see FlowNode.Synthetic.
         foreach (var node in graph.Nodes.Where(n => !n.Synthetic))
         {
             if (include is not null && !include(node)) continue;
-            // Sources/storage/pass-through (grid, solar, battery, inverter) aren't "device consumption" — they
-            // clutter the list and double-count against the dashboard's own grid/solar/battery buckets.
-            if (excluded is not null && excluded.Contains(node.Kind ?? "node"))
+            if (notDevices.Contains(node.Id))
                 continue;
             var stat = statFor(node.Id);
             if (string.IsNullOrEmpty(stat))
                 continue;   // no energy sensor for this tier -> can't be an Energy-Dashboard device
             var power = powerFor?.Invoke(node.Id);   // optional real-time power sensor
-            entries.Add(new HaDeviceConsumption(stat, NearestAncestorStat(graph, node.Id, statFor, excluded), node.Label,
+            entries.Add(new HaDeviceConsumption(stat, NearestAncestorStat(graph, node.Id, statFor, notDevices), node.Label,
                 string.IsNullOrEmpty(power) ? null : power));
         }
         return entries;
@@ -142,9 +144,8 @@ public static class EnergyDashboardSync
     // Walk up the primary-feeder chain to the first ancestor that has an energy stat AND is itself a device
     // (not an excluded source/storage tier), so a device's included_in_stat never points at a tier we left out
     // of the list — and the link still spans intermediate tiers that have no sensor.
-    private static string? NearestAncestorStat(FlowGraph graph, string id, Func<string, string?> statFor, ISet<string>? excluded = null)
+    private static string? NearestAncestorStat(FlowGraph graph, string id, Func<string, string?> statFor, ISet<string> notDevices)
     {
-        var kindOf = graph.Nodes.ToDictionary(n => n.Id, n => n.Kind ?? "node", StringComparer.OrdinalIgnoreCase);
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { id };
         var current = id;
         while (true)
@@ -155,11 +156,46 @@ public static class EnergyDashboardSync
             var parent = parents[0];        // HA upstream is single-parent: follow the primary feeder
             if (!seen.Add(parent))
                 return null;                // cycle guard
-            var isExcluded = excluded is not null && excluded.Contains(kindOf.TryGetValue(parent, out var k) ? k : "node");
             var stat = statFor(parent);
-            if (!string.IsNullOrEmpty(stat) && !isExcluded)
+            if (!string.IsNullOrEmpty(stat) && !notDevices.Contains(parent))
                 return stat;
             current = parent;
         }
+    }
+
+    /// <summary>
+    /// The node ids that are not "individual devices": the excluded kinds themselves, plus the unclassified
+    /// tiers that only ever flow into one — an MPPT or a PV string wired into the inverter is generation, and
+    /// HA would otherwise chart that production as consumption (#382). A tier the user did classify (a panel,
+    /// a load, a PDU) is taken at its word, so a panel feeding an inverter stays a device.
+    /// </summary>
+    private static HashSet<string> NotDevices(FlowGraph graph, ISet<string>? excluded)
+    {
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (excluded is null || excluded.Count == 0) return ids;
+
+        var kindOf = graph.Nodes.ToDictionary(n => n.Id, n => n.Kind ?? "node", StringComparer.OrdinalIgnoreCase);
+        bool IsExcludedKind(string id) => excluded.Contains(kindOf.TryGetValue(id, out var k) ? k : "node");
+        string[] Targets(string id) => graph.Links
+            .Where(l => string.Equals(l.Source, id, StringComparison.OrdinalIgnoreCase))
+            .Select(l => l.Target).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+
+        var walking = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        bool FeedsOnlyGeneration(string id)
+        {
+            // Only an unclassified tier is reclassified this way, and a leaf is a consumer, not a feeder.
+            var kind = kindOf.TryGetValue(id, out var k) ? k : "node";
+            if (!string.IsNullOrEmpty(kind) && !string.Equals(kind, "node", StringComparison.OrdinalIgnoreCase)) return false;
+            var targets = Targets(id);
+            if (targets.Length == 0 || !walking.Add(id)) return false;   // the guard also breaks a cycle
+            var only = targets.All(t => IsExcludedKind(t) || FeedsOnlyGeneration(t));
+            walking.Remove(id);
+            return only;
+        }
+
+        foreach (var node in graph.Nodes)
+            if (IsExcludedKind(node.Id) || FeedsOnlyGeneration(node.Id))
+                ids.Add(node.Id);
+        return ids;
     }
 }

--- a/rPDU2MQTT.Core/Flow/EnergyPeriod.cs
+++ b/rPDU2MQTT.Core/Flow/EnergyPeriod.cs
@@ -50,6 +50,23 @@ public static class EnergyPeriod
     }
 
     /// <summary>
+    /// The window of a period <paramref name="periodsBack"/> before the one <paramref name="utc"/> falls in:
+    /// 0 is the period in progress (ending at <paramref name="utc"/> itself), 1 is yesterday. Each hop reads
+    /// the boundary from the zone again, so a DST day is its own length rather than a fixed 24 hours.
+    /// </summary>
+    public static (DateTime Start, DateTime End) Window(DateTime utc, TimeZoneInfo zone, int startHour, int periodsBack)
+    {
+        var start = PeriodStart(utc, zone, startHour);
+        var end = utc;
+        for (var i = 0; i < Math.Max(0, periodsBack); i++)
+        {
+            end = start.AddSeconds(-1);
+            start = PeriodStart(end, zone, startHour);
+        }
+        return (start, end);
+    }
+
+    /// <summary>
     /// One instant per day for the last <paramref name="days"/> periods, oldest first, with the day each
     /// belongs to.
     /// </summary>

--- a/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
+++ b/rPDU2MQTT.Tests/EnergyDashboardSourcesTests.cs
@@ -156,6 +156,32 @@ public class EnergyDashboardSourcesTests
     }
 
     [Fact]
+    public void DeviceConsumption_ExcludesTheTiersThatOnlyFeedGeneration()
+    {
+        // The MPPTs feed the inverter through a PV string; none of that is something the home consumes (#382).
+        // The sub-panel behind the inverter, and the unclassified circuit under it, still are.
+        var graph = new FlowGraph(
+            new[]
+            {
+                new FlowNode("mppt1", "MPPT 1", "node"), new FlowNode("mppt2", "MPPT 2", "node"),
+                new FlowNode("string", "PV String", "node"), new FlowNode("inv", "Inverter", "inverter"),
+                new FlowNode("sub", "Sub Panel", "panel"), new FlowNode("circuit", "Kitchen", "node"),
+            },
+            new[]
+            {
+                new FlowLink("mppt1", "string", 100), new FlowLink("mppt2", "string", 100),
+                new FlowLink("string", "inv", 200), new FlowLink("inv", "sub", 200),
+                new FlowLink("sub", "circuit", 200),
+            },
+            "realpower", "W");
+        string? stat(string id) => "sensor." + id + "_energy";
+
+        var devices = EnergyDashboardSync.BuildDeviceConsumption(graph, stat, new[] { "grid", "solar", "battery", "inverter" });
+        Assert.Equal(new[] { "sensor.circuit_energy", "sensor.sub_energy" },
+            devices.Select(d => d.stat_consumption).OrderBy(x => x).ToArray());
+    }
+
+    [Fact]
     public void StatsOf_ExtractsEveryReferencedEntity()
     {
         var grid = Assert.Single(EnergyDashboardSync.BuildEnergySources(

--- a/rPDU2MQTT.Tests/PeriodEndsTests.cs
+++ b/rPDU2MQTT.Tests/PeriodEndsTests.cs
@@ -86,6 +86,35 @@ public class PeriodEndsTests
     }
 
     [Fact]
+    public void YesterdayIsTheWholePeriodBeforeThisOne()
+    {
+        // 14:05 CDT on the 8th. "Today" runs from local midnight to now; "yesterday" is the 7th end to end.
+        var now = new DateTime(2026, 8, 8, 19, 5, 0, DateTimeKind.Utc);
+
+        var today = EnergyPeriod.Window(now, Chicago, 0, 0);
+        Assert.Equal(new DateTime(2026, 8, 8, 5, 0, 0, DateTimeKind.Utc), today.Start);
+        Assert.Equal(now, today.End);
+
+        var yesterday = EnergyPeriod.Window(now, Chicago, 0, 1);
+        Assert.Equal(new DateTime(2026, 8, 7, 5, 0, 0, DateTimeKind.Utc), yesterday.Start);
+        Assert.Equal(new DateTime(2026, 8, 8, 4, 59, 59, DateTimeKind.Utc), yesterday.End);
+    }
+
+    [Fact]
+    public void YesterdayKeepsItsOwnLengthAcrossAClockChange()
+    {
+        // The spring-forward day is 23 hours long. Subtracting 24 would start it an hour into the 7th.
+        var now = new DateTime(2026, 3, 9, 18, 0, 0, DateTimeKind.Utc);
+
+        var (start, end) = EnergyPeriod.Window(now, Chicago, 0, 1);
+
+        Assert.Equal("2026-03-08", EnergyPeriod.KeyFor(start, Chicago, 0));
+        Assert.Equal("2026-03-08", EnergyPeriod.KeyFor(end, Chicago, 0));
+        Assert.Equal(0, EnergyPeriod.Local(start, Chicago).Hour);
+        Assert.Equal(23, (end - start).TotalHours, 3);
+    }
+
+    [Fact]
     public void TheDaysComeBackOldestFirst_OneEach()
     {
         var ends = EnergyPeriod.RecentPeriodEnds(DateTime.UtcNow, TimeZoneInfo.Utc, 0, 30);

--- a/rPDU2MQTT.Web/Gui/GuiService.cs
+++ b/rPDU2MQTT.Web/Gui/GuiService.cs
@@ -1763,7 +1763,9 @@ public sealed class GuiService : IHostedService, IAsyncDisposable
             if (ctx.Request.Query["today"] == "1")
             {
                 var dayZone = EnergyPeriod.Resolve(config.EnergyFlow.Aggregation.PeriodTimeZone);
-                var began = EnergyPeriod.PeriodStart(end, dayZone, config.EnergyFlow.Aggregation.PeriodStartHour);
+                // ?back=<n> charts a whole earlier period instead — yesterday is back=1.
+                var back = int.TryParse(ctx.Request.Query["back"].ToString(), out var bk) ? Math.Clamp(bk, 0, 366) : 0;
+                (var began, end) = EnergyPeriod.Window(end, dayZone, config.EnergyFlow.Aggregation.PeriodStartHour, back);
                 var stepToday = int.TryParse(ctx.Request.Query["step"].ToString(), out var ts) ? Math.Clamp(ts, 60, 3600) : 300;
                 var metricToday = string.IsNullOrWhiteSpace(ctx.Request.Query["metric"]) ? FlowGraphBuilder.DefaultMetric : ctx.Request.Query["metric"].ToString();
                 var sinceStart = new List<DateTime>();

--- a/rPDU2MQTT.Web/web/src/charts.ts
+++ b/rPDU2MQTT.Web/web/src/charts.ts
@@ -133,7 +133,8 @@ export function barChart(opts: {
     const every = Math.ceil(days.length / 12);
     if (d % every === 0) {
       const t = svgTag('text', { x: x(d) + slot / 2, y: H - padB + 16, 'text-anchor': 'middle', fill: 'var(--muted)', 'font-size': 11 });
-      t.textContent = day.slice(5);
+      // A day key is charted without its year; a clock label (an intra-day moment) is already what to show.
+      t.textContent = /^\d{4}-\d{2}-\d{2}$/.test(day) ? day.slice(5) : day;
       svg.appendChild(t);
     }
   });

--- a/rPDU2MQTT.Web/web/src/sections/trends.ts
+++ b/rPDU2MQTT.Web/web/src/sections/trends.ts
@@ -26,6 +26,8 @@ export function addTrendsSection(nav: any, sections: any) {
   const RANGES: [string, string, string][] = [
     // Not "the last 24 hours": today starts where the counters last re-based.
     ['today=1&step=300', 'today so far', 'power'],
+    // The whole previous period, on the same boundary — not "the 24 hours before now".
+    ['today=1&back=1&step=300', 'yesterday', 'power'],
     ['minutes=360&step=300', 'last 6 hours', 'power'],
     ['minutes=1440&step=900', 'last 24 hours', 'power'],
     ['days=7', 'last 7 days', 'energy'],
@@ -158,6 +160,9 @@ export function addTrendsSection(nav: any, sections: any) {
       box.appendChild(row);
     }
     charts.appendChild(box);
+    // A chart wider than the page opens on its oldest bars, and the newest are what the page is about —
+    // so start at the right-hand end (#378). scrollWidth is only known once the SVG is in the document.
+    scroll.scrollLeft = scroll.scrollWidth;
     return made.gaps;
   };
 

--- a/rPDU2MQTT.Web/web/trends.check.mjs
+++ b/rPDU2MQTT.Web/web/trends.check.mjs
@@ -266,6 +266,11 @@ hit.dispatch('mouseenter', { clientX: 5, clientY: 5 });
 const intraText = query(sandbox.document.body, '.trend-card').textContent;
 if (!intraText.includes(want) || !intraText.includes('4,400')) fail(`the intra-day hover is wrong: "${intraText}"`);
 
+// …and so are the labels under it. Charting a day key drops its year, and doing that to a clock label left
+// the axis reading "AM" — the one part of the chart that says which hours it covers (#378).
+const axisText = query(sec, 'text', true).map(t => t.textContent);
+if (!axisText.includes(local(at[0]))) fail(`the axis is not labelled with the clock: ${axisText.join(', ')}`);
+
 // Columns sort. Twelve nodes over ninety days is a table you read by scanning for the biggest number.
 // Every node back on first: a one-row table is sorted whatever the code does, which is no test at all.
 query(sec, 'button', true).find(b => b.textContent === 'All').click();
@@ -282,6 +287,18 @@ nameHead.onclick();
 await new Promise(r => setTimeout(r, 50));
 if (order().join() !== [...byName].reverse().join()) fail('clicking the same column again did not reverse it');
 
+// Yesterday is the period before the one in progress, on the same boundary — the server knows where that
+// boundary is, so the page asks for a period back rather than subtracting 24 hours itself (#378).
+const yesterdaySel = query(sec, 'select', true).find(x => (x.children || []).some(o => (o.value || '').includes('back=1')));
+if (!yesterdaySel) fail('no "yesterday" range offered');
+yesterdaySel.value = 'today=1&back=1&step=300';
+yesterdaySel.onchange({});
+await new Promise(r => setTimeout(r, 300));
+const askedYesterday = decodeURIComponent(asked.at(-1));
+if (!/today=1/.test(askedYesterday) || !/back=1/.test(askedYesterday))
+  fail(`yesterday was not asked for as the previous period: ${askedYesterday}`);
+
 console.log('trends: several charts over the chosen range; hovering a day says what is on it; tags select '
   + 'what to chart; days with no reading are empty slots, counted, and left out of totals that say how '
-  + 'many days they cover; within a day it charts power and integrates kWh; the table sorts');
+  + 'many days they cover; within a day it charts power on a clock axis and integrates kWh; yesterday is '
+  + 'the period before this one; the table sorts');

--- a/rPDU2MQTT.Web/wwwroot/app.js
+++ b/rPDU2MQTT.Web/wwwroot/app.js
@@ -935,7 +935,8 @@ function barChart(opts
     const every = Math.ceil(days.length / 12);
     if (d % every === 0) {
       const t = svgTag('text', { x: x(d) + slot / 2, y: H - padB + 16, 'text-anchor': 'middle', fill: 'var(--muted)', 'font-size': 11 });
-      t.textContent = day.slice(5);
+      // A day key is charted without its year; a clock label (an intra-day moment) is already what to show.
+      t.textContent = /^\d{4}-\d{2}-\d{2}$/.test(day) ? day.slice(5) : day;
       svg.appendChild(t);
     }
   });
@@ -5137,6 +5138,8 @@ function addTrendsSection(nav     , sections     ) {
   const RANGES                             = [
     // Not "the last 24 hours": today starts where the counters last re-based.
     ['today=1&step=300', 'today so far', 'power'],
+    // The whole previous period, on the same boundary — not "the 24 hours before now".
+    ['today=1&back=1&step=300', 'yesterday', 'power'],
     ['minutes=360&step=300', 'last 6 hours', 'power'],
     ['minutes=1440&step=900', 'last 24 hours', 'power'],
     ['days=7', 'last 7 days', 'energy'],
@@ -5269,6 +5272,9 @@ function addTrendsSection(nav     , sections     ) {
       box.appendChild(row);
     }
     charts.appendChild(box);
+    // A chart wider than the page opens on its oldest bars, and the newest are what the page is about —
+    // so start at the right-hand end (#378). scrollWidth is only known once the SVG is in the document.
+    scroll.scrollLeft = scroll.scrollWidth;
     return made.gaps;
   };
 


### PR DESCRIPTION
Two reported issues.

**#382 — Home Assistant export lists MPPTs as individual devices**

An MPPT has no role kind of its own (`Kind: node`), so the kind exclusion — grid / solar / battery / inverter — never caught it, and HA charted PV production as household consumption. A tier that only ever flows into an excluded generation/storage kind is now excluded as well, transitively, so a PV string between the MPPTs and the inverter goes too. `included_in_stat` skips those tiers the same way, so nothing dangles.

Only an unclassified tier is reclassified this way. A panel feeding an inverter stays a device — the user said what it is.

Previously-synced MPPT devices are retired on the next sync: `ManagedStats` already covers every tier regardless of exclusion.

**#378 — Trends: the intra-day axis, and Today / Yesterday**

- Every axis tick had its first five characters cut off to strip a day key's year, so `12:15 AM` was drawn as `AM`. Only an actual day key is trimmed now.
- A chart wider than the page opened scrolled to its oldest bars, so the most recent hours were off-screen — with an unreadable axis, that looks like a chart ending hours ago. Trends now opens at the right-hand end.
- Adds a **yesterday** range: the whole period before the one in progress, on the configured rollover boundary (`?today=1&back=1`). Each hop re-reads the boundary from the zone, so the spring-forward day is 23 hours, not 24. "Today so far" already covers the other half of the request.

The timestamps themselves were already correct — `/api/flow/series` returns UTC instants and the page names them in the viewer's clock (#376).

**Checks:** `dotnet build` clean (0 warnings), 760 tests pass, all 12 GUI check scripts pass. New coverage: generation tiers excluded from `device_consumption`, the yesterday window (including across a DST change), the axis reading as a clock, and the yesterday range being requested as a period back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)